### PR TITLE
chore: add retroactive changesets for PR #411 (AG-UI core interop)

### DIFF
--- a/.changeset/agui-core-interop-adapters.md
+++ b/.changeset/agui-core-interop-adapters.md
@@ -1,0 +1,11 @@
+---
+'@tanstack/ai-openai': patch
+'@tanstack/ai-anthropic': patch
+'@tanstack/ai-gemini': patch
+'@tanstack/ai-ollama': patch
+'@tanstack/ai-openrouter': patch
+'@tanstack/ai-grok': patch
+'@tanstack/ai-groq': patch
+---
+
+Align stream output with `@tanstack/ai`'s AG-UI-compliant event shapes: emit `REASONING_*` events alongside `STEP_*`, thread `threadId`/`runId` through `RUN_STARTED`/`RUN_FINISHED`, and return flat `RunErrorEvent` shape. Cast raw events through an internal `asChunk` helper so they line up with the re-exported `@ag-ui/core` `EventType` enum. No changes to adapter factory signatures or config shapes.

--- a/.changeset/agui-core-interop-ai.md
+++ b/.changeset/agui-core-interop-ai.md
@@ -1,0 +1,13 @@
+---
+'@tanstack/ai': major
+---
+
+**AG-UI core interop — spec-compliant event types.** `StreamChunk` now re-uses `@ag-ui/core`'s `EventType` enum and event shapes directly. Practical changes:
+
+- `RunErrorEvent` is flat (`{ message, code }` at the top level) instead of nested under `error: {...}`.
+- `TOOL_CALL_START` / `TOOL_CALL_END` events expose `toolCallName` (the deprecated `toolName` alias is retained as a passthrough for now).
+- Adapters now emit `REASONING_*` events (`REASONING_START`, `REASONING_MESSAGE_START`, `REASONING_MESSAGE_CONTENT`, `REASONING_MESSAGE_END`, `REASONING_END`) alongside the legacy `STEP_*` events; consumers rendering thinking content should migrate to the `REASONING_*` channel.
+- `TOOL_CALL_RESULT` events are emitted after tool execution in the agent loop.
+- New `stripToSpecMiddleware` (always injected last) removes non-spec fields (`model`, `content`, `args`, `finishReason`, `usage`, `toolName`, `stepId`, …) from events before they reach consumers. Internal state management sees the full un-stripped chunks.
+- `ChatOptions` gained optional `threadId` and `runId` for AG-UI run correlation; they flow through to `RUN_STARTED` / `RUN_FINISHED`.
+- `StateDeltaEvent.delta` is now a JSON Patch `any[]` per the AG-UI spec.

--- a/.changeset/agui-core-interop-client.md
+++ b/.changeset/agui-core-interop-client.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-client': patch
+---
+
+Thread `@tanstack/ai`'s AG-UI-compliant event shapes through the headless chat client: handle flat `RUN_ERROR` payloads, consume `REASONING_*` events, and warn when receiving the deprecated `[DONE]` sentinel.

--- a/.changeset/agui-core-interop-event-client.md
+++ b/.changeset/agui-core-interop-event-client.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-event-client': patch
+---
+
+Update the devtools middleware to match `@tanstack/ai`'s AG-UI-compliant event shapes so emitted instrumentation remains accurate after the strip-to-spec pass.


### PR DESCRIPTION
## Summary

PR #411 (AG-UI core interop — spec-compliant event types) landed without changesets, so the next release pass would miss the breaking event-shape work. This PR adds them retroactively.

## Changesets added

- \`@tanstack/ai\` — **major**: flat \`RunErrorEvent\`, \`REASONING_*\` events, \`threadId\`/\`runId\` on \`ChatOptions\`, \`stripToSpecMiddleware\` always-last injection, \`@ag-ui/core\` \`EventType\` re-export, JSON-Patch \`StateDeltaEvent.delta\`.
- \`@tanstack/ai-openai\`, \`ai-anthropic\`, \`ai-gemini\`, \`ai-ollama\`, \`ai-openrouter\`, \`ai-grok\`, \`ai-groq\` — **patch**: emit the new AG-UI-compliant event shapes (REASONING_*, threadId/runId, flat RUN_ERROR). No factory / config-shape changes.
- \`@tanstack/ai-client\` — **patch**: handle flat \`RUN_ERROR\`, \`REASONING_*\`, warn on deprecated \`[DONE]\` sentinel.
- \`@tanstack/ai-event-client\` — **patch**: devtools middleware alignment with the new shapes.

No source changes in this PR — only \`.changeset/*.md\` additions.

## Test plan

- [x] \`pnpm test:sherif\` clean
- [ ] Changeset preview in CI confirms the expected version matrix (core major, adapters/client patch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reasoning event types to expose AI model thinking processes separately from step events.
  * Introduced thread and run tracking via optional `threadId` and `runId` parameters.
  * Enhanced tool call events with improved naming properties.

* **Improvements**
  * Standardized event shapes across all adapters to align with AG-UI specifications.
  * Simplified error event structure with flattened payload format.
  * Added automatic event normalization middleware to ensure spec compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->