### PR TITLE
docs: update OpenAI model examples from gpt-4o to gpt-5.2

### DIFF
--- a/docs/adapters/openai.md
+++ b/docs/adapters/openai.md
@@ -19,7 +19,7 @@ import { chat } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 
 const stream = chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [{ role: "user", content: "Hello!" }],
 });
 ```
@@ -35,7 +35,7 @@ const adapter = createOpenaiChat(process.env.OPENAI_API_KEY!, {
 });
 
 const stream = chat({
-  adapter: adapter("gpt-4o"),
+  adapter: adapter("gpt-5.2"),
   messages: [{ role: "user", content: "Hello!" }],
 });
 ```
@@ -63,7 +63,7 @@ export async function POST(request: Request) {
   const { messages } = await request.json();
 
   const stream = chat({
-    adapter: openaiText("gpt-4o"),
+    adapter: openaiText("gpt-5.2"),
     messages,
   });
 
@@ -92,7 +92,7 @@ const getWeather = getWeatherDef.server(async ({ location }) => {
 });
 
 const stream = chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages,
   tools: [getWeather],
 });
@@ -104,7 +104,7 @@ OpenAI supports various provider-specific options:
 
 ```typescript
 const stream = chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages,
   modelOptions: {
     temperature: 0.7,
@@ -141,7 +141,7 @@ import { summarize } from "@tanstack/ai";
 import { openaiSummarize } from "@tanstack/ai-openai";
 
 const result = await summarize({
-  adapter: openaiSummarize("gpt-4o-mini"),
+  adapter: openaiSummarize("gpt-5-mini"),
   text: "Your long text to summarize...",
   maxLength: 100,
   style: "concise", // "concise" | "bullet-points" | "paragraph"

--- a/docs/api/ai.md
+++ b/docs/api/ai.md
@@ -21,7 +21,7 @@ import { chat } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 
 const stream = chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [{ role: "user", content: "Hello!" }],
   tools: [myTool],
   systemPrompts: ["You are a helpful assistant"],
@@ -31,7 +31,7 @@ const stream = chat({
 
 ### Parameters
 
-- `adapter` - An AI adapter instance with model (e.g., `openaiText('gpt-4o')`, `anthropicText('claude-sonnet-4-5')`)
+- `adapter` - An AI adapter instance with model (e.g., `openaiText('gpt-5.2')`, `anthropicText('claude-sonnet-4-5')`)
 - `messages` - Array of chat messages
 - `tools?` - Array of tools for function calling
 - `systemPrompts?` - System prompts to prepend to messages
@@ -52,7 +52,7 @@ import { summarize } from "@tanstack/ai";
 import { openaiSummarize } from "@tanstack/ai-openai";
 
 const result = await summarize({
-  adapter: openaiSummarize("gpt-4o"),
+  adapter: openaiSummarize("gpt-5.2"),
   text: "Long text to summarize...",
   maxLength: 100,
   style: "concise",
@@ -99,7 +99,7 @@ const myClientTool = myToolDef.client(async ({ param }) => {
 
 // Use directly in chat() (server-side, no execute)
 chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   tools: [myToolDef],
   messages: [{ role: "user", content: "..." }],
 });
@@ -112,7 +112,7 @@ const myServerTool = myToolDef.server(async ({ param }) => {
 
 // Use directly in chat() (server-side, no execute)
 chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   tools: [myServerTool],
   messages: [{ role: "user", content: "..." }],
 });
@@ -140,7 +140,7 @@ import { chat, toServerSentEventsStream } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 
 const stream = chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [...],
 });
 const readableStream = toServerSentEventsStream(stream);
@@ -167,7 +167,7 @@ import { chat, toServerSentEventsResponse } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 
 const stream = chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [...],
 });
 return toServerSentEventsResponse(stream);
@@ -191,7 +191,7 @@ import { chat, maxIterations } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 
 const stream = chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [...],
   agentLoopStrategy: maxIterations(20),
 });
@@ -274,13 +274,13 @@ import {
 
 // --- Streaming chat
 const stream = chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [{ role: "user", content: "Hello!" }],
 });
 
 // --- One-shot chat response (stream: false)
 const response = await chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [{ role: "user", content: "What's the capital of France?" }],
   stream: false, // Returns a Promise<string> instead of AsyncIterable
 });
@@ -288,7 +288,7 @@ const response = await chat({
 // --- Structured response with outputSchema
 import { z } from "zod";
 const parsed = await chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [{ role: "user", content: "Summarize this text in JSON with keys 'summary' and 'keywords': ... " }],
   outputSchema: z.object({
     summary: z.string(),
@@ -310,7 +310,7 @@ const weatherTool = toolDefinition({
 });
 
 const toolResult = await chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [
     { role: "user", content: "What's the weather in Paris?" }
   ],
@@ -326,7 +326,7 @@ const toolResult = await chat({
 
 // --- Summarization
 const summary = await summarize({
-  adapter: openaiSummarize("gpt-4o"),
+  adapter: openaiSummarize("gpt-5.2"),
   text: "Long text to summarize...",
   maxLength: 100,
 });

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -46,7 +46,7 @@ const getProducts = getProductsDef.server(async ({ query }) => {
 
 // Use in AI chat
 chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages: [{ role: 'user', content: 'Find products' }],
   tools: [getProducts]
 })

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -51,7 +51,7 @@ export const Route = createFileRoute("/api/chat")({
           const stream = chat({
             adapter: openai(),
             messages,
-            model: "gpt-4o",
+            model: "gpt-5.2",
             conversationId,
           });
 
@@ -100,7 +100,7 @@ export async function POST(request: Request) {
   try {
     // Create a streaming chat response
     const stream = chat({
-      adapter: openaiText("gpt-4o"),
+      adapter: openaiText("gpt-5.2"),
       messages,
       conversationId
     });
@@ -248,7 +248,7 @@ const getProducts = getProductsDef.server(async ({ query }) => {
 })
 
 chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages: [{ role: 'user', content: 'Find products' }],
   tools: [getProducts]
 })

--- a/docs/guides/agentic-cycle.md
+++ b/docs/guides/agentic-cycle.md
@@ -123,7 +123,7 @@ export async function POST(request: Request) {
   const { messages } = await request.json();
 
   const stream = chat({
-    adapter: openaiText("gpt-4o"),
+    adapter: openaiText("gpt-5.2"),
     messages,
     tools: [getWeather, getClothingAdvice],
   });

--- a/docs/guides/client-tools.md
+++ b/docs/guides/client-tools.md
@@ -102,7 +102,7 @@ export async function POST(request: Request) {
   const { messages } = await request.json();
 
   const stream = chat({
-    adapter: openaiText("gpt-4o"),
+    adapter: openaiText("gpt-5.2"),
     messages,
     tools: [updateUIDef, saveToLocalStorageDef], // Pass definitions
   });
@@ -297,10 +297,10 @@ const addToCartClient = addToCartDef.client((input) => {
 });
 
 // Server: Pass definition for client execution
-chat({ adapter: openaiText('gpt-4o'), messages: [], tools: [addToCartDef] }); // Client will execute
+chat({ adapter: openaiText('gpt-5.2'), messages: [], tools: [addToCartDef] }); // Client will execute
 
 // Or pass server implementation for server execution
-chat({ adapter: openaiText('gpt-4o'), messages: [], tools: [addToCartServer] }); // Server will execute
+chat({ adapter: openaiText('gpt-5.2'), messages: [], tools: [addToCartServer] }); // Server will execute
 ```
 
 ## Best Practices

--- a/docs/guides/migration.md
+++ b/docs/guides/migration.md
@@ -30,7 +30,7 @@ import { openai } from '@tanstack/ai-openai'
 
 const stream = chat({
   adapter: openai(),
-  model: 'gpt-4o',
+  model: 'gpt-5.2',
   messages: [{ role: 'user', content: 'Hello!' }],
 })
 ```
@@ -42,14 +42,14 @@ import { chat } from '@tanstack/ai'
 import { openaiText } from '@tanstack/ai-openai'
 
 const stream = chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages: [{ role: 'user', content: 'Hello!' }],
 })
 ```
 
 ### Key Changes
 
-- **Model is passed to adapter factory** - The model name is now passed directly to the adapter function (e.g., `openaiText('gpt-4o')`)
+- **Model is passed to adapter factory** - The model name is now passed directly to the adapter function (e.g., `openaiText('gpt-5.2')`)
 - **No separate `model` parameter** - The model is stored on the adapter, so you don't need to pass it separately to `chat()`
 - **Activity-specific imports** - Import only what you need (e.g., `openaiText`, `openaiSummarize`, `openaiImage`)
 
@@ -123,7 +123,7 @@ function getAdapter(provider: Provider) {
 
 const stream = chat({
   adapter: getAdapter(provider),
-  model: provider === 'openai' ? 'gpt-4o' : 'claude-sonnet-4-5',
+  model: provider === 'openai' ? 'gpt-5.2' : 'claude-sonnet-4-5',
   messages,
 })
 ```
@@ -138,7 +138,7 @@ import { anthropicText } from '@tanstack/ai-anthropic'
 type Provider = 'openai' | 'anthropic'
 
 const adapters = {
-  openai: () => openaiText('gpt-4o'),
+  openai: () => openaiText('gpt-5.2'),
   anthropic: () => anthropicText('claude-sonnet-4-5'),
 }
 
@@ -157,7 +157,7 @@ Common options that were previously nested in an `options` object are now flatte
 ```typescript
 const stream = chat({
   adapter: openai(),
-  model: 'gpt-4o',
+  model: 'gpt-5.2',
   messages,
   options: {
     temperature: 0.7,
@@ -171,7 +171,7 @@ const stream = chat({
 
 ```typescript
 const stream = chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages,
   temperature: 0.7,
   maxTokens: 1000,
@@ -197,7 +197,7 @@ The `providerOptions` parameter has been renamed to `modelOptions` for clarity. 
 ```typescript
 const stream = chat({
   adapter: openai(),
-  model: 'gpt-4o',
+  model: 'gpt-5.2',
   messages,
   providerOptions: {
     // OpenAI-specific options
@@ -211,7 +211,7 @@ const stream = chat({
 
 ```typescript
 const stream = chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages,
   modelOptions: {
     // OpenAI-specific options
@@ -228,14 +228,14 @@ const stream = chat({
 ```typescript
 import { openaiText } from '@tanstack/ai-openai'
 
-const adapter = openaiText('gpt-4o')
+const adapter = openaiText('gpt-5.2')
 
-// TypeScript knows the exact modelOptions type for gpt-4o
+// TypeScript knows the exact modelOptions type for gpt-5.2
 const stream = chat({
   adapter,
   messages,
   modelOptions: {
-    // Autocomplete and type checking for gpt-4o options
+    // Autocomplete and type checking for gpt-5.2 options
     responseFormat: { type: 'json_object' },
   },
 })
@@ -257,7 +257,7 @@ export async function POST(request: Request) {
 
   const stream = chat({
     adapter: openai(),
-    model: 'gpt-4o',
+    model: 'gpt-5.2',
     messages,
     abortController,
   })
@@ -277,7 +277,7 @@ export async function POST(request: Request) {
   const abortController = new AbortController()
 
   const stream = chat({
-    adapter: openaiText('gpt-4o'),
+    adapter: openaiText('gpt-5.2'),
     messages,
     abortController,
   })
@@ -371,7 +371,7 @@ export async function POST(request: Request) {
 
   const stream = chat({
     adapter: openai(),
-    model: 'gpt-4o',
+    model: 'gpt-5.2',
     messages,
     options: {
       temperature: 0.7,
@@ -398,7 +398,7 @@ export async function POST(request: Request) {
   const abortController = new AbortController()
 
   const stream = chat({
-    adapter: openaiText('gpt-4o'),
+    adapter: openaiText('gpt-5.2'),
     messages,
     temperature: 0.7,
     maxTokens: 1000,

--- a/docs/guides/multimodal-content.md
+++ b/docs/guides/multimodal-content.md
@@ -58,7 +58,7 @@ import { chat } from '@tanstack/ai'
 import { openaiText } from '@tanstack/ai-openai'
 
 const response = await chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages: [
     {
       role: 'user',
@@ -103,8 +103,8 @@ const message = {
 ```
 
 **Supported modalities by model:**
-- `gpt-4o`, `gpt-4o-mini`: text, image
-- `gpt-4o-audio-preview`: text, image, audio
+- `gpt-5.2`, `gpt-5-mini`: text, image
+- `gpt-5.2-audio-preview`: text, image, audio
 
 ### Anthropic
 
@@ -282,9 +282,9 @@ import { openaiText } from '@tanstack/ai-openai'
 // In an API route handler
 const { messages: incomingMessages } = await request.json()
 
-const adapter = openaiText('gpt-4o')
+const adapter = openaiText('gpt-5.2')
 
-// Assert incoming messages are compatible with gpt-4o (text + image only)
+// Assert incoming messages are compatible with gpt-5.2 (text + image only)
 const typedMessages = assertMessages({ adapter }, incomingMessages)
 
 // Now TypeScript will properly check any additional messages you add

--- a/docs/guides/runtime-adapter-switching.md
+++ b/docs/guides/runtime-adapter-switching.md
@@ -22,7 +22,7 @@ type Provider = 'openai' | 'anthropic'
 // Define adapters with their models - autocomplete works here!
 const adapters = {
   anthropic: () => anthropicText('claude-sonnet-4-5'),  // ✅ Autocomplete!
-  openai: () => openaiText('gpt-4o'),  // ✅ Autocomplete!
+  openai: () => openaiText('gpt-5.2'),  // ✅ Autocomplete!
 }
 
 // In your request handler:
@@ -40,11 +40,11 @@ Each adapter factory function accepts a model name as its first argument and ret
 
 ```typescript
 // These are equivalent:
-const adapter1 = openaiText('gpt-4o')
-const adapter2 = new OpenAITextAdapter({ apiKey: process.env.OPENAI_API_KEY }, 'gpt-4o')
+const adapter1 = openaiText('gpt-5.2')
+const adapter2 = new OpenAITextAdapter({ apiKey: process.env.OPENAI_API_KEY }, 'gpt-5.2')
 
 // The model is stored on the adapter
-console.log(adapter1.selectedModel) // 'gpt-4o'
+console.log(adapter1.selectedModel) // 'gpt-5.2'
 ```
 
 When you pass an adapter to `chat()`, it uses the model from `adapter.selectedModel`. This means:
@@ -72,7 +72,7 @@ const adapters = {
   anthropic: () => anthropicText('claude-sonnet-4-5'),
   gemini: () => geminiText('gemini-2.0-flash-exp'),
   ollama: () => ollamaText('mistral:7b'),
-  openai: () => openaiText('gpt-4o'),
+  openai: () => openaiText('gpt-5.2'),
 }
 
 export const Route = createFileRoute('/api/chat')({
@@ -132,7 +132,7 @@ import { openaiSummarize } from '@tanstack/ai-openai'
 import { anthropicSummarize } from '@tanstack/ai-anthropic'
 
 const summarizeAdapters = {
-  openai: () => openaiSummarize('gpt-4o-mini'),
+  openai: () => openaiSummarize('gpt-5-mini'),
   anthropic: () => anthropicSummarize('claude-sonnet-4-5'),
 }
 
@@ -163,7 +163,7 @@ switch (provider) {
   case 'openai':
   default:
     adapter = openaiText()
-    model = 'gpt-4o'
+    model = 'gpt-5.2'
     break
 }
 
@@ -179,7 +179,7 @@ const stream = chat({
 ```typescript
 const adapters = {
   anthropic: () => anthropicText('claude-sonnet-4-5'),
-  openai: () => openaiText('gpt-4o'),
+  openai: () => openaiText('gpt-5.2'),
 }
 
 const stream = chat({

--- a/docs/guides/server-tools.md
+++ b/docs/guides/server-tools.md
@@ -149,7 +149,7 @@ export async function POST(request: Request) {
   const { messages } = await request.json();
 
   const stream = chat({
-    adapter: openaiText("gpt-4o"),
+    adapter: openaiText("gpt-5.2"),
     messages,
     tools: [getUserData, searchProducts],
   });
@@ -207,7 +207,7 @@ import { openaiText } from "@tanstack/ai-openai";
 import { getUserData, searchProducts } from "@/tools/server";
 
 const stream = chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages,
   tools: [getUserData, searchProducts],
 });

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -15,7 +15,7 @@ import { chat } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 
 const stream = chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages,
 });
 
@@ -37,7 +37,7 @@ export async function POST(request: Request) {
   const { messages } = await request.json();
 
   const stream = chat({
-    adapter: openaiText("gpt-4o"),
+    adapter: openaiText("gpt-5.2"),
     messages,
   });
 

--- a/docs/guides/structured-outputs.md
+++ b/docs/guides/structured-outputs.md
@@ -51,7 +51,7 @@ const PersonSchema = z.object({
 
 // Use it with chat()
 const person = await chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [
     {
       role: "user",
@@ -97,7 +97,7 @@ const RecipeSchema = z.object({
 
 // TypeScript knows the exact return type
 const recipe = await chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [{ role: "user", content: "Give me a recipe for scrambled eggs" }],
   outputSchema: RecipeSchema,
 });
@@ -201,7 +201,7 @@ const RecommendationSchema = z.object({
 });
 
 const recommendation = await chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [
     {
       role: "user",
@@ -235,7 +235,7 @@ const schema: JSONSchema = {
 };
 
 const result = await chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages: [{ role: "user", content: "Extract: John is 25 years old" }],
   outputSchema: schema,
 });
@@ -286,7 +286,7 @@ If the AI response doesn't match your schema, TanStack AI will throw a validatio
 ```typescript
 try {
   const result = await chat({
-    adapter: openaiText("gpt-4o"),
+    adapter: openaiText("gpt-5.2"),
     messages: [{ role: "user", content: "..." }],
     outputSchema: MySchema,
   });

--- a/docs/guides/tool-approval.md
+++ b/docs/guides/tool-approval.md
@@ -65,7 +65,7 @@ export async function POST(request: Request) {
   const { messages } = await request.json();
 
   const stream = chat({
-    adapter: openaiText("gpt-4o"),
+    adapter: openaiText("gpt-5.2"),
     messages,
     tools: [sendEmail],
   });

--- a/docs/guides/tool-architecture.md
+++ b/docs/guides/tool-architecture.md
@@ -78,7 +78,7 @@ export async function POST(request: Request) {
 
   // Create streaming chat with tools
   const stream = chat({
-    adapter: openaiText("gpt-4o"),
+    adapter: openaiText("gpt-5.2"),
     messages,
     tools: [getWeather, sendEmail], // Tool definitions passed here
   });

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -188,7 +188,7 @@ export async function POST(request: Request) {
   });
 
   const stream = chat({
-    adapter: openaiText("gpt-4o"),
+    adapter: openaiText("gpt-5.2"),
     messages,
     tools: [getWeather], // Pass server tools
   });
@@ -280,7 +280,7 @@ On the server, pass the definition (for client execution) or server implementati
 
 ```typescript
 chat({
-  adapter: openaiText("gpt-4o"),
+  adapter: openaiText("gpt-5.2"),
   messages,
   tools: [addToCartDef], // Client will execute, or
   tools: [addToCartServer], // Server will execute

--- a/docs/guides/tree-shaking.md
+++ b/docs/guides/tree-shaking.md
@@ -43,7 +43,7 @@ import { chat } from '@tanstack/ai'
 import { openaiText } from '@tanstack/ai-openai'
 
 const stream = chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages: [{ role: 'user', content: 'Hello!' }],
 })
 ```
@@ -110,7 +110,7 @@ import { openaiText } from '@tanstack/ai-openai'
 
 // Chat generation - returns AsyncIterable<StreamChunk>
 const chatResult = chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages: [{ role: 'user', content: 'Hello!' }],
 })
 
@@ -143,12 +143,12 @@ import {
 
 // Each activity is independent
 const chatResult = chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages: [{ role: 'user', content: 'Hello!' }],
 })
 
 const summarizeResult = await summarize({
-  adapter: openaiSummarize('gpt-4o-mini'),
+  adapter: openaiSummarize('gpt-5-mini'),
   text: 'Long text to summarize...',
 })
 ```
@@ -165,7 +165,7 @@ import { openaiText, type OpenAIChatModel } from '@tanstack/ai-openai'
 const adapter = openaiText()
 
 // TypeScript knows the exact models supported
-const model: OpenAIChatModel = 'gpt-4o' // ✓ Valid
+const model: OpenAIChatModel = 'gpt-5.2' // ✓ Valid
 const model2: OpenAIChatModel = 'invalid' // ✗ Type error
 ```
 
@@ -181,7 +181,7 @@ import {
 
 // Only import what you need
 const chatOptions = createChatOptions({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
 })
 ```
 

--- a/docs/protocol/chunk-definitions.md
+++ b/docs/protocol/chunk-definitions.md
@@ -16,7 +16,7 @@ All chunks share a common base structure:
 interface BaseStreamChunk {
   type: StreamChunkType;
   id: string;          // Unique identifier for the message/response
-  model: string;       // Model identifier (e.g., "gpt-4o", "claude-3-5-sonnet")
+  model: string;       // Model identifier (e.g., "gpt-5.2", "claude-3-5-sonnet")
   timestamp: number;   // Unix timestamp in milliseconds
 }
 ```
@@ -55,7 +55,7 @@ interface ContentStreamChunk extends BaseStreamChunk {
 {
   "type": "content",
   "id": "chatcmpl-abc123",
-  "model": "gpt-4o",
+  "model": "gpt-5.2",
   "timestamp": 1701234567890,
   "delta": "Hello",
   "content": "Hello",
@@ -125,7 +125,7 @@ interface ToolCallStreamChunk extends BaseStreamChunk {
 {
   "type": "tool_call",
   "id": "chatcmpl-abc123",
-  "model": "gpt-4o",
+  "model": "gpt-5.2",
   "timestamp": 1701234567890,
   "toolCall": {
     "id": "call_abc123",
@@ -164,7 +164,7 @@ interface ToolInputAvailableStreamChunk extends BaseStreamChunk {
 {
   "type": "tool-input-available",
   "id": "chatcmpl-abc123",
-  "model": "gpt-4o",
+  "model": "gpt-5.2",
   "timestamp": 1701234567890,
   "toolCallId": "call_abc123",
   "toolName": "get_weather",
@@ -204,7 +204,7 @@ interface ApprovalRequestedStreamChunk extends BaseStreamChunk {
 {
   "type": "approval-requested",
   "id": "chatcmpl-abc123",
-  "model": "gpt-4o",
+  "model": "gpt-5.2",
   "timestamp": 1701234567890,
   "toolCallId": "call_abc123",
   "toolName": "send_email",
@@ -244,7 +244,7 @@ interface ToolResultStreamChunk extends BaseStreamChunk {
 {
   "type": "tool_result",
   "id": "chatcmpl-abc123",
-  "model": "gpt-4o",
+  "model": "gpt-5.2",
   "timestamp": 1701234567891,
   "toolCallId": "call_abc123",
   "content": "{\"temperature\":72,\"conditions\":\"sunny\"}"
@@ -279,7 +279,7 @@ interface DoneStreamChunk extends BaseStreamChunk {
 {
   "type": "done",
   "id": "chatcmpl-abc123",
-  "model": "gpt-4o",
+  "model": "gpt-5.2",
   "timestamp": 1701234567892,
   "finishReason": "stop",
   "usage": {
@@ -323,7 +323,7 @@ interface ErrorStreamChunk extends BaseStreamChunk {
 {
   "type": "error",
   "id": "chatcmpl-abc123",
-  "model": "gpt-4o",
+  "model": "gpt-5.2",
   "timestamp": 1701234567893,
   "error": {
     "message": "Rate limit exceeded",

--- a/docs/protocol/http-stream-protocol.md
+++ b/docs/protocol/http-stream-protocol.md
@@ -83,22 +83,22 @@ Each StreamChunk is transmitted as a single line of JSON followed by a newline (
 #### Content Chunks
 
 ```json
-{"type":"content","id":"chatcmpl-abc123","model":"gpt-4o","timestamp":1701234567890,"delta":"Hello","content":"Hello","role":"assistant"}
-{"type":"content","id":"chatcmpl-abc123","model":"gpt-4o","timestamp":1701234567891,"delta":" world","content":"Hello world","role":"assistant"}
-{"type":"content","id":"chatcmpl-abc123","model":"gpt-4o","timestamp":1701234567892,"delta":"!","content":"Hello world!","role":"assistant"}
+{"type":"content","id":"chatcmpl-abc123","model":"gpt-5.2","timestamp":1701234567890,"delta":"Hello","content":"Hello","role":"assistant"}
+{"type":"content","id":"chatcmpl-abc123","model":"gpt-5.2","timestamp":1701234567891,"delta":" world","content":"Hello world","role":"assistant"}
+{"type":"content","id":"chatcmpl-abc123","model":"gpt-5.2","timestamp":1701234567892,"delta":"!","content":"Hello world!","role":"assistant"}
 ```
 
 #### Tool Call
 
 ```json
-{"type":"tool_call","id":"chatcmpl-abc123","model":"gpt-4o","timestamp":1701234567893,"toolCall":{"id":"call_xyz","type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"SF\"}"}},"index":0}
-{"type":"tool_result","id":"chatcmpl-abc123","model":"gpt-4o","timestamp":1701234567894,"toolCallId":"call_xyz","content":"{\"temperature\":72,\"conditions\":\"sunny\"}"}
+{"type":"tool_call","id":"chatcmpl-abc123","model":"gpt-5.2","timestamp":1701234567893,"toolCall":{"id":"call_xyz","type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"SF\"}"}},"index":0}
+{"type":"tool_result","id":"chatcmpl-abc123","model":"gpt-5.2","timestamp":1701234567894,"toolCallId":"call_xyz","content":"{\"temperature\":72,\"conditions\":\"sunny\"}"}
 ```
 
 #### Stream Completion
 
 ```json
-{"type":"done","id":"chatcmpl-abc123","model":"gpt-4o","timestamp":1701234567895,"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":15,"totalTokens":25}}
+{"type":"done","id":"chatcmpl-abc123","model":"gpt-5.2","timestamp":1701234567895,"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":15,"totalTokens":25}}
 ```
 
 ---
@@ -130,11 +130,11 @@ Transfer-Encoding: chunked
 The server sends newline-delimited JSON:
 
 ```json
-{"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567890,"delta":"The","content":"The"}
-{"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567891,"delta":" weather","content":"The weather"}
-{"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567892,"delta":" is","content":"The weather is"}
-{"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567893,"delta":" sunny","content":"The weather is sunny"}
-{"type":"done","id":"msg_1","model":"gpt-4o","timestamp":1701234567894,"finishReason":"stop"}
+{"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567890,"delta":"The","content":"The"}
+{"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567891,"delta":" weather","content":"The weather"}
+{"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567892,"delta":" is","content":"The weather is"}
+{"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567893,"delta":" sunny","content":"The weather is sunny"}
+{"type":"done","id":"msg_1","model":"gpt-5.2","timestamp":1701234567894,"finishReason":"stop"}
 ```
 
 ### 4. Stream Completion
@@ -150,7 +150,7 @@ Server closes the connection. No special marker needed (unlike SSE's `[DONE]`).
 If an error occurs during generation, send an error chunk:
 
 ```json
-{"type":"error","id":"msg_1","model":"gpt-4o","timestamp":1701234567895,"error":{"message":"Rate limit exceeded","code":"rate_limit_exceeded"}}
+{"type":"error","id":"msg_1","model":"gpt-5.2","timestamp":1701234567895,"error":{"message":"Rate limit exceeded","code":"rate_limit_exceeded"}}
 ```
 
 Then close the connection.
@@ -181,7 +181,7 @@ export async function POST(request: Request) {
   const encoder = new TextEncoder();
 
   const stream = chat({
-    adapter: openaiText('gpt-4o'),
+    adapter: openaiText('gpt-5.2'),
     messages,
   });
 
@@ -236,7 +236,7 @@ app.post('/api/chat', async (req, res) => {
 
   try {
     const stream = chat({
-      adapter: openaiText('gpt-4o'),
+      adapter: openaiText('gpt-5.2'),
       messages,
     });
 
@@ -360,9 +360,9 @@ The `-N` flag disables buffering to see real-time output.
 
 **Example Output:**
 ```json
-{"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567890,"delta":"Hello","content":"Hello"}
-{"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567891,"delta":" there","content":"Hello there"}
-{"type":"done","id":"msg_1","model":"gpt-4o","timestamp":1701234567892,"finishReason":"stop"}
+{"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567890,"delta":"Hello","content":"Hello"}
+{"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567891,"delta":" there","content":"Hello there"}
+{"type":"done","id":"msg_1","model":"gpt-5.2","timestamp":1701234567892,"finishReason":"stop"}
 ```
 
 ### Validating NDJSON

--- a/docs/protocol/sse-protocol.md
+++ b/docs/protocol/sse-protocol.md
@@ -74,19 +74,19 @@ data: {JSON_ENCODED_CHUNK}\n\n
 #### Content Chunk
 
 ```
-data: {"type":"content","id":"chatcmpl-abc123","model":"gpt-4o","timestamp":1701234567890,"delta":"Hello","content":"Hello","role":"assistant"}\n\n
+data: {"type":"content","id":"chatcmpl-abc123","model":"gpt-5.2","timestamp":1701234567890,"delta":"Hello","content":"Hello","role":"assistant"}\n\n
 ```
 
 #### Tool Call Chunk
 
 ```
-data: {"type":"tool_call","id":"chatcmpl-abc123","model":"gpt-4o","timestamp":1701234567891,"toolCall":{"id":"call_xyz","type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"SF\"}"}},"index":0}\n\n
+data: {"type":"tool_call","id":"chatcmpl-abc123","model":"gpt-5.2","timestamp":1701234567891,"toolCall":{"id":"call_xyz","type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"SF\"}"}},"index":0}\n\n
 ```
 
 #### Done Chunk
 
 ```
-data: {"type":"done","id":"chatcmpl-abc123","model":"gpt-4o","timestamp":1701234567892,"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":5,"totalTokens":15}}\n\n
+data: {"type":"done","id":"chatcmpl-abc123","model":"gpt-5.2","timestamp":1701234567892,"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":5,"totalTokens":15}}\n\n
 ```
 
 ---
@@ -120,11 +120,11 @@ Connection: keep-alive
 The server sends multiple `data:` events as chunks are generated:
 
 ```
-data: {"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567890,"delta":"The","content":"The"}\n\n
-data: {"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567891,"delta":" weather","content":"The weather"}\n\n
-data: {"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567892,"delta":" is","content":"The weather is"}\n\n
-data: {"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567893,"delta":" sunny","content":"The weather is sunny"}\n\n
-data: {"type":"done","id":"msg_1","model":"gpt-4o","timestamp":1701234567894,"finishReason":"stop"}\n\n
+data: {"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567890,"delta":"The","content":"The"}\n\n
+data: {"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567891,"delta":" weather","content":"The weather"}\n\n
+data: {"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567892,"delta":" is","content":"The weather is"}\n\n
+data: {"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567893,"delta":" sunny","content":"The weather is sunny"}\n\n
+data: {"type":"done","id":"msg_1","model":"gpt-5.2","timestamp":1701234567894,"finishReason":"stop"}\n\n
 ```
 
 ### 4. Stream Completion
@@ -146,7 +146,7 @@ Then closes the connection.
 If an error occurs during generation, send an error chunk:
 
 ```
-data: {"type":"error","id":"msg_1","model":"gpt-4o","timestamp":1701234567895,"error":{"message":"Rate limit exceeded","code":"rate_limit_exceeded"}}\n\n
+data: {"type":"error","id":"msg_1","model":"gpt-5.2","timestamp":1701234567895,"error":{"message":"Rate limit exceeded","code":"rate_limit_exceeded"}}\n\n
 ```
 
 Then close the connection.
@@ -174,7 +174,7 @@ export async function POST(request: Request) {
   const { messages } = await request.json();
 
   const stream = chat({
-    adapter: openaiText('gpt-4o'),
+    adapter: openaiText('gpt-5.2'),
     messages,
   });
 
@@ -223,7 +223,7 @@ export async function POST(request: Request) {
   const stream = new ReadableStream({
     async start(controller) {
       try {
-        for await (const chunk of chat({ adapter: openaiText('gpt-4o'), messages })) {
+        for await (const chunk of chat({ adapter: openaiText('gpt-5.2'), messages })) {
           const sseData = `data: ${JSON.stringify(chunk)}\n\n`;
           controller.enqueue(encoder.encode(sseData));
         }
@@ -304,11 +304,11 @@ The `-N` flag disables buffering to see real-time output.
 
 **Example Output:**
 ```
-data: {"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567890,"delta":"Hello","content":"Hello"}
+data: {"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567890,"delta":"Hello","content":"Hello"}
 
-data: {"type":"content","id":"msg_1","model":"gpt-4o","timestamp":1701234567891,"delta":" there","content":"Hello there"}
+data: {"type":"content","id":"msg_1","model":"gpt-5.2","timestamp":1701234567891,"delta":" there","content":"Hello there"}
 
-data: {"type":"done","id":"msg_1","model":"gpt-4o","timestamp":1701234567892,"finishReason":"stop"}
+data: {"type":"done","id":"msg_1","model":"gpt-5.2","timestamp":1701234567892,"finishReason":"stop"}
 
 data: [DONE]
 ```

--- a/docs/reference/functions/chat.md
+++ b/docs/reference/functions/chat.md
@@ -50,7 +50,7 @@ import { chat } from '@tanstack/ai'
 import { openaiText } from '@tanstack/ai-openai'
 
 for await (const chunk of chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages: [{ role: 'user', content: 'What is the weather?' }],
   tools: [weatherTool]
 })) {
@@ -62,7 +62,7 @@ for await (const chunk of chat({
 
 ```ts
 for await (const chunk of chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages: [{ role: 'user', content: 'Hello!' }]
 })) {
   console.log(chunk)
@@ -71,7 +71,7 @@ for await (const chunk of chat({
 
 ```ts
 const text = await chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages: [{ role: 'user', content: 'Hello!' }],
   stream: false
 })
@@ -82,7 +82,7 @@ const text = await chat({
 import { z } from 'zod'
 
 const result = await chat({
-  adapter: openaiText('gpt-4o'),
+  adapter: openaiText('gpt-5.2'),
   messages: [{ role: 'user', content: 'Research and summarize the topic' }],
   tools: [researchTool, analyzeTool],
   outputSchema: z.object({

--- a/docs/reference/functions/combineStrategies.md
+++ b/docs/reference/functions/combineStrategies.md
@@ -33,7 +33,7 @@ AgentLoopStrategy that continues only if all strategies return true
 ```typescript
 const stream = chat({
   adapter: openaiText(),
-  model: "gpt-4o",
+  model: "gpt-5.2",
   messages: [...],
   tools: [weatherTool],
   agentLoopStrategy: combineStrategies([

--- a/docs/reference/functions/maxIterations.md
+++ b/docs/reference/functions/maxIterations.md
@@ -32,7 +32,7 @@ AgentLoopStrategy that stops after max iterations
 ```typescript
 const stream = chat({
   adapter: openaiText(),
-  model: "gpt-4o",
+  model: "gpt-5.2",
   messages: [...],
   tools: [weatherTool],
   agentLoopStrategy: maxIterations(3), // Max 3 iterations

--- a/docs/reference/functions/streamToText.md
+++ b/docs/reference/functions/streamToText.md
@@ -35,7 +35,7 @@ Promise<string> - The accumulated text content
 ```typescript
 const stream = chat({
   adapter: openaiText(),
-  model: 'gpt-4o',
+  model: 'gpt-5.2',
   messages: [{ role: 'user', content: 'Hello!' }]
 });
 const text = await streamToText(stream);

--- a/docs/reference/functions/summarize.md
+++ b/docs/reference/functions/summarize.md
@@ -42,7 +42,7 @@ import { summarize } from '@tanstack/ai'
 import { openaiSummarize } from '@tanstack/ai-openai'
 
 const result = await summarize({
-  adapter: openaiSummarize('gpt-4o-mini'),
+  adapter: openaiSummarize('gpt-5-mini'),
   text: 'Long article text here...'
 })
 
@@ -51,7 +51,7 @@ console.log(result.summary)
 
 ```ts
 const result = await summarize({
-  adapter: openaiSummarize('gpt-4o-mini'),
+  adapter: openaiSummarize('gpt-5-mini'),
   text: 'Long article text here...',
   style: 'bullet-points',
   maxLength: 100
@@ -60,7 +60,7 @@ const result = await summarize({
 
 ```ts
 const result = await summarize({
-  adapter: openaiSummarize('gpt-4o-mini'),
+  adapter: openaiSummarize('gpt-5-mini'),
   text: 'Long technical document...',
   focus: ['key findings', 'methodology']
 })
@@ -68,7 +68,7 @@ const result = await summarize({
 
 ```ts
 for await (const chunk of summarize({
-  adapter: openaiSummarize('gpt-4o-mini'),
+  adapter: openaiSummarize('gpt-5-mini'),
   text: 'Long article text here...',
   stream: true
 })) {

--- a/docs/reference/functions/toHttpResponse.md
+++ b/docs/reference/functions/toHttpResponse.md
@@ -42,6 +42,6 @@ Response in HTTP stream format (newline-delimited JSON)
 ## Example
 
 ```typescript
-const stream = chat({ adapter: openaiText(), model: "gpt-4o", messages: [...] });
+const stream = chat({ adapter: openaiText(), model: "gpt-5.2", messages: [...] });
 return toHttpResponse(stream, { abortController });
 ```

--- a/docs/reference/functions/toHttpStream.md
+++ b/docs/reference/functions/toHttpStream.md
@@ -42,7 +42,7 @@ ReadableStream in HTTP stream format (newline-delimited JSON)
 ## Example
 
 ```typescript
-const stream = chat({ adapter: openaiText(), model: "gpt-4o", messages: [...] });
+const stream = chat({ adapter: openaiText(), model: "gpt-5.2", messages: [...] });
 const readableStream = toHttpStream(stream);
 // Use with Response for HTTP streaming (not SSE)
 return new Response(readableStream, {

--- a/docs/reference/functions/toServerSentEventsResponse.md
+++ b/docs/reference/functions/toServerSentEventsResponse.md
@@ -41,6 +41,6 @@ Response in Server-Sent Events format
 ## Example
 
 ```typescript
-const stream = chat({ adapter: openaiText(), model: "gpt-4o", messages: [...] });
+const stream = chat({ adapter: openaiText(), model: "gpt-5.2", messages: [...] });
 return toServerSentEventsResponse(stream, { abortController });
 ```

--- a/docs/reference/functions/untilFinishReason.md
+++ b/docs/reference/functions/untilFinishReason.md
@@ -32,7 +32,7 @@ AgentLoopStrategy that stops on specific finish reasons
 ```typescript
 const stream = chat({
   adapter: openaiText(),
-  model: "gpt-4o",
+  model: "gpt-5.2",
   messages: [...],
   tools: [weatherTool],
   agentLoopStrategy: untilFinishReason(["stop", "length"]),

--- a/docs/reference/interfaces/SummarizeAdapter.md
+++ b/docs/reference/interfaces/SummarizeAdapter.md
@@ -13,7 +13,7 @@ An adapter is created by a provider function: `provider('model')` → `adapter`
 All type resolution happens at the provider call site, not in this interface.
 
 Generic parameters:
-- TModel: The specific model name (e.g., 'gpt-4o')
+- TModel: The specific model name (e.g., 'gpt-5.2')
 - TProviderOptions: Provider-specific options (already resolved)
 
 ## Type Parameters

--- a/docs/reference/interfaces/TextAdapter.md
+++ b/docs/reference/interfaces/TextAdapter.md
@@ -13,7 +13,7 @@ An adapter is created by a provider function: `provider('model')` → `adapter`
 All type resolution happens at the provider call site, not in this interface.
 
 Generic parameters:
-- TModel: The specific model name (e.g., 'gpt-4o')
+- TModel: The specific model name (e.g., 'gpt-5.2')
 - TProviderOptions: Provider-specific options for this model (already resolved)
 - TInputModalities: Supported input modalities for this model (already resolved)
 - TMessageMetadata: Metadata types for content parts (already resolved)


### PR DESCRIPTION
## Summary

- Updated all documentation examples to use `gpt-5.2` instead of `gpt-4o`
- Updated summarization examples to use `gpt-5-mini` instead of `gpt-4o-mini`
- Left audio/transcription docs unchanged (they use specialized models like `gpt-4o-audio-preview`, `whisper-1`, etc.)

## The Story Behind This PR 📖

You know how AI coding agents have knowledge cutoffs? Well, at their cutoff, `gpt-4o` was the latest and greatest OpenAI model. This means every AI agent out there defaults to suggesting `gpt-4o` in their code examples.

I've had to fight AI agents **so many times** to stop using `gpt-4o` in my code that now whenever I see `gpt-4o` in documentation, it triggers me. 😅

So I decided to update all the examples to `gpt-5.2` - not just for my sanity, but also because:
1. It keeps the docs feeling fresh and forward-looking
2. It might help break the habit of AI agents always suggesting `gpt-4o`
3. Future readers won't think the SDK only works with older models

## Test Plan

- [x] Verified all changes are in documentation only
- [x] Confirmed audio/transcription files were left unchanged (different model naming)
- [x] No code changes, only markdown files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation examples across guides, tutorials, and API/reference pages to use gpt-5.2 (and gpt-5-mini where applicable) in place of gpt-4o. All changes are illustrative text/sample updates; no behavioral, API signature, or runtime logic changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->