### PR TITLE
docs: fix quickstart example adapter

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -24,7 +24,7 @@ First, create an API route that handles chat requests. Here's a simplified examp
 
 ```typescript
 import { chat, toServerSentEventsResponse } from "@tanstack/ai";
-import { openai } from "@tanstack/ai-openai";
+import { openaiText } from "@tanstack/ai-openai";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/api/chat")({
@@ -49,9 +49,8 @@ export const Route = createFileRoute("/api/chat")({
         try {
           // Create a streaming chat response
           const stream = chat({
-            adapter: openai(),
+            adapter: openaiText("gpt-5.2"),
             messages,
-            model: "gpt-5.2",
             conversationId,
           });
 


### PR DESCRIPTION
## 🎯 Changes

Updated the Quickstart streaming chat example to use the correct openaiText("gpt-5.2") adapter signature.
The previous example incorrectly passed the model separately, which no longer reflects the current adapter API and could lead to confusion for new users.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quick-start guide with current OpenAI adapter configuration examples for TanStack Start and Next.js projects.
  * Simplified model specification by consolidating it into the adapter initialization call.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->