### PR TITLE
fix(ai-devtools-core): bundle solid-js deps to fix SSR compatibility

### DIFF
--- a/packages/typescript/ai-devtools/package.json
+++ b/packages/typescript/ai-devtools/package.json
@@ -46,15 +46,15 @@
     "embeddings"
   ],
   "dependencies": {
-    "@tanstack/ai": "workspace:*",
-    "@tanstack/devtools-ui": "^0.4.4",
-    "@tanstack/devtools-utils": "^0.3.0",
-    "goober": "^2.1.18",
-    "solid-js": "^1.9.10"
+    "@tanstack/ai": "workspace:*"
   },
   "devDependencies": {
+    "@tanstack/devtools-ui": "^0.4.4",
+    "@tanstack/devtools-utils": "^0.3.0",
     "@vitest/coverage-v8": "4.0.14",
+    "goober": "^2.1.18",
     "jsdom": "^27.2.0",
+    "solid-js": "^1.9.10",
     "vite": "^7.2.7",
     "vite-plugin-solid": "^2.11.10"
   }

--- a/packages/typescript/ai-devtools/vite.config.ts
+++ b/packages/typescript/ai-devtools/vite.config.ts
@@ -15,11 +15,25 @@ const config = defineConfig({
   },
 })
 
-export default mergeConfig(
+const merged = mergeConfig(
   config,
   tanstackViteConfig({
     entry: ['./src/index.ts', './src/production.ts'],
     srcDir: './src',
     cjs: false,
+    bundledDeps: [
+      'solid-js',
+      'solid-js/web',
+      'solid-js/store',
+      '@tanstack/devtools-utils',
+      '@tanstack/devtools-utils/solid',
+      '@tanstack/devtools-ui',
+      'goober',
+    ],
   }),
 )
+
+merged.build.rollupOptions.output.manualChunks = undefined
+merged.build.rollupOptions.output.preserveModules = false
+
+export default merged


### PR DESCRIPTION
solid-js, devtools-utils, devtools-ui and goober were kept as external imports in the build output. This caused Vite's SSR dep optimizer to resolve solid-js/web to its server build, which lacks browser-only APIs like setStyleProperty, template, and use — breaking any consumer using SSR (e.g. TanStack Start, Next.js, Cloudflare Workers).

Bundle all solid-js related deps into the package output, matching the pattern used by @tanstack/router-devtools-core and @tanstack/query-devtools. Move bundled deps from dependencies to devDependencies.

Closes #333

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for improved package bundling and output handling.
  * Reorganized dependencies to better reflect development-time requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->