### PR TITLE
[WIP]: Chat audio

### DIFF
--- a/packages/typescript/ai-openai/src/model-meta.ts
+++ b/packages/typescript/ai-openai/src/model-meta.ts
@@ -1,4 +1,5 @@
 import type {
+  OpenAIAudioOutputOptions,
   OpenAIBaseOptions,
   OpenAIMetadataOptions,
   OpenAIReasoningOptions,
@@ -1072,6 +1073,32 @@ const GPT_4O_AUDIO = {
     OpenAIMetadataOptions
 >
 
+const GPT_4O_AUDIO_PREVIEW = {
+  name: 'gpt-4o-audio-preview',
+  context_window: 128_000,
+  max_output_tokens: 16_384,
+  knowledge_cutoff: '2023-10-01',
+  pricing: {
+    input: {
+      normal: 2.5,
+    },
+    output: {
+      normal: 10,
+    },
+  },
+  supports: {
+    input: ['text', 'audio'],
+    output: ['text', 'audio'],
+    endpoints: ['chat-completions'],
+    features: ['streaming', 'function_calling'],
+  },
+} as const satisfies ModelMeta<
+  OpenAIBaseOptions &
+    OpenAIToolsOptions &
+    OpenAIStreamingOptions &
+    OpenAIMetadataOptions
+>
+
 const GPT_4O_MINI = {
   name: 'gpt-4o-mini',
   context_window: 128_000,
@@ -1635,6 +1662,7 @@ export const OPENAI_CHAT_MODELS = [
   GPT_AUDIO.name,
   GPT_AUDIO_MINI.name,
   GPT_4O_AUDIO.name,
+  GPT_4O_AUDIO_PREVIEW.name,
   GPT_4O_MINI_AUDIO.name,
   // ChatGPT models
   GPT_5_1_CHAT.name,
@@ -1879,16 +1907,24 @@ export type OpenAIChatModelProviderOptionsByName = {
   // Audio models
   [GPT_AUDIO.name]: OpenAIBaseOptions &
     OpenAIStreamingOptions &
-    OpenAIMetadataOptions
+    OpenAIMetadataOptions &
+    OpenAIAudioOutputOptions
   [GPT_AUDIO_MINI.name]: OpenAIBaseOptions &
     OpenAIStreamingOptions &
-    OpenAIMetadataOptions
+    OpenAIMetadataOptions &
+    OpenAIAudioOutputOptions
   [GPT_4O_AUDIO.name]: OpenAIBaseOptions &
     OpenAIStreamingOptions &
-    OpenAIMetadataOptions
+    OpenAIMetadataOptions &
+    OpenAIAudioOutputOptions
+  [GPT_4O_AUDIO_PREVIEW.name]: OpenAIBaseOptions &
+    OpenAIStreamingOptions &
+    OpenAIMetadataOptions &
+    OpenAIAudioOutputOptions
   [GPT_4O_MINI_AUDIO.name]: OpenAIBaseOptions &
     OpenAIStreamingOptions &
-    OpenAIMetadataOptions
+    OpenAIMetadataOptions &
+    OpenAIAudioOutputOptions
 
   // Chat-only models
   [GPT_5_1_CHAT.name]: OpenAIBaseOptions &
@@ -1974,6 +2010,7 @@ export type OpenAIModelInputModalitiesByName = {
   [GPT_AUDIO.name]: typeof GPT_AUDIO.supports.input
   [GPT_AUDIO_MINI.name]: typeof GPT_AUDIO_MINI.supports.input
   [GPT_4O_AUDIO.name]: typeof GPT_4O_AUDIO.supports.input
+  [GPT_4O_AUDIO_PREVIEW.name]: typeof GPT_4O_AUDIO_PREVIEW.supports.input
   [GPT_4O_MINI_AUDIO.name]: typeof GPT_4O_MINI_AUDIO.supports.input
 
   // Text-only models

--- a/packages/typescript/ai-openai/src/text/text-provider-options.ts
+++ b/packages/typescript/ai-openai/src/text/text-provider-options.ts
@@ -234,12 +234,57 @@ https://platform.openai.com/docs/api-reference/responses/create#responses_create
   metadata?: Record<string, string>
 }
 
+/**
+ * Audio output options for models that support audio generation (e.g., gpt-4o-audio-preview).
+ * When specified, the model will generate audio output in addition to or instead of text.
+ * Note: Audio output requires the Chat Completions API, not the Responses API.
+ * @see https://platform.openai.com/docs/guides/audio
+ */
+export interface OpenAIAudioOutputOptions {
+  /**
+   * Output modalities to generate. Include 'audio' to enable audio output.
+   * Example: ['text', 'audio'] for both text and audio output.
+   */
+  modalities?: Array<'text' | 'audio'>
+  /**
+   * Audio output configuration. Required when modalities includes 'audio'.
+   */
+  audio?: {
+    /**
+     * The voice to use for audio generation.
+     * Available voices: alloy, ash, ballad, coral, echo, fable, onyx, nova, sage, shimmer, verse
+     */
+    voice:
+      | 'alloy'
+      | 'ash'
+      | 'ballad'
+      | 'coral'
+      | 'echo'
+      | 'fable'
+      | 'onyx'
+      | 'nova'
+      | 'sage'
+      | 'shimmer'
+      | 'verse'
+    /**
+     * The audio format for output.
+     * - 'pcm16': Raw 16-bit PCM audio at 24kHz (best for real-time streaming)
+     * - 'wav': WAV format
+     * - 'mp3': MP3 format
+     * - 'opus': Opus format
+     * - 'flac': FLAC format
+     */
+    format: 'pcm16' | 'wav' | 'mp3' | 'opus' | 'flac'
+  }
+}
+
 export type ExternalTextProviderOptions = OpenAIBaseOptions &
   OpenAIReasoningOptions &
   OpenAIStructuredOutputOptions &
   OpenAIToolsOptions &
   OpenAIStreamingOptions &
-  OpenAIMetadataOptions
+  OpenAIMetadataOptions &
+  OpenAIAudioOutputOptions
 
 /**
  * Options your SDK forwards to OpenAI when doing chat/responses.

--- a/packages/typescript/ai/src/types.ts
+++ b/packages/typescript/ai/src/types.ts
@@ -583,6 +583,7 @@ export interface ChatOptions<
 
 export type StreamChunkType =
   | 'content'
+  | 'audio'
   | 'tool_call'
   | 'tool_result'
   | 'done'
@@ -667,10 +668,25 @@ export interface ThinkingStreamChunk extends BaseStreamChunk {
 }
 
 /**
+ * Audio output stream chunk for models that support audio output (e.g., gpt-4o-audio-preview).
+ * Contains base64-encoded audio data and optional transcript.
+ */
+export interface AudioStreamChunk extends BaseStreamChunk {
+  type: 'audio'
+  /** Base64-encoded audio data (e.g., PCM16, WAV) */
+  data: string
+  /** Optional transcript of the audio content */
+  transcript?: string
+  /** Audio format (e.g., 'pcm16', 'wav', 'mp3') */
+  format?: string
+}
+
+/**
  * Chunk returned by the sdk during streaming chat completions.
  */
 export type StreamChunk =
   | ContentStreamChunk
+  | AudioStreamChunk
   | ToolCallStreamChunk
   | ToolResultStreamChunk
   | DoneStreamChunk


### PR DESCRIPTION
## 🎯 Changes

**Very Early WIP: Add audio output streaming support to OpenAI adapter**

This PR adds support for streaming audio output from OpenAI's audio-capable models (e.g., `gpt-4o-audio-preview`) via the Chat Completions API.

Opening as a discussion starter.

### Background

The current OpenAI adapter uses the Responses API (`client.responses.create()`), which does not support audio output modalities. Audio output streaming requires the Chat Completions API with `modalities: ['text', 'audio']` and `audio: { voice, format }` configuration.

### Changes

**1. New `AudioStreamChunk` type** (`packages/typescript/ai/src/types.ts`)
- Added `'audio'` to `StreamChunkType` union
- Added `AudioStreamChunk` interface with `data` (base64), `transcript`, and `format` fields
- Added to `StreamChunk` union type

**2. Audio output options** (`packages/typescript/ai-openai/src/text/text-provider-options.ts`)
- Added `OpenAIAudioOutputOptions` interface with `modalities` and `audio` config
- Included in `ExternalTextProviderOptions`

**3. OpenAI adapter audio routing** (`packages/typescript/ai-openai/src/openai-adapter.ts`)
- `chatStream()` now detects `modalities.includes('audio')` in provider options
- When audio is requested, routes to new `chatStreamWithAudio()` method
- `chatStreamWithAudio()` uses Chat Completions API instead of Responses API
- Yields `AudioStreamChunk` for audio data and `ContentStreamChunk` for transcripts

**4. Model metadata** (`packages/typescript/ai-openai/src/model-meta.ts`)
- Added `gpt-4o-audio-preview` model definition
- Added `OpenAIAudioOutputOptions` to audio model provider option types

### Usage

```typescript
import { chat } from "@tanstack/ai"
import { createOpenAI } from "@tanstack/ai-openai"

const stream = chat({
  adapter: createOpenAI(apiKey),
  model: "gpt-4o-audio-preview",
  messages: [{ role: "user", content: "Tell me a story" }],
  providerOptions: {
    modalities: ["text", "audio"],
    audio: { voice: "alloy", format: "pcm16" },
  },
})

for await (const chunk of stream) {
  if (chunk.type === "audio") {
    // chunk.data is base64-encoded PCM16 audio
  }
  if (chunk.type === "content") {
    // chunk.delta is transcript text
  }
}
```

### Real-world usage

This is being used by the [Durable Streams](https://github.com/durable-streams/durable-streams/pull/73) story-app example - a child-friendly AI story generator that streams both narrated audio and synchronized text transcripts to a durable stream for resilient playback.

### Open questions

- Should audio routing be explicit via a separate method, or is auto-detection from `modalities` the right approach?
- Should we add a `ChatCompletionsAdapter` as a separate class for broader Chat Completions API support?
- Are there other audio-related events from the Chat Completions API we should handle?

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
