### PR TITLE
fix(ai-client): prevent continuation stall when multiple client tools complete in the same round

### DIFF
--- a/.changeset/fix-client-tool-continuation-stall.md
+++ b/.changeset/fix-client-tool-continuation-stall.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-client': patch
+---
+
+fix: prevent client tool continuation stall when multiple tools complete in the same round
+
+When an LLM response triggers multiple client-side tool calls simultaneously, the chat would permanently stall after all tools completed. This was caused by nested `drainPostStreamActions` calls stealing queued continuation checks from the outer drain. Added a re-entrancy guard on `drainPostStreamActions` and a `tool-result` type check in `checkForContinuation` to prevent both the structural and semantic causes of the stall.

--- a/packages/typescript/ai-client/src/chat-client.ts
+++ b/packages/typescript/ai-client/src/chat-client.ts
@@ -40,6 +40,8 @@ export class ChatClient {
   private pendingToolExecutions: Map<string, Promise<void>> = new Map()
   // Flag to deduplicate continuation checks during action draining
   private continuationPending = false
+  // Re-entrancy guard for drainPostStreamActions
+  private draining = false
 
   private callbacksRef: {
     current: {
@@ -619,9 +621,15 @@ export class ChatClient {
    * Drain and execute all queued post-stream actions
    */
   private async drainPostStreamActions(): Promise<void> {
-    while (this.postStreamActions.length > 0) {
-      const action = this.postStreamActions.shift()!
-      await action()
+    if (this.draining) return
+    this.draining = true
+    try {
+      while (this.postStreamActions.length > 0) {
+        const action = this.postStreamActions.shift()!
+        await action()
+      }
+    } finally {
+      this.draining = false
     }
   }
 
@@ -631,6 +639,12 @@ export class ChatClient {
   private async checkForContinuation(): Promise<void> {
     // Prevent duplicate continuation attempts
     if (this.continuationPending || this.isLoading) {
+      return
+    }
+
+    const messages = this.processor.getMessages()
+    const lastPart = messages.at(-1)?.parts.at(-1)
+    if (lastPart?.type !== 'tool-result') {
       return
     }
 


### PR DESCRIPTION
## 🎯 Changes

Fixes #302 — when an LLM response triggers multiple client-side tool calls in a single round, the chat permanently stalls after all tools complete because the continuation request never fires.

**Two changes in `ChatClient` (`packages/typescript/ai-client/src/chat-client.ts`):**

1. **Re-entrancy guard on `drainPostStreamActions`**: Adds a `draining` flag that prevents nested calls. When a continuation stream fires inside the drain and its `finally` block tries to drain again, the nested call is skipped. The outer drain's `while` loop naturally picks up any actions queued during the nested stream.

2. **`tool-result` type guard in `checkForContinuation`**: Adds an early return when the last message part is not a `tool-result`. This prevents duplicate queued checks from the same round from firing spurious continuation requests after the model has already produced its text response.

Both changes are needed together — the drain guard fixes the structural cause (nested drain stealing actions), and the lastPart guard fixes the semantic cause (duplicate checks firing after continuation already succeeded).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a stall that occurred when multiple client-side tools completed simultaneously in the same processing round.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->