### PR TITLE
Add/Register Soniox community adapter to sidebar (config.json)

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -172,6 +172,10 @@
         {
           "label": "Decart",
           "to": "community-adapters/decart"
+        },
+        {
+          "label": "Soniox",
+          "to": "community-adapters/soniox"
         }
       ]
     },


### PR DESCRIPTION
## 🎯 Changes

This change only registers the existing Soniox community adapter in the docs config.json so it appears in the sidebar and is indexed by the search system.

- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Soniox to the community adapters section in the documentation. This new entry expands the available community-developed adapter options for users to discover and explore, providing more choices to extend and customize their workflows with community-supported integration solutions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->