### PR TITLE
fix(examples/ts-code-mode-web): persist reports across reloads

### DIFF
--- a/examples/ts-code-mode-web/src/lib/reports/use-persisted-reports.ts
+++ b/examples/ts-code-mode-web/src/lib/reports/use-persisted-reports.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import type { Report, ReportState, UIEvent, UINode } from './types'
 import { applyUIEvent, createEmptyReportState } from './apply-event'
 
@@ -42,7 +42,6 @@ export function usePersistedReports() {
   const [reports, setReports] = useState<Map<string, ReportState>>(new Map())
   const [activeReportId, setActiveReportId] = useState<string | null>(null)
   const [isHydrated, setIsHydrated] = useState(false)
-  const saveRef = useRef<ReturnType<typeof debounce<() => void>> | null>(null)
 
   // Load from localStorage on mount
   useEffect(() => {
@@ -74,29 +73,27 @@ export function usePersistedReports() {
   useEffect(() => {
     if (!isHydrated) return
 
-    if (!saveRef.current) {
-      saveRef.current = debounce(() => {
-        const data: ReportsStorage = {
-          reports: Array.from(reports.values()).map(
-            ({ report, nodes, rootIds }) => ({
-              report,
-              nodes: Array.from(nodes.entries()),
-              rootIds,
-            }),
-          ),
-          activeReportId,
-          version: STORAGE_VERSION,
-        }
-        try {
-          localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
-        } catch (e) {
-          console.error('Failed to save reports to storage:', e)
-        }
-      }, 500)
-    }
+    const save = debounce(() => {
+      const data: ReportsStorage = {
+        reports: Array.from(reports.values()).map(
+          ({ report, nodes, rootIds }) => ({
+            report,
+            nodes: Array.from(nodes.entries()),
+            rootIds,
+          }),
+        ),
+        activeReportId,
+        version: STORAGE_VERSION,
+      }
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+      } catch (e) {
+        console.error('Failed to save reports to storage:', e)
+      }
+    }, 500)
 
-    saveRef.current()
-    return () => saveRef.current?.cancel()
+    save()
+    return () => save.cancel()
   }, [reports, activeReportId, isHydrated])
 
   // Create a new report


### PR DESCRIPTION
## 🎯 Changes

The debounced save in `usePersistedReports` is created once and cached in a ref, capturing the initial empty `reports` Map and `null` `activeReportId` from the first effect run. Subsequent renders re-fire the effect but reuse the cached closure, so every `localStorage.setItem` writes the empty initial state — the UI shows populated reports while localStorage stays empty, and reports vanish on reload.

- Recreate the debounced save each effect run; cleanup cancels the in-flight debounce on each render so debouncing semantics are preserved.
- Drop the now-unused `useRef` import and `saveRef` declaration.

## Repro on `main`

1. `pnpm dev` in `examples/ts-code-mode-web`, open `/reporting-agent`
2. DevTools → Application → Local Storage → `http://localhost:3001`
3. Generate a report — `tanstack-ai-reports` stays `{"reports":[],"activeReportId":null,"version":1}` despite the populated UI; reload → report disappears

After this PR the value contains the full serialized report and survives reload.

## Note on the missing contributing guide

The repo currently has no `CONTRIBUTING.md` — both `README.md` and `.github/pull_request_template.md` link to one that 404s. Filed #514 with details. As a substitute, I followed `TanStack/query`'s [CONTRIBUTING.md](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md), adapted for this repo:

- pnpm 10 + `pnpm build:all` ✅
- `pnpm run test:pr` (the nx-based per-PR entrypoint) ✅, all tasks pass
- Ran on Node 22.13.1 rather than the `.nvmrc`-pinned 24.8.0
- No changeset since the affected example is `"private": true` (`pnpm changeset status` confirms no packages to bump)
- E2E coverage not added — there is no existing test infra for this example's persistence layer; happy to add one if maintainers want

## ✅ Checklist

- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release). The `ts-code-mode-web` example is `"private": true` and not published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of report saving to local storage by refining how debounced save operations are managed and cleaned up during component lifecycle changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->