### PR TITLE
fix(prettier): remove quotes from glob pattern in prettier script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:all": "nx run-many --targets=build --exclude=examples/**",
     "watch": "pnpm run build:all && nx watch --all -- pnpm run build:all",
     "dev": "pnpm run watch",
-    "prettier": "prettier --ignore-unknown '**/*'",
+    "prettier": "prettier --ignore-unknown **/*",
     "prettier:write": "pnpm run prettier --write",
     "generate-docs": "node scripts/generate-docs.ts && pnpm run copy:readme",
     "copy:readme": "cp README.md packages/typescript/ai/README.md && cp README.md packages/typescript/ai-devtools/README.md && cp README.md packages/typescript/ai-client/README.md && cp README.md packages/typescript/ai-gemini/README.md && cp README.md packages/typescript/ai-ollama/README.md && cp README.md packages/typescript/ai-openai/README.md && cp README.md packages/typescript/ai-react/README.md && cp README.md packages/typescript/ai-react-ui/README.md && cp README.md packages/typescript/react-ai-devtools/README.md && cp README.md packages/typescript/solid-ai-devtools/README.md",


### PR DESCRIPTION
I'm using both systems, so I noticed that Prettier is not working in the Windows environment.

## 🎯 Changes

- Fixes Windows compatibility issue with quoted glob patterns in package.json scripts
- Ensures prettier command works correctly on Windows systems

## ✅ Checklist

- 🤷 I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md). - The file does not exist. 🚨
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

No impact.
The command still works on macOS.
