### PR TITLE
fix: unresponsive chat after client tool execution

### DIFF
--- a/.changeset/fix-silent-chat-continuation.md
+++ b/.changeset/fix-silent-chat-continuation.md
@@ -1,0 +1,6 @@
+---
+"@tanstack/ai": patch
+"@tanstack/ai-client": patch
+---
+
+fix: Continue conversation after client tool execution

--- a/packages/typescript/ai-client/src/chat-client.ts
+++ b/packages/typescript/ai-client/src/chat-client.ts
@@ -331,7 +331,11 @@ export class ChatClient {
       const lastPart = lastMessage?.parts[lastMessage.parts.length - 1]
 
       if (lastPart?.type === 'tool-result' && this.shouldAutoSend()) {
-        await this.continueFlow()
+        try {
+          await this.continueFlow()
+        } catch (error) {
+          console.error('Failed to continue flow after tool result:', error)
+        }
       }
     }
   }

--- a/packages/typescript/ai-client/src/chat-client.ts
+++ b/packages/typescript/ai-client/src/chat-client.ts
@@ -55,13 +55,13 @@ export class ChatClient {
 
     this.callbacksRef = {
       current: {
-        onResponse: options.onResponse || (() => { }),
-        onChunk: options.onChunk || (() => { }),
-        onFinish: options.onFinish || (() => { }),
-        onError: options.onError || (() => { }),
-        onMessagesChange: options.onMessagesChange || (() => { }),
-        onLoadingChange: options.onLoadingChange || (() => { }),
-        onErrorChange: options.onErrorChange || (() => { }),
+        onResponse: options.onResponse || (() => {}),
+        onChunk: options.onChunk || (() => {}),
+        onFinish: options.onFinish || (() => {}),
+        onError: options.onError || (() => {}),
+        onMessagesChange: options.onMessagesChange || (() => {}),
+        onLoadingChange: options.onLoadingChange || (() => {}),
+        onErrorChange: options.onErrorChange || (() => {}),
       },
     }
 

--- a/packages/typescript/ai-client/src/chat-client.ts
+++ b/packages/typescript/ai-client/src/chat-client.ts
@@ -27,6 +27,7 @@ export class ChatClient {
   private currentStreamId: string | null = null
   private currentMessageId: string | null = null
 
+
   private callbacksRef: {
     current: {
       onResponse: (response?: Response) => void | Promise<void>
@@ -323,6 +324,15 @@ export class ChatClient {
     } finally {
       this.abortController = null
       this.setIsLoading(false)
+
+      // Continue conversation if the stream ended with a tool result
+      const messages = this.processor.getMessages()
+      const lastMessage = messages[messages.length - 1]
+      const lastPart = lastMessage?.parts[lastMessage.parts.length - 1]
+
+      if (lastPart?.type === 'tool-result' && this.shouldAutoSend()) {
+        await this.continueFlow()
+      }
     }
   }
 

--- a/packages/typescript/ai-client/src/chat-client.ts
+++ b/packages/typescript/ai-client/src/chat-client.ts
@@ -55,13 +55,13 @@ export class ChatClient {
 
     this.callbacksRef = {
       current: {
-        onResponse: options.onResponse || (() => {}),
-        onChunk: options.onChunk || (() => {}),
-        onFinish: options.onFinish || (() => {}),
-        onError: options.onError || (() => {}),
-        onMessagesChange: options.onMessagesChange || (() => {}),
-        onLoadingChange: options.onLoadingChange || (() => {}),
-        onErrorChange: options.onErrorChange || (() => {}),
+        onResponse: options.onResponse || (() => { }),
+        onChunk: options.onChunk || (() => { }),
+        onFinish: options.onFinish || (() => { }),
+        onError: options.onError || (() => { }),
+        onMessagesChange: options.onMessagesChange || (() => { }),
+        onLoadingChange: options.onLoadingChange || (() => { }),
+        onErrorChange: options.onErrorChange || (() => { }),
       },
     }
 
@@ -329,8 +329,7 @@ export class ChatClient {
       // Continue conversation if the stream ended with a tool result
       if (streamCompletedSuccessfully) {
         const messages = this.processor.getMessages()
-        const lastMessage = messages[messages.length - 1]
-        const lastPart = lastMessage?.parts[lastMessage.parts.length - 1]
+        const lastPart = messages.at(-1)?.parts?.at(-1)
 
         if (lastPart?.type === 'tool-result' && this.shouldAutoSend()) {
           try {

--- a/packages/typescript/ai/src/stream/processor.ts
+++ b/packages/typescript/ai/src/stream/processor.ts
@@ -355,11 +355,20 @@ export class StreamProcessor {
 
     if (toolParts.length === 0) return true
 
+    // Check for server tool completions via tool-result parts
+    const toolResultParts = lastAssistant.parts.filter(
+      (p) => p.type === 'tool-result',
+    )
+    const completedToolCallIds = new Set(
+      toolResultParts.map((p) => (p as { toolCallId: string }).toolCallId),
+    )
+
     // All tool calls must be in a terminal state
     return toolParts.every(
       (part) =>
         part.state === 'approval-responded' ||
-        (part.output !== undefined && !part.approval),
+        (part.output !== undefined && !part.approval) ||
+        completedToolCallIds.has(part.id),
     )
   }
 

--- a/packages/typescript/ai/src/stream/processor.ts
+++ b/packages/typescript/ai/src/stream/processor.ts
@@ -357,10 +357,11 @@ export class StreamProcessor {
 
     // Check for server tool completions via tool-result parts
     const toolResultParts = lastAssistant.parts.filter(
-      (p) => p.type === 'tool-result',
+      (p): p is Extract<typeof p, { type: 'tool-result' }> =>
+        p.type === 'tool-result',
     )
     const completedToolCallIds = new Set(
-      toolResultParts.map((p) => (p as { toolCallId: string }).toolCallId),
+      toolResultParts.map((p) => p.toolCallId),
     )
 
     // All tool calls must be in a terminal state


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

The conversation becomes unresponsive after a client-side tool execution, as the LLM fails to receive the tool result effectively.
- Updated `StreamProcessor.areAllToolsComplete` to check for `tool-result` parts (server tools) in addition to `output` fields (client tools).
- Updated `ChatClient.streamResponse` to check if the stream ended with a `tool-result` part. If so, it automatically triggers `continueFlow()` to send the result back to the LLM. This handles cases where `addToolResult` was called while the stream was still active (and thus blocked from continuing immediately).


## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection of tool execution completion so server-side tool results mark calls as finished, reducing stalled actions.
  * Streaming responses now, after a successful stream, automatically continue the conversation when the last streamed item is a tool result and auto-send is enabled; continuation errors are logged but do not interrupt the flow.

* **Chores**
  * Patch version metadata updated for two packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->