### PR TITLE
example: ts-solid-chat only import necessary lucide-solid icons in dev

### DIFF
--- a/examples/ts-solid-chat/src/components/Header.tsx
+++ b/examples/ts-solid-chat/src/components/Header.tsx
@@ -1,6 +1,8 @@
 import { Link } from '@tanstack/solid-router'
-
-import { Guitar, Home, Menu, X } from 'lucide-solid'
+import Guitar from 'lucide-solid/icons/guitar'
+import Home from 'lucide-solid/icons/home'
+import Menu from 'lucide-solid/icons/menu'
+import X from 'lucide-solid/icons/x'
 import { createSignal } from 'solid-js'
 
 export default function Header() {

--- a/examples/ts-solid-chat/src/routes/index.tsx
+++ b/examples/ts-solid-chat/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/solid-router'
-import { Send, Square } from 'lucide-solid'
+import Send from 'lucide-solid/icons/send'
+import Square from 'lucide-solid/icons/square'
 import { fetchServerSentEvents, useChat } from '@tanstack/ai-solid'
 import { ThinkingPart, TextPart } from '@tanstack/ai-solid-ui'
 import { createSignal, For } from 'solid-js'


### PR DESCRIPTION
without this the dev server loads all lucide-solid icons resulting in very long startup time