### PR TITLE
fix(ai-client): capture abort signal before await to prevent race condition

### DIFF
--- a/.changeset/tricky-wings-sniff.md
+++ b/.changeset/tricky-wings-sniff.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-client': patch
+---
+
+Fixes a race condition in ChatClient.streamResponse() where this.abortController.signal could reference a stale or null controller by the time it is passed to this.connection.connect()

--- a/packages/typescript/ai-client/src/chat-client.ts
+++ b/packages/typescript/ai-client/src/chat-client.ts
@@ -572,6 +572,10 @@ export class ChatClient {
     this.setError(undefined)
     this.errorReportedGeneration = null
     this.abortController = new AbortController()
+    // Capture the signal immediately so that a concurrent stop() or
+    // sendMessage() that reassigns this.abortController cannot cause
+    // connect() to receive a stale or null signal.
+    const signal = this.abortController.signal
     // Reset pending tool executions for the new stream
     this.pendingToolExecutions.clear()
     let streamCompletedSuccessfully = false
@@ -613,7 +617,7 @@ export class ChatClient {
       await this.connection.send(
         messages,
         mergedBody,
-        this.abortController.signal,
+        signal,
       )
 
       // Wait for subscription loop to finish processing all chunks

--- a/packages/typescript/ai-client/src/chat-client.ts
+++ b/packages/typescript/ai-client/src/chat-client.ts
@@ -614,11 +614,7 @@ export class ChatClient {
       const processingComplete = this.waitForProcessing()
 
       // Send through normalized connection (pushes chunks to subscription queue)
-      await this.connection.send(
-        messages,
-        mergedBody,
-        signal,
-      )
+      await this.connection.send(messages, mergedBody, signal)
 
       // Wait for subscription loop to finish processing all chunks
       await processingComplete

--- a/packages/typescript/ai-client/src/chat-client.ts
+++ b/packages/typescript/ai-client/src/chat-client.ts
@@ -587,6 +587,15 @@ export class ChatClient {
       // Call onResponse callback
       await this.callbacksRef.current.onResponse()
 
+      // If the stream was cancelled during the onResponse await (e.g. stop()
+      // from a callback or unmount, or reload() superseding this stream),
+      // bail out before allocating waitForProcessing() — otherwise the
+      // resolveProcessing() that ran during cancellation is a no-op and the
+      // await processingComplete below would deadlock.
+      if (signal.aborted) {
+        return false
+      }
+
       // Merge body: base body + per-message body (per-message takes priority)
       // Include conversationId for server-side event correlation
       const mergedBody = {

--- a/packages/typescript/ai-client/tests/chat-client-abort.test.ts
+++ b/packages/typescript/ai-client/tests/chat-client-abort.test.ts
@@ -311,13 +311,14 @@ describe('ChatClient - Abort Signal Handling', () => {
     expect(abortSignals[0]).not.toBe(abortSignals[1])
   })
 
-  it('should pass the original signal to connect() even if stop() is called during onResponse', async () => {
-    let signalPassedToConnect: AbortSignal | undefined
+  it('should resolve cleanly when stop() is called during onResponse', async () => {
+    let connectCalled = false
+    const errorSpy = vi.fn()
 
     const adapter: ConnectionAdapter = {
       // eslint-disable-next-line @typescript-eslint/require-await
-      async *connect(_messages, _data, abortSignal) {
-        signalPassedToConnect = abortSignal
+      async *connect(_messages, _data, _abortSignal) {
+        connectCalled = true
         yield asChunk({
           type: 'RUN_FINISHED',
           runId: 'run-1',
@@ -330,11 +331,12 @@ describe('ChatClient - Abort Signal Handling', () => {
 
     const client = new ChatClient({
       connection: adapter,
+      onError: errorSpy,
       onResponse: () => {
-        // Simulate a concurrent stop() during the onResponse callback,
-        // which sets this.abortController to null. Without the fix,
-        // the code would dereference this.abortController.signal after
-        // this point and crash with a null reference.
+        // stop() during the onResponse await aborts the captured signal and
+        // nulls this.abortController. Pre-fix this dereferenced null and
+        // threw a TypeError; with the captured-signal fix and the post-await
+        // signal.aborted check, streamResponse short-circuits cleanly.
         client.stop()
       },
     })
@@ -346,14 +348,18 @@ describe('ChatClient - Abort Signal Handling', () => {
       createdAt: new Date(),
     })
 
-    // The signal should still be a valid AbortSignal instance
-    // (captured before the await), not undefined/null
-    expect(signalPassedToConnect).toBeInstanceOf(AbortSignal)
+    // Cancelled streams must not invoke the connection (no wasted request),
+    // surface no error to user code, and not deadlock the append() promise.
+    expect(connectCalled).toBe(false)
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(client.getError()).toBeUndefined()
+    expect(client.getIsLoading()).toBe(false)
   })
 
-  it('should pass the original signal to send() even if reload() reassigns abortController during onResponse', async () => {
+  it('should resolve cleanly when reload() supersedes the stream during onResponse', async () => {
     const signalsPassedToConnect: Array<AbortSignal> = []
     let reloadPromise: Promise<unknown> | undefined
+    const errorSpy = vi.fn()
 
     const adapter: ConnectionAdapter = {
       // eslint-disable-next-line @typescript-eslint/require-await
@@ -374,14 +380,16 @@ describe('ChatClient - Abort Signal Handling', () => {
     let firstCall = true
     const client = new ChatClient({
       connection: adapter,
+      onError: errorSpy,
       onResponse: () => {
         if (firstCall) {
           firstCall = false
-          // reload() synchronously aborts and nulls this.abortController via
-          // cancelInFlightStream(), then starts a fresh streamResponse that
-          // assigns a new AbortController. Without the fix, the first stream
-          // would re-read this.abortController.signal after this await and
-          // receive the *second* stream's signal instead of its own.
+          // reload() aborts the in-flight stream's signal and starts a fresh
+          // streamResponse that assigns a new AbortController. Pre-fix, the
+          // first stream re-read this.abortController.signal after this
+          // await and would either crash or pass the second stream's signal
+          // to its own connect() call. With the fix, the first stream
+          // short-circuits because its captured signal was aborted.
           reloadPromise = client.reload()
         }
       },
@@ -396,17 +404,13 @@ describe('ChatClient - Abort Signal Handling', () => {
 
     await reloadPromise
 
-    // Both calls must have received distinct AbortSignal instances.
-    // Pre-fix, both would receive the second stream's signal because the
-    // first stream re-read this.abortController.signal after reload().
-    expect(signalsPassedToConnect.length).toBe(2)
+    // Only the surviving (reload) stream invokes connect(); the cancelled
+    // first stream short-circuits before reaching the connection layer.
+    // Its signal must be fresh (not the aborted one from the cancelled stream).
+    expect(signalsPassedToConnect.length).toBe(1)
     expect(signalsPassedToConnect[0]).toBeInstanceOf(AbortSignal)
-    expect(signalsPassedToConnect[1]).toBeInstanceOf(AbortSignal)
-    expect(signalsPassedToConnect[0]).not.toBe(signalsPassedToConnect[1])
-    // Exactly one of the two should be aborted (the first stream's signal,
-    // aborted by cancelInFlightStream()); the other is fresh. Order-agnostic
-    // because microtask scheduling determines which connect() runs first.
-    const abortedCount = signalsPassedToConnect.filter((s) => s.aborted).length
-    expect(abortedCount).toBe(1)
+    expect(signalsPassedToConnect[0]?.aborted).toBe(false)
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(client.getError()).toBeUndefined()
   })
 })

--- a/packages/typescript/ai-client/tests/chat-client-abort.test.ts
+++ b/packages/typescript/ai-client/tests/chat-client-abort.test.ts
@@ -310,4 +310,100 @@ describe('ChatClient - Abort Signal Handling', () => {
     // Each should be a different signal instance
     expect(abortSignals[0]).not.toBe(abortSignals[1])
   })
+
+  it('should pass the original signal to connect() even if stop() is called during onResponse', async () => {
+    let signalPassedToConnect: AbortSignal | undefined
+
+    const adapter: ConnectionAdapter = {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *connect(_messages, _data, abortSignal) {
+        signalPassedToConnect = abortSignal
+        yield {
+          type: 'RUN_FINISHED',
+          runId: 'run-1',
+          model: 'test',
+          timestamp: Date.now(),
+          finishReason: 'stop',
+        }
+      },
+    }
+
+    const client = new ChatClient({
+      connection: adapter,
+      onResponse: () => {
+        // Simulate a concurrent stop() during the onResponse callback,
+        // which sets this.abortController to null. Without the fix,
+        // the code would dereference this.abortController.signal after
+        // this point and crash with a null reference.
+        client.stop()
+      },
+    })
+
+    await client.append({
+      id: 'user-1',
+      role: 'user',
+      parts: [{ type: 'text', content: 'Hello' }],
+      createdAt: new Date(),
+    })
+
+    // The signal should still be a valid AbortSignal instance
+    // (captured before the await), not undefined/null
+    expect(signalPassedToConnect).toBeInstanceOf(AbortSignal)
+  })
+
+  it('should pass the original signal to connect() even if sendMessage() reassigns abortController during onResponse', async () => {
+    const signalsPassedToConnect: Array<AbortSignal> = []
+
+    const adapter: ConnectionAdapter = {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *connect(_messages, _data, abortSignal) {
+        if (abortSignal) {
+          signalsPassedToConnect.push(abortSignal)
+        }
+        yield {
+          type: 'RUN_FINISHED',
+          runId: 'run-1',
+          model: 'test',
+          timestamp: Date.now(),
+          finishReason: 'stop',
+        }
+      },
+    }
+
+    let firstCall = true
+    const client = new ChatClient({
+      connection: adapter,
+      onResponse: () => {
+        if (firstCall) {
+          firstCall = false
+          // Trigger a second message during onResponse callback.
+          // This queues a new streamResponse that would create a new
+          // AbortController, potentially overwriting this.abortController
+          // before the first connect() call reads the signal.
+          client.append({
+            id: 'user-2',
+            role: 'user',
+            parts: [{ type: 'text', content: 'Second message' }],
+            createdAt: new Date(),
+          })
+        }
+      },
+    })
+
+    await client.append({
+      id: 'user-1',
+      role: 'user',
+      parts: [{ type: 'text', content: 'Hello' }],
+      createdAt: new Date(),
+    })
+
+    // Wait for the queued second stream to complete
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // Both calls should have received valid, distinct AbortSignal instances
+    expect(signalsPassedToConnect.length).toBe(2)
+    expect(signalsPassedToConnect[0]).toBeInstanceOf(AbortSignal)
+    expect(signalsPassedToConnect[1]).toBeInstanceOf(AbortSignal)
+    expect(signalsPassedToConnect[0]).not.toBe(signalsPassedToConnect[1])
+  })
 })

--- a/packages/typescript/ai-client/tests/chat-client-abort.test.ts
+++ b/packages/typescript/ai-client/tests/chat-client-abort.test.ts
@@ -318,13 +318,13 @@ describe('ChatClient - Abort Signal Handling', () => {
       // eslint-disable-next-line @typescript-eslint/require-await
       async *connect(_messages, _data, abortSignal) {
         signalPassedToConnect = abortSignal
-        yield {
+        yield asChunk({
           type: 'RUN_FINISHED',
           runId: 'run-1',
           model: 'test',
           timestamp: Date.now(),
           finishReason: 'stop',
-        }
+        })
       },
     }
 
@@ -351,9 +351,9 @@ describe('ChatClient - Abort Signal Handling', () => {
     expect(signalPassedToConnect).toBeInstanceOf(AbortSignal)
   })
 
-  it('should pass the original signal to connect() even if sendMessage() reassigns abortController during onResponse', async () => {
+  it('should pass the original signal to send() even if reload() reassigns abortController during onResponse', async () => {
     const signalsPassedToConnect: Array<AbortSignal> = []
-    let secondAppendPromise: Promise<unknown> | undefined
+    let reloadPromise: Promise<unknown> | undefined
 
     const adapter: ConnectionAdapter = {
       // eslint-disable-next-line @typescript-eslint/require-await
@@ -361,13 +361,13 @@ describe('ChatClient - Abort Signal Handling', () => {
         if (abortSignal) {
           signalsPassedToConnect.push(abortSignal)
         }
-        yield {
+        yield asChunk({
           type: 'RUN_FINISHED',
           runId: 'run-1',
           model: 'test',
           timestamp: Date.now(),
           finishReason: 'stop',
-        }
+        })
       },
     }
 
@@ -377,16 +377,12 @@ describe('ChatClient - Abort Signal Handling', () => {
       onResponse: () => {
         if (firstCall) {
           firstCall = false
-          // Trigger a second message during onResponse callback.
-          // This queues a new streamResponse that would create a new
-          // AbortController, potentially overwriting this.abortController
-          // before the first connect() call reads the signal.
-          secondAppendPromise = client.append({
-            id: 'user-2',
-            role: 'user',
-            parts: [{ type: 'text', content: 'Second message' }],
-            createdAt: new Date(),
-          })
+          // reload() synchronously aborts and nulls this.abortController via
+          // cancelInFlightStream(), then starts a fresh streamResponse that
+          // assigns a new AbortController. Without the fix, the first stream
+          // would re-read this.abortController.signal after this await and
+          // receive the *second* stream's signal instead of its own.
+          reloadPromise = client.reload()
         }
       },
     })
@@ -398,13 +394,19 @@ describe('ChatClient - Abort Signal Handling', () => {
       createdAt: new Date(),
     })
 
-    // Deterministically wait for the queued second stream
-    await secondAppendPromise
+    await reloadPromise
 
-    // Both calls should have received valid, distinct AbortSignal instances
+    // Both calls must have received distinct AbortSignal instances.
+    // Pre-fix, both would receive the second stream's signal because the
+    // first stream re-read this.abortController.signal after reload().
     expect(signalsPassedToConnect.length).toBe(2)
     expect(signalsPassedToConnect[0]).toBeInstanceOf(AbortSignal)
     expect(signalsPassedToConnect[1]).toBeInstanceOf(AbortSignal)
     expect(signalsPassedToConnect[0]).not.toBe(signalsPassedToConnect[1])
+    // Exactly one of the two should be aborted (the first stream's signal,
+    // aborted by cancelInFlightStream()); the other is fresh. Order-agnostic
+    // because microtask scheduling determines which connect() runs first.
+    const abortedCount = signalsPassedToConnect.filter((s) => s.aborted).length
+    expect(abortedCount).toBe(1)
   })
 })

--- a/packages/typescript/ai-client/tests/chat-client-abort.test.ts
+++ b/packages/typescript/ai-client/tests/chat-client-abort.test.ts
@@ -353,6 +353,7 @@ describe('ChatClient - Abort Signal Handling', () => {
 
   it('should pass the original signal to connect() even if sendMessage() reassigns abortController during onResponse', async () => {
     const signalsPassedToConnect: Array<AbortSignal> = []
+    let secondAppendPromise: Promise<unknown> | undefined
 
     const adapter: ConnectionAdapter = {
       // eslint-disable-next-line @typescript-eslint/require-await
@@ -380,7 +381,7 @@ describe('ChatClient - Abort Signal Handling', () => {
           // This queues a new streamResponse that would create a new
           // AbortController, potentially overwriting this.abortController
           // before the first connect() call reads the signal.
-          client.append({
+          secondAppendPromise = client.append({
             id: 'user-2',
             role: 'user',
             parts: [{ type: 'text', content: 'Second message' }],
@@ -397,8 +398,8 @@ describe('ChatClient - Abort Signal Handling', () => {
       createdAt: new Date(),
     })
 
-    // Wait for the queued second stream to complete
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    // Deterministically wait for the queued second stream
+    await secondAppendPromise
 
     // Both calls should have received valid, distinct AbortSignal instances
     expect(signalsPassedToConnect.length).toBe(2)


### PR DESCRIPTION
## Summary

Fixes a race condition in `ChatClient.streamResponse()` where `this.abortController.signal` could reference a stale or null controller by the time it is passed to `this.connection.connect()`.

- **Root cause:** Between `this.abortController = new AbortController()` (line 432) and the `this.connection.connect(..., this.abortController.signal)` call (line 459), there is an `await this.callbacksRef.current.onResponse()`. During that await, a concurrent `stop()` call nulls out `this.abortController`, or a rapid second `sendMessage()` could replace it with a new controller.
- **Fix:** Capture `const signal = this.abortController.signal` immediately after creation, then pass the local `signal` variable to `connect()`, ensuring it always receives the signal from the correct AbortController regardless of concurrent mutations.

## How to reproduce

1. Create a `ChatClient` and call `sendMessage("hello")`
2. Before the stream connects (e.g., during the `onResponse` callback), call `stop()` or fire another `sendMessage()`
3. `this.abortController` is now null or points to a different controller
4. `connect()` receives a wrong/null signal, leading to either a runtime error or the inability to abort the correct stream

## Changes

- `packages/typescript/ai-client/src/chat-client.ts`: Capture `signal` locally right after `AbortController` creation; pass it to `connect()` instead of re-reading `this.abortController.signal`

## Test plan

- [x] All 165 existing tests pass (8 test files in `@tanstack/ai-client`)
- [x] Abort-specific tests in `chat-client-abort.test.ts` all pass (6 tests)
- [x] Verified the diff is minimal and correct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the correct cancellation signal is captured and used during streaming so stop/send races no longer produce stale or null signals, preventing interrupted or unrecoverable streams.

* **Tests**
  * Added tests validating cancellation behavior when stop is called during a response and across sequential messages, asserting distinct, valid cancellation signals are passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->