### PR TITLE
fix(ai): produce new object references in tool-call message updaters

### DIFF
--- a/.changeset/immutable-tool-call-updates.md
+++ b/.changeset/immutable-tool-call-updates.md
@@ -1,0 +1,18 @@
+---
+'@tanstack/ai': patch
+---
+
+fix(ai): produce new object references in tool-call message updaters
+
+`updateToolCallApproval`, `updateToolCallState`, `updateToolCallWithOutput`,
+and `updateToolCallApprovalResponse` previously mutated the found tool-call
+part in-place (`toolCallPart.state = ...`) after spreading the parts array.
+The shallow `[...msg.parts]` copy created a new array but preserved the
+original object references, so frameworks that rely on reference identity
+for change detection (Svelte 5 proxies, Vue 3 reactivity, etc.) could not
+observe the updates.
+
+Each function now replaces the part at its index with a spread copy
+(`parts[index] = { ...toolCallPart, ...changes }`), producing a fresh
+object on every update. This aligns with the pattern already used by
+`updateToolCallPart`, `updateTextPart`, and `updateThinkingPart`.

--- a/packages/ai/src/activities/chat/stream/message-updaters.ts
+++ b/packages/ai/src/activities/chat/stream/message-updaters.ts
@@ -161,10 +161,14 @@ export function updateToolCallApproval(
     )
 
     if (toolCallPart) {
-      toolCallPart.state = 'approval-requested'
-      toolCallPart.approval = {
-        id: approvalId,
-        needsApproval: true,
+      const index = parts.indexOf(toolCallPart)
+      parts[index] = {
+        ...toolCallPart,
+        state: 'approval-requested',
+        approval: {
+          id: approvalId,
+          needsApproval: true,
+        },
       }
     }
 
@@ -192,7 +196,8 @@ export function updateToolCallState(
     )
 
     if (toolCallPart) {
-      toolCallPart.state = state
+      const index = parts.indexOf(toolCallPart)
+      parts[index] = { ...toolCallPart, state }
     }
 
     return { ...msg, parts }
@@ -217,8 +222,12 @@ export function updateToolCallWithOutput(
     )
 
     if (toolCallPart) {
-      toolCallPart.output = errorText ? { error: errorText } : output
-      toolCallPart.state = state ?? (errorText ? 'input-complete' : 'complete')
+      const index = parts.indexOf(toolCallPart)
+      parts[index] = {
+        ...toolCallPart,
+        output: errorText ? { error: errorText } : output,
+        state: state ?? (errorText ? 'input-complete' : 'complete'),
+      }
     }
 
     return { ...msg, parts }
@@ -242,8 +251,12 @@ export function updateToolCallApprovalResponse(
     )
 
     if (toolCallPart && toolCallPart.approval) {
-      toolCallPart.approval.approved = approved
-      toolCallPart.state = 'approval-responded'
+      const index = parts.indexOf(toolCallPart)
+      parts[index] = {
+        ...toolCallPart,
+        approval: { ...toolCallPart.approval, approved },
+        state: 'approval-responded',
+      }
     }
 
     return { ...msg, parts }

--- a/packages/ai/tests/message-updaters.test.ts
+++ b/packages/ai/tests/message-updaters.test.ts
@@ -887,6 +887,114 @@ describe('message-updaters', () => {
       expect(result[0]?.parts).not.toBe(originalParts)
       expect(messages[0]?.parts).toBe(originalParts)
     })
+
+    it('updateToolCallApproval should not mutate the original tool-call part', () => {
+      const originalPart: ToolCallPart = {
+        type: 'tool-call',
+        id: 'call-1',
+        name: 'deleteFile',
+        arguments: '{"path":"/tmp/file"}',
+        state: 'input-complete',
+      }
+      const messages = [createMessage('msg-1', 'assistant', [originalPart])]
+
+      const result = updateToolCallApproval(
+        messages,
+        'msg-1',
+        'call-1',
+        'approval-1',
+      )
+
+      // Original part must be unchanged
+      expect(originalPart.state).toBe('input-complete')
+      expect(originalPart.approval).toBeUndefined()
+
+      // Result must have new values
+      const resultPart = result[0]?.parts[0] as ToolCallPart
+      expect(resultPart).not.toBe(originalPart)
+      expect(resultPart.state).toBe('approval-requested')
+      expect(resultPart.approval).toEqual({
+        id: 'approval-1',
+        needsApproval: true,
+      })
+    })
+
+    it('updateToolCallState should not mutate the original tool-call part', () => {
+      const originalPart: ToolCallPart = {
+        type: 'tool-call',
+        id: 'call-1',
+        name: 'getWeather',
+        arguments: '{}',
+        state: 'input-streaming',
+      }
+      const messages = [createMessage('msg-1', 'assistant', [originalPart])]
+
+      const result = updateToolCallState(
+        messages,
+        'msg-1',
+        'call-1',
+        'input-complete',
+      )
+
+      expect(originalPart.state).toBe('input-streaming')
+
+      const resultPart = result[0]?.parts[0] as ToolCallPart
+      expect(resultPart).not.toBe(originalPart)
+      expect(resultPart.state).toBe('input-complete')
+    })
+
+    it('updateToolCallWithOutput should not mutate the original tool-call part', () => {
+      const originalPart: ToolCallPart = {
+        type: 'tool-call',
+        id: 'call-1',
+        name: 'getWeather',
+        arguments: '{}',
+        state: 'input-complete',
+      }
+      const messages = [createMessage('msg-1', 'assistant', [originalPart])]
+      const output = { temperature: 20 }
+
+      const result = updateToolCallWithOutput(messages, 'call-1', output)
+
+      expect(originalPart.output).toBeUndefined()
+      expect(originalPart.state).toBe('input-complete')
+
+      const resultPart = result[0]?.parts[0] as ToolCallPart
+      expect(resultPart).not.toBe(originalPart)
+      expect(resultPart.output).toEqual(output)
+    })
+
+    it('updateToolCallApprovalResponse should not mutate the original tool-call part', () => {
+      const originalApproval: NonNullable<ToolCallPart['approval']> = {
+        id: 'approval-1',
+        needsApproval: true,
+      }
+      const originalPart: ToolCallPart = {
+        type: 'tool-call',
+        id: 'call-1',
+        name: 'deleteFile',
+        arguments: '{}',
+        state: 'approval-requested',
+        approval: originalApproval,
+      }
+      const messages = [createMessage('msg-1', 'assistant', [originalPart])]
+
+      const result = updateToolCallApprovalResponse(
+        messages,
+        'approval-1',
+        true,
+      )
+
+      // Original part and approval must be unchanged
+      expect(originalPart.state).toBe('approval-requested')
+      expect(originalApproval.approved).toBeUndefined()
+
+      const resultPart = result[0]?.parts[0] as ToolCallPart
+      expect(resultPart).not.toBe(originalPart)
+      expect(resultPart.approval).not.toBe(originalApproval)
+      expect(resultPart.state).toBe('approval-responded')
+      expect(resultPart.approval?.approved).toBe(true)
+    })
   })
 
   describe('appendStructuredOutputDelta', () => {


### PR DESCRIPTION
I ran into this while building a Svelte 5 chat UI with tool-call approvals. Svelte 5 uses proxies for reactivity, and `$derived(part.state === 'approval-requested')` never fired because the part object identity didn't change.

The root cause is four functions in `message-updaters.ts` that mutate tool-call parts in-place after `[...msg.parts]`. The shallow copy creates a new array but the elements are the same references, so `toolCallPart.state = 'approval-requested'` changes the original object in both arrays. This affects any framework using proxy-based reactivity (Svelte 5, Vue 3).

The other updaters (`updateToolCallPart`, `updateTextPart`, `updateThinkingPart`) already produce new objects via spread. This PR aligns the four remaining functions to the same pattern:

```typescript
const index = parts.indexOf(toolCallPart)
parts[index] = { ...toolCallPart, state: 'approval-requested', approval: { ... } }
```

Functions fixed: `updateToolCallApproval`, `updateToolCallState`, `updateToolCallWithOutput`, `updateToolCallApprovalResponse`. Four immutability tests added.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] Changeset included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool-call message updater behavior to ensure proper state isolation and consistency when processing multiple updates, improving reliability of tool interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->