### PR TITLE
Fix component name in docs

### DIFF
--- a/docs/getting-started/devtools.md
+++ b/docs/getting-started/devtools.md
@@ -31,7 +31,7 @@ npm install -D @tanstack/preact-ai-devtools @tanstack/preact-devtools
 
 ## Usage
 
-Import and include the Devtools component in your application:
+Import and include the TanStackDevtools component in your application:
 
 ```tsx
 import { TanStackDevtools } from '@tanstack/react-devtools'


### PR DESCRIPTION
## 🎯 Changes

A subtle change to correct the suggested component to import.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified wording in the getting started guide: renamed the “Devtools component” reference to “TanStackDevtools component” to align terminology in the devtools setup documentation while keeping existing usage examples and configuration guidance unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->