### PR TITLE
fix(ai-gemini): parse usageMetadata in image adapter response

### DIFF
--- a/.changeset/gemini-image-usage-metadata.md
+++ b/.changeset/gemini-image-usage-metadata.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-gemini': patch
+---
+
+Parse `usageMetadata` in the Gemini image adapter response so image generations report token usage (`inputTokens` / `outputTokens` / `totalTokens`) instead of always returning `usage: undefined`.

--- a/packages/typescript/ai-gemini/src/adapters/image.ts
+++ b/packages/typescript/ai-gemini/src/adapters/image.ts
@@ -168,7 +168,13 @@ export class GeminiImageAdapter<
       id: generateId(this.name),
       model,
       images,
-      usage: undefined,
+      usage: response.usageMetadata
+    ? {
+        inputTokens: response.usageMetadata.promptTokenCount,
+        outputTokens: response.usageMetadata.candidatesTokenCount,
+        totalTokens: response.usageMetadata.totalTokenCount,
+      }
+    : undefined,
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix Gemini image adapter always returning `usage: undefined` by mapping `usageMetadata` from the API response to the `ImageGenerationResult.usage` field
- Maps `promptTokenCount` → `inputTokens`, `candidatesTokenCount` → `outputTokens`, `totalTokenCount` → `totalTokens`
- Consistent with how the OpenAI image adapter already handles usage data

Closes #330

## Test plan

- [ ] Generate an image using Gemini adapter and verify `usage` is populated with token counts
- [ ] Verify that when `usageMetadata` is absent, `usage` gracefully falls back to `undefined`
- [ ] Run `pnpm test:lib` and `pnpm test:types` on the `ai-gemini` package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gemini image generation responses now include token usage details when provided, improving visibility into API consumption metrics (input, output, and total tokens).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->