### PR TITLE
fix #392  docs(openai): update OpenAI adapter documentation to reflect model pa…

### DIFF
--- a/docs/adapters/openai.md
+++ b/docs/adapters/openai.md
@@ -30,12 +30,12 @@ const stream = chat({
 import { chat } from "@tanstack/ai";
 import { createOpenaiChat } from "@tanstack/ai-openai";
 
-const adapter = createOpenaiChat(process.env.OPENAI_API_KEY!, {
+const adapter = createOpenaiChat("gpt-5.2", process.env.OPENAI_API_KEY!, {
   // ... your config options
 });
 
 const stream = chat({
-  adapter: adapter("gpt-5.2"),
+  adapter,
   messages: [{ role: "user", content: "Hello!" }],
 });
 ```
@@ -43,14 +43,14 @@ const stream = chat({
 ## Configuration
 
 ```typescript
-import { createOpenaiChat, type OpenAIChatConfig } from "@tanstack/ai-openai";
+import { createOpenaiChat, type OpenAITextConfig } from "@tanstack/ai-openai";
 
-const config: Omit<OpenAIChatConfig, 'apiKey'> = {
+const config: Omit<OpenAITextConfig, 'apiKey'> = {
   organization: "org-...", // Optional
   baseURL: "https://api.openai.com/v1", // Optional, for custom endpoints
 };
 
-const adapter = createOpenaiChat(process.env.OPENAI_API_KEY!, config);
+const adapter = createOpenaiChat("gpt-5.2", process.env.OPENAI_API_KEY!, config);
 ```
  
 ## Example: Chat Completion
@@ -187,10 +187,10 @@ Generate speech from text:
 
 ```typescript
 import { generateSpeech } from "@tanstack/ai";
-import { openaiTTS } from "@tanstack/ai-openai";
+import { openaiSpeech } from "@tanstack/ai-openai";
 
 const result = await generateSpeech({
-  adapter: openaiTTS("tts-1"),
+  adapter: openaiSpeech("tts-1"),
   text: "Hello, welcome to TanStack AI!",
   voice: "alloy",
   format: "mp3",
@@ -208,7 +208,7 @@ Available voices: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`, `ash`, `b
 
 ```typescript
 const result = await generateSpeech({
-  adapter: openaiTTS("tts-1-hd"),
+  adapter: openaiSpeech("tts-1-hd"),
   text: "High quality speech",
   modelOptions: {
     speed: 1.0, // 0.25 to 4.0
@@ -260,67 +260,68 @@ OPENAI_API_KEY=sk-...
 
 ## API Reference
 
-### `openaiText(config?)`
+### `openaiText(model, config?)`
 
 Creates an OpenAI chat adapter using environment variables.
 
 **Returns:** An OpenAI chat adapter instance.
 
-### `createOpenaiChat(apiKey, config?)`
+### `createOpenaiChat(model, apiKey, config?)`
 
 Creates an OpenAI chat adapter with an explicit API key.
 
 **Parameters:**
 
+- `model` - OpenAI chat model name (e.g., `gpt-5.2`)
 - `apiKey` - Your OpenAI API key
 - `config.organization?` - Organization ID (optional)
 - `config.baseURL?` - Custom base URL (optional)
 
 **Returns:** An OpenAI chat adapter instance.
 
-### `openaiSummarize(config?)`
+### `openaiSummarize(model, config?)`
 
 Creates an OpenAI summarization adapter using environment variables.
 
 **Returns:** An OpenAI summarize adapter instance.
 
-### `createOpenaiSummarize(apiKey, config?)`
+### `createOpenaiSummarize(model, apiKey, config?)`
 
 Creates an OpenAI summarization adapter with an explicit API key.
 
 **Returns:** An OpenAI summarize adapter instance.
 
-### `openaiImage(config?)`
+### `openaiImage(model, config?)`
 
 Creates an OpenAI image generation adapter using environment variables.
 
 **Returns:** An OpenAI image adapter instance.
 
-### `createOpenaiImage(apiKey, config?)`
+### `createOpenaiImage(model, apiKey, config?)`
 
 Creates an OpenAI image generation adapter with an explicit API key.
 
 **Returns:** An OpenAI image adapter instance.
 
-### `openaiTTS(config?)`
+### `openaiSpeech(model, config?)`
 
 Creates an OpenAI TTS adapter using environment variables.
 
 **Returns:** An OpenAI TTS adapter instance.
 
-### `createOpenaiTTS(apiKey, config?)`
+### `createOpenaiSpeech(model, apiKey, config?)`
 
 Creates an OpenAI TTS adapter with an explicit API key.
 
 **Returns:** An OpenAI TTS adapter instance.
 
-### `openaiTranscription(config?)`
+### `openaiTranscription(model, config?)`
 
 Creates an OpenAI transcription adapter using environment variables.
 
 **Returns:** An OpenAI transcription adapter instance.
 
-### `createOpenaiTranscription(apiKey, config?)`
+### `createOpenaiTranscription(model, apiKey, config?)`
 
 Creates an OpenAI transcription adapter with an explicit API key.
 


### PR DESCRIPTION
  Updated OpenAI adapter docs to match the current API signatures and naming:

  - Fixed examples to use createOpenai* with model as the first parameter:
      - createOpenaiChat(model, apiKey, config?)
      - createOpenaiSummarize(model, apiKey, config?)
      - createOpenaiImage(model, apiKey, config?)
      - createOpenaiSpeech(model, apiKey, config?)
      - createOpenaiTranscription(model, apiKey, config?)
  - Corrected the custom API key chat example so it uses a created adapter directly (not as a factory call).
  - Updated type import in config example from OpenAIChatConfig to OpenAITextConfig.
  - Renamed TTS docs usage from openaiTTS / createOpenaiTTS to openaiSpeech / createOpenaiSpeech to match actual exports.
  - Updated API reference headings/signatures accordingly.

  Motivation: docs were inconsistent with the current adapter API and could mislead users into passing apiKey as arg #1 or using non-existent TTS
  function names.

  ## ✅ Checklist

  - [x] I have followed the steps in the Contributing guide (https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
  - [x] I have tested this code locally with pnpm run test:pr.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenAI adapter API documentation with revised function signatures requiring explicit model specification across all adapter constructors
  * Renamed text-to-speech adapter naming convention from TTS to Speech terminology
  * Refreshed all examples and configuration references to reflect current API patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->