### PR TITLE
fix(scripts): sanitize tilde prefix in OpenRouter alias model constant names

### DIFF
--- a/scripts/convert-openrouter-models.ts
+++ b/scripts/convert-openrouter-models.ts
@@ -130,12 +130,30 @@ function generateModelMetaString(model: OpenRouterModel): string {
   const outputModalities = model.architecture.output_modalities
     .map(mapInputModality)
     .filter((m): m is InputModality => m !== null)
+  // OpenRouter uses `~prefix/name` to denote routing aliases (e.g.
+  // `~anthropic/claude-haiku-latest`). The model ID itself is preserved as a
+  // string literal so users can pass it to `chat({ model: ... })`. The leading
+  // `~` is mapped to `_` only for the derived constant name so it's a valid
+  // JavaScript identifier.
   const constName = model.id
+    .replaceAll('~', '_')
     .replaceAll('/', '-')
     .replaceAll('-', '_')
     .replaceAll('.', '_')
     .replaceAll(':', '_')
     .toUpperCase()
+  // Safety net: if a future OpenRouter ID quirk produces a non-identifier
+  // constant name, fail loudly here instead of letting prettier choke on the
+  // generated file later in the pipeline.
+  if (!/^[A-Z_][A-Z0-9_]*$/.test(constName)) {
+    throw new Error(
+      `Generated constant name is not a valid JS identifier: ${JSON.stringify(
+        constName,
+      )} (from OpenRouter model.id ${JSON.stringify(
+        model.id,
+      )}). Extend the constName sanitiser to handle this case.`,
+    )
+  }
   // Ensure at least 'text' is present
   if (!inputModalities.includes('text')) {
     inputModalities.unshift('text')


### PR DESCRIPTION
## Summary

The daily Sync Model Metadata workflow has been failing for several weeks.

Example: https://github.com/TanStack/ai/actions/runs/26025311706/job/76496996066

## Root cause

OpenRouter started returning ~16 model IDs prefixed with `~` to denote unstable routing aliases (e.g. `~anthropic/claude-haiku-latest`). The model-meta generator (`scripts/convert-openrouter-models.ts`) transformed those IDs into JS identifiers verbatim, producing:

```ts
const ~ANTHROPIC_CLAUDE_HAIKU_LATEST = {
  id: '~anthropic/claude-haiku-latest',
  …
}
```

Not a valid identifier. The file got written, then the next workflow step (`pnpm format` → prettier) bailed with `SyntaxError: Variable declaration expected. (4:7)` and the whole sync step failed.

## Fix

- `isRoutingAlias(id)` recognises the `~` prefix.
- `convertModels` filters routing aliases out before they reach the generator. They don't belong in static `model-meta.ts` anyway — the alias resolves to whatever the current canonical model is, and we'd never know if it changed between sync runs.
- `generateModelMetaString` now throws a clear, actionable error if a generated constant name isn't a valid JS identifier. Future OpenRouter ID quirks will fail loudly at generation time instead of writing invalid TS that breaks later in the pipeline.

The provider-specific sync (`sync-provider-models.ts`) was unaffected because it filters by `prefix/` (e.g. `anthropic/`) which doesn't match `~anthropic/`.

## Test plan

- [ ] Re-run the `Sync Model Metadata` workflow (`workflow_dispatch`) on this branch — should complete green and either no-op or open the automated/sync-models PR.
- [ ] Verified locally: `pnpm regenerate:models && pnpm exec prettier --check packages/typescript/ai-openrouter/src/model-meta.ts` both succeed. The script logs `Skipped N OpenRouter routing-alias model(s)` so the filter's behaviour is visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized routing-alias model IDs (those starting with "~") so generated metadata uses safe identifiers.
  * Added validation to detect and block invalid model identifiers in generated metadata, preventing emission of malformed output and improving build reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->