### PR TITLE
feat(ai-elevenlabs): Add session overrides to ElevenLabs adapter

### DIFF
--- a/.changeset/lazy-plums-knock.md
+++ b/.changeset/lazy-plums-knock.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-elevenlabs': minor
+---
+
+add session overrides support

--- a/packages/typescript/ai-elevenlabs/README.md
+++ b/packages/typescript/ai-elevenlabs/README.md
@@ -62,6 +62,78 @@ function VoiceChat() {
 }
 ```
 
+## Session Overrides
+
+You can customize the agent session at two levels: **server-side** (via the token adapter) and **client-side** (via the realtime adapter).
+
+### Server-side overrides (token generation)
+
+Pass overrides to `elevenlabsRealtimeToken()` to bake them into the signed URL:
+
+```typescript
+const token = await realtimeToken({
+  adapter: elevenlabsRealtimeToken({
+    agentId: 'your-agent-id',
+    overrides: {
+      systemPrompt: 'You are a helpful assistant. Be concise.',
+      firstMessage: 'Hi! How can I help you today?',
+      voiceId: 'your-voice-id',
+      language: 'en',
+    },
+  }),
+})
+```
+
+| Option         | Type     | Description                                   |
+| -------------- | -------- | --------------------------------------------- |
+| `systemPrompt` | `string` | Custom system prompt for the agent            |
+| `firstMessage` | `string` | First message the agent speaks when connected |
+| `voiceId`      | `string` | ElevenLabs voice ID                           |
+| `language`     | `string` | Language code (e.g. `'en'`, `'es'`, `'fr'`)   |
+
+### Client-side overrides (adapter options)
+
+Pass overrides to `elevenlabsRealtime()` on the client. These take precedence over token-level overrides for agent prompt, firstMessage, and language.
+
+```typescript
+const client = new RealtimeClient({
+  getToken: () => fetch('/api/realtime-token').then((r) => r.json()),
+  adapter: elevenlabsRealtime({
+    overrides: {
+      agent: {
+        prompt: { prompt: 'You are a helpful assistant.' },
+        firstMessage: 'Hello! How can I assist you?',
+        language: 'en',
+      },
+      tts: {
+        voiceId: 'your-voice-id',
+        speed: 1.0,
+        stability: 0.5,
+        similarityBoost: 0.8,
+      },
+      conversation: {
+        textOnly: false,
+      },
+    },
+  }),
+})
+```
+
+| Option                  | Type      | Description                                  |
+| ----------------------- | --------- | -------------------------------------------- |
+| `agent.prompt.prompt`   | `string`  | System prompt (overrides token instructions) |
+| `agent.firstMessage`    | `string`  | First message the agent speaks               |
+| `agent.language`        | `string`  | Language code                                |
+| `tts.voiceId`           | `string`  | ElevenLabs voice ID                          |
+| `tts.speed`             | `number`  | Speaking speed multiplier                    |
+| `tts.stability`         | `number`  | Voice stability (0–1)                        |
+| `tts.similarityBoost`   | `number`  | Voice similarity boost (0–1)                 |
+| `conversation.textOnly` | `boolean` | Disable audio, use text only                 |
+
+### Override precedence
+
+When both levels are set, client-side `overrides.agent.prompt.prompt` takes precedence over the server-side `systemPrompt`. If only the server-side prompt is set, it is used as the fallback.
+
 ## Environment Variables
 
 Set `ELEVENLABS_API_KEY` in your environment for server-side token generation.

--- a/packages/typescript/ai-elevenlabs/package.json
+++ b/packages/typescript/ai-elevenlabs/package.json
@@ -41,7 +41,7 @@
     "test:types": "tsc"
   },
   "dependencies": {
-    "@11labs/client": "^0.2.0"
+    "@elevenlabs/client": "^1.2.0"
   },
   "peerDependencies": {
     "@tanstack/ai": "workspace:^",

--- a/packages/typescript/ai-elevenlabs/src/realtime/adapter.ts
+++ b/packages/typescript/ai-elevenlabs/src/realtime/adapter.ts
@@ -1,4 +1,5 @@
-import { Conversation } from '@11labs/client'
+import { Conversation } from '@elevenlabs/client'
+import type { Language } from '@elevenlabs/client'
 import type {
   AnyClientTool,
   AudioVisualization,
@@ -16,7 +17,7 @@ import type { ElevenLabsRealtimeOptions } from './types'
 /**
  * Creates an ElevenLabs realtime adapter for client-side use.
  *
- * Wraps the @11labs/client SDK for voice conversations.
+ * Wraps the @elevenlabs/client SDK for voice conversations.
  *
  * @param options - Optional configuration
  * @returns A RealtimeAdapter for use with RealtimeClient
@@ -45,6 +46,56 @@ export function elevenlabsRealtime(
       return createElevenLabsConnection(token, options, clientToolDefs)
     },
   }
+}
+
+type SessionOverrides = NonNullable<
+  Parameters<typeof Conversation.startSession>[0]['overrides']
+>
+
+/**
+ * Merges token instructions with user-provided overrides into
+ * the shape expected by Conversation.startSession.
+ * Option overrides take precedence over token instructions.
+ */
+function buildOverrides(
+  instructions: string | undefined,
+  optionOverrides: ElevenLabsRealtimeOptions['overrides'],
+): SessionOverrides | undefined {
+  const hasInstructions = instructions !== undefined
+  const hasOptions = optionOverrides !== undefined
+
+  if (!hasInstructions && !hasOptions) return undefined
+
+  const overrides: SessionOverrides = {}
+
+  if (hasInstructions || optionOverrides?.agent) {
+    const agentOverrides = optionOverrides?.agent
+
+    overrides.agent = {
+      prompt: {
+        prompt: agentOverrides?.prompt?.prompt ?? instructions,
+      },
+      firstMessage: agentOverrides?.firstMessage,
+      language: agentOverrides?.language as Language | undefined,
+    }
+  }
+
+  if (optionOverrides?.tts) {
+    overrides.tts = {
+      voiceId: optionOverrides.tts.voiceId,
+      speed: optionOverrides.tts.speed,
+      stability: optionOverrides.tts.stability,
+      similarityBoost: optionOverrides.tts.similarityBoost,
+    }
+  }
+
+  if (optionOverrides?.conversation) {
+    overrides.conversation = {
+      textOnly: optionOverrides.conversation.textOnly,
+    }
+  }
+
+  return overrides
 }
 
 /**
@@ -159,6 +210,15 @@ async function createElevenLabsConnection(
   // Only add clientTools if we have any
   if (Object.keys(elevenLabsClientTools).length > 0) {
     sessionOptions.clientTools = elevenLabsClientTools
+  }
+
+  const overrides = buildOverrides(
+    token.config.instructions,
+    _options.overrides,
+  )
+
+  if (overrides) {
+    sessionOptions.overrides = overrides
   }
 
   // Start the conversation session

--- a/packages/typescript/ai-elevenlabs/src/realtime/types.ts
+++ b/packages/typescript/ai-elevenlabs/src/realtime/types.ts
@@ -25,6 +25,25 @@ export interface ElevenLabsRealtimeOptions {
   connectionMode?: 'websocket' | 'webrtc'
   /** Enable debug logging */
   debug?: boolean
+  /** Optional overrides passed directly to Conversation.startSession */
+  overrides?: {
+    agent?: {
+      prompt?: {
+        prompt?: string
+      }
+      firstMessage?: string
+      language?: string
+    }
+    tts?: {
+      voiceId?: string
+      speed?: number
+      stability?: number
+      similarityBoost?: number
+    }
+    conversation?: {
+      textOnly?: boolean
+    }
+  }
 }
 
 /**

--- a/packages/typescript/ai-elevenlabs/tests/realtime-adapter.test.ts
+++ b/packages/typescript/ai-elevenlabs/tests/realtime-adapter.test.ts
@@ -302,7 +302,7 @@ describe('elevenlabsRealtime adapter', () => {
   })
 
   describe('clientTools registration', () => {
-    it('should pass client tools as plain functions to @11labs/client', async () => {
+    it('should pass client tools as plain functions to @elevenlabs/client', async () => {
       const mockTool: AnyClientTool = {
         name: 'get_weather',
         description: 'Get current weather',

--- a/packages/typescript/ai-elevenlabs/tests/realtime-adapter.test.ts
+++ b/packages/typescript/ai-elevenlabs/tests/realtime-adapter.test.ts
@@ -5,7 +5,7 @@ import type { AnyClientTool, RealtimeMessage } from '@tanstack/ai'
 // Capture the session options passed to Conversation.startSession
 let capturedSessionOptions: Record<string, any> = {}
 
-vi.mock('@11labs/client', () => ({
+vi.mock('@elevenlabs/client', () => ({
   Conversation: {
     startSession: vi.fn(async (options: Record<string, any>) => {
       capturedSessionOptions = options
@@ -33,6 +33,7 @@ describe('elevenlabsRealtime adapter', () => {
   const fakeToken = {
     token: 'wss://fake-signed-url',
     expiresAt: Date.now() + 60_000,
+    config: {},
   }
 
   async function createConnection(
@@ -142,6 +143,161 @@ describe('elevenlabsRealtime adapter', () => {
       // One message_complete event (assistant only)
       expect(messageCompleteEvents).toHaveLength(1)
       expect(messageCompleteEvents[0].message.role).toBe('assistant')
+    })
+  })
+
+  describe('overrides', () => {
+    const fakeTokenWithInstructions = {
+      token: 'wss://fake-signed-url',
+      expiresAt: Date.now() + 60_000,
+      config: { instructions: 'Be concise.' },
+    }
+
+    async function createConnectionWithOptions(
+      adapterOptions: import('../src/realtime/types').ElevenLabsRealtimeOptions,
+      token: typeof fakeToken = fakeToken,
+    ): Promise<RealtimeConnection> {
+      const adapter = elevenlabsRealtime(adapterOptions)
+      return adapter.connect(token as any, undefined)
+    }
+
+    it('should not include overrides when no instructions and no overrides option', async () => {
+      await createConnectionWithOptions({}, { ...fakeToken, config: {} } as any)
+
+      expect(capturedSessionOptions.overrides).toBeUndefined()
+    })
+
+    it('should set agent prompt from token instructions', async () => {
+      await createConnectionWithOptions({}, fakeTokenWithInstructions as any)
+
+      expect(capturedSessionOptions.overrides).toMatchObject({
+        agent: {
+          prompt: { prompt: 'Be concise.' },
+        },
+      })
+    })
+
+    it('should set agent prompt from options, ignoring token instructions', async () => {
+      await createConnectionWithOptions(
+        {
+          overrides: {
+            agent: { prompt: { prompt: 'Custom system prompt.' } },
+          },
+        },
+        fakeTokenWithInstructions as any,
+      )
+
+      expect(capturedSessionOptions.overrides?.agent?.prompt?.prompt).toBe(
+        'Custom system prompt.',
+      )
+    })
+
+    it('should fall back to token instructions when options prompt is absent', async () => {
+      await createConnectionWithOptions(
+        {
+          overrides: {
+            agent: { firstMessage: 'Hello!' },
+          },
+        },
+        fakeTokenWithInstructions as any,
+      )
+
+      expect(capturedSessionOptions.overrides?.agent?.prompt?.prompt).toBe(
+        'Be concise.',
+      )
+      expect(capturedSessionOptions.overrides?.agent?.firstMessage).toBe(
+        'Hello!',
+      )
+    })
+
+    it('should set agent firstMessage and language', async () => {
+      await createConnectionWithOptions(
+        {
+          overrides: {
+            agent: {
+              firstMessage: 'Hola!',
+              language: 'es',
+            },
+          },
+        },
+        { ...fakeToken, config: {} } as any,
+      )
+
+      expect(capturedSessionOptions.overrides?.agent?.firstMessage).toBe(
+        'Hola!',
+      )
+      expect(capturedSessionOptions.overrides?.agent?.language).toBe('es')
+    })
+
+    it('should set tts overrides correctly', async () => {
+      await createConnectionWithOptions(
+        {
+          overrides: {
+            tts: {
+              voiceId: 'voice-abc',
+              speed: 1.2,
+              stability: 0.7,
+              similarityBoost: 0.9,
+            },
+          },
+        },
+        { ...fakeToken, config: {} } as any,
+      )
+
+      expect(capturedSessionOptions.overrides?.tts).toMatchObject({
+        voiceId: 'voice-abc',
+        speed: 1.2,
+        stability: 0.7,
+        similarityBoost: 0.9,
+      })
+    })
+
+    it('should set conversation textOnly override', async () => {
+      await createConnectionWithOptions(
+        {
+          overrides: {
+            conversation: { textOnly: true },
+          },
+        },
+        { ...fakeToken, config: {} } as any,
+      )
+
+      expect(capturedSessionOptions.overrides?.conversation?.textOnly).toBe(
+        true,
+      )
+    })
+
+    it('should set all override sections simultaneously', async () => {
+      await createConnectionWithOptions(
+        {
+          overrides: {
+            agent: {
+              prompt: { prompt: 'Full test prompt.' },
+              firstMessage: 'Hi there!',
+              language: 'fr',
+            },
+            tts: {
+              voiceId: 'voice-xyz',
+              speed: 0.9,
+            },
+            conversation: { textOnly: false },
+          },
+        },
+        { ...fakeToken, config: {} } as any,
+      )
+
+      expect(capturedSessionOptions.overrides).toMatchObject({
+        agent: {
+          prompt: { prompt: 'Full test prompt.' },
+          firstMessage: 'Hi there!',
+          language: 'fr',
+        },
+        tts: {
+          voiceId: 'voice-xyz',
+          speed: 0.9,
+        },
+        conversation: { textOnly: false },
+      })
     })
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -994,9 +994,9 @@ importers:
 
   packages/typescript/ai-elevenlabs:
     dependencies:
-      '@11labs/client':
-        specifier: ^0.2.0
-        version: 0.2.0(@types/dom-mediacapture-record@1.0.22)
+      '@elevenlabs/client':
+        specifier: ^1.2.0
+        version: 1.2.0(@types/dom-mediacapture-record@1.0.22)
     devDependencies:
       '@tanstack/ai':
         specifier: workspace:*
@@ -1529,7 +1529,7 @@ importers:
     dependencies:
       '@copilotkit/aimock':
         specifier: latest
-        version: 1.9.0
+        version: 1.13.0
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -1741,10 +1741,6 @@ importers:
         version: 7.2.7(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
-
-  '@11labs/client@0.2.0':
-    resolution: {integrity: sha512-GBplAV4WDbcoThsIzdSDPN3xbcitK0ZZ4iJfJZKfltqvgvS6Uw8GZxHwVgiPwnQoA3uosYyY3L9TuPwmel18xQ==}
-    deprecated: This package is no longer maintained. Please use @elevenlabs/client for the latest version
 
   '@acemir/cssom@0.9.29':
     resolution: {integrity: sha512-G90x0VW+9nW4dFajtjCoT+NM0scAfH9Mb08IcjgFHYbfiL/lU04dTF9JuVOi3/OH+DJCQdcIseSXkdCB9Ky6JA==}
@@ -2044,8 +2040,8 @@ packages:
   '@cloudflare/workers-types@4.20260317.1':
     resolution: {integrity: sha512-+G4eVwyCpm8Au1ex8vQBCuA9wnwqetz4tPNRoB/53qvktERWBRMQnrtvC1k584yRE3emMThtuY0gWshvSJ++PQ==}
 
-  '@copilotkit/aimock@1.9.0':
-    resolution: {integrity: sha512-tUnt0747SOs5PNuYWLqcVsv56XlMDUd8DEpZJTw1Ya/xJ7McZ1U9U6BUJDDEDEjBGbaKGxGt5+W73JieT+2XYw==}
+  '@copilotkit/aimock@1.13.0':
+    resolution: {integrity: sha512-wcNQdicxSuaHf4MLtoC9bouKeYGcV9aBoIVJbeLtrBUhqz5LUAmo/U/S1WT69kyAEuM0uO1XyD3Jz+V+H9jsUw==}
     engines: {node: '>=20.15.0'}
     hasBin: true
 
@@ -2099,6 +2095,12 @@ packages:
   '@deno/shim-deno@0.19.2':
     resolution: {integrity: sha512-q3VTHl44ad8T2Tw2SpeAvghdGOjlnLPDNO2cpOxwMrBE/PVas6geWpbpIgrM+czOCH0yejp0yi8OaTuB+NU40Q==}
 
+  '@elevenlabs/client@1.2.0':
+    resolution: {integrity: sha512-eZJUylgI5oUMPvjMdmYbaC/Nn70Mu7yuxN0YG1L0x5MDBRw+2YD+yRDNNTDg6Axz3RYz2ayKrTqd8HlHytHDcQ==}
+
+  '@elevenlabs/types@0.9.1':
+    resolution: {integrity: sha512-lkWAMaFJLsGNWcblryBRHbtozMh7wHy0YsqURLwQwjhpvycuFN5qUa94CZtVU01jFwrfr5h1ca24+nYEkKf0Ew==}
+
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
 
@@ -2116,12 +2118,6 @@ packages:
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/aix-ppc64@0.27.2':
-    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -2150,12 +2146,6 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.27.2':
-    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
@@ -2176,12 +2166,6 @@ packages:
 
   '@esbuild/android-arm@0.25.12':
     resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.2':
-    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -2210,12 +2194,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.27.2':
-    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
@@ -2236,12 +2214,6 @@ packages:
 
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -2270,12 +2242,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.2':
-    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
   '@esbuild/darwin-x64@0.27.3':
     resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
     engines: {node: '>=18'}
@@ -2296,12 +2262,6 @@ packages:
 
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -2330,12 +2290,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.2':
-    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
   '@esbuild/freebsd-x64@0.27.3':
     resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
     engines: {node: '>=18'}
@@ -2356,12 +2310,6 @@ packages:
 
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm64@0.27.2':
-    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -2390,12 +2338,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.2':
-    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
   '@esbuild/linux-arm@0.27.3':
     resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
     engines: {node: '>=18'}
@@ -2416,12 +2358,6 @@ packages:
 
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.2':
-    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -2450,12 +2386,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.2':
-    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
   '@esbuild/linux-loong64@0.27.3':
     resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
     engines: {node: '>=18'}
@@ -2476,12 +2406,6 @@ packages:
 
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.2':
-    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -2510,12 +2434,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.2':
-    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
   '@esbuild/linux-ppc64@0.27.3':
     resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
     engines: {node: '>=18'}
@@ -2536,12 +2454,6 @@ packages:
 
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.2':
-    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -2570,12 +2482,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.2':
-    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
     engines: {node: '>=18'}
@@ -2600,12 +2506,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.2':
-    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.27.3':
     resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     engines: {node: '>=18'}
@@ -2620,12 +2520,6 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2654,12 +2548,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.2':
-    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.27.3':
     resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
     engines: {node: '>=18'}
@@ -2674,12 +2562,6 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2708,12 +2590,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.2':
-    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openbsd-x64@0.27.3':
     resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
     engines: {node: '>=18'}
@@ -2728,12 +2604,6 @@ packages:
 
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -2762,12 +2632,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.2':
-    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.27.3':
     resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
     engines: {node: '>=18'}
@@ -2788,12 +2652,6 @@ packages:
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.27.2':
-    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2822,12 +2680,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.2':
-    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.3':
     resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
     engines: {node: '>=18'}
@@ -2848,12 +2700,6 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.2':
-    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -6081,6 +5927,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -6844,11 +6691,6 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.27.2:
-    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -10875,12 +10717,6 @@ packages:
 
 snapshots:
 
-  '@11labs/client@0.2.0(@types/dom-mediacapture-record@1.0.22)':
-    dependencies:
-      livekit-client: 2.17.2(@types/dom-mediacapture-record@1.0.22)
-    transitivePeerDependencies:
-      - '@types/dom-mediacapture-record'
-
   '@acemir/cssom@0.9.29': {}
 
   '@anthropic-ai/sdk@0.71.2(zod@4.2.1)':
@@ -11307,7 +11143,7 @@ snapshots:
 
   '@cloudflare/workers-types@4.20260317.1': {}
 
-  '@copilotkit/aimock@1.9.0': {}
+  '@copilotkit/aimock@1.13.0': {}
 
   '@crazydos/vue-markdown@1.1.4(vue@3.5.25(typescript@5.9.3))':
     dependencies:
@@ -11356,6 +11192,15 @@ snapshots:
       '@deno/shim-deno-test': 0.5.0
       which: 4.0.0
 
+  '@elevenlabs/client@1.2.0(@types/dom-mediacapture-record@1.0.22)':
+    dependencies:
+      '@elevenlabs/types': 0.9.1
+      livekit-client: 2.17.2(@types/dom-mediacapture-record@1.0.22)
+    transitivePeerDependencies:
+      - '@types/dom-mediacapture-record'
+
+  '@elevenlabs/types@0.9.1': {}
+
   '@emnapi/core@1.7.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -11375,9 +11220,6 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.2':
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
@@ -11388,9 +11230,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.2':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
@@ -11405,9 +11244,6 @@ snapshots:
   '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.27.2':
-    optional: true
-
   '@esbuild/android-arm@0.27.3':
     optional: true
 
@@ -11418,9 +11254,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.25.12':
-    optional: true
-
-  '@esbuild/android-x64@0.27.2':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
@@ -11435,9 +11268,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.2':
-    optional: true
-
   '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
@@ -11448,9 +11278,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.2':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
@@ -11465,9 +11292,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.2':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
@@ -11478,9 +11302,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
@@ -11495,9 +11316,6 @@ snapshots:
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.2':
-    optional: true
-
   '@esbuild/linux-arm64@0.27.3':
     optional: true
 
@@ -11508,9 +11326,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.2':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
@@ -11525,9 +11340,6 @@ snapshots:
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.2':
-    optional: true
-
   '@esbuild/linux-ia32@0.27.3':
     optional: true
 
@@ -11538,9 +11350,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.2':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
@@ -11555,9 +11364,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.2':
-    optional: true
-
   '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
@@ -11568,9 +11374,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
@@ -11585,9 +11388,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.2':
-    optional: true
-
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
@@ -11598,9 +11398,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.2':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
@@ -11615,9 +11412,6 @@ snapshots:
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.27.2':
-    optional: true
-
   '@esbuild/linux-x64@0.27.3':
     optional: true
 
@@ -11625,9 +11419,6 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
@@ -11642,9 +11433,6 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.2':
-    optional: true
-
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
@@ -11652,9 +11440,6 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
@@ -11669,9 +11454,6 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.2':
-    optional: true
-
   '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
@@ -11679,9 +11461,6 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.3':
@@ -11696,9 +11475,6 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.2':
-    optional: true
-
   '@esbuild/sunos-x64@0.27.3':
     optional: true
 
@@ -11709,9 +11485,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.2':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
@@ -11726,9 +11499,6 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.2':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
@@ -11739,9 +11509,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.2':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
@@ -16558,35 +16325,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
-  esbuild@0.27.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.2
-      '@esbuild/android-arm': 0.27.2
-      '@esbuild/android-arm64': 0.27.2
-      '@esbuild/android-x64': 0.27.2
-      '@esbuild/darwin-arm64': 0.27.2
-      '@esbuild/darwin-x64': 0.27.2
-      '@esbuild/freebsd-arm64': 0.27.2
-      '@esbuild/freebsd-x64': 0.27.2
-      '@esbuild/linux-arm': 0.27.2
-      '@esbuild/linux-arm64': 0.27.2
-      '@esbuild/linux-ia32': 0.27.2
-      '@esbuild/linux-loong64': 0.27.2
-      '@esbuild/linux-mips64el': 0.27.2
-      '@esbuild/linux-ppc64': 0.27.2
-      '@esbuild/linux-riscv64': 0.27.2
-      '@esbuild/linux-s390x': 0.27.2
-      '@esbuild/linux-x64': 0.27.2
-      '@esbuild/netbsd-arm64': 0.27.2
-      '@esbuild/netbsd-x64': 0.27.2
-      '@esbuild/openbsd-arm64': 0.27.2
-      '@esbuild/openbsd-x64': 0.27.2
-      '@esbuild/openharmony-arm64': 0.27.2
-      '@esbuild/sunos-x64': 0.27.2
-      '@esbuild/win32-arm64': 0.27.2
-      '@esbuild/win32-ia32': 0.27.2
-      '@esbuild/win32-x64': 0.27.2
-
   esbuild@0.27.3:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.3
@@ -17868,7 +17606,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.18.3
+      ws: 8.19.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -20646,7 +20384,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3


### PR DESCRIPTION
## 🎯 Changes

**Migrated from `@11labs/client` to `@elevenlabs/client`** - the current official SDK from ElevenLabs. The old `@11labs/client` package is deprecated and no longer maintained.

Added an `overrides` option to `elevenlabsRealtime()` so callers can customize the ElevenLabs session at connection time without changing server-side token logic.

- **`overrides.agent`** — set system prompt (`prompt.prompt`), first message, and language
- **`overrides.tts`** — set voice ID, speed, stability, and similarity boost
- **`overrides.conversation`** — enable text-only mode

Token-level instructions (`token.config.instructions`) are used as a fallback for the agent prompt. Client-side `overrides.agent.prompt.prompt` takes precedence when both are set.

Also adds unit tests covering all override combinations and documents the feature in the package README.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session overrides to customize agent prompts, voice, language, TTS, and conversation options at server and client levels.

* **Documentation**
  * Added session overrides docs with precedence rules when both server and client overrides are provided.

* **Tests**
  * Added tests covering override mapping, precedence, and passthrough of agent, TTS, and conversation settings.

* **Chores**
  * Added changeset for a minor version bump and updated the ElevenLabs client dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->