### PR TITLE
fix(release): move pnpm overrides + patchedDependencies to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,6 @@
   },
   "packageManager": "pnpm@11.1.1",
   "type": "module",
-  "pnpm": {
-    "overrides": {
-      "abbrev": "^3.0.0"
-    },
-    "patchedDependencies": {
-      "@changesets/assemble-release-plan@6.0.9": "patches/@changesets__assemble-release-plan@6.0.9.patch"
-    }
-  },
   "scripts": {
     "clean": "pnpm --filter \"./packages/**\" run clean",
     "clean:all": "git clean -fdx --exclude=\"!.env\"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  abbrev: ^3.0.0
+
+patchedDependencies:
+  '@changesets/assemble-release-plan@6.0.9': 1bc53c741da20baad9cdeb674c599225dcf9fe6aa7b0de16ff87e63f12a97b24
+
 importers:
 
   .:
@@ -6945,10 +6951,6 @@ packages:
     resolution: {integrity: sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==}
     hasBin: true
 
-  abbrev@2.0.0:
-    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -12514,7 +12516,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.4
 
-  '@changesets/assemble-release-plan@6.0.9':
+  '@changesets/assemble-release-plan@6.0.9(patch_hash=1bc53c741da20baad9cdeb674c599225dcf9fe6aa7b0de16ff87e63f12a97b24)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -12530,7 +12532,7 @@ snapshots:
   '@changesets/cli@2.30.0(@types/node@24.10.3)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=1bc53c741da20baad9cdeb674c599225dcf9fe6aa7b0de16ff87e63f12a97b24)
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.3
       '@changesets/errors': 0.2.0
@@ -12589,7 +12591,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.15':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=1bc53c741da20baad9cdeb674c599225dcf9fe6aa7b0de16ff87e63f12a97b24)
       '@changesets/config': 3.1.3
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.7
@@ -17647,8 +17649,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  abbrev@2.0.0: {}
-
   abbrev@3.0.1: {}
 
   abort-controller@3.0.0:
@@ -21158,7 +21158,7 @@ snapshots:
 
   nopt@7.2.1:
     dependencies:
-      abbrev: 2.0.0
+      abbrev: 3.0.1
 
   nopt@8.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,14 @@ cleanupUnusedCatalogs: true
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 
+# pnpm v11 dropped support for these fields in package.json — they must live
+# here. See https://github.com/pnpm/pnpm/releases/tag/v11.0.0.
+overrides:
+  abbrev: ^3.0.0
+
+patchedDependencies:
+  '@changesets/assemble-release-plan@6.0.9': patches/@changesets__assemble-release-plan@6.0.9.patch
+
 packages:
   - 'packages/typescript/*'
   - 'packages/typescript/ai-code-mode/models-eval'


### PR DESCRIPTION
## Summary

pnpm v11 stopped reading settings from the `pnpm` field of `package.json` ([release notes](https://github.com/pnpm/pnpm/releases/tag/v11.0.0)). Settings now have to live in `pnpm-workspace.yaml` instead. The repo's `packageManager` was bumped from pnpm v10 to v11.1.1 in #550, but the two settings under the `pnpm` key — `overrides` and `patchedDependencies` — weren't moved, so they've been silently ignored ever since.

The `abbrev` override is benign. The missing `@changesets/assemble-release-plan` patch is **the cause of #554's broken version bumps**:
- `@tanstack/ai-anthropic`: 0.8.6 → **1.0.0** (should be → 0.9.0)
- `@tanstack/ai-gemini`: 0.10.3 → **1.0.0** (should be → 0.11.0)
- `@tanstack/ai-ollama`: 0.6.13 → **1.0.0** (should be → 0.7.0)
- … and similarly across other patch-bumped packages

The patch short-circuits `shouldBumpMajor` for any `peerDependencies` change so peer-only updates don't cascade into major bumps across the workspace.

## Verification

```bash
rm -rf node_modules && pnpm install
grep -A12 "function shouldBumpMajor" node_modules/.pnpm/@changesets+assemble-releas_*/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js
```

Shows the patched `if (depType === 'peerDependencies') return false;` early-return is now present.

## Test plan

- [x] `pnpm install` from clean state applies the patch
- [x] `pnpm test:knip` / `pnpm test:sherif` pass
- [ ] After this lands on main, the changesets workflow will regenerate #554 with the correct minor bumps on the next run