### PR TITLE
Refactor OpenRouter options to use camelCase naming convention 

### DIFF
--- a/examples/ts-solid-chat/src/routes/__root.tsx
+++ b/examples/ts-solid-chat/src/routes/__root.tsx
@@ -37,10 +37,11 @@ function RootDocument({ children }: { children: JSXElement }) {
 
   onMount(async () => {
     try {
-      const [{ TanStackDevtools }, { TanStackRouterDevtoolsPanel }] = await Promise.all([
-        import('@tanstack/solid-devtools'),
-        import('@tanstack/solid-router-devtools'),
-      ])
+      const [{ TanStackDevtools }, { TanStackRouterDevtoolsPanel }] =
+        await Promise.all([
+          import('@tanstack/solid-devtools'),
+          import('@tanstack/solid-router-devtools'),
+        ])
 
       setDevtools(
         <TanStackDevtools


### PR DESCRIPTION
## 🎯 Changes

This PR fixes Solid SSR build failures caused by client-only devtools imports and improves option naming consistency across the OpenRouter integration.

### Solid Devtools SSR Fix
- Problem: SSR and server builds failed with errors such as:
  - "No matching export ... setStyleProperty"
  - "No matching export ... use"
- Root cause: Top-level imports of @tanstack/solid-devtools and @tanstack/solid-router-devtools caused server bundles to import client-only solid-js/web APIs.
- Fix:
  - Removed top-level devtools imports.
  - Devtools are now dynamically imported and rendered inside onMount in
    examples/ts-solid-chat/src/routes/__root.tsx.
  - Devtools JSX is stored in a signal and injected only after client mount.
- Result:
  - Devtools run only on the client.
  - SSR/build no longer attempts to import unsupported Solid exports.
  - Verified that ts-solid-chat builds (client + SSR) complete successfully.

### OpenRouter Options Refactor
- Refactored OpenRouter option names to camelCase for consistency.
- Updated interface definitions in text-provider-options.ts.
- Updated tests in openrouter-adapter.test.ts.
- Ensured all options are correctly passed through to the SDK request.

### CI
- Applied automated CI fixes.

## ✅ Checklist

- [✅] I have followed the steps in the Contributing guide:
  https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md
- [✅] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [✅] This change is docs/CI/dev-only (no release).

Co-authored-by: autofix-ci[bot] <114827586+autofix-ci[bot]@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Devtools now load dynamically at runtime instead of being bundled, reducing the app's initial bundle size and improving load/build performance.
  * Added resilient handling so the app continues gracefully if devtools fail to initialize, avoiding user-facing disruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->