### PR TITLE
fix(ai-gemini): generate unique IDs for parallel function calls

### DIFF
--- a/.changeset/silly-islands-shave.md
+++ b/.changeset/silly-islands-shave.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-gemini': patch
+---
+
+fix: generate unique IDs for parallel function calls in Gemini adapter

--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -227,7 +227,8 @@ export class GeminiTextAdapter<
           const functionCall = part.functionCall
           if (functionCall) {
             const toolCallId =
-              functionCall.name || `call_${Date.now()}_${nextToolIndex}`
+              functionCall.id ||
+              `${functionCall.name}_${Date.now()}_${nextToolIndex}`
             const functionArgs = functionCall.args || {}
 
             let toolCallData = toolCallMap.get(toolCallId)
@@ -297,7 +298,8 @@ export class GeminiTextAdapter<
               const functionCall = part.functionCall
               if (functionCall) {
                 const toolCallId =
-                  functionCall.name || `call_${Date.now()}_${nextToolIndex}`
+                  functionCall.id ||
+                  `${functionCall.name}_${Date.now()}_${nextToolIndex}`
                 const functionArgs = functionCall.args || {}
 
                 toolCallMap.set(toolCallId, {


### PR DESCRIPTION
## 🎯 Changes
<!-- What changes are made in this PR? Describe the change and its motivation. -->

**Fix: Gemini adapter generates duplicate tool call IDs for parallel function calls**

When Gemini returns multiple parallel tool calls for the same function, all tool calls currently receive the same ID (the function name), causing them to be merged/deduplicated.

### Problem

In `packages/typescript/ai-gemini/src/adapters/text.ts`, line 229-230:

```typescript
const toolCallId = functionCall.name || `call_${Date.now()}_${nextToolIndex}`
```

When calling the same function in parallel (e.g., "Compare weather in NYC, SF, and LA"), all three `get_weather` calls get `toolCallId = "get_weather"`, breaking parallel tool execution.

### Solution

Generate unique IDs using the function name combined with timestamp and index:

```diff
- const toolCallId = functionCall.name || `call_${Date.now()}_${nextToolIndex}`
+ const toolCallId = functionCall.id || `${functionCall.name}_${Date.now()}_${nextToolIndex}`
```

This change is applied in two locations:
- Line 229-230 (main streaming loop)
- Line 299-300 (UNEXPECTED_TOOL_CALL handling)

### Related Issues

Similar issues in other SDKs:
- camel-ai/camel#3027
- microsoft/semantic-kernel#10597

## Background

The native Gemini API is designed to use **order-based matching** for function calls/responses,
not ID-based matching. This is intentional - Gemini uses name, order, and thought signatures
for call matching ([docs](https://ai.google.dev/gemini-api/docs/function-calling)).

However, `@tanstack/ai` uses **ID-based matching** internally via ToolCallManager.
The adapter's responsibility is to bridge this difference by generating unique fallback IDs.

**Test result with gemini-2.5-flash:**
```javascript
{ id: undefined, name: "get_weather", args: { city: "NYC" } }
{ id: undefined, name: "get_weather", args: { city: "SF" } }
{ id: undefined, name: "get_weather", args: { city: "LA" } }
```

## ✅ Checklist
- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with pnpm run test:pr.
## 🚀 Release Impact
- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).