### PR TITLE
fix(ai-ollama): forward systemPrompts to Ollama API

### DIFF
--- a/packages/typescript/ai-ollama/src/adapters/text.ts
+++ b/packages/typescript/ai-ollama/src/adapters/text.ts
@@ -452,6 +452,9 @@ export class OllamaTextAdapter<TModel extends string> extends BaseTextAdapter<
       options: ollamaOptions,
       messages: this.formatMessages(options.messages),
       tools: this.convertToolsToOllamaFormat(options.tools),
+      ...(options.systemPrompts?.length
+        ? { system: options.systemPrompts.join('\n') }
+        : {}),
     }
   }
 }


### PR DESCRIPTION
Fixes #388 

The `mapCommonOptionsToOllama()` method was silently dropping the `systemPrompts` field from chat options. System prompts passed via `chat({ systemPrompts: [...] })` now correctly reach the Ollama API as the `system` parameter on the chat request. This is how other adapters (e.g. Anthropic) handle it.

## 🎯 Changes

Forward `systemPrompts` as the `system` field on the Ollama `ChatRequest` in `mapCommonOptionsToOllama()`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Ollama adapter now properly supports system prompts in API requests. When system prompts are provided, they are automatically combined with line breaks and incorporated into the request payload. This enhancement enables users to provide multiple system prompts that work together for improved control over AI behavior and response quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->