### PR TITLE
chore: downgrade @tanstack/ai AG-UI interop changeset to minor

### DIFF
--- a/.changeset/agui-core-interop-ai.md
+++ b/.changeset/agui-core-interop-ai.md
@@ -1,5 +1,5 @@
 ---
-'@tanstack/ai': major
+'@tanstack/ai': minor
 ---
 
 **AG-UI core interop — spec-compliant event types.** `StreamChunk` now re-uses `@ag-ui/core`'s `EventType` enum and event shapes directly. Practical changes:


### PR DESCRIPTION
## Summary
- Changes `.changeset/agui-core-interop-ai.md` bump type for `@tanstack/ai` from `major` to `minor`.

## Test plan
- [ ] Changeset validates in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version management for AI integration package with interoperability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->