### PR TITLE
fix(ai): infer Zod outputSchema instead of collapsing to unknown

### DIFF
--- a/.changeset/infer-schema-type-zod.md
+++ b/.changeset/infer-schema-type-zod.md
@@ -1,0 +1,25 @@
+---
+'@tanstack/ai': patch
+---
+
+fix(ai): infer Zod-typed `outputSchema` instead of collapsing to `unknown`
+
+`chat({ outputSchema: zodSchema })` previously returned `Promise<unknown>` (and
+`StructuredOutputCompleteEvent<T>` resolved with `T = unknown`) because
+`InferSchemaType` only matched `StandardJSONSchemaV1`. Zod's core `$ZodType`
+declares `~standard` as `StandardSchemaV1.Props` — without a type-level
+`jsonSchema` converter — so Zod schemas (and any other library that exposes
+only the Standard Schema validator surface to the type checker) fell through
+to `unknown`, forcing callers to either cast or run a redundant `schema.parse()`.
+
+`SchemaInput` now also accepts `StandardSchemaV1<any, any>`, and
+`InferSchemaType` recovers the input type from that branch when the
+JSON-schema branch doesn't match. The runtime path is unchanged for Zod /
+ArkType / Valibot (`convertSchemaToJsonSchema` still detects the runtime
+`~standard.jsonSchema` converter); only the static types are widened.
+
+`convertSchemaToJsonSchema` now throws an actionable error when given a
+Standard Schema validator that lacks a JSON-schema converter, instead of
+silently shipping the raw `{ '~standard': ... }` object to the LLM provider.
+
+Closes #562

--- a/packages/typescript/ai/src/activities/chat/tools/schema-converter.ts
+++ b/packages/typescript/ai/src/activities/chat/tools/schema-converter.ts
@@ -254,6 +254,20 @@ export function convertSchemaToJsonSchema(
     return result as JSONSchema
   }
 
+  // Detect Standard Schema validators (Zod, ArkType, Valibot, …) that don't
+  // expose a `~standard.jsonSchema` converter. These would otherwise fall
+  // through to the JSONSchema pass-through below and ship `{ '~standard': … }`
+  // straight to the LLM provider, producing an opaque downstream error. Fail
+  // fast with actionable guidance instead.
+  if (isStandardSchema(schema)) {
+    throw new Error(
+      'Schema is a Standard Schema validator but does not expose a JSON Schema ' +
+        'converter on `~standard.jsonSchema`. Use Zod v4.2+, ArkType v2.1.28+, ' +
+        'or wrap a Valibot schema with `toStandardJsonSchema()` from ' +
+        '`@valibot/to-json-schema` before passing it as `outputSchema`.',
+    )
+  }
+
   // If it's not a Standard JSON Schema, assume it's already a JSONSchema and pass through
   // Still apply structured output transformation if requested
 

--- a/packages/typescript/ai/src/types.ts
+++ b/packages/typescript/ai/src/types.ts
@@ -1,4 +1,7 @@
-import type { StandardJSONSchemaV1 } from '@standard-schema/spec'
+import type {
+  StandardJSONSchemaV1,
+  StandardSchemaV1,
+} from '@standard-schema/spec'
 import type { InternalLogger } from './logger/internal-logger'
 import type {
   BaseEvent as AGUIBaseEvent,
@@ -91,25 +94,42 @@ export interface JSONSchema {
 }
 
 /**
- * Union type for schema input - can be any Standard JSON Schema compliant schema or a plain JSONSchema object.
+ * Union type for schema input - can be any Standard Schema compliant validator,
+ * any Standard JSON Schema compliant schema, or a plain JSONSchema object.
  *
- * Standard JSON Schema compliant libraries include:
+ * Standard JSON Schema compliant libraries (carry the JSON-schema converter):
  * - Zod v4.2+ (natively supports StandardJSONSchemaV1)
  * - ArkType v2.1.28+ (natively supports StandardJSONSchemaV1)
  * - Valibot v1.2+ (via `toStandardJsonSchema()` from `@valibot/to-json-schema`)
  *
+ * StandardSchemaV1 covers libraries whose published types only expose the
+ * validator surface — Zod's core `$ZodType['~standard']` is currently typed
+ * as `StandardSchemaV1.Props` even though the runtime attaches the
+ * `jsonSchema` converter, so this branch is what makes `InferSchemaType`
+ * recover the inferred type for callers using `z.ZodType<T>`.
+ *
  * @see https://standardschema.dev/json-schema
  */
 
-export type SchemaInput = StandardJSONSchemaV1<any, any> | JSONSchema
+export type SchemaInput =
+  | StandardJSONSchemaV1<any, any>
+  | StandardSchemaV1<any, any>
+  | JSONSchema
 
 /**
  * Infer the TypeScript type from a schema.
  * For Standard JSON Schema compliant schemas, extracts the input type.
- * For plain JSONSchema, returns `any` since we can't infer types from JSON Schema at compile time.
+ * For Standard Schema validators (e.g. Zod's `~standard` surface), extracts
+ * the input type from the `StandardSchemaV1` shape.
+ * For plain JSONSchema, returns `unknown` since we can't infer types from
+ * JSON Schema at compile time.
  */
 export type InferSchemaType<T> =
-  T extends StandardJSONSchemaV1<infer TInput, unknown> ? TInput : unknown
+  T extends StandardJSONSchemaV1<infer TInput, unknown>
+    ? TInput
+    : T extends StandardSchemaV1<infer TInput, unknown>
+      ? TInput
+      : unknown
 
 export interface ToolCall<TMetadata = unknown> {
   id: string

--- a/packages/typescript/ai/tests/chat-result-types.test.ts
+++ b/packages/typescript/ai/tests/chat-result-types.test.ts
@@ -7,9 +7,14 @@
  */
 
 import { describe, expectTypeOf, it } from 'vitest'
+import { z } from 'zod'
 import type { StandardJSONSchemaV1 } from '@standard-schema/spec'
 import type { TextActivityResult } from '../src/activities/chat'
-import type { StreamChunk, StructuredOutputStream } from '../src/types'
+import type {
+  InferSchemaType,
+  StreamChunk,
+  StructuredOutputStream,
+} from '../src/types'
 
 type Person = { name: string }
 
@@ -37,6 +42,39 @@ describe('chat() return type', () => {
       // is false, so the conditional falls through to `Promise<T>`.
       expectTypeOf<TextActivityResult<PersonSchema>>().toEqualTypeOf<
         Promise<Person>
+      >()
+    })
+  })
+
+  describe('with Zod outputSchema (regression guard for #562)', () => {
+    // A real Zod schema — the failure mode #562 describes is that Zod's
+    // `~standard` is typed as `StandardSchemaV1.Props` (no `jsonSchema`
+    // converter), so the JSONSchema-only branch of `InferSchemaType` falls
+    // through and the result type collapses to `unknown`. Pinning these
+    // expectations against `typeof zodSchema` is what would have caught it.
+    const zodSchema = z.object({ greeting: z.string() })
+    type ZodSchema = typeof zodSchema
+    type ZodPerson = { greeting: string }
+
+    it('InferSchemaType recovers the Zod input shape', () => {
+      expectTypeOf<InferSchemaType<ZodSchema>>().toEqualTypeOf<ZodPerson>()
+    })
+
+    it('stream: false → Promise<T>', () => {
+      expectTypeOf<TextActivityResult<ZodSchema, false>>().toEqualTypeOf<
+        Promise<ZodPerson>
+      >()
+    })
+
+    it('stream: true → StructuredOutputStream<T>', () => {
+      expectTypeOf<TextActivityResult<ZodSchema, true>>().toEqualTypeOf<
+        StructuredOutputStream<ZodPerson>
+      >()
+    })
+
+    it('default stream (boolean) → Promise<T>', () => {
+      expectTypeOf<TextActivityResult<ZodSchema>>().toEqualTypeOf<
+        Promise<ZodPerson>
       >()
     })
   })

--- a/packages/typescript/ai/tests/standard-converter.test.ts
+++ b/packages/typescript/ai/tests/standard-converter.test.ts
@@ -555,6 +555,28 @@ describe('convertSchemaToJsonSchema', () => {
       expect(zodResult).not.toBe(zodSchema)
     })
   })
+
+  describe('Standard Schema validator without jsonSchema converter', () => {
+    // Regression guard for #562: widening `SchemaInput` to also accept
+    // `StandardSchemaV1<any, any>` means a validator-only schema (no
+    // `~standard.jsonSchema`) now type-checks. Without the runtime guard
+    // this would fall through and ship `{ '~standard': … }` to the LLM —
+    // throw a clear, actionable error instead.
+    it('should throw an actionable error pointing at the missing converter', () => {
+      const validatorOnlySchema = {
+        '~standard': {
+          version: 1 as const,
+          vendor: 'fake',
+          validate: (value: unknown) => ({ value }),
+          types: undefined,
+        },
+      }
+
+      expect(() => convertSchemaToJsonSchema(validatorOnlySchema)).toThrow(
+        /does not expose a JSON Schema converter/i,
+      )
+    })
+  })
 })
 
 describe('isStandardJSONSchema', () => {


### PR DESCRIPTION
## Summary

\`chat({ outputSchema: zodSchema })\` returned \`Promise<unknown>\` (and \`StructuredOutputCompleteEvent<T>\` resolved with \`T = unknown\`) because \`InferSchemaType\` only matched \`StandardJSONSchemaV1\`. Zod's core \`\$ZodType['~standard']\` is typed as \`StandardSchemaV1.Props\` — without the \`jsonSchema\` converter at the type level — so Zod schemas didn't structurally satisfy the JSON-schema branch and fell through to \`unknown\`, forcing callers to either cast or run a redundant \`schema.parse()\`.

## The Zod type/runtime mismatch

|                 | Runtime                                                  | Compile-time type                                                                  |
| --------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| Zod 4.2+        | \`~standard\` has both \`validate\` and \`jsonSchema.input()\` | \`~standard\` declared as \`StandardSchemaV1.Props\` — no \`jsonSchema\` field visible |
| ArkType 2.1.28+ | same                                                     | public type *does* include the converter                                           |
| Plain Valibot   | \`~standard\` has only \`validate\`                          | \`StandardSchemaV1.Props\` (validator only)                                          |

Zod schemas *are* truly \`StandardJSONSchemaV1\` at runtime — Zod just hasn't widened the public \`~standard\` declaration on \`\$ZodType\` to include the \`jsonSchema\` converter (the \`StandardSchemaWithJSONProps\` interface exists in their source but isn't applied to \`\$ZodType\`). Looks like an in-progress upstream change.

## Approach

**\`types.ts\`** — widen \`SchemaInput\` to also accept \`StandardSchemaV1<any, any>\`, add a \`StandardSchemaV1\` branch to \`InferSchemaType\`. The JSON-schema branch is still tried first (structurally narrower), so callers passing a real \`StandardJSONSchemaV1\` keep that resolution; Zod (and any future validator-only library) gets the inference via the new branch. \`unknown\` now means "I have no information," not "Zod was too clever for the matcher."

**\`schema-converter.ts\`** — add a runtime guard that throws an actionable error when a Standard Schema validator without \`~standard.jsonSchema\` is passed. This category was previously rejected at compile time; now that types accept it, the runtime needs to fail loudly instead of shipping \`{ '~standard': ... }\` straight to the LLM provider.

**Runtime path is unchanged for Zod / ArkType / Valibot** — \`convertSchemaToJsonSchema\` still uses the existing \`isStandardJSONSchema\` structural check, which Zod 4.2+ schemas pass at runtime regardless of their narrow type.

## Test plan

- [x] \`pnpm test:types\` — passes; new \`expectTypeOf<InferSchemaType<typeof zodSchema>>().toEqualTypeOf<{ greeting: string }>()\` would have caught #562
- [x] \`pnpm test:lib\` — 774 passing in \`@tanstack/ai\`; full affected suite green (29 projects + 14 deps)
- [x] \`pnpm test:eslint\` — clean
- [x] New test in \`standard-converter.test.ts\` covers the validator-only error path
- [x] Existing e2e (\`structured-output.spec.ts\` + \`api.chat.ts:46\`) already exercises Zod \`outputSchema\` at runtime — behavior is unchanged before/after this fix

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)