### PR TITLE
docs: fix invalid closing tag in README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A powerful, type-safe AI SDK for building AI-powered applications.
 - **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
 - **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
 
-### <a href="https://tanstack.com/ai">Read the docs →</b></a>
+### <a href="https://tanstack.com/ai">Read the docs →</a>
 
 ## Tree-Shakeable Adapters
 


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
Fixed an invalid HTML closing tag in the README (“Read the docs →” link had a stray </b>).
## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an HTML markup issue in the documentation to ensure proper tag formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->