### PR TITLE
fix(ai): make chat({ stream: false }) actually non-streaming on the wire

### DIFF
--- a/.changeset/stream-false-actually-non-streaming.md
+++ b/.changeset/stream-false-actually-non-streaming.md
@@ -1,0 +1,27 @@
+---
+'@tanstack/ai': minor
+'@tanstack/openai-base': minor
+'@tanstack/ai-openrouter': minor
+'@tanstack/ai-anthropic': minor
+'@tanstack/ai-gemini': minor
+'@tanstack/ai-ollama': minor
+'@tanstack/ai-openai': patch
+'@tanstack/ai-grok': patch
+'@tanstack/ai-groq': patch
+---
+
+Make `chat({ stream: false })` actually non-streaming on the wire.
+
+Previously, `chat({ stream: false })` ran `runStreamingText()` and concatenated the SSE response via `streamToText`. The wire request still carried `Accept: text/event-stream` and `"stream": true` in the body — the only practical effect of `stream: false` was that the SDK returned `Promise<string>` instead of `AsyncIterable<StreamChunk>`. Reasoning models with long pre-content thinking phases (Grok 4.3 via OpenRouter was the original repro) could be cut off by sub-30s socket-idle timeouts in proxies along the path.
+
+Now `chat({ stream: false })` calls a new optional adapter method `chatNonStreaming()` that sends `stream: false` directly to the provider and returns a single JSON response. When tools are involved, the dispatch layer drives a wire-level non-streaming agent loop: call `chatNonStreaming`, execute any returned tool calls, append the results, repeat until the model stops requesting tools or the agent-loop strategy halts.
+
+**Adapter API addition.** `TextAdapter.chatNonStreaming(options)` is added as an optional method returning `Promise<NonStreamingChatResult>` (`{ content, reasoning?, toolCalls?, finishReason?, usage? }`). All in-tree adapters implement it:
+
+- `@tanstack/openai-base` — `OpenAIBaseChatCompletionsTextAdapter` and `OpenAIBaseResponsesTextAdapter`. Covers `@tanstack/ai-openai`, `@tanstack/ai-grok`, `@tanstack/ai-groq` automatically.
+- `@tanstack/ai-openrouter` — both `OpenRouterTextAdapter` and the Responses variant.
+- `@tanstack/ai-anthropic`, `@tanstack/ai-gemini`, `@tanstack/ai-ollama`.
+
+Adapters that don't override `chatNonStreaming` keep the legacy stream-then-concatenate behaviour — out-of-tree adapters continue working unchanged but won't get the wire-level fix until they opt in by implementing the method.
+
+**Behaviour notes:** approval-required tools and pure client-side tools cannot round-trip through a `Promise<string>`; the loop throws an explicit error directing callers to `stream: true` for those flows. Middleware is intentionally not invoked on the non-streaming path, matching the silence of the existing `adapter.structuredOutput` call inside `runAgenticStructuredOutput`. The `Promise<string>` return value remains content-only — reasoning is captured on the internal result for future surfaces but is not part of the public return type.

--- a/packages/typescript/ai-anthropic/src/adapters/text.ts
+++ b/packages/typescript/ai-anthropic/src/adapters/text.ts
@@ -14,6 +14,7 @@ import type {
   AnthropicModelInputModalitiesByName,
 } from '../model-meta'
 import type {
+  NonStreamingChatResult,
   StructuredOutputOptions,
   StructuredOutputResult,
 } from '@tanstack/ai/adapters'
@@ -184,6 +185,118 @@ export class AnthropicTextAdapter<
           code: err.code || String(err.status),
         },
       }
+    }
+  }
+
+  /**
+   * Wire-level non-streaming chat — sends `stream: false` to Anthropic
+   * and returns the single JSON response (issue #557). Mirrors `chatStream`
+   * for tools / interleaved-thinking / betas, then maps the
+   * `MessageCreateParamsNonStreaming` response shape to NonStreamingChatResult.
+   */
+  async chatNonStreaming(
+    options: TextOptions<TProviderOptions>,
+  ): Promise<NonStreamingChatResult> {
+    const { logger } = options
+    try {
+      const requestParams = this.mapCommonOptionsToAnthropic(options)
+
+      // Mirror chatStream: interleaved-thinking is only available on the
+      // beta endpoint when `thinking.budget_tokens > 0` is set.
+      const modelOptions = options.modelOptions as
+        | InternalTextProviderOptions
+        | undefined
+      const useInterleavedThinking =
+        modelOptions?.thinking?.type === 'enabled' &&
+        typeof modelOptions.thinking.budget_tokens === 'number' &&
+        modelOptions.thinking.budget_tokens > 0
+      const betas: Array<AnthropicBeta> | undefined = useInterleavedThinking
+        ? ['interleaved-thinking-2025-05-14']
+        : undefined
+
+      logger.request(
+        `activity=chat provider=anthropic model=${this.model} messages=${options.messages.length} tools=${options.tools?.length ?? 0} stream=false`,
+        { provider: 'anthropic', model: this.model },
+      )
+
+      const response = await this.client.beta.messages.create(
+        { ...requestParams, stream: false, ...(betas && { betas }) },
+        {
+          signal: options.request?.signal,
+          headers: options.request?.headers,
+        },
+      )
+
+      let content = ''
+      let reasoning = ''
+      const toolCalls: NonStreamingChatResult['toolCalls'] = []
+
+      for (const block of response.content) {
+        switch (block.type) {
+          case 'text':
+            content += block.text
+            break
+          case 'thinking':
+            // `thinking.signature` is needed to round-trip into the next
+            // turn but the public `chat({stream:false})` return drops it;
+            // the streaming path keeps signatures via the message thread.
+            if (typeof block.thinking === 'string') reasoning += block.thinking
+            break
+          case 'tool_use':
+            toolCalls.push({
+              id: block.id,
+              type: 'function' as const,
+              function: {
+                name: block.name,
+                // Anthropic returns parsed input objects; normalise to a
+                // JSON string to match the streaming TOOL_CALL_END shape
+                // and the OpenAI/OpenRouter wire conventions.
+                arguments: JSON.stringify(block.input ?? {}),
+              },
+            })
+            break
+        }
+      }
+
+      // Anthropic stop_reason values: 'end_turn' | 'max_tokens' |
+      // 'stop_sequence' | 'tool_use' | 'pause_turn' | 'refusal'.
+      // Map to the streaming finishReason vocabulary so the dispatch loop
+      // recognises 'tool_calls' regardless of provider.
+      const finishReason: NonStreamingChatResult['finishReason'] = (() => {
+        switch (response.stop_reason) {
+          case 'tool_use':
+            return 'tool_calls'
+          case 'max_tokens':
+            return 'length'
+          case 'refusal':
+            return 'content_filter'
+          case 'end_turn':
+          case 'stop_sequence':
+            return 'stop'
+          default:
+            return response.stop_reason ?? undefined
+        }
+      })()
+
+      const usage = {
+        promptTokens: response.usage.input_tokens,
+        completionTokens: response.usage.output_tokens,
+        totalTokens: response.usage.input_tokens + response.usage.output_tokens,
+      }
+
+      return {
+        content,
+        ...(reasoning ? { reasoning } : {}),
+        ...(toolCalls.length > 0 ? { toolCalls } : {}),
+        ...(finishReason ? { finishReason } : {}),
+        usage,
+      }
+    } catch (error: unknown) {
+      logger.errors('anthropic.chatNonStreaming fatal', {
+        error,
+        source: 'anthropic.chatNonStreaming',
+      })
+      throw error
     }
   }
 

--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -14,6 +14,7 @@ import type {
   GeminiModelInputModalitiesByName,
 } from '../model-meta'
 import type {
+  NonStreamingChatResult,
   StructuredOutputOptions,
   StructuredOutputResult,
 } from '@tanstack/ai/adapters'
@@ -151,6 +152,110 @@ export class GeminiTextAdapter<
               : 'An unknown error occurred during the chat stream.',
         },
       }
+    }
+  }
+
+  /**
+   * Wire-level non-streaming chat — sends a single `generateContent` request
+   * to Gemini (issue #557). Mirrors `chatStream` for option mapping, then
+   * extracts content / function calls / reasoning / usage from the typed
+   * `GenerateContentResponse`.
+   */
+  async chatNonStreaming(
+    options: TextOptions<GeminiTextProviderOptions>,
+  ): Promise<NonStreamingChatResult<GeminiToolCallMetadata>> {
+    const { logger } = options
+    const mappedOptions = this.mapCommonOptionsToGemini(options)
+
+    try {
+      logger.request(
+        `activity=chat provider=gemini model=${this.model} messages=${options.messages.length} tools=${options.tools?.length ?? 0} stream=false`,
+        { provider: 'gemini', model: this.model },
+      )
+
+      const response = await this.client.models.generateContent(mappedOptions)
+
+      let content = ''
+      let reasoning = ''
+      const toolCalls: NonStreamingChatResult<GeminiToolCallMetadata>['toolCalls'] =
+        []
+      let toolIndex = 0
+
+      const candidate = response.candidates?.[0]
+      if (candidate?.content?.parts) {
+        for (const part of candidate.content.parts) {
+          if (part.functionCall) {
+            const fc = part.functionCall
+            const id = fc.id || `${fc.name}_${Date.now()}_${toolIndex++}`
+            const args = fc.args ?? {}
+            toolCalls.push({
+              id,
+              type: 'function' as const,
+              function: {
+                name: fc.name || '',
+                arguments:
+                  typeof args === 'string' ? args : JSON.stringify(args),
+              },
+              // Gemini's thoughtSignature lives at the part level. Carry it
+              // forward so subsequent turns can replay it (matches the
+              // streaming side's TOOL_CALL_START metadata).
+              ...(part.thoughtSignature
+                ? { metadata: { thoughtSignature: part.thoughtSignature } }
+                : {}),
+            })
+          } else if (part.thought) {
+            // `part.thought === true` flags reasoning content; the actual
+            // thinking text is in `part.text` on the same part.
+            if (part.text) reasoning += part.text
+          } else if (part.text) {
+            content += part.text
+          }
+        }
+      }
+
+      // Map Gemini FinishReason → streaming finishReason vocabulary.
+      const finishReason: NonStreamingChatResult['finishReason'] = (() => {
+        const r = candidate?.finishReason
+        if (!r) return undefined
+        if (toolCalls.length > 0) return 'tool_calls'
+        switch (r) {
+          case FinishReason.STOP:
+            return 'stop'
+          case FinishReason.MAX_TOKENS:
+            return 'length'
+          case FinishReason.SAFETY:
+          case FinishReason.PROHIBITED_CONTENT:
+          case FinishReason.SPII:
+          case FinishReason.IMAGE_SAFETY:
+          case FinishReason.BLOCKLIST:
+            return 'content_filter'
+          default:
+            return String(r)
+        }
+      })()
+
+      const usageMeta = response.usageMetadata
+      const usage = usageMeta
+        ? {
+            promptTokens: usageMeta.promptTokenCount ?? 0,
+            completionTokens: usageMeta.candidatesTokenCount ?? 0,
+            totalTokens: usageMeta.totalTokenCount ?? 0,
+          }
+        : undefined
+
+      return {
+        content,
+        ...(reasoning ? { reasoning } : {}),
+        ...(toolCalls.length > 0 ? { toolCalls } : {}),
+        ...(finishReason ? { finishReason } : {}),
+        ...(usage ? { usage } : {}),
+      }
+    } catch (error) {
+      logger.errors('gemini.chatNonStreaming fatal', {
+        error,
+        source: 'gemini.chatNonStreaming',
+      })
+      throw error
     }
   }
 

--- a/packages/typescript/ai-ollama/src/adapters/text.ts
+++ b/packages/typescript/ai-ollama/src/adapters/text.ts
@@ -10,6 +10,7 @@ import type {
   OllamaChatModelOptionsByName,
 } from '../model-meta'
 import type {
+  NonStreamingChatResult,
   StructuredOutputOptions,
   StructuredOutputResult,
 } from '@tanstack/ai/adapters'
@@ -159,6 +160,76 @@ export class OllamaTextAdapter<TModel extends string> extends BaseTextAdapter<
       logger.errors('ollama.chatStream fatal', {
         error,
         source: 'ollama.chatStream',
+      })
+      throw error
+    }
+  }
+
+  /**
+   * Wire-level non-streaming chat — sends `stream: false` to Ollama
+   * (issue #557). Mirrors `chatStream` for option mapping and tool/format
+   * conversion, then maps Ollama's `ChatResponse` shape to NonStreamingChatResult.
+   */
+  async chatNonStreaming(
+    options: TextOptions<ResolveModelOptions<TModel>>,
+  ): Promise<NonStreamingChatResult> {
+    const { logger } = options
+    const mappedOptions = this.mapCommonOptionsToOllama(options)
+
+    try {
+      logger.request(
+        `activity=chat provider=ollama model=${this.model} messages=${options.messages.length} tools=${options.tools?.length ?? 0} stream=false`,
+        { provider: 'ollama', model: this.model },
+      )
+
+      const response = await this.client.chat({
+        ...mappedOptions,
+        stream: false,
+      })
+
+      const message = response.message
+      const content = message.content
+      const reasoning = (message as { thinking?: string }).thinking
+
+      const toolCalls = message.tool_calls?.map((tc, idx) => ({
+        // Ollama tool calls don't carry IDs — synthesise one matching the
+        // streaming side's convention so subsequent turns can correlate
+        // tool results back to calls.
+        id: `${this.name}-tool-${Date.now()}-${idx}`,
+        type: 'function' as const,
+        function: {
+          name: tc.function.name,
+          // Ollama returns parsed argument objects; normalise to a JSON
+          // string to match TOOL_CALL_END / OpenAI conventions so the
+          // dispatch layer's tool executor can JSON.parse them uniformly.
+          arguments: JSON.stringify(tc.function.arguments),
+        },
+      }))
+
+      const finishReason: NonStreamingChatResult['finishReason'] =
+        toolCalls && toolCalls.length > 0
+          ? 'tool_calls'
+          : response.done_reason === 'length'
+            ? 'length'
+            : 'stop'
+
+      const usage = {
+        promptTokens: response.prompt_eval_count,
+        completionTokens: response.eval_count,
+        totalTokens: response.prompt_eval_count + response.eval_count,
+      }
+
+      return {
+        content,
+        ...(reasoning ? { reasoning } : {}),
+        ...(toolCalls && toolCalls.length > 0 ? { toolCalls } : {}),
+        finishReason,
+        usage,
+      }
+    } catch (error: unknown) {
+      logger.errors('ollama.chatNonStreaming fatal', {
+        error,
+        source: 'ollama.chatNonStreaming',
       })
       throw error
     }

--- a/packages/typescript/ai-openrouter/src/adapters/text.ts
+++ b/packages/typescript/ai-openrouter/src/adapters/text.ts
@@ -16,6 +16,7 @@ import type {
   ChatStreamChunk,
 } from '@openrouter/sdk/models'
 import type {
+  NonStreamingChatResult,
   StructuredOutputOptions,
   StructuredOutputResult,
 } from '@tanstack/ai/adapters'
@@ -176,6 +177,103 @@ export class OpenRouterTextAdapter<
         error: errorPayload,
         source: `${this.name}.chatStream`,
       })
+    }
+  }
+
+  /**
+   * Wire-level non-streaming chat — sends `stream: false` to OpenRouter
+   * and returns the single JSON response. The original repro for issue
+   * #557 was an OpenRouter user (Grok 4.3) whose long reasoning phase was
+   * truncated by a 30s socket-idle proxy timeout on the SSE stream;
+   * `chat()` sidesteps that class of failure.
+   *
+   * Mirrors `structuredOutput` minus the `responseFormat` enforcement.
+   */
+  async chatNonStreaming(
+    options: TextOptions<ResolveProviderOptions<TModel>>,
+  ): Promise<NonStreamingChatResult> {
+    const chatRequest = this.mapOptionsToRequest(options)
+
+    try {
+      const { streamOptions: _streamOptions, ...cleanParams } = chatRequest
+      void _streamOptions
+
+      options.logger.request(
+        `activity=chat provider=${this.name} model=${this.model} messages=${options.messages.length} tools=${options.tools?.length ?? 0} stream=false`,
+        { provider: this.name, model: this.model },
+      )
+
+      const reqOptions = extractRequestOptions(options.request)
+      const response = await this.orClient.chat.send(
+        {
+          chatRequest: {
+            ...cleanParams,
+            stream: false,
+          },
+        },
+        {
+          signal: reqOptions.signal ?? undefined,
+          ...(reqOptions.headers && { headers: reqOptions.headers }),
+        },
+      )
+
+      const choice = response.choices[0]
+      const message = choice?.message
+
+      const content =
+        typeof message?.content === 'string' ? message.content : ''
+
+      // OpenRouter exposes reasoning as either `message.reasoning` (string)
+      // or `message.reasoningDetails` (array of detail objects). Concatenate
+      // any text payloads we find — the public `Promise<string>` return
+      // value drops it, but the result object surfaces it for observability.
+      let reasoning = ''
+      const reasoningStr = (message as { reasoning?: string } | undefined)
+        ?.reasoning
+      if (typeof reasoningStr === 'string') reasoning += reasoningStr
+      const reasoningDetails = (
+        message as { reasoningDetails?: Array<{ text?: string }> } | undefined
+      )?.reasoningDetails
+      if (Array.isArray(reasoningDetails)) {
+        for (const detail of reasoningDetails) {
+          if (typeof detail.text === 'string') reasoning += detail.text
+        }
+      }
+
+      const toolCalls = message?.toolCalls?.map((tc) => ({
+        id: tc.id,
+        type: 'function' as const,
+        function: {
+          name: tc.function.name,
+          arguments: tc.function.arguments,
+        },
+      }))
+
+      const finishReason = choice?.finishReason ?? undefined
+
+      const usage = response.usage
+        ? {
+            promptTokens: response.usage.promptTokens,
+            completionTokens: response.usage.completionTokens,
+            totalTokens: response.usage.totalTokens,
+          }
+        : undefined
+
+      return {
+        content,
+        ...(reasoning ? { reasoning } : {}),
+        ...(toolCalls && toolCalls.length > 0 ? { toolCalls } : {}),
+        ...(finishReason ? { finishReason } : {}),
+        ...(usage ? { usage } : {}),
+      }
+    } catch (error: unknown) {
+      // Narrow before logging: raw SDK errors can carry request metadata
+      // (including auth headers) which we must never surface to user loggers.
+      options.logger.errors(`${this.name}.chatNonStreaming fatal`, {
+        error: toRunErrorPayload(error, `${this.name}.chatNonStreaming failed`),
+        source: `${this.name}.chatNonStreaming`,
+      })
+      throw error
     }
   }
 

--- a/packages/typescript/ai/src/activities/chat/adapter.ts
+++ b/packages/typescript/ai/src/activities/chat/adapter.ts
@@ -4,6 +4,7 @@ import type {
   Modality,
   StreamChunk,
   TextOptions,
+  ToolCall,
 } from '../../types'
 
 /**
@@ -40,6 +41,45 @@ export interface StructuredOutputResult<T = unknown> {
   data: T
   /** The raw text response from the model before parsing */
   rawText: string
+}
+
+/**
+ * Result from a wire-level non-streaming chat call (`adapter.chat()`).
+ *
+ * Returned by adapters that send `stream: false` on the wire and receive a
+ * single JSON response. The dispatch layer (`runNonStreamingText`) uses this
+ * shape to drive a non-streaming agent loop: keep calling `adapter.chat()`,
+ * execute any returned tool calls, append the tool results, and call again
+ * until `finishReason !== 'tool_calls'` or the agent loop strategy stops.
+ */
+export interface NonStreamingChatResult<TToolCallMetadata = unknown> {
+  /** Concatenated assistant text content. May be empty when only tool calls fired. */
+  content: string
+  /**
+   * Reasoning / thinking content if the provider returned it (Claude
+   * extended thinking, OpenRouter reasoningDetails, etc.). Captured on the
+   * result for completeness; the public `chat({stream:false})` return value
+   * stays content-only to preserve the existing `Promise<string>` contract.
+   */
+  reasoning?: string
+  /**
+   * Tool calls the model wants to execute. Empty / undefined when the turn
+   * is terminal. Argument strings stay as JSON strings to match the
+   * streaming `TOOL_CALL_END` shape — the tool executor parses them.
+   */
+  toolCalls?: Array<ToolCall<TToolCallMetadata>>
+  /**
+   * Finish reason normalised to the set used by the streaming
+   * RUN_FINISHED event. The dispatch loop uses `'tool_calls'` to decide
+   * whether to continue.
+   */
+  finishReason?: 'stop' | 'length' | 'content_filter' | 'tool_calls' | string
+  /** Token usage if the provider returned it. */
+  usage?: {
+    promptTokens?: number
+    completionTokens?: number
+    totalTokens?: number
+  }
 }
 
 /**
@@ -88,6 +128,25 @@ export interface TextAdapter<
   chatStream: (
     options: TextOptions<TProviderOptions>,
   ) => AsyncIterable<StreamChunk>
+
+  /**
+   * Optional: generate a single text completion in one round-trip with
+   * `stream: false` on the wire. When an adapter implements this, the
+   * dispatch layer (`chat({ stream: false })`) routes through it instead
+   * of stream-then-concatenate — see issue #557.
+   *
+   * Adapters that omit this method keep the legacy behaviour:
+   * `runNonStreamingText` drains `chatStream` and concatenates text. That
+   * preserves API stability for out-of-tree adapters at the cost of still
+   * sending an SSE wire request when the caller asked for non-streaming.
+   *
+   * Named `chatNonStreaming` (rather than `chat`) so it doesn't collide
+   * with the public top-level `chat()` activity function exported from
+   * `@tanstack/ai`.
+   */
+  chatNonStreaming?: (
+    options: TextOptions<TProviderOptions>,
+  ) => Promise<NonStreamingChatResult<TToolCallMetadata>>
 
   /**
    * Generate structured output using the provider's native structured output API.
@@ -169,6 +228,16 @@ export abstract class BaseTextAdapter<
   abstract chatStream(
     options: TextOptions<TProviderOptions>,
   ): AsyncIterable<StreamChunk>
+
+  /**
+   * Optional wire-level non-streaming chat. Override on subclasses to send
+   * `stream: false` directly to the provider — see {@link TextAdapter.chatNonStreaming}.
+   * When omitted, `chat({ stream: false })` falls back to draining
+   * `chatStream` (legacy behaviour).
+   */
+  chatNonStreaming?(
+    options: TextOptions<TProviderOptions>,
+  ): Promise<NonStreamingChatResult<TToolCallMetadata>>
 
   /**
    * Generate structured output using the provider's native structured output API.

--- a/packages/typescript/ai/src/activities/chat/index.ts
+++ b/packages/typescript/ai/src/activities/chat/index.ts
@@ -1661,18 +1661,173 @@ async function* runStreamingText(
 }
 
 /**
- * Run non-streaming text - collects all content and returns as a string.
- * Runs the full agentic loop (if tools are provided) but returns collected text.
+ * Run non-streaming text — `chat({ stream: false })`.
+ *
+ * If the adapter implements `chatNonStreaming()` (in-tree: openai, grok,
+ * groq, openrouter, anthropic, gemini, ollama, …), this drives a wire-level
+ * non-streaming agent loop: call `adapter.chatNonStreaming()`, execute any
+ * returned tool calls, append the results, repeat until `finishReason !==
+ * 'tool_calls'` or the agent-loop strategy stops. The wire request carries
+ * `stream: false` and the response is a single JSON body — eliminating the
+ * SSE pitfalls that issue #557 hit (proxy-idle truncations on long
+ * reasoning turns, awkward fixture reassembly).
+ *
+ * If the adapter does NOT implement `chatNonStreaming()` (out-of-tree
+ * adapters), this falls back to the legacy behaviour — drain `chatStream`
+ * via `streamToText`. That keeps backwards compat for adapters that
+ * haven't migrated, at the cost of still streaming on the wire.
+ *
+ * Behaviour notes when on the wire-level path:
+ *  - Middleware is intentionally not invoked here, matching the silence of
+ *    the `adapter.structuredOutput` call inside `runAgenticStructuredOutput`.
+ *  - Approval-required tools and pure client tools cannot round-trip
+ *    through a `Promise<string>`; if the model requests one, the loop
+ *    surfaces an error so the caller knows to switch to streaming.
  */
-function runNonStreamingText(
+async function runNonStreamingText(
   options: TextActivityOptions<AnyTextAdapter, undefined, false>,
 ): Promise<string> {
-  // Run the streaming text and collect all text using streamToText
-  const stream = runStreamingText(
-    options as unknown as TextActivityOptions<AnyTextAdapter, undefined, true>,
+  const {
+    adapter,
+    middleware: _middleware,
+    context: _context,
+    debug,
+    messages: rawMessages = [],
+    tools: rawTools,
+    agentLoopStrategy,
+    abortController,
+    ...rest
+  } = options
+
+  // Fallback for adapters that haven't implemented chatNonStreaming yet:
+  // preserve the pre-#557 behaviour of stream-then-concatenate. Out-of-tree
+  // adapters keep working unchanged.
+  const chatNonStreaming = adapter.chatNonStreaming?.bind(adapter)
+  if (!chatNonStreaming) {
+    return streamToText(
+      runStreamingText(
+        options as unknown as TextActivityOptions<
+          AnyTextAdapter,
+          undefined,
+          true
+        >,
+      ),
+    )
+  }
+  const logger = resolveDebugOption(debug)
+  const model = adapter.model
+
+  // Convert UIMessage / ConstrainedModelMessage input to ModelMessage. The
+  // streaming engine does this in its constructor; mirror it here so the
+  // adapter sees the same shape across paths.
+  const messages: Array<ModelMessage> = convertMessagesToModelMessages(
+    rawMessages as Array<any>,
   )
 
-  return streamToText(stream)
+  // Build tools-with-JSON-schema once. This matches what TextEngine.streamModelResponse
+  // sends to the adapter, so the wire payload is identical apart from `stream: false`.
+  const tools: Array<Tool> = (rawTools ?? []) as Array<Tool>
+  const toolsWithJsonSchemas = tools.map((tool) => ({
+    ...tool,
+    inputSchema: tool.inputSchema
+      ? convertSchemaToJsonSchema(tool.inputSchema)
+      : undefined,
+    outputSchema: tool.outputSchema
+      ? convertSchemaToJsonSchema(tool.outputSchema)
+      : undefined,
+  }))
+
+  const strategy: AgentLoopStrategy =
+    agentLoopStrategy ?? maxIterationsStrategy(5)
+
+  const effectiveRequest = abortController
+    ? { signal: abortController.signal }
+    : undefined
+
+  const baseChatOptions = {
+    ...rest,
+    model,
+    logger,
+    request: effectiveRequest,
+  } as TextOptions<Record<string, any>>
+
+  let accumulatedContent = ''
+  let iterationCount = 0
+  let lastFinishReason: string | null = null
+
+  while (
+    strategy({ iterationCount, messages, finishReason: lastFinishReason })
+  ) {
+    const result = await chatNonStreaming({
+      ...baseChatOptions,
+      messages,
+      tools: toolsWithJsonSchemas,
+    })
+
+    if (result.content) {
+      accumulatedContent += result.content
+    }
+
+    lastFinishReason = result.finishReason ?? null
+    iterationCount++
+
+    const toolCalls = result.toolCalls ?? []
+    if (
+      result.finishReason !== 'tool_calls' ||
+      toolCalls.length === 0 ||
+      tools.length === 0
+    ) {
+      return accumulatedContent
+    }
+
+    // Append the assistant turn that requested the tool calls before
+    // executing them, so the next chatNonStreaming() call sees the same
+    // conversation shape the streaming path produces.
+    messages.push({
+      role: 'assistant',
+      content: result.content || null,
+      toolCalls,
+      ...(result.reasoning
+        ? { thinking: [{ content: result.reasoning }] }
+        : {}),
+    })
+
+    // Execute server-side tools. Reuses the same generator the streaming
+    // engine drives in `processToolCalls`, with no middleware hooks /
+    // custom-event factory — non-streaming callers don't get those signals.
+    // We discard yielded CustomEvents and only consume the return value.
+    const generator = executeToolCalls(toolCalls, tools)
+    let next = await generator.next()
+    while (!next.done) {
+      next = await generator.next()
+    }
+    const executionResult: {
+      results: Array<ToolResult>
+      needsApproval: Array<ApprovalRequest>
+      needsClientExecution: Array<ClientToolRequest>
+    } = next.value
+
+    if (
+      executionResult.needsApproval.length > 0 ||
+      executionResult.needsClientExecution.length > 0
+    ) {
+      // Approval and client-side tools require an interactive transport.
+      // Fail loud so callers don't silently lose tool results.
+      throw new Error(
+        'chat({ stream: false }) cannot service tools that require approval or client-side execution. Use chat({ stream: true }) and consume the AG-UI events to handle these flows.',
+      )
+    }
+
+    for (const toolResult of executionResult.results) {
+      messages.push({
+        role: 'tool',
+        content: JSON.stringify(toolResult.result),
+        toolCallId: toolResult.toolCallId,
+      })
+    }
+  }
+
+  return accumulatedContent
 }
 
 /**
@@ -2089,5 +2244,6 @@ export type {
   TextAdapterConfig,
   StructuredOutputOptions,
   StructuredOutputResult,
+  NonStreamingChatResult,
 } from './adapter'
 export { BaseTextAdapter } from './adapter'

--- a/packages/typescript/ai/src/activities/index.ts
+++ b/packages/typescript/ai/src/activities/index.ts
@@ -40,6 +40,7 @@ export {
   type TextAdapterConfig,
   type StructuredOutputOptions,
   type StructuredOutputResult,
+  type NonStreamingChatResult,
 } from './chat/adapter'
 
 // ===========================

--- a/packages/typescript/ai/tests/chat.test.ts
+++ b/packages/typescript/ai/tests/chat.test.ts
@@ -181,6 +181,192 @@ describe('chat()', () => {
   })
 
   // ==========================================================================
+  // Wire-level non-streaming via adapter.chatNonStreaming() — issue #557
+  // ==========================================================================
+  describe('wire-level non-streaming (adapter.chatNonStreaming)', () => {
+    it('routes through adapter.chatNonStreaming and never opens a stream when set', async () => {
+      const { adapter, calls, chatCalls } = createMockAdapter({
+        chatIterations: [{ content: 'Hello world!', finishReason: 'stop' }],
+      })
+
+      const result = await chat({
+        adapter,
+        messages: [{ role: 'user', content: 'Hi' }],
+        stream: false,
+      })
+
+      expect(result).toBe('Hello world!')
+      expect(chatCalls).toHaveLength(1)
+      // chatStream must not be touched — that's the whole point of #557.
+      expect(calls).toHaveLength(0)
+    })
+
+    it('drives a non-streaming agent loop across multiple turns when tools fire', async () => {
+      const executeSpy = vi.fn().mockReturnValue({ temp: 72 })
+
+      const { adapter, chatCalls, calls } = createMockAdapter({
+        chatIterations: [
+          // Turn 1: model asks for the tool
+          {
+            content: '',
+            toolCalls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: {
+                  name: 'getWeather',
+                  arguments: '{"city":"NYC"}',
+                },
+              },
+            ],
+            finishReason: 'tool_calls',
+          },
+          // Turn 2: model produces final text
+          { content: '72F in NYC', finishReason: 'stop' },
+        ],
+      })
+
+      const result = await chat({
+        adapter,
+        messages: [{ role: 'user', content: 'Weather in NYC?' }],
+        tools: [serverTool('getWeather', executeSpy)],
+        stream: false,
+      })
+
+      expect(result).toBe('72F in NYC')
+      expect(executeSpy).toHaveBeenCalledTimes(1)
+      expect(chatCalls).toHaveLength(2)
+      expect(calls).toHaveLength(0)
+
+      // Turn 2 must see the assistant tool_calls turn + tool result appended.
+      const turn2Messages = chatCalls[1]!.messages as Array<{
+        role: string
+        content: unknown
+        toolCalls?: unknown
+        toolCallId?: string
+      }>
+      expect(turn2Messages.map((m) => m.role)).toEqual([
+        'user',
+        'assistant',
+        'tool',
+      ])
+      expect(turn2Messages[1]!.toolCalls).toBeDefined()
+      expect(turn2Messages[2]!.toolCallId).toBe('call_1')
+    })
+
+    it('honors agentLoopStrategy in the non-streaming loop', async () => {
+      const executeSpy = vi.fn().mockReturnValue({ ok: true })
+
+      const { adapter, chatCalls } = createMockAdapter({
+        // Every turn requests the tool — without a cap this would spin
+        // forever. We expect the loop to bail after maxIterations(2).
+        chatFn: async () => ({
+          content: '',
+          toolCalls: [
+            {
+              id: 'call_x',
+              type: 'function',
+              function: { name: 'noop', arguments: '{}' },
+            },
+          ],
+          finishReason: 'tool_calls',
+        }),
+      })
+
+      const result = await chat({
+        adapter,
+        messages: [{ role: 'user', content: 'go' }],
+        tools: [serverTool('noop', executeSpy)],
+        stream: false,
+        agentLoopStrategy: ({ iterationCount }) => iterationCount < 2,
+      })
+
+      expect(chatCalls).toHaveLength(2)
+      // No final-turn content was ever produced.
+      expect(result).toBe('')
+    })
+
+    it('surfaces an error when a non-streaming tool requires approval', async () => {
+      const { adapter } = createMockAdapter({
+        chatIterations: [
+          {
+            content: '',
+            toolCalls: [
+              {
+                id: 'call_a',
+                type: 'function',
+                function: { name: 'addToCart', arguments: '{}' },
+              },
+            ],
+            finishReason: 'tool_calls',
+          },
+        ],
+      })
+
+      const approvalTool: Tool = {
+        name: 'addToCart',
+        description: 'add to cart',
+        execute: () => ({ ok: true }),
+        needsApproval: true,
+      }
+
+      await expect(
+        chat({
+          adapter,
+          messages: [{ role: 'user', content: 'cart please' }],
+          tools: [approvalTool],
+          stream: false,
+        }),
+      ).rejects.toThrow(/approval/i)
+    })
+
+    it('falls back to chatStream + streamToText when adapter omits chatNonStreaming', async () => {
+      // Build an adapter that satisfies the public surface but omits the
+      // optional chatNonStreaming method — out-of-tree adapters look like
+      // this until they migrate.
+      const calls: Array<unknown> = []
+      const adapter = {
+        kind: 'text' as const,
+        name: 'legacy-mock',
+        model: 'legacy-model' as const,
+        '~types': {
+          providerOptions: {} as Record<string, unknown>,
+          inputModalities: ['text'] as readonly ['text'],
+          messageMetadataByModality: {
+            text: undefined as unknown,
+            image: undefined as unknown,
+            audio: undefined as unknown,
+            video: undefined as unknown,
+            document: undefined as unknown,
+          },
+          toolCapabilities: [] as ReadonlyArray<string>,
+          toolCallMetadata: undefined as unknown,
+        },
+        chatStream: (opts: unknown) => {
+          calls.push(opts)
+          return (async function* () {
+            yield ev.runStarted()
+            yield ev.textStart()
+            yield ev.textContent('hello from stream')
+            yield ev.textEnd()
+            yield ev.runFinished('stop')
+          })()
+        },
+        structuredOutput: async () => ({ data: {}, rawText: '{}' }),
+      }
+
+      const result = await chat({
+        adapter,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      })
+
+      expect(result).toBe('hello from stream')
+      expect(calls).toHaveLength(1)
+    })
+  })
+
+  // ==========================================================================
   // Server tool execution
   // ==========================================================================
   describe('server tool execution', () => {

--- a/packages/typescript/ai/tests/test-utils.ts
+++ b/packages/typescript/ai/tests/test-utils.ts
@@ -152,9 +152,47 @@ export function createMockAdapter(options: {
   /** Array of chunk sequences: chatStream returns iterations[0] on first call, iterations[1] on second, etc. */
   iterations?: Array<Array<StreamChunk>>
   structuredOutput?: (opts: any) => Promise<{ data: unknown; rawText: string }>
+  /**
+   * Override `adapter.chat()` for non-streaming tests. If omitted the
+   * BaseTextAdapter default (drains chatStream) applies — which is fine
+   * for tests that only care that *some* chat() impl runs.
+   */
+  chatFn?: (opts: any) => Promise<{
+    content: string
+    reasoning?: string
+    toolCalls?: Array<{
+      id: string
+      type: 'function'
+      function: { name: string; arguments: string }
+    }>
+    finishReason?: string
+    usage?: {
+      promptTokens?: number
+      completionTokens?: number
+      totalTokens?: number
+    }
+  }>
+  /** Array of chat() responses: chatFn returns chatIterations[0] on first call, etc. */
+  chatIterations?: Array<{
+    content: string
+    reasoning?: string
+    toolCalls?: Array<{
+      id: string
+      type: 'function'
+      function: { name: string; arguments: string }
+    }>
+    finishReason?: string
+    usage?: {
+      promptTokens?: number
+      completionTokens?: number
+      totalTokens?: number
+    }
+  }>
 }) {
   const calls: Array<Record<string, unknown>> = []
+  const chatCalls: Array<Record<string, unknown>> = []
   let callIndex = 0
+  let chatCallIndex = 0
 
   const adapter: AnyTextAdapter = {
     kind: 'text' as const,
@@ -190,11 +228,112 @@ export function createMockAdapter(options: {
 
       return (async function* () {})()
     },
+    chatNonStreaming: async (opts: any) => {
+      chatCalls.push(opts)
+
+      if (options.chatFn) {
+        return options.chatFn(opts)
+      }
+
+      if (options.chatIterations) {
+        const result = options.chatIterations[chatCallIndex] || {
+          content: '',
+        }
+        chatCallIndex++
+        return result
+      }
+
+      // Default: drain the mock's chatStream and reassemble — mirrors the
+      // legacy stream-then-concatenate behaviour so existing tests that
+      // configure `iterations` (stream chunks) keep working when invoked
+      // through the non-streaming path.
+      let content = ''
+      let reasoning = ''
+      const toolCallsByIndex = new Map<
+        number,
+        { id: string; name: string; args: string }
+      >()
+      let nextIndex = 0
+      let finishReason: string | undefined
+      let usage:
+        | {
+            promptTokens?: number
+            completionTokens?: number
+            totalTokens?: number
+          }
+        | undefined
+
+      for await (const chunk of adapter.chatStream(opts)) {
+        switch (chunk.type) {
+          case 'TEXT_MESSAGE_CONTENT': {
+            const e = chunk as { delta?: string }
+            if (e.delta) content += e.delta
+            break
+          }
+          case 'REASONING_MESSAGE_CONTENT': {
+            const e = chunk as { delta?: string }
+            if (e.delta) reasoning += e.delta
+            break
+          }
+          case 'TOOL_CALL_START': {
+            const e = chunk as {
+              toolCallId: string
+              toolCallName?: string
+              toolName?: string
+              index?: number
+            }
+            const index = e.index ?? nextIndex++
+            toolCallsByIndex.set(index, {
+              id: e.toolCallId,
+              name: e.toolCallName ?? e.toolName ?? '',
+              args: '',
+            })
+            break
+          }
+          case 'TOOL_CALL_ARGS': {
+            const e = chunk as { toolCallId: string; delta?: string }
+            for (const tc of toolCallsByIndex.values()) {
+              if (tc.id === e.toolCallId) {
+                tc.args += e.delta ?? ''
+                break
+              }
+            }
+            break
+          }
+          case 'RUN_FINISHED': {
+            const e = chunk as {
+              finishReason?: string
+              usage?: typeof usage
+            }
+            if (e.finishReason) finishReason = e.finishReason
+            if (e.usage) usage = e.usage
+            break
+          }
+        }
+      }
+
+      const toolCalls =
+        toolCallsByIndex.size > 0
+          ? Array.from(toolCallsByIndex.values()).map((tc) => ({
+              id: tc.id,
+              type: 'function' as const,
+              function: { name: tc.name, arguments: tc.args },
+            }))
+          : undefined
+
+      return {
+        content,
+        ...(reasoning ? { reasoning } : {}),
+        ...(toolCalls ? { toolCalls } : {}),
+        ...(finishReason ? { finishReason } : {}),
+        ...(usage ? { usage } : {}),
+      }
+    },
     structuredOutput:
       options.structuredOutput ?? (async () => ({ data: {}, rawText: '{}' })),
   }
 
-  return { adapter, calls }
+  return { adapter, calls, chatCalls }
 }
 
 // ============================================================================

--- a/packages/typescript/ai/tests/type-check.test.ts
+++ b/packages/typescript/ai/tests/type-check.test.ts
@@ -39,6 +39,8 @@ const mockAdapter = {
     toolCallMetadata: undefined as unknown,
   },
   chatStream: async function* () {},
+  // chatNonStreaming is now optional on the adapter interface — leave it
+  // off so the satisfies check exercises the fallback typing path.
   structuredOutput: async () => ({ data: {}, rawText: '{}' }),
 } satisfies MockAdapter
 

--- a/packages/typescript/openai-base/src/adapters/chat-completions-text.ts
+++ b/packages/typescript/openai-base/src/adapters/chat-completions-text.ts
@@ -7,6 +7,7 @@ import { makeStructuredOutputCompatible } from '../utils/schema-converter'
 import { convertToolsToChatCompletionsFormat } from './chat-completions-tool-converter'
 import type OpenAI from 'openai'
 import type {
+  NonStreamingChatResult,
   StructuredOutputOptions,
   StructuredOutputResult,
 } from '@tanstack/ai/adapters'
@@ -124,6 +125,109 @@ export abstract class OpenAIBaseChatCompletionsTextAdapter<
         source: `${this.name}.chatStream`,
       })
     }
+  }
+
+  /**
+   * Wire-level non-streaming chat — sends `stream: false` to the Chat
+   * Completions endpoint and returns the single JSON response. Used by
+   * `chat({ stream: false })` to avoid the proxy-idle/SSE-reassembly
+   * pitfalls of stream-then-concatenate. See issue #557.
+   *
+   * Mirrors `chatStream` request mapping (so the wire payload is identical
+   * apart from the stream flag) and `structuredOutput` error handling
+   * (sanitised payload, fail-loud on caller-side validation).
+   */
+  async chatNonStreaming(
+    options: TextOptions<TProviderOptions>,
+  ): Promise<NonStreamingChatResult> {
+    try {
+      const requestParams = this.mapOptionsToRequest(options)
+      const {
+        stream_options: _streamOptions,
+        stream: _stream,
+        ...cleanParams
+      } = requestParams as any
+      void _streamOptions
+      void _stream
+
+      options.logger.request(
+        `activity=chat provider=${this.name} model=${this.model} messages=${options.messages.length} tools=${options.tools?.length ?? 0} stream=false`,
+        { provider: this.name, model: this.model },
+      )
+
+      const response = await this.client.chat.completions.create(
+        { ...cleanParams, stream: false },
+        extractRequestOptions(options.request),
+      )
+
+      const choice = response.choices[0]
+      const message = choice?.message
+
+      const content =
+        typeof message?.content === 'string' ? message.content : ''
+
+      const toolCalls = message?.tool_calls
+        ?.filter(
+          (tc): tc is typeof tc & { type: 'function' } =>
+            tc.type === 'function',
+        )
+        .map((tc) => ({
+          id: tc.id,
+          type: 'function' as const,
+          function: {
+            name: tc.function.name,
+            arguments: tc.function.arguments,
+          },
+        }))
+
+      const reasoning = this.extractReasoningFromMessage(message)
+
+      const finishReason: NonStreamingChatResult['finishReason'] = (() => {
+        switch (choice?.finish_reason) {
+          case 'stop':
+          case 'length':
+          case 'content_filter':
+          case 'tool_calls':
+            return choice.finish_reason
+          default:
+            return choice?.finish_reason ?? undefined
+        }
+      })()
+
+      const usage = response.usage
+        ? {
+            promptTokens: response.usage.prompt_tokens,
+            completionTokens: response.usage.completion_tokens,
+            totalTokens: response.usage.total_tokens,
+          }
+        : undefined
+
+      return {
+        content,
+        ...(reasoning ? { reasoning } : {}),
+        ...(toolCalls && toolCalls.length > 0 ? { toolCalls } : {}),
+        ...(finishReason ? { finishReason } : {}),
+        ...(usage ? { usage } : {}),
+      }
+    } catch (error: unknown) {
+      // Narrow before logging: raw SDK errors can carry request metadata
+      // (including auth headers) which we must never surface to user loggers.
+      options.logger.errors(`${this.name}.chatNonStreaming fatal`, {
+        error: toRunErrorPayload(error, `${this.name}.chatNonStreaming failed`),
+        source: `${this.name}.chatNonStreaming`,
+      })
+      throw error
+    }
+  }
+
+  /**
+   * Extract reasoning content from a non-streaming response message.
+   * Default returns undefined — base OpenAI Chat Completions has no
+   * reasoning field. Subclasses (e.g., Grok with `reasoning_content`)
+   * override to surface it. Mirrors the streaming `extractReasoning` hook.
+   */
+  protected extractReasoningFromMessage(_message: unknown): string | undefined {
+    return undefined
   }
 
   /**

--- a/packages/typescript/openai-base/src/adapters/responses-text.ts
+++ b/packages/typescript/openai-base/src/adapters/responses-text.ts
@@ -7,6 +7,7 @@ import { makeStructuredOutputCompatible } from '../utils/schema-converter'
 import { convertToolsToResponsesFormat } from './responses-tool-converter'
 import type OpenAI from 'openai'
 import type {
+  NonStreamingChatResult,
   StructuredOutputOptions,
   StructuredOutputResult,
 } from '@tanstack/ai/adapters'
@@ -160,6 +161,136 @@ export abstract class OpenAIBaseResponsesTextAdapter<
    * The outputSchema is already JSON Schema (converted in the ai layer).
    * We apply provider-specific transformations for structured output compatibility.
    */
+  /**
+   * Wire-level non-streaming chat — sends `stream: false` to the Responses
+   * endpoint and returns the single JSON response. Used by
+   * `chat({ stream: false })` to avoid SSE proxy-idle / fixture-reassembly
+   * pitfalls (issue #557).
+   *
+   * Mirrors `structuredOutput`'s sanitisation and error handling, then
+   * extracts content / tool calls / reasoning / usage from the typed
+   * `Response` so the dispatch-layer agent loop can keep iterating without
+   * touching the wire format.
+   */
+  async chatNonStreaming(
+    options: TextOptions<TProviderOptions>,
+  ): Promise<NonStreamingChatResult> {
+    try {
+      const requestParams = this.mapOptionsToRequest(options)
+      const {
+        stream: _stream,
+        stream_options: _streamOptions,
+        ...cleanParams
+      } = requestParams as Record<string, unknown>
+      void _stream
+      void _streamOptions
+
+      options.logger.request(
+        `activity=chat provider=${this.name} model=${this.model} messages=${options.messages.length} tools=${options.tools?.length ?? 0} stream=false`,
+        { provider: this.name, model: this.model },
+      )
+
+      const response: Response = await this.client.responses.create(
+        {
+          ...(cleanParams as Omit<ResponseCreateParams, 'stream'>),
+          stream: false,
+        },
+        extractRequestOptions(options.request),
+      )
+
+      let content = ''
+      let reasoning = ''
+      const toolCalls: NonStreamingChatResult['toolCalls'] = []
+
+      for (const item of response.output) {
+        if (item.type === 'message') {
+          for (const part of item.content) {
+            const partType = (part as { type: string }).type
+            if (partType === 'output_text') {
+              content += (part as { text?: string }).text ?? ''
+            } else if (partType === 'refusal') {
+              const refusalText = (part as { refusal?: string }).refusal
+              const err = new Error(
+                `Model refused to respond: ${refusalText || 'Refused without explanation'}`,
+              )
+              ;(err as Error & { code?: string }).code = 'refusal'
+              throw err
+            }
+            // Other part types (output_audio, output_image, etc.) are not
+            // surfaced through chat() — callers asking for non-streaming
+            // text get the text-only slice, matching streaming behaviour.
+          }
+        } else if (item.type === 'function_call') {
+          // Responses API function calls carry the call_id, name, and a
+          // complete arguments string in non-streaming mode.
+          const fc = item as {
+            type: 'function_call'
+            call_id?: string
+            id?: string
+            name: string
+            arguments: string
+          }
+          toolCalls.push({
+            id: fc.call_id ?? fc.id ?? '',
+            type: 'function' as const,
+            function: { name: fc.name, arguments: fc.arguments },
+          })
+        } else if (item.type === 'reasoning') {
+          // Reasoning items contain summary[].text and/or content[].text
+          // depending on whether `reasoning.summary` was requested.
+          const reasoningItem = item as {
+            type: 'reasoning'
+            summary?: Array<{ type: string; text?: string }>
+            content?: Array<{ type: string; text?: string }>
+          }
+          for (const s of reasoningItem.summary ?? []) {
+            if (s.text) reasoning += s.text
+          }
+          for (const c of reasoningItem.content ?? []) {
+            if (c.text) reasoning += c.text
+          }
+        }
+      }
+
+      // Mirror the streaming finish-reason mapping (line ~1084) so a tool
+      // call response surfaces as `tool_calls` regardless of how the
+      // Responses API reports `incomplete_details`.
+      const incompleteReason = response.incomplete_details?.reason
+      const finishReason: NonStreamingChatResult['finishReason'] =
+        toolCalls.length > 0
+          ? 'tool_calls'
+          : incompleteReason === 'max_output_tokens'
+            ? 'length'
+            : incompleteReason === 'content_filter'
+              ? 'content_filter'
+              : 'stop'
+
+      const usage = response.usage
+        ? {
+            promptTokens: response.usage.input_tokens || 0,
+            completionTokens: response.usage.output_tokens || 0,
+            totalTokens: response.usage.total_tokens || 0,
+          }
+        : undefined
+
+      return {
+        content,
+        ...(reasoning ? { reasoning } : {}),
+        ...(toolCalls.length > 0 ? { toolCalls } : {}),
+        finishReason,
+        ...(usage ? { usage } : {}),
+      }
+    } catch (error: unknown) {
+      // Narrow before logging: raw SDK errors can carry request metadata
+      // (including auth headers) which we must never surface to user loggers.
+      options.logger.errors(`${this.name}.chatNonStreaming fatal`, {
+        error: toRunErrorPayload(error, `${this.name}.chatNonStreaming failed`),
+        source: `${this.name}.chatNonStreaming`,
+      })
+      throw error
+    }
+  }
+
   async structuredOutput(
     options: StructuredOutputOptions<TProviderOptions>,
   ): Promise<StructuredOutputResult<unknown>> {

--- a/testing/e2e/fixtures/one-shot-text/basic.json
+++ b/testing/e2e/fixtures/one-shot-text/basic.json
@@ -3,7 +3,8 @@
     {
       "match": { "userMessage": "[oneshot] what is your most popular guitar" },
       "response": {
-        "content": "Our most popular guitar is the Fender Stratocaster. It's loved for its versatile tone and comfortable neck profile."
+        "content": "Our most popular guitar is the Fender Stratocaster. It's loved for its versatile tone and comfortable neck profile.",
+        "systemFingerprint": null
       }
     }
   ]

--- a/testing/e2e/src/routes/api.chat.ts
+++ b/testing/e2e/src/routes/api.chat.ts
@@ -1,6 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { chat, maxIterations, toServerSentEventsResponse } from '@tanstack/ai'
+import {
+  EventType,
+  chat,
+  maxIterations,
+  toServerSentEventsResponse,
+} from '@tanstack/ai'
 import type { Feature, Provider } from '@/lib/types'
+import type { StreamChunk } from '@tanstack/ai'
 import { createTextAdapter } from '@/lib/providers'
 import { featureConfigs } from '@/lib/features'
 import { guitarRecommendationSchema } from '@/lib/schemas'
@@ -34,6 +40,72 @@ export const Route = createFileRoute('/api/chat')({
         )
 
         try {
+          // The `one-shot-text` feature exists to verify the wire-level
+          // non-streaming path (issue #557): `chat({ stream: false })` must
+          // call `adapter.chatNonStreaming()` and send `stream: false` to
+          // the upstream provider — not stream-then-concatenate. Wrap the
+          // resulting Promise<string> in a single SSE lifecycle so the
+          // client (which always uses `fetchServerSentEvents`) renders it
+          // identically to the streaming case.
+          if (feature === 'one-shot-text') {
+            const text = await chat({
+              ...adapterOptions,
+              modelOptions: config.modelOptions,
+              systemPrompts: [
+                'You are a helpful assistant for a guitar store.',
+              ],
+              messages,
+              abortController,
+              stream: false,
+            })
+
+            const oneShotStream =
+              (async function* (): AsyncGenerator<StreamChunk> {
+                const messageId = `oneshot-${Date.now()}`
+                const runId = `oneshot-run-${Date.now()}`
+                const threadId = `oneshot-thread-${Date.now()}`
+                yield {
+                  type: EventType.RUN_STARTED,
+                  runId,
+                  threadId,
+                  model: adapterOptions.adapter.model,
+                  timestamp: Date.now(),
+                }
+                yield {
+                  type: EventType.TEXT_MESSAGE_START,
+                  messageId,
+                  role: 'assistant',
+                  model: adapterOptions.adapter.model,
+                  timestamp: Date.now(),
+                }
+                yield {
+                  type: EventType.TEXT_MESSAGE_CONTENT,
+                  messageId,
+                  delta: text,
+                  model: adapterOptions.adapter.model,
+                  timestamp: Date.now(),
+                }
+                yield {
+                  type: EventType.TEXT_MESSAGE_END,
+                  messageId,
+                  model: adapterOptions.adapter.model,
+                  timestamp: Date.now(),
+                }
+                yield {
+                  type: EventType.RUN_FINISHED,
+                  runId,
+                  threadId,
+                  model: adapterOptions.adapter.model,
+                  timestamp: Date.now(),
+                  finishReason: 'stop',
+                }
+              })()
+
+            return toServerSentEventsResponse(oneShotStream, {
+              abortController,
+            })
+          }
+
           const stream =
             feature === 'structured-output-stream'
               ? chat({


### PR DESCRIPTION
Closes #557.

## Summary

- Adds optional `TextAdapter.chatNonStreaming()` returning `Promise<NonStreamingChatResult>` (`{ content, reasoning?, toolCalls?, finishReason?, usage? }`). When implemented, `chat({ stream: false })` routes through it for a true wire-level non-streaming request; when omitted, the legacy stream-then-concatenate fallback applies — out-of-tree adapters keep working unchanged.
- Implements `chatNonStreaming()` on all in-tree adapters: openai-base chat-completions + responses (covers openai, grok, groq), openrouter (chat-completions + responses), anthropic, gemini, ollama.
- Rewires `runNonStreamingText` as a wire-level non-streaming agent loop: call adapter → execute returned tool calls server-side → append results → repeat until `finishReason !== 'tool_calls'` or `agentLoopStrategy` halts. Approval-required and pure client-side tools throw an explicit error directing callers to streaming, since they can't round-trip through `Promise<string>`.

## Why

Previously `chat({ stream: false })` invoked `runStreamingText()` and concatenated the SSE response via `streamToText`. The wire request still carried `Accept: text/event-stream` and `"stream": true` in the body — only the SDK return type changed (`Promise<string>` instead of `AsyncIterable<StreamChunk>`). On reasoning models with long pre-content thinking phases (Grok 4.3 via OpenRouter was the original repro), proxies with sub-30s socket-idle timeouts could cut off the stream mid-flight even though a real non-streaming POST would complete fine.

## Test plan

- [x] Unit: 5 new tests covering wire-level dispatch, multi-turn tool loop, `agentLoopStrategy` cap, approval-tool error, and out-of-tree fallback. Existing 757 tests still pass (762 total).
- [x] E2E: rewired `api.chat.ts` so `feature === 'one-shot-text'` actually calls `chat({ stream: false })`. The existing `one-shot-text.spec.ts` now runs end-to-end against the new path across all 8 providers (openai, anthropic, gemini, ollama, groq, grok, openrouter, openrouter-responses). Updated the aimock fixture to include `systemFingerprint: null` so OpenRouter SDK's strict zod validation accepts the response. Full e2e suite (190 tests) passes.
- [x] `pnpm test:lib`, `pnpm test:types`, `pnpm test:eslint`, `pnpm build`: all clean.

## Notes

- Marked draft per author's request — wants more review before merging.
- Middleware is intentionally not invoked on the non-streaming path, mirroring the silence of the existing `adapter.structuredOutput` call inside `runAgenticStructuredOutput`.
- The `Promise<string>` return value remains content-only — reasoning is captured on the internal `NonStreamingChatResult` for future surfaces but is not part of the public contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)