### PR TITLE
fix(gemini): preserve thought signatures for Gemini 3.0 compatibility

### DIFF
--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -332,8 +332,8 @@ export class GeminiTextAdapter<
 
                 // Capture thought signature for Gemini 3.0 compatibility
                 const metadata =
-                  'thoughtSignature' in part && part.thoughtSignature
-                    ? { thoughtSignature: part.thoughtSignature }
+                  'thoughtSignature' in part && (part as any).thoughtSignature
+                    ? { thoughtSignature: (part as any).thoughtSignature }
                     : undefined
 
                 yield {

--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -271,6 +271,12 @@ export class GeminiTextAdapter<
               }
             }
 
+            // Capture thought signature for Gemini 3.0 compatibility
+            const metadata =
+              'thoughtSignature' in part && part.thoughtSignature
+                ? { thoughtSignature: part.thoughtSignature }
+                : undefined
+
             yield {
               type: 'tool_call',
               id: generateId(this.name),
@@ -283,6 +289,7 @@ export class GeminiTextAdapter<
                   name: toolCallData.name,
                   arguments: toolCallData.args,
                 },
+                metadata,
               },
               index: toolCallData.index,
             }
@@ -323,6 +330,12 @@ export class GeminiTextAdapter<
                   index: nextToolIndex++,
                 })
 
+                // Capture thought signature for Gemini 3.0 compatibility
+                const metadata =
+                  'thoughtSignature' in part && part.thoughtSignature
+                    ? { thoughtSignature: part.thoughtSignature }
+                    : undefined
+
                 yield {
                   type: 'tool_call',
                   id: generateId(this.name),
@@ -338,6 +351,7 @@ export class GeminiTextAdapter<
                           ? functionArgs
                           : JSON.stringify(functionArgs),
                     },
+                    metadata,
                   },
                   index: nextToolIndex - 1,
                 }
@@ -461,12 +475,24 @@ export class GeminiTextAdapter<
             >
           }
 
-          parts.push({
+          const part: Part = {
             functionCall: {
               name: toolCall.function.name,
               args: parsedArgs,
             },
-          })
+          }
+
+          // Include thought signature if present for Gemini 3.0 compatibility
+          if (
+            toolCall.metadata &&
+            typeof toolCall.metadata === 'object' &&
+            'thoughtSignature' in toolCall.metadata &&
+            typeof toolCall.metadata.thoughtSignature === 'string'
+          ) {
+            ;(part as any).thoughtSignature = toolCall.metadata.thoughtSignature
+          }
+
+          parts.push(part)
         }
       }
 

--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -273,8 +273,8 @@ export class GeminiTextAdapter<
 
             // Capture thought signature for Gemini 3.0 compatibility
             const metadata =
-              'thoughtSignature' in part && part.thoughtSignature
-                ? { thoughtSignature: part.thoughtSignature }
+              'thoughtSignature' in (part as any) && (part as any).thoughtSignature
+                ? { thoughtSignature: (part as any).thoughtSignature }
                 : undefined
 
             yield {

--- a/packages/typescript/ai/src/types.ts
+++ b/packages/typescript/ai/src/types.ts
@@ -91,6 +91,12 @@ export interface ToolCall {
     name: string
     arguments: string // JSON string
   }
+  /**
+   * Provider-specific metadata associated with this tool call.
+   * Used by adapters to store additional information needed for API compatibility.
+   * For example, Gemini stores thought signatures here for Gemini 3.0 models.
+   */
+  metadata?: unknown
 }
 
 // ============================================================================
@@ -675,14 +681,7 @@ export interface ContentStreamChunk extends BaseStreamChunk {
 
 export interface ToolCallStreamChunk extends BaseStreamChunk {
   type: 'tool_call'
-  toolCall: {
-    id: string
-    type: 'function'
-    function: {
-      name: string
-      arguments: string // Incremental JSON arguments
-    }
-  }
+  toolCall: ToolCall
   index: number
 }
 


### PR DESCRIPTION
Fixes #216

Gemini 3.0 models require thought signatures to be preserved and sent back during function calling. When the model returns a functionCall with a thoughtSignature, it must be included in subsequent API requests or the API returns a 400 validation error.

Changes:
- Add optional `metadata` field to `ToolCall` type for provider-specific data
- Update `ToolCallStreamChunk` to use the `ToolCall` interface
- Capture thoughtSignature from Gemini responses in stream processing
- Include thoughtSignature when formatting messages back to Gemini API

This fix ensures compatibility with Gemini 3.0 Flash and other Gemini 3 models that enforce thought signature validation for tool calls.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gemini 3.0 compatibility for AI adapters, preserving thoughtSignature metadata across streaming tool-call events.
  * Added support for provider-specific metadata on tool calls so extra fields are retained in streaming payloads.

* **Tests**
  * Added tests verifying preservation of thoughtSignature/metadata through streaming tool-call events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->