### PR TITLE
fix(ai): preserve `providerMetadata` through client-side UIMessage pipeline

### DIFF
--- a/packages/typescript/ai/src/activities/chat/messages.ts
+++ b/packages/typescript/ai/src/activities/chat/messages.ts
@@ -138,6 +138,7 @@ interface AssistantSegment {
     id: string
     type: 'function'
     function: { name: string; arguments: string }
+    providerMetadata?: Record<string, unknown>
   }>
 }
 
@@ -205,6 +206,9 @@ function buildAssistantMessages(uiMessage: UIMessage): Array<ModelMessage> {
               name: part.name,
               arguments: part.arguments,
             },
+            ...(part.providerMetadata && {
+              providerMetadata: part.providerMetadata,
+            }),
           })
         }
         break
@@ -340,6 +344,9 @@ export function modelMessageToUIMessage(
         name: toolCall.function.name,
         arguments: toolCall.function.arguments,
         state: 'input-complete', // Model messages have complete arguments
+        ...(toolCall.providerMetadata && {
+          providerMetadata: toolCall.providerMetadata,
+        }),
       })
     }
   }

--- a/packages/typescript/ai/src/activities/chat/stream/message-updaters.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/message-updaters.ts
@@ -55,6 +55,7 @@ export function updateToolCallPart(
     name: string
     arguments: string
     state: ToolCallState
+    providerMetadata?: Record<string, unknown>
   },
 ): Array<UIMessage> {
   return messages.map((msg) => {
@@ -67,6 +68,10 @@ export function updateToolCallPart(
       (p): p is ToolCallPart => p.type === 'tool-call' && p.id === toolCall.id,
     )
 
+    // Carry forward providerMetadata from either the new toolCall or the existing part
+    const providerMetadata =
+      toolCall.providerMetadata ?? existing?.providerMetadata
+
     const toolCallPart: ToolCallPart = {
       type: 'tool-call',
       id: toolCall.id,
@@ -76,6 +81,7 @@ export function updateToolCallPart(
       // Carry forward approval and output from the existing part
       ...(existing?.approval && { approval: { ...existing.approval } }),
       ...(existing?.output !== undefined && { output: existing.output }),
+      ...(providerMetadata && { providerMetadata }),
     }
 
     if (existing) {

--- a/packages/typescript/ai/src/activities/chat/stream/processor.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/processor.ts
@@ -856,6 +856,9 @@ export class StreamProcessor {
         state: initialState,
         parsedArguments: undefined,
         index: chunk.index ?? state.toolCalls.size,
+        ...(chunk.providerMetadata && {
+          providerMetadata: chunk.providerMetadata,
+        }),
       }
 
       state.toolCalls.set(toolCallId, newToolCall)
@@ -870,6 +873,9 @@ export class StreamProcessor {
         name: chunk.toolName,
         arguments: '',
         state: initialState,
+        ...(chunk.providerMetadata && {
+          providerMetadata: chunk.providerMetadata,
+        }),
       })
       this.emitMessagesChange()
 
@@ -1367,6 +1373,9 @@ export class StreamProcessor {
               name: tc.name,
               arguments: tc.arguments,
             },
+            ...(tc.providerMetadata && {
+              providerMetadata: tc.providerMetadata,
+            }),
           })
         }
       }

--- a/packages/typescript/ai/src/activities/chat/stream/types.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/types.ts
@@ -25,6 +25,8 @@ export interface InternalToolCallState {
   state: ToolCallState
   parsedArguments?: any
   index: number
+  /** Provider-specific metadata (e.g. Gemini thoughtSignature) */
+  providerMetadata?: Record<string, unknown>
 }
 
 /**

--- a/packages/typescript/ai/src/types.ts
+++ b/packages/typescript/ai/src/types.ts
@@ -295,6 +295,8 @@ export interface ToolCallPart {
   }
   /** Tool execution output (for client tools or after approval) */
   output?: any
+  /** Provider-specific metadata carried through the tool call lifecycle (e.g. Gemini thoughtSignature) */
+  providerMetadata?: Record<string, unknown>
 }
 
 export interface ToolResultPart {


### PR DESCRIPTION
### Summary

PR #401 added `providerMetadata` to `ToolCall` and `ToolCallStartEvent` and wired it through the server-side `ToolCallManager`. However, the client-side pipeline (`StreamProcessor` → UIMessage → ModelMessage) drops `providerMetadata` entirely, breaking Gemini 3+ thinking models on multi-turn tool calls.

This PR completes the round-trip by carrying `providerMetadata` through every step of the client-side pipeline.

Fixes #403 (follow-up to #216, #401)

### Changes (5 files, 26 lines added)

| File | Change |
|------|--------|
| `types.ts` | Add optional `providerMetadata` to `ToolCallPart` interface |
| `stream/types.ts` | Add optional `providerMetadata` to `InternalToolCallState` |
| `stream/message-updaters.ts` | Accept and carry forward `providerMetadata` in `updateToolCallPart()` |
| `stream/processor.ts` | Pass `chunk.providerMetadata` into `InternalToolCallState` and `updateToolCallPart()` in `handleToolCallStartEvent()`; include it in `getCompletedToolCalls()` |
| `messages.ts` | Include `providerMetadata` on `toolCalls` in `buildAssistantMessages()` (UIMessage → ModelMessage); preserve it in `modelMessageToUIMessage()` (ModelMessage → UIMessage) |

### How it works

The data flow is now:

```
Gemini API response
  → GeminiTextAdapter.processStreamChunks() captures thoughtSignature
  → TOOL_CALL_START event with providerMetadata: { thoughtSignature }
  → StreamProcessor.handleToolCallStartEvent() stores on InternalToolCallState + ToolCallPart
  → UIMessage.parts[].providerMetadata preserved
  → uiMessageToModelMessages() → buildAssistantMessages() includes providerMetadata on toolCalls
  → ModelMessage.toolCalls[].providerMetadata
  → GeminiTextAdapter.formatMessages() reads toolCall.providerMetadata?.thoughtSignature
  → functionCall part includes thoughtSignature
  → Gemini API accepts ✅
```

### Test plan

- Existing test from PR #401 (`preserves thoughtSignature in functionCall parts when sending history back to Gemini`) continues to pass (server-side path)
- TODO: Add test for the client-side path: process TOOL_CALL_START with providerMetadata through StreamProcessor, convert to ModelMessages via toModelMessages(), verify providerMetadata is present on toolCalls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool calls now support optional provider-specific metadata that is preserved throughout their complete lifecycle during streaming and message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->