### PR TITLE
fix(ai-react): reset useChat partial/final on user action, not just RUN_STARTED

### DIFF
--- a/.changeset/use-chat-reset-on-action.md
+++ b/.changeset/use-chat-reset-on-action.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-react': patch
+---
+
+fix(ai-react): reset `partial` and `final` synchronously on user actions, not only on `RUN_STARTED`
+
+`useChat({ outputSchema })` previously kept the prior run's `partial`/`final` visible in the window between calling `sendMessage`/`reload`/`append`/`clear` and the server's first chunk. The reset now fires immediately on the user action, so the UI clears in sync with intent. The existing `RUN_STARTED` reset is preserved for agent-loop iterations within a single run.

--- a/packages/typescript/ai-react/src/use-chat.ts
+++ b/packages/typescript/ai-react/src/use-chat.ts
@@ -196,31 +196,51 @@ export function useChat<
   // All callback options are read through optionsRef at call time, so fresh
   // closures from each render are picked up without recreating the client.
 
+  // Clear structured-output state on any user-initiated action that starts (or
+  // discards) a run. The RUN_STARTED handler also resets, but that fires only
+  // when the server's first chunk lands — leaving `partial`/`final` stale in
+  // the gap between the user action and the network response. Resetting here
+  // keeps the UI in sync with intent. The RUN_STARTED reset is still needed
+  // for agent-loop iterations within a single user action (each tool round
+  // emits its own RUN_STARTED, and intermediate text must not leak into the
+  // final structured buffer).
+  const resetStructuredOutput = useCallback(() => {
+    if (optionsRef.current.outputSchema !== undefined) {
+      rawJsonRef.current = ''
+      setPartial({} as Partial)
+      setFinal(null)
+    }
+  }, [])
+
   const sendMessage = useCallback(
     async (content: string | MultimodalContent) => {
+      resetStructuredOutput()
       await client.sendMessage(content)
     },
-    [client],
+    [client, resetStructuredOutput],
   )
 
   const append = useCallback(
     async (message: ModelMessage | UIMessage) => {
+      resetStructuredOutput()
       await client.append(message)
     },
-    [client],
+    [client, resetStructuredOutput],
   )
 
   const reload = useCallback(async () => {
+    resetStructuredOutput()
     await client.reload()
-  }, [client])
+  }, [client, resetStructuredOutput])
 
   const stop = useCallback(() => {
     client.stop()
   }, [client])
 
   const clear = useCallback(() => {
+    resetStructuredOutput()
     client.clear()
-  }, [client])
+  }, [client, resetStructuredOutput])
 
   const setMessagesManually = useCallback(
     (newMessages: Array<UIMessage<TTools>>) => {

--- a/packages/typescript/ai-react/tests/use-chat-structured-output.test.ts
+++ b/packages/typescript/ai-react/tests/use-chat-structured-output.test.ts
@@ -154,6 +154,89 @@ describe('useChat({ outputSchema }) — runtime', () => {
     expect(result.current.partial).toEqual(personB)
   })
 
+  it('clears `partial` and `final` at sendMessage time, not just on RUN_STARTED', async () => {
+    const personA: Person = {
+      name: 'Alice',
+      age: 25,
+      email: 'alice@example.com',
+    }
+
+    // Second connect() never yields — simulates the gap between sendMessage
+    // dispatch and the server's first chunk. If reset only happens on
+    // RUN_STARTED, the previous run's `partial`/`final` linger here.
+    let call = 0
+    let releaseSecond: (() => void) | null = null
+    const secondStarted = new Promise<void>((resolve) => {
+      releaseSecond = resolve
+    })
+    const adapter = {
+      async *connect() {
+        if (call === 0) {
+          call++
+          for (const chunk of buildStructuredStream(
+            JSON.stringify(personA),
+            personA,
+            'run-a',
+          )) {
+            yield chunk
+          }
+          return
+        }
+        // Block until the test inspects state, then yield nothing (the test
+        // only cares about the pre-first-chunk window).
+        await secondStarted
+      },
+    }
+
+    const { result } = renderHook(() =>
+      useChat({ connection: adapter, outputSchema: personSchema }),
+    )
+
+    await act(async () => {
+      await result.current.sendMessage('A')
+    })
+    await waitFor(() => {
+      expect(result.current.final).toEqual(personA)
+    })
+
+    // Fire the second send. We do NOT await — the adapter is parked on
+    // `secondStarted`, so awaiting would deadlock. We just need the
+    // synchronous reset inside sendMessage to fire.
+    act(() => {
+      void result.current.sendMessage('B')
+    })
+
+    await waitFor(() => {
+      expect(result.current.partial).toEqual({})
+      expect(result.current.final).toBeNull()
+    })
+
+    releaseSecond?.()
+  })
+
+  it('clears `partial` and `final` on clear()', async () => {
+    const chunks = buildStructuredStream(json, person)
+    const adapter = createMockConnectionAdapter({ chunks })
+
+    const { result } = renderHook(() =>
+      useChat({ connection: adapter, outputSchema: personSchema }),
+    )
+
+    await act(async () => {
+      await result.current.sendMessage('Extract')
+    })
+    await waitFor(() => {
+      expect(result.current.final).toEqual(person)
+    })
+
+    act(() => {
+      result.current.clear()
+    })
+
+    expect(result.current.partial).toEqual({})
+    expect(result.current.final).toBeNull()
+  })
+
   it("invokes the user's onChunk callback alongside internal tracking", async () => {
     const chunks = buildStructuredStream(json, person)
     const adapter = createMockConnectionAdapter({ chunks })


### PR DESCRIPTION
## Summary

- `useChat({ outputSchema })` previously left the previous run's `partial`/`final` visible from when the user called `sendMessage`/`reload`/`append`/`clear` until the server's first chunk arrived — and never cleared at all when a request errored before any chunk.
- Reset now happens synchronously inside the user-action callbacks. The existing `RUN_STARTED` reset stays for agent-loop iterations within a single run (each tool round emits its own `RUN_STARTED`, and intermediate text must not leak into the final structured buffer).

Reported by @AlemTuzlak as a blocker for an upcoming workshop.

Files:
- `packages/typescript/ai-react/src/use-chat.ts` — extract `resetStructuredOutput` and call it from `sendMessage`/`append`/`reload`/`clear`.
- `packages/typescript/ai-react/tests/use-chat-structured-output.test.ts` — new tests pinning the pre-first-chunk window and the `clear()` path.

## Test plan

- [x] `pnpm --filter @tanstack/ai-react test:lib` — 112 passing (including 2 new tests).
- [x] `pnpm --filter @tanstack/ai-react test:eslint` — clean.
- [ ] E2E coverage: the existing E2E matrix doesn't have a structured-output scenario keyed on UI reset timing; the unit tests in `ai-react` pin the contract at the hook boundary. If we add a structured-output E2E test later it should include a "between-send staleness" assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed structured output state not being properly cleared immediately when user actions occur (send message, reload, append, clear). State is now reset synchronously with user actions rather than waiting for the server response.

* **Tests**
  * Added test coverage for structured output state reset behavior during user actions and conversation clearing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->