### PR TITLE
fix: add missing Anthropic models type and update the anthropic docs

### DIFF
--- a/.changeset/add-anthropic-models-export.md
+++ b/.changeset/add-anthropic-models-export.md
@@ -1,43 +1,32 @@
 ---
-'@tanstack/ai-anthropic': minor
+'@tanstack/ai-anthropic': major
 ---
 
-## Add missing ANTHROPIC_MODELS type export
+## Add missing AnthropicModels type export
 
 ### WHAT
 
-Added missing `ANTHROPIC_MODELS` type export to the public API of `@tanstack/ai-anthropic` and updated the documentation to correctly reference it.
-
-The `ANTHROPIC_MODELS` is a const tuple that contains all supported Anthropic model identifiers:
+Added new `AnthropicModels` **type** export to the public API of `@tanstack/ai-anthropic`. This is a union type that represents all supported Anthropic model identifiers, derived from the internal `ANTHROPIC_MODELS` const tuple.
 
 ```typescript
-type ANTHROPIC_MODELS = readonly [
-  'claude-opus-4-5',
-  'claude-sonnet-4-5',
-  'claude-haiku-4-5',
-  'claude-opus-4-1',
-  'claude-sonnet-4',
-  'claude-sonnet-3-7',
-  'claude-opus-4',
-  'claude-haiku-3-5',
-  'claude-haiku-3',
-]
+export type AnthropicModels = (typeof ANTHROPIC_MODELS)[number]
+// Equivalent to: 'claude-opus-4-5' | 'claude-sonnet-4-5' | 'claude-haiku-4-5' | ... (and more)
 ```
+
+**Note:** The `ANTHROPIC_MODELS` const tuple itself remains internal and is not exported. Only the derived type is part of the public API.
 
 ### WHY
 
-The `ANTHROPIC_MODELS` type was already used internally and in the model metadata but was not exported from the main package entry point. This prevented consumers from using it for type-safe model selection when creating custom adapter instances, resulting in incomplete TypeScript support and requiring workarounds like manual type assertions.
-
-By exporting this type, consumers now have full type safety when working with Anthropic models and can write more maintainable code.
+Consumers previously had no easy way to get the type-safe union of model names for use in function signatures and variable declarations.
 
 ### HOW - Consumers Should Update
 
-Now you can import and use `ANTHROPIC_MODELS` for proper type safety when creating adapter instances:
+Now you can import and use `AnthropicModels` for proper type safety when creating adapter instances:
 
 ```typescript
-import { createAnthropicChat, ANTHROPIC_MODELS } from '@tanstack/ai-anthropic'
+import { createAnthropicChat, AnthropicModels } from '@tanstack/ai-anthropic'
 
-const adapter = (model: ANTHROPIC_MODELS) =>
+const adapter = (model: AnthropicModels) =>
   createAnthropicChat(model, process.env.ANTHROPIC_API_KEY!, {
     // ... your config options
   })

--- a/docs/adapters/anthropic.md
+++ b/docs/adapters/anthropic.md
@@ -28,9 +28,9 @@ const stream = chat({
 
 ```typescript
 import { chat } from "@tanstack/ai";
-import { createAnthropicChat, ANTHROPIC_MODELS } from "@tanstack/ai-anthropic";
+import { createAnthropicChat, AnthropicModels } from "@tanstack/ai-anthropic";
 
-const adapter = (model: ANTHROPIC_MODELS) =>
+const adapter = (model: AnthropicModels) =>
   createAnthropicChat(model, process.env.ANTHROPIC_API_KEY!, {
     // ... your config options
   });

--- a/packages/typescript/ai-anthropic/src/index.ts
+++ b/packages/typescript/ai-anthropic/src/index.ts
@@ -27,7 +27,7 @@ export {
 export type {
   AnthropicChatModelProviderOptionsByName,
   AnthropicModelInputModalitiesByName,
-  ANTHROPIC_MODELS
+  AnthropicModels,
 } from './model-meta'
 export type {
   AnthropicTextMetadata,

--- a/packages/typescript/ai-anthropic/src/model-meta.ts
+++ b/packages/typescript/ai-anthropic/src/model-meta.ts
@@ -372,6 +372,8 @@ export const ANTHROPIC_MODELS = [
   CLAUDE_HAIKU_3.id,
 ] as const
 
+export type AnthropicModels = (typeof ANTHROPIC_MODELS)[number]
+
 // const ANTHROPIC_IMAGE_MODELS = [] as const
 // const ANTHROPIC_EMBEDDING_MODELS = [] as const
 // const ANTHROPIC_AUDIO_MODELS = [] as const


### PR DESCRIPTION
## 🎯 Changes

### WHAT

Added missing `ANTHROPIC_MODELS` type export to the public API of `@tanstack/ai-anthropic` and updated the documentation to correctly reference it.

The `ANTHROPIC_MODELS` is a const tuple that contains all supported Anthropic model identifiers:

```typescript
type ANTHROPIC_MODELS = readonly [
  'claude-opus-4-5',
  'claude-sonnet-4-5',
  'claude-haiku-4-5',
  'claude-opus-4-1',
  'claude-sonnet-4',
  'claude-sonnet-3-7',
  'claude-opus-4',
  'claude-haiku-3-5',
  'claude-haiku-3',
]
```

### WHY

When I tried to use the `createAnthropicChat` according to the docs it gave me type errors and I find out that the first parameter it takes is the model name, not the API KEY as the docs suggest. 

Then I find out that there is actually a type `ANTHROPIC_MODELS` which is not exported that I can use to construct the adapter. 

### HOW - Consumers Should Update

Now you can import and use `ANTHROPIC_MODELS` for proper type safety when creating adapter instances:

```typescript
import { createAnthropicChat, ANTHROPIC_MODELS } from '@tanstack/ai-anthropic'

const adapter = (model: ANTHROPIC_MODELS) =>
  createAnthropicChat(model, process.env.ANTHROPIC_API_KEY!, {
    // ... your config options
  })

const stream = chat({
  adapter: adapter('claude-sonnet-4-5'), // Type-checked model selection!
  messages: [{ role: 'user', content: 'Hello!' }],
})
```



## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The Anthropic adapter factory now requires the model identifier as the first argument when creating an instance.

* **New Features**
  * Public, type-safe export for Anthropic model identifiers.
  * Adapter usage updated to support runtime model selection with improved type safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->