### PR TITLE
messages parameter to fetchServerSentEvents function

### DIFF
--- a/packages/typescript/ai-client/src/connection-adapters.ts
+++ b/packages/typescript/ai-client/src/connection-adapters.ts
@@ -265,14 +265,14 @@ export function fetchServerSentEvents(
   url: string | (() => string),
   options:
     | FetchConnectionOptions
-    | (() => FetchConnectionOptions | Promise<FetchConnectionOptions>) = {},
+    | ((messages:Array<UIMessage> | Array<ModelMessage>) => FetchConnectionOptions | Promise<FetchConnectionOptions>) = {},
 ): ConnectConnectionAdapter {
   return {
     async *connect(messages, data, abortSignal) {
       // Resolve URL and options if they are functions
       const resolvedUrl = typeof url === 'function' ? url() : url
       const resolvedOptions =
-        typeof options === 'function' ? await options() : options
+        typeof options === 'function' ? await options(messages) : options
 
       const requestHeaders: Record<string, string> = {
         'Content-Type': 'application/json',


### PR DESCRIPTION
Hi,

I added a `messages` parameter to the `fetchServerSentEvents` connection adapter.

You might ask why. It's simple: Transtack AI provides all the tools to create an AI chat, for example, but we still manage our backend as we see fit in a scenario where my chats and messages are saved in a database that I can quickly access. 
I don't need the frontend to send me ALL the messages again. The culprit is the React `useChat` hook from `@tanstack/ai-react`, and it doesn't directly allow sending only new messages to the backend when `sendMessage()` function is called. 
So I figured the simplest way to implement this would be with a few lines in the connection adapter. I can therefore create something that solves my problem and looks like this:

```ts
 const chat = useChat({
    // [ ... ]
    connection: fetchServerSentEvents('/api/chat', async (messages) => {
      return {
        body: {
          // Send last message only :-)
          messages: [messages[messages.length - 1]]
        }
      }
    }),
    // [ ... ]
  })
 ```
 
This pull request doesn't introduce any breaking changes. And I think it could be relevant for certain use cases like mine.

But maybe I'm missing something ? Is there a cleaner, more appropriate way to do this without adding this hacky parameter ? Perhaps by using `@tanstack/ai-client` ? Anyway, that's how I solved my problem. I'd really like to know if anyone else has had the same question as me and if there's another way to do it. 

Thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connection options for server-sent events can now be dynamically configured as a function that receives the messages being sent, enabling message-aware connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->