### PR TITLE
docs: surface OpenRouter as recommended starting point

### DIFF
--- a/docs/adapters/openrouter.md
+++ b/docs/adapters/openrouter.md
@@ -3,7 +3,7 @@ title: OpenRouter Adapter
 id: openrouter-adapter
 ---
 
-The OpenRouter adapter provides access to 300+ AI models from various providers through a single unified API, including models from OpenAI, Anthropic, Google, Meta, Mistral, and many more.
+OpenRouter is TanStack AI's first official AI partner and the recommended starting point for most projects. It provides access to 300+ models from OpenAI, Anthropic, Google, Meta, Mistral, and many more — all through a single API key and unified interface.
 
 ## Installation
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -12,7 +12,7 @@ TanStack AI is a lightweight, type-safe SDK for building production-ready AI exp
 - ✅ **Streaming** - Built-in streaming support for real-time responses
 - ✅ **Isomorphic Tools** - Define once with `toolDefinition()`, implement with `.server()` or `.client()`
 - ✅ **Framework Agnostic** - Core library works anywhere
-- ✅ **Multiple Providers** - OpenAI, Anthropic, Gemini, Ollama, and more
+- ✅ **Multiple Providers** - OpenRouter, OpenAI, Anthropic, Gemini, Ollama, and more
 - ✅ **Approval Flow** - Built-in support for tool approval workflows
 - ✅ **Automatic Execution** - Both server and client tools execute automatically
 
@@ -92,10 +92,14 @@ Solid hooks for TanStack AI:
 
 With the help of adapters, TanStack AI can connect to various LLM providers. Available adapters include:
 
-- **@tanstack/ai-openai** - OpenAI (GPT-4, GPT-3.5, etc.)
+- **@tanstack/ai-openrouter** - OpenRouter (300+ models via a single API key — recommended)
+- **@tanstack/ai-openai** - OpenAI (GPT series)
 - **@tanstack/ai-anthropic** - Anthropic (Claude)
 - **@tanstack/ai-gemini** - Google Gemini
 - **@tanstack/ai-ollama** - Ollama (local models)
+- **@tanstack/ai-groq** - Groq
+- **@tanstack/ai-grok** - xAI Grok
+- **@tanstack/ai-fal** - fal (image & video generation)
 
 ## Next Steps
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -6,6 +6,8 @@ order: 2
 
 Get started with TanStack AI in minutes. This guide will walk you through creating a simple chat application using the React integration and OpenAI adapter.
 
+> **Tip:** If you'd prefer not to sign up with individual AI providers, [OpenRouter](../adapters/openrouter) gives you access to 300+ models with a single API key and is the easiest way to get started.
+
 ## Installation
 
 ```bash
@@ -209,6 +211,9 @@ export function Chat() {
 
 To connect to AI providers, set your API keys in your environment variables. Create a `.env.local` file (or `.env` depending on your setup):
 ```bash
+# OpenRouter (recommended — access 300+ models with one key)
+OPENROUTER_API_KEY=sk-or-...
+
 # OpenAI
 OPENAI_API_KEY=your-openai-api-key
 


### PR DESCRIPTION
## Summary

- Adds OpenRouter to the Key Features "Multiple Providers" bullet in the overview
- Expands the incomplete adapters list in the overview to include all official adapters, with OpenRouter listed first as recommended
- Adds a tip in the Quick Start guide pointing to OpenRouter as the easiest onboarding path
- Adds `OPENROUTER_API_KEY` to the Quick Start environment variables section
- Strengthens the OpenRouter adapter doc intro to establish it as TanStack AI's first official partner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * OpenRouter is now highlighted as the recommended AI provider and official TanStack AI partner for most projects.
  * Added new supported adapters: OpenRouter, Groq, Grok, and fal to the ecosystem.
  * Added OpenRouter API key configuration guidance for quick setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->