### PR TITLE
Add devtools usage in NextJS

### DIFF
--- a/docs/getting-started/devtools.md
+++ b/docs/getting-started/devtools.md
@@ -74,6 +74,3 @@ export async function register() {
          await bus.start();
      }
 }
-
-This sets globalThis.__TANSTACK_EVENT_TARGET__ so the server-side devtoolsMiddleware (which runs automatically inside every chat() call) can emit tool call events to the bus, which then forwards them to the devtools panel.
-```

--- a/docs/getting-started/devtools.md
+++ b/docs/getting-started/devtools.md
@@ -54,3 +54,26 @@ const App = () => {
   )
 }
 ```
+
+## Using with Next.js (or without a Vite plugin)
+
+`connectToServerBus: true` relies on a WebSocket/SSE server on port 4206 that is normally started by `@tanstack/devtools-vite`. If you're using Next.js (or any non-Vite bundler), you need to start `ServerEventBus` manually at server boot.
+
+In Next.js, do this in `instrumentation.ts`:
+
+```ts
+export async function register() {
+     if (
+         process.env["NEXT_RUNTIME"] === "nodejs" &&
+         process.env.NODE_ENV === "development"
+     ) {
+         const { ServerEventBus } = await import(
+             "@tanstack/devtools-event-bus/server"
+         );
+         const bus = new ServerEventBus();
+         await bus.start();
+     }
+}
+
+This sets globalThis.__TANSTACK_EVENT_TARGET__ so the server-side devtoolsMiddleware (which runs automatically inside every chat() call) can emit tool call events to the bus, which then forwards them to the devtools panel.
+```

--- a/docs/getting-started/devtools.md
+++ b/docs/getting-started/devtools.md
@@ -74,3 +74,6 @@ export async function register() {
          await bus.start();
      }
 }
+```
+
+This sets globalThis.__TANSTACK_EVENT_TARGET__ so the server-side devtoolsMiddleware (which runs automatically inside every chat() call) can emit tool call events to the bus, which then forwards them to the devtools panel.


### PR DESCRIPTION
## 🎯 Changes

This adds a section about how to run the SSE bus in NextJS

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using the devtools with Next.js and other non‑Vite bundlers, including instructions for enabling a server-side event bus during development.
  * Included a conditional example showing how to initialize the server-side event bus only on the Node/dev server.
  * Minor formatting fix (trailing newline).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->