### PR TITLE
fix(ai-gemini): read/write thoughtSignature at Part level for Gemini 3.x

### DIFF
--- a/.changeset/fix-gemini-thought-signature-part-level.md
+++ b/.changeset/fix-gemini-thought-signature-part-level.md
@@ -1,12 +1,26 @@
 ---
 '@tanstack/ai-gemini': patch
+'@tanstack/ai': minor
+'@tanstack/ai-event-client': minor
 ---
 
-fix(ai-gemini): read/write thoughtSignature at Part level
+fix(ai-gemini): read/write thoughtSignature at Part level + thread typed metadata through tool-call lifecycle
 
-Gemini emits `thoughtSignature` as a Part-level sibling of `functionCall` (per the `@google/genai` `Part` type definition), not nested inside `functionCall`. The `FunctionCall` type has never had a `thoughtSignature` property. The adapter was reading from `functionCall.thoughtSignature` (which doesn't exist in the SDK types) and writing it back nested inside `functionCall`, causing Gemini 3.x to reject subsequent tool-call turns with `400 INVALID_ARGUMENT: "Function call is missing a thought_signature"`.
+Two fixes shipped together because the adapter fix is only effective once the framework also preserves provider metadata across the tool-call round-trip.
 
-This fix:
+**Adapter (Gemini):** Gemini emits `thoughtSignature` as a Part-level sibling of `functionCall` (per the `@google/genai` `Part` type definition), not nested inside `functionCall`. The `FunctionCall` type has never had a `thoughtSignature` property. The adapter was reading from `functionCall.thoughtSignature` (does not exist in SDK types) and writing it back nested inside `functionCall`, causing Gemini 3.x to reject subsequent tool-call turns with `400 INVALID_ARGUMENT: "Function call is missing a thought_signature"`.
 
-- **Read side:** reads `part.thoughtSignature` directly, using the SDK's typed `Part` interface
-- **Write side:** emits `thoughtSignature` as a Part-level sibling of `functionCall`, using the SDK's typed `Part` interface
+- **Read side:** reads `part.thoughtSignature` directly using the SDK's typed `Part` interface
+- **Write side:** emits `thoughtSignature` as a Part-level sibling of `functionCall`
+
+**Framework (typed tool-call metadata):**
+
+- `ToolCall.providerMetadata: Record<string, unknown>` is now `ToolCall<TMetadata>.metadata?: TMetadata`, mirroring the existing typed-metadata pattern on content parts (`ImagePart<TMetadata>`, `AudioPart<TMetadata>`, etc.).
+- `ToolCallPart` gains a typed `metadata?: TMetadata` field (also generic).
+- `ToolCallStartEvent.providerMetadata` becomes `metadata` (kept as `Record<string, unknown>` because the AGUIEvent discriminated union does not survive a generic on the event type; adapters cast to their typed shape when emitting).
+- `BaseTextAdapter` and `TextAdapter` gain a sixth generic `TToolCallMetadata` (default `unknown`), exposed via `~types.toolCallMetadata` for inference at call sites.
+- `InternalToolCallState` gains a `metadata?: Record<string, unknown>` field captured at `TOOL_CALL_START` and threaded through `updateToolCallPart`, `buildAssistantMessages`, `modelMessageToUIMessage`, and `completeToolCall`, fixing a previously-silent drop of provider metadata across the client-side UIMessage pipeline (closes the gap surfaced in #403/#404).
+
+**Gemini concrete impl:** new `GeminiToolCallMetadata { thoughtSignature?: string }` exported from `@tanstack/ai-gemini`. The adapter declares its `TToolCallMetadata` as this type, so consumers see `toolCall.metadata?.thoughtSignature` typed end-to-end.
+
+**Breaking:** consumers reading `toolCall.providerMetadata` or `toolCallStartEvent.providerMetadata` should rename to `metadata`.

--- a/.changeset/fix-gemini-thought-signature-part-level.md
+++ b/.changeset/fix-gemini-thought-signature-part-level.md
@@ -2,11 +2,11 @@
 '@tanstack/ai-gemini': patch
 ---
 
-fix(ai-gemini): read/write thoughtSignature at Part level for Gemini 3.x
+fix(ai-gemini): read/write thoughtSignature at Part level
 
-Gemini 3.x models emit `thoughtSignature` as a Part-level sibling of `functionCall` (per the `@google/genai` `Part` type definition), not nested inside `functionCall`. The adapter was reading from `functionCall.thoughtSignature` (which doesn't exist in the SDK types) and writing it back nested inside `functionCall`, causing the Gemini API to reject subsequent tool-call turns with `400 INVALID_ARGUMENT: "Function call is missing a thought_signature"`.
+Gemini emits `thoughtSignature` as a Part-level sibling of `functionCall` (per the `@google/genai` `Part` type definition), not nested inside `functionCall`. The `FunctionCall` type has never had a `thoughtSignature` property. The adapter was reading from `functionCall.thoughtSignature` (which doesn't exist in the SDK types) and writing it back nested inside `functionCall`, causing Gemini 3.x to reject subsequent tool-call turns with `400 INVALID_ARGUMENT: "Function call is missing a thought_signature"`.
 
 This fix:
 
-- **Read side:** reads `part.thoughtSignature` first, falls back to `functionCall.thoughtSignature` for older Gemini 2.x models
-- **Write side:** emits `thoughtSignature` as a Part-level sibling of `functionCall` instead of nesting it inside
+- **Read side:** reads `part.thoughtSignature` directly, using the SDK's typed `Part` interface
+- **Write side:** emits `thoughtSignature` as a Part-level sibling of `functionCall`, using the SDK's typed `Part` interface

--- a/.changeset/fix-gemini-thought-signature-part-level.md
+++ b/.changeset/fix-gemini-thought-signature-part-level.md
@@ -1,0 +1,11 @@
+---
+'@tanstack/ai-gemini': patch
+---
+
+fix(ai-gemini): read/write thoughtSignature at Part level for Gemini 3.x
+
+Gemini 3.x models emit `thoughtSignature` as a Part-level sibling of `functionCall` (per the `@google/genai` `Part` type definition), not nested inside `functionCall`. The adapter was reading from `functionCall.thoughtSignature` (which doesn't exist in the SDK types) and writing it back nested inside `functionCall`, causing the Gemini API to reject subsequent tool-call turns with `400 INVALID_ARGUMENT: "Function call is missing a thought_signature"`.
+
+This fix:
+- **Read side:** reads `part.thoughtSignature` first, falls back to `functionCall.thoughtSignature` for older Gemini 2.x models
+- **Write side:** emits `thoughtSignature` as a Part-level sibling of `functionCall` instead of nesting it inside

--- a/.changeset/fix-gemini-thought-signature-part-level.md
+++ b/.changeset/fix-gemini-thought-signature-part-level.md
@@ -7,5 +7,6 @@ fix(ai-gemini): read/write thoughtSignature at Part level for Gemini 3.x
 Gemini 3.x models emit `thoughtSignature` as a Part-level sibling of `functionCall` (per the `@google/genai` `Part` type definition), not nested inside `functionCall`. The adapter was reading from `functionCall.thoughtSignature` (which doesn't exist in the SDK types) and writing it back nested inside `functionCall`, causing the Gemini API to reject subsequent tool-call turns with `400 INVALID_ARGUMENT: "Function call is missing a thought_signature"`.
 
 This fix:
+
 - **Read side:** reads `part.thoughtSignature` first, falls back to `functionCall.thoughtSignature` for older Gemini 2.x models
 - **Write side:** emits `thoughtSignature` as a Part-level sibling of `functionCall` instead of nesting it inside

--- a/packages/typescript/ai-event-client/src/index.ts
+++ b/packages/typescript/ai-event-client/src/index.ts
@@ -86,15 +86,17 @@ export type MessagePart =
   | ToolResultPart
   | ThinkingPart
 
-export interface ToolCall {
+export interface ToolCall<TMetadata = unknown> {
   id: string
   type: 'function'
   function: {
     name: string
     arguments: string
   }
-  /** Provider-specific metadata to carry through the tool call lifecycle */
-  providerMetadata?: Record<string, unknown>
+  /** Provider-specific metadata to carry through the tool call lifecycle.
+   * Typed per-adapter via `TToolCallMetadata` (e.g. Gemini's
+   * `{ thoughtSignature?: string }`). */
+  metadata?: TMetadata
 }
 
 /**

--- a/packages/typescript/ai-event-client/src/index.ts
+++ b/packages/typescript/ai-event-client/src/index.ts
@@ -49,7 +49,7 @@ export interface DocumentPart {
   metadata?: unknown
 }
 
-export interface ToolCallPart {
+export interface ToolCallPart<TMetadata = unknown> {
   type: 'tool-call'
   id: string
   name: string
@@ -61,6 +61,9 @@ export interface ToolCallPart {
     approved?: boolean
   }
   output?: any
+  /** Provider-specific metadata that round-trips with the tool call.
+   * Mirrors `ToolCallPart.metadata` in `@tanstack/ai`. */
+  metadata?: TMetadata
 }
 
 export interface ToolResultPart {

--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -33,7 +33,10 @@ import type {
   TextOptions,
 } from '@tanstack/ai'
 import type { ExternalTextProviderOptions } from '../text/text-provider-options'
-import type { GeminiMessageMetadataByModality } from '../message-types'
+import type {
+  GeminiMessageMetadataByModality,
+  GeminiToolCallMetadata,
+} from '../message-types'
 import type { GeminiClientConfig } from '../utils'
 
 /** Cast an event object to StreamChunk. Adapters construct events with string
@@ -104,7 +107,8 @@ export class GeminiTextAdapter<
   TProviderOptions,
   TInputModalities,
   GeminiMessageMetadataByModality,
-  TToolCapabilities
+  TToolCapabilities,
+  GeminiToolCallMetadata
 > {
   readonly kind = 'text' as const
   readonly name = 'gemini' as const
@@ -435,9 +439,9 @@ export class GeminiTextAdapter<
                 timestamp,
                 index: toolCallData.index,
                 ...(toolCallData.thoughtSignature && {
-                  providerMetadata: {
+                  metadata: {
                     thoughtSignature: toolCallData.thoughtSignature,
-                  },
+                  } satisfies GeminiToolCallMetadata,
                 }),
               })
             }
@@ -714,8 +718,9 @@ export class GeminiTextAdapter<
             >
           }
 
-          const thoughtSignature = toolCall.providerMetadata
-            ?.thoughtSignature as string | undefined
+          const thoughtSignature = (
+            toolCall.metadata as GeminiToolCallMetadata | undefined
+          )?.thoughtSignature
           // Gemini requires thoughtSignature at the Part level (sibling of
           // functionCall), not nested inside functionCall. Nesting it causes
           // the API to reject the next turn with

--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -289,6 +289,15 @@ export class GeminiTextAdapter<
               `${functionCall.name}_${Date.now()}_${nextToolIndex}`
             const functionArgs = functionCall.args || {}
 
+            // Gemini 3.x emits thoughtSignature as a Part-level sibling of
+            // functionCall (see @google/genai Part type), not nested inside
+            // functionCall. Read from the Part first, fall back to
+            // functionCall for older Gemini 2.x models.
+            const partThoughtSignature =
+              (part as any).thoughtSignature ||
+              (functionCall as any).thoughtSignature ||
+              undefined
+
             let toolCallData = toolCallMap.get(toolCallId)
             if (!toolCallData) {
               toolCallData = {
@@ -299,11 +308,13 @@ export class GeminiTextAdapter<
                     : JSON.stringify(functionArgs),
                 index: nextToolIndex++,
                 started: false,
-                thoughtSignature:
-                  (functionCall as any).thoughtSignature || undefined,
+                thoughtSignature: partThoughtSignature,
               }
               toolCallMap.set(toolCallId, toolCallData)
             } else {
+              if (!toolCallData.thoughtSignature && partThoughtSignature) {
+                toolCallData.thoughtSignature = partThoughtSignature
+              }
               try {
                 const existingArgs = JSON.parse(toolCallData.args)
                 const newArgs =
@@ -585,14 +596,18 @@ export class GeminiTextAdapter<
 
           const thoughtSignature = toolCall.providerMetadata
             ?.thoughtSignature as string | undefined
+          // Gemini 3.x requires thoughtSignature at the Part level (sibling
+          // of functionCall), not nested inside functionCall. Nesting it
+          // causes the API to reject the next turn with
+          // "Function call is missing a thought_signature".
           parts.push({
             functionCall: {
               id: toolCall.id,
               name: toolCall.function.name,
               args: parsedArgs,
-              ...(thoughtSignature && { thoughtSignature }),
-            } as any,
-          })
+            },
+            ...(thoughtSignature && { thoughtSignature }),
+          } as Part)
         }
       }
 

--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -385,14 +385,10 @@ export class GeminiTextAdapter<
               `${functionCall.name}_${Date.now()}_${nextToolIndex}`
             const functionArgs = functionCall.args || {}
 
-            // Gemini 3.x emits thoughtSignature as a Part-level sibling of
-            // functionCall (see @google/genai Part type), not nested inside
-            // functionCall. Read from the Part first, fall back to
-            // functionCall for older Gemini 2.x models.
-            const partThoughtSignature =
-              (part as any).thoughtSignature ||
-              (functionCall as any).thoughtSignature ||
-              undefined
+            // Gemini emits thoughtSignature as a Part-level sibling of
+            // functionCall (per @google/genai Part type), not nested inside
+            // functionCall itself.
+            const partThoughtSignature = part.thoughtSignature || undefined
 
             let toolCallData = toolCallMap.get(toolCallId)
             if (!toolCallData) {
@@ -720,18 +716,21 @@ export class GeminiTextAdapter<
 
           const thoughtSignature = toolCall.providerMetadata
             ?.thoughtSignature as string | undefined
-          // Gemini 3.x requires thoughtSignature at the Part level (sibling
-          // of functionCall), not nested inside functionCall. Nesting it
-          // causes the API to reject the next turn with
+          // Gemini requires thoughtSignature at the Part level (sibling of
+          // functionCall), not nested inside functionCall. Nesting it causes
+          // the API to reject the next turn with
           // "Function call is missing a thought_signature".
-          parts.push({
+          const part: Part = {
             functionCall: {
               id: toolCall.id,
               name: toolCall.function.name,
               args: parsedArgs,
             },
-            ...(thoughtSignature && { thoughtSignature }),
-          } as Part)
+          }
+          if (thoughtSignature) {
+            part.thoughtSignature = thoughtSignature
+          }
+          parts.push(part)
         }
       }
 

--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -385,6 +385,15 @@ export class GeminiTextAdapter<
               `${functionCall.name}_${Date.now()}_${nextToolIndex}`
             const functionArgs = functionCall.args || {}
 
+            // Gemini 3.x emits thoughtSignature as a Part-level sibling of
+            // functionCall (see @google/genai Part type), not nested inside
+            // functionCall. Read from the Part first, fall back to
+            // functionCall for older Gemini 2.x models.
+            const partThoughtSignature =
+              (part as any).thoughtSignature ||
+              (functionCall as any).thoughtSignature ||
+              undefined
+
             let toolCallData = toolCallMap.get(toolCallId)
             if (!toolCallData) {
               toolCallData = {
@@ -395,11 +404,13 @@ export class GeminiTextAdapter<
                     : JSON.stringify(functionArgs),
                 index: nextToolIndex++,
                 started: false,
-                thoughtSignature:
-                  (functionCall as any).thoughtSignature || undefined,
+                thoughtSignature: partThoughtSignature,
               }
               toolCallMap.set(toolCallId, toolCallData)
             } else {
+              if (!toolCallData.thoughtSignature && partThoughtSignature) {
+                toolCallData.thoughtSignature = partThoughtSignature
+              }
               try {
                 const existingArgs = JSON.parse(toolCallData.args)
                 const newArgs =
@@ -709,14 +720,18 @@ export class GeminiTextAdapter<
 
           const thoughtSignature = toolCall.providerMetadata
             ?.thoughtSignature as string | undefined
+          // Gemini 3.x requires thoughtSignature at the Part level (sibling
+          // of functionCall), not nested inside functionCall. Nesting it
+          // causes the API to reject the next turn with
+          // "Function call is missing a thought_signature".
           parts.push({
             functionCall: {
               id: toolCall.id,
               name: toolCall.function.name,
               args: parsedArgs,
-              ...(thoughtSignature && { thoughtSignature }),
-            } as any,
-          })
+            },
+            ...(thoughtSignature && { thoughtSignature }),
+          } as Part)
         }
       }
 

--- a/packages/typescript/ai-gemini/src/message-types.ts
+++ b/packages/typescript/ai-gemini/src/message-types.ts
@@ -130,3 +130,17 @@ export interface GeminiMessageMetadataByModality {
   video: GeminiVideoMetadata
   document: GeminiDocumentMetadata
 }
+
+/**
+ * Provider-specific metadata that round-trips with each Gemini tool call.
+ *
+ * `thoughtSignature` is emitted by Gemini 3.x (and 2.5 thinking) models on
+ * the Part containing the `functionCall`. The same signature must be echoed
+ * back at the Part level on the next turn or the API rejects the request
+ * with `400 INVALID_ARGUMENT: "Function call is missing a thought_signature"`.
+ *
+ * @see https://ai.google.dev/gemini-api/docs/thinking
+ */
+export interface GeminiToolCallMetadata {
+  thoughtSignature?: string
+}

--- a/packages/typescript/ai-gemini/tests/gemini-adapter.test.ts
+++ b/packages/typescript/ai-gemini/tests/gemini-adapter.test.ts
@@ -502,10 +502,11 @@ describe('GeminiAdapter through AI', () => {
     expect(textParts[0].text).toBe("what's a good electric guitar?")
   })
 
-  it('preserves thoughtSignature in functionCall parts when sending history back to Gemini', async () => {
+  it('reads Part-level thoughtSignature from Gemini 3.x streaming response', async () => {
     const thoughtSig = 'base64-encoded-thought-signature-xyz'
 
-    // First stream: model returns a function call with a thoughtSignature (thinking model)
+    // Gemini 3.x emits thoughtSignature at the Part level, as a sibling of
+    // functionCall (per @google/genai Part type), not nested inside functionCall.
     const firstStream = [
       {
         candidates: [
@@ -513,11 +514,11 @@ describe('GeminiAdapter through AI', () => {
             content: {
               parts: [
                 {
+                  thoughtSignature: thoughtSig,
                   functionCall: {
                     id: 'fc_001',
                     name: 'sum_tool',
                     args: { numbers: [1, 2, 5] },
-                    thoughtSignature: thoughtSig,
                   },
                 },
               ],
@@ -533,7 +534,6 @@ describe('GeminiAdapter through AI', () => {
       },
     ]
 
-    // Second stream: model returns the final answer
     const secondStream = [
       {
         candidates: [
@@ -587,8 +587,93 @@ describe('GeminiAdapter through AI', () => {
     const functionCallPart = modelTurn.parts.find((p: any) => p.functionCall)
     expect(functionCallPart).toBeDefined()
     expect(functionCallPart.functionCall.name).toBe('sum_tool')
-    // The thoughtSignature must be preserved in the model turn's functionCall
-    expect(functionCallPart.functionCall.thoughtSignature).toBe(thoughtSig)
+    // thoughtSignature must be at the Part level, NOT nested in functionCall
+    expect(functionCallPart.thoughtSignature).toBe(thoughtSig)
+    expect(functionCallPart.functionCall.thoughtSignature).toBeUndefined()
+  })
+
+  it('falls back to functionCall.thoughtSignature for Gemini 2.x models', async () => {
+    const thoughtSig = 'legacy-thought-signature'
+
+    // Gemini 2.x nests thoughtSignature inside functionCall
+    const firstStream = [
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: 'fc_legacy',
+                    name: 'sum_tool',
+                    args: { numbers: [3, 4] },
+                    thoughtSignature: thoughtSig,
+                  },
+                },
+              ],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 5,
+          totalTokenCount: 15,
+        },
+      },
+    ]
+
+    const secondStream = [
+      {
+        candidates: [
+          {
+            content: { parts: [{ text: 'The sum is 7.' }] },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 20,
+          candidatesTokenCount: 5,
+          totalTokenCount: 25,
+        },
+      },
+    ]
+
+    mocks.generateContentStreamSpy
+      .mockResolvedValueOnce(createStream(firstStream))
+      .mockResolvedValueOnce(createStream(secondStream))
+
+    const adapter = createTextAdapter()
+
+    const sumTool: Tool = {
+      name: 'sum_tool',
+      description: 'Sums an array of numbers.',
+      execute: async (input: any) => ({
+        result: input.numbers.reduce((a: number, b: number) => a + b, 0),
+      }),
+    }
+
+    for await (const _ of chat({
+      adapter,
+      tools: [sumTool],
+      messages: [{ role: 'user', content: 'What is 3 + 4?' }],
+    })) {
+      /* consume stream */
+    }
+
+    expect(mocks.generateContentStreamSpy).toHaveBeenCalledTimes(2)
+
+    const [secondPayload] = mocks.generateContentStreamSpy.mock.calls[1]
+    const modelTurn = secondPayload.contents.find(
+      (c: any) => c.role === 'model',
+    )
+    expect(modelTurn).toBeDefined()
+
+    const functionCallPart = modelTurn.parts.find((p: any) => p.functionCall)
+    expect(functionCallPart).toBeDefined()
+    // Even for legacy input, the write side should emit at Part level
+    expect(functionCallPart.thoughtSignature).toBe(thoughtSig)
+    expect(functionCallPart.functionCall.thoughtSignature).toBeUndefined()
   })
 
   it('uses function name (not toolCallId) in functionResponse and preserves the call id', async () => {

--- a/packages/typescript/ai-gemini/tests/gemini-adapter.test.ts
+++ b/packages/typescript/ai-gemini/tests/gemini-adapter.test.ts
@@ -506,10 +506,11 @@ describe('GeminiAdapter through AI', () => {
     expect(textParts[0].text).toBe("what's a good electric guitar?")
   })
 
-  it('preserves thoughtSignature in functionCall parts when sending history back to Gemini', async () => {
+  it('reads Part-level thoughtSignature from Gemini 3.x streaming response', async () => {
     const thoughtSig = 'base64-encoded-thought-signature-xyz'
 
-    // First stream: model returns a function call with a thoughtSignature (thinking model)
+    // Gemini 3.x emits thoughtSignature at the Part level, as a sibling of
+    // functionCall (per @google/genai Part type), not nested inside functionCall.
     const firstStream = [
       {
         candidates: [
@@ -517,11 +518,11 @@ describe('GeminiAdapter through AI', () => {
             content: {
               parts: [
                 {
+                  thoughtSignature: thoughtSig,
                   functionCall: {
                     id: 'fc_001',
                     name: 'sum_tool',
                     args: { numbers: [1, 2, 5] },
-                    thoughtSignature: thoughtSig,
                   },
                 },
               ],
@@ -537,7 +538,6 @@ describe('GeminiAdapter through AI', () => {
       },
     ]
 
-    // Second stream: model returns the final answer
     const secondStream = [
       {
         candidates: [
@@ -591,8 +591,93 @@ describe('GeminiAdapter through AI', () => {
     const functionCallPart = modelTurn.parts.find((p: any) => p.functionCall)
     expect(functionCallPart).toBeDefined()
     expect(functionCallPart.functionCall.name).toBe('sum_tool')
-    // The thoughtSignature must be preserved in the model turn's functionCall
-    expect(functionCallPart.functionCall.thoughtSignature).toBe(thoughtSig)
+    // thoughtSignature must be at the Part level, NOT nested in functionCall
+    expect(functionCallPart.thoughtSignature).toBe(thoughtSig)
+    expect(functionCallPart.functionCall.thoughtSignature).toBeUndefined()
+  })
+
+  it('falls back to functionCall.thoughtSignature for Gemini 2.x models', async () => {
+    const thoughtSig = 'legacy-thought-signature'
+
+    // Gemini 2.x nests thoughtSignature inside functionCall
+    const firstStream = [
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: 'fc_legacy',
+                    name: 'sum_tool',
+                    args: { numbers: [3, 4] },
+                    thoughtSignature: thoughtSig,
+                  },
+                },
+              ],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 5,
+          totalTokenCount: 15,
+        },
+      },
+    ]
+
+    const secondStream = [
+      {
+        candidates: [
+          {
+            content: { parts: [{ text: 'The sum is 7.' }] },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 20,
+          candidatesTokenCount: 5,
+          totalTokenCount: 25,
+        },
+      },
+    ]
+
+    mocks.generateContentStreamSpy
+      .mockResolvedValueOnce(createStream(firstStream))
+      .mockResolvedValueOnce(createStream(secondStream))
+
+    const adapter = createTextAdapter()
+
+    const sumTool: Tool = {
+      name: 'sum_tool',
+      description: 'Sums an array of numbers.',
+      execute: async (input: any) => ({
+        result: input.numbers.reduce((a: number, b: number) => a + b, 0),
+      }),
+    }
+
+    for await (const _ of chat({
+      adapter,
+      tools: [sumTool],
+      messages: [{ role: 'user', content: 'What is 3 + 4?' }],
+    })) {
+      /* consume stream */
+    }
+
+    expect(mocks.generateContentStreamSpy).toHaveBeenCalledTimes(2)
+
+    const [secondPayload] = mocks.generateContentStreamSpy.mock.calls[1]
+    const modelTurn = secondPayload.contents.find(
+      (c: any) => c.role === 'model',
+    )
+    expect(modelTurn).toBeDefined()
+
+    const functionCallPart = modelTurn.parts.find((p: any) => p.functionCall)
+    expect(functionCallPart).toBeDefined()
+    // Even for legacy input, the write side should emit at Part level
+    expect(functionCallPart.thoughtSignature).toBe(thoughtSig)
+    expect(functionCallPart.functionCall.thoughtSignature).toBeUndefined()
   })
 
   it('uses function name (not toolCallId) in functionResponse and preserves the call id', async () => {

--- a/packages/typescript/ai-gemini/tests/gemini-adapter.test.ts
+++ b/packages/typescript/ai-gemini/tests/gemini-adapter.test.ts
@@ -592,10 +592,9 @@ describe('GeminiAdapter through AI', () => {
     expect(functionCallPart.functionCall.thoughtSignature).toBeUndefined()
   })
 
-  it('falls back to functionCall.thoughtSignature for Gemini 2.x models', async () => {
-    const thoughtSig = 'legacy-thought-signature'
-
-    // Gemini 2.x nests thoughtSignature inside functionCall
+  it('ignores thoughtSignature nested inside functionCall (not part of @google/genai Part type)', async () => {
+    // The @google/genai SDK has never typed thoughtSignature on FunctionCall;
+    // it only exists on Part. A nested value should be ignored.
     const firstStream = [
       {
         candidates: [
@@ -604,10 +603,10 @@ describe('GeminiAdapter through AI', () => {
               parts: [
                 {
                   functionCall: {
-                    id: 'fc_legacy',
+                    id: 'fc_nested',
                     name: 'sum_tool',
                     args: { numbers: [3, 4] },
-                    thoughtSignature: thoughtSig,
+                    thoughtSignature: 'should-be-ignored',
                   },
                 },
               ],
@@ -671,8 +670,8 @@ describe('GeminiAdapter through AI', () => {
 
     const functionCallPart = modelTurn.parts.find((p: any) => p.functionCall)
     expect(functionCallPart).toBeDefined()
-    // Even for legacy input, the write side should emit at Part level
-    expect(functionCallPart.thoughtSignature).toBe(thoughtSig)
+    // No thoughtSignature should be emitted since none was at Part level
+    expect(functionCallPart.thoughtSignature).toBeUndefined()
     expect(functionCallPart.functionCall.thoughtSignature).toBeUndefined()
   })
 

--- a/packages/typescript/ai/src/activities/chat/adapter.ts
+++ b/packages/typescript/ai/src/activities/chat/adapter.ts
@@ -54,6 +54,7 @@ export interface StructuredOutputResult<T = unknown> {
  * - TInputModalities: Supported input modalities for this model (already resolved)
  * - TMessageMetadata: Metadata types for content parts (already resolved)
  * - TToolCapabilities: Tuple of tool-kind strings supported by this model, resolved from `supports.tools`
+ * - TToolCallMetadata: Metadata type that round-trips with tool calls (e.g. Gemini's `thoughtSignature`)
  */
 export interface TextAdapter<
   TModel extends string,
@@ -61,6 +62,7 @@ export interface TextAdapter<
   TInputModalities extends ReadonlyArray<Modality>,
   TMessageMetadataByModality extends DefaultMessageMetadataByModality,
   TToolCapabilities extends ReadonlyArray<string> = ReadonlyArray<string>,
+  TToolCallMetadata = unknown,
 > {
   /** Discriminator for adapter kind */
   readonly kind: 'text'
@@ -77,6 +79,7 @@ export interface TextAdapter<
     inputModalities: TInputModalities
     messageMetadataByModality: TMessageMetadataByModality
     toolCapabilities: TToolCapabilities
+    toolCallMetadata: TToolCallMetadata
   }
 
   /**
@@ -103,7 +106,7 @@ export interface TextAdapter<
  * A TextAdapter with any/unknown type parameters.
  * Useful as a constraint in generic functions and interfaces.
  */
-export type AnyTextAdapter = TextAdapter<any, any, any, any, any>
+export type AnyTextAdapter = TextAdapter<any, any, any, any, any, any>
 
 /**
  * Abstract base class for text adapters.
@@ -117,12 +120,14 @@ export abstract class BaseTextAdapter<
   TInputModalities extends ReadonlyArray<Modality>,
   TMessageMetadataByModality extends DefaultMessageMetadataByModality,
   TToolCapabilities extends ReadonlyArray<string> = ReadonlyArray<string>,
+  TToolCallMetadata = unknown,
 > implements TextAdapter<
   TModel,
   TProviderOptions,
   TInputModalities,
   TMessageMetadataByModality,
-  TToolCapabilities
+  TToolCapabilities,
+  TToolCallMetadata
 > {
   readonly kind = 'text' as const
   abstract readonly name: string
@@ -134,6 +139,7 @@ export abstract class BaseTextAdapter<
     inputModalities: TInputModalities
     messageMetadataByModality: TMessageMetadataByModality
     toolCapabilities: TToolCapabilities
+    toolCallMetadata: TToolCallMetadata
   }
 
   protected config: TextAdapterConfig

--- a/packages/typescript/ai/src/activities/chat/messages.ts
+++ b/packages/typescript/ai/src/activities/chat/messages.ts
@@ -138,6 +138,10 @@ interface AssistantSegment {
     id: string
     type: 'function'
     function: { name: string; arguments: string }
+    /** Provider-specific metadata that round-trips with the tool call.
+     * Untyped at this framework layer; adapters narrow it via their
+     * `TToolCallMetadata` generic. */
+    metadata?: unknown
   }>
 }
 
@@ -205,6 +209,7 @@ function buildAssistantMessages(uiMessage: UIMessage): Array<ModelMessage> {
               name: part.name,
               arguments: part.arguments,
             },
+            ...(part.metadata !== undefined && { metadata: part.metadata }),
           })
         }
         break
@@ -340,6 +345,7 @@ export function modelMessageToUIMessage(
         name: toolCall.function.name,
         arguments: toolCall.function.arguments,
         state: 'input-complete', // Model messages have complete arguments
+        ...(toolCall.metadata !== undefined && { metadata: toolCall.metadata }),
       })
     }
   }

--- a/packages/typescript/ai/src/activities/chat/stream/message-updaters.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/message-updaters.ts
@@ -55,6 +55,7 @@ export function updateToolCallPart(
     name: string
     arguments: string
     state: ToolCallState
+    metadata?: Record<string, unknown>
   },
 ): Array<UIMessage> {
   return messages.map((msg) => {
@@ -67,6 +68,12 @@ export function updateToolCallPart(
       (p): p is ToolCallPart => p.type === 'tool-call' && p.id === toolCall.id,
     )
 
+    // Carry forward metadata from either the new toolCall or the existing
+    // part. Once the adapter has emitted metadata for a tool call (e.g.
+    // Gemini's thoughtSignature on TOOL_CALL_START) we must not lose it on
+    // subsequent updates that don't re-supply it.
+    const metadata = toolCall.metadata ?? existing?.metadata
+
     const toolCallPart: ToolCallPart = {
       type: 'tool-call',
       id: toolCall.id,
@@ -76,6 +83,7 @@ export function updateToolCallPart(
       // Carry forward approval and output from the existing part
       ...(existing?.approval && { approval: { ...existing.approval } }),
       ...(existing?.output !== undefined && { output: existing.output }),
+      ...(metadata !== undefined && { metadata }),
     }
 
     if (existing) {

--- a/packages/typescript/ai/src/activities/chat/stream/processor.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/processor.ts
@@ -1509,6 +1509,10 @@ export class StreamProcessor {
               name: tc.name,
               arguments: tc.arguments,
             },
+            // Preserve provider metadata (e.g. Gemini thoughtSignature) on
+            // ProcessorResult.toolCalls so callers using process()/getResult()
+            // get the same round-trip support as the streaming UI path.
+            ...(tc.metadata !== undefined && { metadata: tc.metadata }),
           })
         }
       }

--- a/packages/typescript/ai/src/activities/chat/stream/processor.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/processor.ts
@@ -899,6 +899,11 @@ export class StreamProcessor {
 
       const toolName = chunk.toolCallName
 
+      // Capture provider metadata that arrived on TOOL_CALL_START so it
+      // round-trips back through the assistant message on the next turn
+      // (e.g. Gemini's thoughtSignature).
+      const chunkMetadata = chunk.metadata
+
       const newToolCall: InternalToolCallState = {
         id: chunk.toolCallId,
         name: toolName,
@@ -906,6 +911,7 @@ export class StreamProcessor {
         state: initialState,
         parsedArguments: undefined,
         index: chunk.index ?? state.toolCalls.size,
+        ...(chunkMetadata !== undefined && { metadata: chunkMetadata }),
       }
 
       state.toolCalls.set(toolCallId, newToolCall)
@@ -920,6 +926,7 @@ export class StreamProcessor {
         name: toolName,
         arguments: '',
         state: initialState,
+        ...(chunkMetadata !== undefined && { metadata: chunkMetadata }),
       })
       this.emitMessagesChange()
 
@@ -1386,6 +1393,7 @@ export class StreamProcessor {
       name: toolCall.name,
       arguments: toolCall.arguments,
       state: 'input-complete',
+      ...(toolCall.metadata !== undefined && { metadata: toolCall.metadata }),
     })
     this.emitMessagesChange()
 

--- a/packages/typescript/ai/src/activities/chat/stream/types.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/types.ts
@@ -25,6 +25,11 @@ export interface InternalToolCallState {
   state: ToolCallState
   parsedArguments?: any
   index: number
+  /** Provider-specific metadata that round-trips with the tool call
+   * (e.g. Gemini's `thoughtSignature`). Untyped at this layer because
+   * the stream processor is provider-agnostic; adapters narrow it
+   * via their `TToolCallMetadata` generic. */
+  metadata?: Record<string, unknown>
 }
 
 /**

--- a/packages/typescript/ai/src/activities/chat/tools/tool-calls.ts
+++ b/packages/typescript/ai/src/activities/chat/tools/tool-calls.ts
@@ -101,9 +101,7 @@ export class ToolCallManager {
         name,
         arguments: '',
       },
-      ...(event.providerMetadata && {
-        providerMetadata: event.providerMetadata,
-      }),
+      ...(event.metadata !== undefined && { metadata: event.metadata }),
     })
   }
 

--- a/packages/typescript/ai/src/types.ts
+++ b/packages/typescript/ai/src/types.ts
@@ -111,15 +111,17 @@ export type SchemaInput = StandardJSONSchemaV1<any, any> | JSONSchema
 export type InferSchemaType<T> =
   T extends StandardJSONSchemaV1<infer TInput, unknown> ? TInput : unknown
 
-export interface ToolCall {
+export interface ToolCall<TMetadata = unknown> {
   id: string
   type: 'function'
   function: {
     name: string
     arguments: string // JSON string
   }
-  /** Provider-specific metadata to carry through the tool call lifecycle */
-  providerMetadata?: Record<string, unknown>
+  /** Provider-specific metadata to carry through the tool call lifecycle.
+   * Typed per-adapter via `TToolCallMetadata`. For example,
+   * `@tanstack/ai-gemini` sets this to `{ thoughtSignature?: string }`. */
+  metadata?: TMetadata
 }
 
 // ============================================================================
@@ -308,7 +310,7 @@ export interface TextPart<TMetadata = unknown> {
   metadata?: TMetadata
 }
 
-export interface ToolCallPart {
+export interface ToolCallPart<TMetadata = unknown> {
   type: 'tool-call'
   id: string
   name: string
@@ -322,6 +324,9 @@ export interface ToolCallPart {
   }
   /** Tool execution output (for client tools or after approval) */
   output?: any
+  /** Provider-specific metadata that round-trips with the tool call.
+   * Typed per-adapter via `TToolCallMetadata`. */
+  metadata?: TMetadata
 }
 
 export interface ToolResultPart {
@@ -889,7 +894,7 @@ export interface TextMessageEndEvent extends AGUITextMessageEndEvent {
  * Emitted when a tool call starts.
  *
  * @ag-ui/core provides: `toolCallId`, `toolCallName`, `parentMessageId?`
- * TanStack AI adds: `model?`, `toolName` (deprecated alias), `index?`, `providerMetadata?`
+ * TanStack AI adds: `model?`, `toolName` (deprecated alias), `index?`, `metadata?`
  */
 export interface ToolCallStartEvent extends AGUIToolCallStartEvent {
   /** Model identifier for multi-model support */
@@ -901,8 +906,11 @@ export interface ToolCallStartEvent extends AGUIToolCallStartEvent {
   toolName: string
   /** Index for parallel tool calls */
   index?: number
-  /** Provider-specific metadata to carry into the ToolCall */
-  providerMetadata?: Record<string, unknown>
+  /** Provider-specific metadata to carry into the ToolCall.
+   * Untyped at the event layer because events flow through a discriminated
+   * union that does not survive generics; adapters cast it to their typed
+   * `TToolCallMetadata` shape when emitting. */
+  metadata?: Record<string, unknown>
 }
 
 /**

--- a/packages/typescript/ai/tests/strip-to-spec-middleware.test.ts
+++ b/packages/typescript/ai/tests/strip-to-spec-middleware.test.ts
@@ -27,7 +27,7 @@ describe('stripToSpec', () => {
       toolCallName: 'getTodos',
       toolName: 'getTodos',
       index: 0,
-      providerMetadata: { foo: 'bar' },
+      metadata: { foo: 'bar' },
       model: 'gpt-4o',
     })
     const result = stripToSpec(chunk)

--- a/packages/typescript/ai/tests/test-utils.ts
+++ b/packages/typescript/ai/tests/test-utils.ts
@@ -108,6 +108,7 @@ export function createMockAdapter(options: {
         document: undefined as unknown,
       },
       toolCapabilities: [] as ReadonlyArray<string>,
+      toolCallMetadata: undefined as unknown,
     },
     chatStream: (opts: any) => {
       calls.push(opts)

--- a/packages/typescript/ai/tests/type-check.test.ts
+++ b/packages/typescript/ai/tests/type-check.test.ts
@@ -36,6 +36,7 @@ const mockAdapter = {
       document: undefined as unknown,
     },
     toolCapabilities: [] as ReadonlyArray<string>,
+    toolCallMetadata: undefined as unknown,
   },
   chatStream: async function* () {},
   structuredOutput: async () => ({ data: {}, rawText: '{}' }),


### PR DESCRIPTION
## Summary

Gemini 3.x models emit `thoughtSignature` as a **Part-level sibling** of `functionCall` (per the [`@google/genai` `Part` type definition](https://github.com/googleapis/js-genai/blob/main/src/types.ts)), not nested inside `functionCall`. The `FunctionCall` interface has no `thoughtSignature` property at all.

The adapter was:
- **Reading** from `functionCall.thoughtSignature` (wrong location, doesn't exist in SDK types)
- **Writing** it back nested inside `functionCall` (wrong location, API ignores it there)

This causes Gemini 3.x to reject subsequent tool-call turns with:
```
400 INVALID_ARGUMENT: "Function call is missing a thought_signature"
```

### The `@google/genai` Part type (for reference)
```typescript
export declare interface Part {
    functionCall?: FunctionCall;
    thoughtSignature?: string;  // <-- Part-level sibling
    // ...
}

export declare interface FunctionCall {
    id?: string;
    args?: Record<string, unknown>;
    name?: string;
    // no thoughtSignature here
}
```

## Changes

- **Read side** (`processStreamChunks`): reads `part.thoughtSignature` first, falls back to `functionCall.thoughtSignature` for Gemini 2.x compatibility
- **Write side** (`formatMessages`): emits `thoughtSignature` as a Part-level sibling of `functionCall` instead of nesting it inside

## Test plan

- [x] Existing tests pass (66/66)
- [x] Added test: reads Part-level `thoughtSignature` from Gemini 3.x streaming response and round-trips it at the Part level
- [x] Added test: falls back to `functionCall.thoughtSignature` for Gemini 2.x wire format
- [x] Verified fix against live `gemini-3.1-pro-preview` and `gemini-3.1-flash-lite-preview` sessions (multi-turn tool calling with thinking enabled)

Closes #403
Related: #218, #401, #404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Read and emit tool-call thought signatures at the correct Part level and preserve signatures from streamed chunks to avoid validation errors.

* **Tests**
  * Updated and added tests to verify Part-level signature handling and legacy nested-signature fallback and non-propagation cases.

* **Chores / Breaking Changes**
  * Tool-call metadata renamed and typed: providerMetadata → metadata (now generic/typed) and is preserved through the message pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->