### PR TITLE
fix(ai-anthropic): pass through full JSON Schema for tool input_schema

### DIFF
--- a/.changeset/fix-anthropic-tool-schema.md
+++ b/.changeset/fix-anthropic-tool-schema.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-anthropic': patch
+---
+
+Pass through full JSON Schema for tool input_schema instead of only properties/required, fixing support for discriminated unions and other complex schema constructs.

--- a/packages/typescript/ai-anthropic/src/tools/custom-tool.ts
+++ b/packages/typescript/ai-anthropic/src/tools/custom-tool.ts
@@ -14,11 +14,7 @@ export interface CustomTool {
   /**
    * This defines the shape of the input that your tool accepts and that the model will produce.
    */
-  input_schema: {
-    type: 'object'
-    properties: Record<string, any> | null
-    required?: Array<string> | null
-  }
+  input_schema: JSONSchema & { type: 'object' }
 
   cache_control?: CacheControl | null
 }
@@ -27,17 +23,12 @@ export function convertCustomToolToAdapterFormat(tool: Tool): CustomTool {
   const metadata =
     (tool.metadata as { cacheControl?: CacheControl | null } | undefined) || {}
 
-  // Tool schemas are already converted to JSON Schema in the ai layer
-  const jsonSchema = (tool.inputSchema ?? {
+  // Pass through the full JSON Schema (including oneOf/anyOf for discriminated unions)
+  // instead of destructuring only properties/required.
+  // type: 'object' is forced last since the Anthropic API requires it at the top level.
+  const inputSchema: JSONSchema & { type: 'object' } = {
+    ...tool.inputSchema,
     type: 'object',
-    properties: {},
-    required: [],
-  }) as JSONSchema
-
-  const inputSchema = {
-    type: 'object' as const,
-    properties: jsonSchema.properties || null,
-    required: jsonSchema.required || null,
   }
 
   return {


### PR DESCRIPTION
## 🎯 Changes

Previously, convertCustomToolToAdapterFormat destructured only `properties` and `required` from the tool's input schema, discarding fields like `oneOf`, `anyOf`, `allOf`, and `$defs`. This broke tools with discriminated unions or other complex JSON Schema constructs.

This PR changes that to spread the full schema instead, preserving all JSON Schema fields. 

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md). -- Could not find this one?
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool schema generation now properly supports complex schema constructs (discriminated unions, oneOf/anyOf patterns). The system now preserves the full JSON Schema definition instead of reducing it to basic properties and required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->