### PR TITLE
fix(ai): rename providerMetadata -> metadata in makeToolCall test helper

### DIFF
--- a/packages/typescript/ai/tests/middlewares/fake-otel.ts
+++ b/packages/typescript/ai/tests/middlewares/fake-otel.ts
@@ -229,8 +229,8 @@ export function makeToolCall(
       name: overrides.function?.name ?? 'test_tool',
       arguments: overrides.function?.arguments ?? '{}',
     },
-    ...(overrides.providerMetadata !== undefined
-      ? { providerMetadata: overrides.providerMetadata }
+    ...(overrides.metadata !== undefined
+      ? { metadata: overrides.metadata }
       : {}),
   }
 }


### PR DESCRIPTION
## Summary

- Fixes `pnpm test:ci` on `main`, which has been failing on `@tanstack/ai:test:types` since #459 was merged.
- #459 renamed `ToolCall.providerMetadata` → `ToolCall<TMetadata>.metadata` across `src/`, but missed the `makeToolCall` test helper in `packages/typescript/ai/tests/middlewares/fake-otel.ts`. `tsc` now errors with `TS2339: Property 'providerMetadata' does not exist`, which is what's blocking the Release workflow's `Run Tests` step and preventing the changesets release PR from being (re)created.
- Test-only change: 2-line rename in the helper. No published surface affected, no changeset needed.

## Root cause

In #459 (87f305c9), `ToolCall.providerMetadata: Record<string, unknown>` became `ToolCall<TMetadata>.metadata?: TMetadata` everywhere except the `makeToolCall` test helper, whose conditional spread still references the old field name. The helper is typed against the current `ToolCall`, so `tsc` rejects it.

## Test plan

- [x] `pnpm --filter @tanstack/ai test:types` passes locally
- [x] `pnpm --filter @tanstack/ai test:lib` passes locally (751 tests)
- [x] `pnpm --filter @tanstack/ai test:eslint` clean
- [ ] Release workflow on `main` goes green after merge, allowing the changesets release PR to be created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test infrastructure to refine mock data structure handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/546)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->