### PR TITLE
fix: patch changesets to prevent major bumps from peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "pnpm": {
     "overrides": {
       "abbrev": "^3.0.0"
+    },
+    "patchedDependencies": {
+      "@changesets/assemble-release-plan@6.0.9": "patches/@changesets__assemble-release-plan@6.0.9.patch"
     }
   },
   "scripts": {

--- a/patches/@changesets__assemble-release-plan@6.0.9.patch
+++ b/patches/@changesets__assemble-release-plan@6.0.9.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index e07ba6e793021b6cfdec898afca517e293386ddb..8afc4efbd0d8350d14abb488747e85bbd955c9dc 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -317,6 +317,9 @@ function shouldBumpMajor({
+   preInfo,
+   onlyUpdatePeerDependentsWhenOutOfRange
+ }) {
++  if(depType === "peerDependencies" ) {
++    return false;
++  }
+   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
+   return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && (
+   // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   abbrev: ^3.0.0
 
+patchedDependencies:
+  '@changesets/assemble-release-plan@6.0.9':
+    hash: 1bc53c741da20baad9cdeb674c599225dcf9fe6aa7b0de16ff87e63f12a97b24
+    path: patches/@changesets__assemble-release-plan@6.0.9.patch
+
 importers:
 
   .:
@@ -9778,7 +9783,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.3
 
-  '@changesets/assemble-release-plan@6.0.9':
+  '@changesets/assemble-release-plan@6.0.9(patch_hash=1bc53c741da20baad9cdeb674c599225dcf9fe6aa7b0de16ff87e63f12a97b24)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -9794,7 +9799,7 @@ snapshots:
   '@changesets/cli@2.29.8(@types/node@24.10.3)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=1bc53c741da20baad9cdeb674c599225dcf9fe6aa7b0de16ff87e63f12a97b24)
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.2
       '@changesets/errors': 0.2.0
@@ -9854,7 +9859,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.14':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=1bc53c741da20baad9cdeb674c599225dcf9fe6aa7b0de16ff87e63f12a97b24)
       '@changesets/config': 3.1.2
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.6


### PR DESCRIPTION
## Summary
- Patches `@changesets/assemble-release-plan@6.0.9` to always return `false` in `shouldBumpMajor` for `peerDependencies`
- Prevents unnecessary major version bumps when peer dependencies change
- Adds patch file and configures `pnpm.patchedDependencies` in root `package.json`

## Test plan
- [ ] Verify `pnpm install` applies the patch without errors
- [ ] Run `pnpm changeset:version` and confirm peer dep changes no longer trigger major bumps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Peer dependencies are now properly excluded from triggering major version bumps during release assembly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->