### PR TITLE
fix(ai-gemini): remove redundant text part from functionResponse messages

### DIFF
--- a/.changeset/fix-gemini-function-response.md
+++ b/.changeset/fix-gemini-function-response.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-gemini': patch
+---
+
+Fix 400 error when sending tool results to Gemini API by removing redundant text part from functionResponse messages. Newer models (gemini-3.1-flash-lite, gemma-4) reject messages that mix text and functionResponse parts.

--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -562,7 +562,7 @@ export class GeminiTextAdapter<
         for (const contentPart of msg.content) {
           parts.push(this.convertContentPartToGemini(contentPart))
         }
-      } else if (msg.content) {
+      } else if (msg.content && msg.role !== 'tool') {
         parts.push({ text: msg.content })
       }
 

--- a/packages/typescript/ai-gemini/tests/gemini-adapter.test.ts
+++ b/packages/typescript/ai-gemini/tests/gemini-adapter.test.ts
@@ -394,12 +394,17 @@ describe('GeminiAdapter through AI', () => {
     expect(payload.contents[1].role).toBe('model')
     expect(payload.contents[2].role).toBe('user')
 
-    // Last user message should contain both functionResponse and text
+    // Last user message should contain functionResponse (no redundant text part
+    // for the tool result) and the follow-up user text
     const lastParts = payload.contents[2].parts
     const hasFunctionResponse = lastParts.some((p: any) => p.functionResponse)
-    const hasText = lastParts.some((p: any) => p.text === 'What about Paris?')
+    const hasFollowUp = lastParts.some((p: any) => p.text === 'What about Paris?')
+    const hasToolResultText = lastParts.some(
+      (p: any) => p.text === '{"temp":72}',
+    )
     expect(hasFunctionResponse).toBe(true)
-    expect(hasText).toBe(true)
+    expect(hasFollowUp).toBe(true)
+    expect(hasToolResultText).toBe(false)
   })
 
   it('handles full multi-turn with duplicate tool results and empty model message', async () => {
@@ -487,15 +492,16 @@ describe('GeminiAdapter through AI', () => {
     expect(payload.contents).toHaveLength(3)
 
     // Last user should have deduplicated functionResponses + follow-up text
+    // (no redundant text parts for tool results)
     const lastParts = payload.contents[2].parts
     const functionResponses = lastParts.filter((p: any) => p.functionResponse)
     // 2 unique tool call IDs, not 3 (duplicate removed)
     expect(functionResponses).toHaveLength(2)
 
-    const textParts = lastParts.filter(
-      (p: any) => p.text === "what's a good electric guitar?",
-    )
+    const textParts = lastParts.filter((p: any) => p.text)
+    // Only the follow-up user message text, no tool result text parts
     expect(textParts).toHaveLength(1)
+    expect(textParts[0].text).toBe("what's a good electric guitar?")
   })
 
   it('preserves thoughtSignature in functionCall parts when sending history back to Gemini', async () => {

--- a/packages/typescript/ai-gemini/tests/gemini-adapter.test.ts
+++ b/packages/typescript/ai-gemini/tests/gemini-adapter.test.ts
@@ -398,7 +398,9 @@ describe('GeminiAdapter through AI', () => {
     // for the tool result) and the follow-up user text
     const lastParts = payload.contents[2].parts
     const hasFunctionResponse = lastParts.some((p: any) => p.functionResponse)
-    const hasFollowUp = lastParts.some((p: any) => p.text === 'What about Paris?')
+    const hasFollowUp = lastParts.some(
+      (p: any) => p.text === 'What about Paris?',
+    )
     const hasToolResultText = lastParts.some(
       (p: any) => p.text === '{"temp":72}',
     )


### PR DESCRIPTION
## Summary
- Fixes #436 — tool result messages were emitting both a `{ text }` part and a `{ functionResponse }` part in the same Gemini API message
- Newer models (gemini-3.1-flash-lite, gemma-4) reject this combination with a 400 error
- The fix skips emitting the redundant text part for `role: "tool"` messages since the content is already in the `functionResponse`

## Test plan
- [x] Updated existing tests to assert tool-result text parts are no longer emitted
- [x] All 65 ai-gemini tests pass
- [x] Full test suite (29 projects) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a 400 error when sending tool results to newer Gemini models by changing how tool response messages are formatted. Tool-result content is no longer included as redundant text parts, preventing API rejections and improving reliability when delivering tool outputs to Gemini.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->