### PR TITLE
feat: per-turn schemas for structured-output chat (Phase 2)

### DIFF
--- a/.changeset/structured-output-as-message-part.md
+++ b/.changeset/structured-output-as-message-part.md
@@ -1,0 +1,25 @@
+---
+'@tanstack/ai': minor
+'@tanstack/ai-client': minor
+'@tanstack/ai-react': minor
+---
+
+feat: structured-output as a typed MessagePart on each assistant UIMessage
+
+`useChat({ outputSchema })` previously kept a single hook-level `partial`/`final`
+slot, so multi-turn structured chats lost every prior turn's response as soon
+as a new one streamed in. Each assistant turn now carries its own typed
+`structured-output` MessagePart on the UIMessage it belongs to. History walks
+`messages` and finds the typed part on each turn; the hook-level `partial`
+and `final` are derived from the latest assistant message's part and continue
+to work as before.
+
+Server-side `chat({ outputSchema, stream: true })` emits a new
+`structured-output.start` CUSTOM event before the JSON deltas so the client
+processor can route them into the StructuredOutputPart instead of building a
+TextPart. The wire converter serializes the part's raw JSON back as assistant
+content, so multi-turn structured chats stay coherent (the LLM sees its own
+prior structured responses on follow-up turns).
+
+A new example route demonstrating this pattern is at
+`/generations/structured-chat` in the `ts-react-chat` example.

--- a/.changeset/structured-output-per-turn-schemas.md
+++ b/.changeset/structured-output-per-turn-schemas.md
@@ -1,0 +1,28 @@
+---
+'@tanstack/ai': minor
+'@tanstack/ai-client': minor
+'@tanstack/ai-react': minor
+---
+
+feat: per-turn schemas for structured-output chat
+
+`useChat` now accepts an `outputSchemas: Record<string, SchemaInput>` map and
+`sendMessage(content, { schema: 'name' })` to pick which schema the assistant
+should respond against on a per-turn basis. Each assistant message's
+`structured-output` part carries the chosen `schemaName` as a runtime
+discriminator, and the new `getStructuredPart(message, name)` helper returns
+a typed view of the part for that schema (`data` and `partial` narrowed
+against `InferSchemaType<TSchemas[name]>`).
+
+Server-side, `chat()` accepts an optional `schemaName` field that propagates
+into the `structured-output.start` and `structured-output.complete` events,
+so the client-side StreamProcessor stamps the discriminator onto the part
+without any extra plumbing.
+
+Useful when one chat surface produces multiple kinds of structured artifacts
+(e.g. a single assistant that can return either a recipe or a weekly plan
+depending on the user's request). Builds on the message-part design from the
+previous release; single-schema `outputSchema` flows continue to work unchanged.
+
+A new example demonstrating this pattern is at
+`/generations/structured-multi` in the `ts-react-chat` example.

--- a/examples/ts-react-chat/src/components/Header.tsx
+++ b/examples/ts-react-chat/src/components/Header.tsx
@@ -166,6 +166,19 @@ export default function Header() {
             <span className="font-medium">Structured Output</span>
           </Link>
 
+          <Link
+            to="/generations/structured-chat"
+            onClick={() => setIsOpen(false)}
+            className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-800 transition-colors mb-1"
+            activeProps={{
+              className:
+                'flex items-center gap-3 p-3 rounded-lg bg-cyan-600 hover:bg-cyan-700 transition-colors mb-1',
+            }}
+          >
+            <Braces size={20} />
+            <span className="font-medium">Structured Chat</span>
+          </Link>
+
           <hr className="border-gray-700 my-2" />
 
           <p className="text-xs text-gray-500 uppercase tracking-wider px-3 pt-2 pb-1">

--- a/examples/ts-react-chat/src/components/Header.tsx
+++ b/examples/ts-react-chat/src/components/Header.tsx
@@ -179,6 +179,19 @@ export default function Header() {
             <span className="font-medium">Structured Chat</span>
           </Link>
 
+          <Link
+            to="/generations/structured-multi"
+            onClick={() => setIsOpen(false)}
+            className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-800 transition-colors mb-1"
+            activeProps={{
+              className:
+                'flex items-center gap-3 p-3 rounded-lg bg-cyan-600 hover:bg-cyan-700 transition-colors mb-1',
+            }}
+          >
+            <Braces size={20} />
+            <span className="font-medium">Structured Multi-schema</span>
+          </Link>
+
           <hr className="border-gray-700 my-2" />
 
           <p className="text-xs text-gray-500 uppercase tracking-wider px-3 pt-2 pb-1">

--- a/examples/ts-react-chat/src/routeTree.gen.ts
+++ b/examples/ts-react-chat/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as GenerationsVideoRouteImport } from './routes/generations.video
 import { Route as GenerationsTranscriptionRouteImport } from './routes/generations.transcription'
 import { Route as GenerationsSummarizeRouteImport } from './routes/generations.summarize'
 import { Route as GenerationsStructuredOutputRouteImport } from './routes/generations.structured-output'
+import { Route as GenerationsStructuredChatRouteImport } from './routes/generations.structured-chat'
 import { Route as GenerationsSpeechRouteImport } from './routes/generations.speech'
 import { Route as GenerationsImageRouteImport } from './routes/generations.image'
 import { Route as GenerationsAudioRouteImport } from './routes/generations.audio'
@@ -23,6 +24,7 @@ import { Route as ApiTranscribeRouteImport } from './routes/api.transcribe'
 import { Route as ApiTanchatRouteImport } from './routes/api.tanchat'
 import { Route as ApiSummarizeRouteImport } from './routes/api.summarize'
 import { Route as ApiStructuredOutputRouteImport } from './routes/api.structured-output'
+import { Route as ApiStructuredChatRouteImport } from './routes/api.structured-chat'
 import { Route as ApiImageGenRouteImport } from './routes/api.image-gen'
 import { Route as ExampleGuitarsIndexRouteImport } from './routes/example.guitars/index'
 import { Route as ExampleGuitarsGuitarIdRouteImport } from './routes/example.guitars/$guitarId'
@@ -68,6 +70,12 @@ const GenerationsStructuredOutputRoute =
     path: '/generations/structured-output',
     getParentRoute: () => rootRouteImport,
   } as any)
+const GenerationsStructuredChatRoute =
+  GenerationsStructuredChatRouteImport.update({
+    id: '/generations/structured-chat',
+    path: '/generations/structured-chat',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const GenerationsSpeechRoute = GenerationsSpeechRouteImport.update({
   id: '/generations/speech',
   path: '/generations/speech',
@@ -101,6 +109,11 @@ const ApiSummarizeRoute = ApiSummarizeRouteImport.update({
 const ApiStructuredOutputRoute = ApiStructuredOutputRouteImport.update({
   id: '/api/structured-output',
   path: '/api/structured-output',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiStructuredChatRoute = ApiStructuredChatRouteImport.update({
+  id: '/api/structured-chat',
+  path: '/api/structured-chat',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiImageGenRoute = ApiImageGenRouteImport.update({
@@ -144,6 +157,7 @@ export interface FileRoutesByFullPath {
   '/image-gen': typeof ImageGenRoute
   '/realtime': typeof RealtimeRoute
   '/api/image-gen': typeof ApiImageGenRoute
+  '/api/structured-chat': typeof ApiStructuredChatRoute
   '/api/structured-output': typeof ApiStructuredOutputRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tanchat': typeof ApiTanchatRoute
@@ -151,6 +165,7 @@ export interface FileRoutesByFullPath {
   '/generations/audio': typeof GenerationsAudioRoute
   '/generations/image': typeof GenerationsImageRoute
   '/generations/speech': typeof GenerationsSpeechRoute
+  '/generations/structured-chat': typeof GenerationsStructuredChatRoute
   '/generations/structured-output': typeof GenerationsStructuredOutputRoute
   '/generations/summarize': typeof GenerationsSummarizeRoute
   '/generations/transcription': typeof GenerationsTranscriptionRoute
@@ -167,6 +182,7 @@ export interface FileRoutesByTo {
   '/image-gen': typeof ImageGenRoute
   '/realtime': typeof RealtimeRoute
   '/api/image-gen': typeof ApiImageGenRoute
+  '/api/structured-chat': typeof ApiStructuredChatRoute
   '/api/structured-output': typeof ApiStructuredOutputRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tanchat': typeof ApiTanchatRoute
@@ -174,6 +190,7 @@ export interface FileRoutesByTo {
   '/generations/audio': typeof GenerationsAudioRoute
   '/generations/image': typeof GenerationsImageRoute
   '/generations/speech': typeof GenerationsSpeechRoute
+  '/generations/structured-chat': typeof GenerationsStructuredChatRoute
   '/generations/structured-output': typeof GenerationsStructuredOutputRoute
   '/generations/summarize': typeof GenerationsSummarizeRoute
   '/generations/transcription': typeof GenerationsTranscriptionRoute
@@ -191,6 +208,7 @@ export interface FileRoutesById {
   '/image-gen': typeof ImageGenRoute
   '/realtime': typeof RealtimeRoute
   '/api/image-gen': typeof ApiImageGenRoute
+  '/api/structured-chat': typeof ApiStructuredChatRoute
   '/api/structured-output': typeof ApiStructuredOutputRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tanchat': typeof ApiTanchatRoute
@@ -198,6 +216,7 @@ export interface FileRoutesById {
   '/generations/audio': typeof GenerationsAudioRoute
   '/generations/image': typeof GenerationsImageRoute
   '/generations/speech': typeof GenerationsSpeechRoute
+  '/generations/structured-chat': typeof GenerationsStructuredChatRoute
   '/generations/structured-output': typeof GenerationsStructuredOutputRoute
   '/generations/summarize': typeof GenerationsSummarizeRoute
   '/generations/transcription': typeof GenerationsTranscriptionRoute
@@ -216,6 +235,7 @@ export interface FileRouteTypes {
     | '/image-gen'
     | '/realtime'
     | '/api/image-gen'
+    | '/api/structured-chat'
     | '/api/structured-output'
     | '/api/summarize'
     | '/api/tanchat'
@@ -223,6 +243,7 @@ export interface FileRouteTypes {
     | '/generations/audio'
     | '/generations/image'
     | '/generations/speech'
+    | '/generations/structured-chat'
     | '/generations/structured-output'
     | '/generations/summarize'
     | '/generations/transcription'
@@ -239,6 +260,7 @@ export interface FileRouteTypes {
     | '/image-gen'
     | '/realtime'
     | '/api/image-gen'
+    | '/api/structured-chat'
     | '/api/structured-output'
     | '/api/summarize'
     | '/api/tanchat'
@@ -246,6 +268,7 @@ export interface FileRouteTypes {
     | '/generations/audio'
     | '/generations/image'
     | '/generations/speech'
+    | '/generations/structured-chat'
     | '/generations/structured-output'
     | '/generations/summarize'
     | '/generations/transcription'
@@ -262,6 +285,7 @@ export interface FileRouteTypes {
     | '/image-gen'
     | '/realtime'
     | '/api/image-gen'
+    | '/api/structured-chat'
     | '/api/structured-output'
     | '/api/summarize'
     | '/api/tanchat'
@@ -269,6 +293,7 @@ export interface FileRouteTypes {
     | '/generations/audio'
     | '/generations/image'
     | '/generations/speech'
+    | '/generations/structured-chat'
     | '/generations/structured-output'
     | '/generations/summarize'
     | '/generations/transcription'
@@ -286,6 +311,7 @@ export interface RootRouteChildren {
   ImageGenRoute: typeof ImageGenRoute
   RealtimeRoute: typeof RealtimeRoute
   ApiImageGenRoute: typeof ApiImageGenRoute
+  ApiStructuredChatRoute: typeof ApiStructuredChatRoute
   ApiStructuredOutputRoute: typeof ApiStructuredOutputRoute
   ApiSummarizeRoute: typeof ApiSummarizeRoute
   ApiTanchatRoute: typeof ApiTanchatRoute
@@ -293,6 +319,7 @@ export interface RootRouteChildren {
   GenerationsAudioRoute: typeof GenerationsAudioRoute
   GenerationsImageRoute: typeof GenerationsImageRoute
   GenerationsSpeechRoute: typeof GenerationsSpeechRoute
+  GenerationsStructuredChatRoute: typeof GenerationsStructuredChatRoute
   GenerationsStructuredOutputRoute: typeof GenerationsStructuredOutputRoute
   GenerationsSummarizeRoute: typeof GenerationsSummarizeRoute
   GenerationsTranscriptionRoute: typeof GenerationsTranscriptionRoute
@@ -356,6 +383,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GenerationsStructuredOutputRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/generations/structured-chat': {
+      id: '/generations/structured-chat'
+      path: '/generations/structured-chat'
+      fullPath: '/generations/structured-chat'
+      preLoaderRoute: typeof GenerationsStructuredChatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/generations/speech': {
       id: '/generations/speech'
       path: '/generations/speech'
@@ -403,6 +437,13 @@ declare module '@tanstack/react-router' {
       path: '/api/structured-output'
       fullPath: '/api/structured-output'
       preLoaderRoute: typeof ApiStructuredOutputRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/structured-chat': {
+      id: '/api/structured-chat'
+      path: '/api/structured-chat'
+      fullPath: '/api/structured-chat'
+      preLoaderRoute: typeof ApiStructuredChatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/image-gen': {
@@ -462,6 +503,7 @@ const rootRouteChildren: RootRouteChildren = {
   ImageGenRoute: ImageGenRoute,
   RealtimeRoute: RealtimeRoute,
   ApiImageGenRoute: ApiImageGenRoute,
+  ApiStructuredChatRoute: ApiStructuredChatRoute,
   ApiStructuredOutputRoute: ApiStructuredOutputRoute,
   ApiSummarizeRoute: ApiSummarizeRoute,
   ApiTanchatRoute: ApiTanchatRoute,
@@ -469,6 +511,7 @@ const rootRouteChildren: RootRouteChildren = {
   GenerationsAudioRoute: GenerationsAudioRoute,
   GenerationsImageRoute: GenerationsImageRoute,
   GenerationsSpeechRoute: GenerationsSpeechRoute,
+  GenerationsStructuredChatRoute: GenerationsStructuredChatRoute,
   GenerationsStructuredOutputRoute: GenerationsStructuredOutputRoute,
   GenerationsSummarizeRoute: GenerationsSummarizeRoute,
   GenerationsTranscriptionRoute: GenerationsTranscriptionRoute,

--- a/examples/ts-react-chat/src/routeTree.gen.ts
+++ b/examples/ts-react-chat/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as GenerationsVideoRouteImport } from './routes/generations.video
 import { Route as GenerationsTranscriptionRouteImport } from './routes/generations.transcription'
 import { Route as GenerationsSummarizeRouteImport } from './routes/generations.summarize'
 import { Route as GenerationsStructuredOutputRouteImport } from './routes/generations.structured-output'
+import { Route as GenerationsStructuredMultiRouteImport } from './routes/generations.structured-multi'
 import { Route as GenerationsStructuredChatRouteImport } from './routes/generations.structured-chat'
 import { Route as GenerationsSpeechRouteImport } from './routes/generations.speech'
 import { Route as GenerationsImageRouteImport } from './routes/generations.image'
@@ -24,6 +25,7 @@ import { Route as ApiTranscribeRouteImport } from './routes/api.transcribe'
 import { Route as ApiTanchatRouteImport } from './routes/api.tanchat'
 import { Route as ApiSummarizeRouteImport } from './routes/api.summarize'
 import { Route as ApiStructuredOutputRouteImport } from './routes/api.structured-output'
+import { Route as ApiStructuredMultiRouteImport } from './routes/api.structured-multi'
 import { Route as ApiStructuredChatRouteImport } from './routes/api.structured-chat'
 import { Route as ApiImageGenRouteImport } from './routes/api.image-gen'
 import { Route as ExampleGuitarsIndexRouteImport } from './routes/example.guitars/index'
@@ -70,6 +72,12 @@ const GenerationsStructuredOutputRoute =
     path: '/generations/structured-output',
     getParentRoute: () => rootRouteImport,
   } as any)
+const GenerationsStructuredMultiRoute =
+  GenerationsStructuredMultiRouteImport.update({
+    id: '/generations/structured-multi',
+    path: '/generations/structured-multi',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const GenerationsStructuredChatRoute =
   GenerationsStructuredChatRouteImport.update({
     id: '/generations/structured-chat',
@@ -109,6 +117,11 @@ const ApiSummarizeRoute = ApiSummarizeRouteImport.update({
 const ApiStructuredOutputRoute = ApiStructuredOutputRouteImport.update({
   id: '/api/structured-output',
   path: '/api/structured-output',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiStructuredMultiRoute = ApiStructuredMultiRouteImport.update({
+  id: '/api/structured-multi',
+  path: '/api/structured-multi',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiStructuredChatRoute = ApiStructuredChatRouteImport.update({
@@ -158,6 +171,7 @@ export interface FileRoutesByFullPath {
   '/realtime': typeof RealtimeRoute
   '/api/image-gen': typeof ApiImageGenRoute
   '/api/structured-chat': typeof ApiStructuredChatRoute
+  '/api/structured-multi': typeof ApiStructuredMultiRoute
   '/api/structured-output': typeof ApiStructuredOutputRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tanchat': typeof ApiTanchatRoute
@@ -166,6 +180,7 @@ export interface FileRoutesByFullPath {
   '/generations/image': typeof GenerationsImageRoute
   '/generations/speech': typeof GenerationsSpeechRoute
   '/generations/structured-chat': typeof GenerationsStructuredChatRoute
+  '/generations/structured-multi': typeof GenerationsStructuredMultiRoute
   '/generations/structured-output': typeof GenerationsStructuredOutputRoute
   '/generations/summarize': typeof GenerationsSummarizeRoute
   '/generations/transcription': typeof GenerationsTranscriptionRoute
@@ -183,6 +198,7 @@ export interface FileRoutesByTo {
   '/realtime': typeof RealtimeRoute
   '/api/image-gen': typeof ApiImageGenRoute
   '/api/structured-chat': typeof ApiStructuredChatRoute
+  '/api/structured-multi': typeof ApiStructuredMultiRoute
   '/api/structured-output': typeof ApiStructuredOutputRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tanchat': typeof ApiTanchatRoute
@@ -191,6 +207,7 @@ export interface FileRoutesByTo {
   '/generations/image': typeof GenerationsImageRoute
   '/generations/speech': typeof GenerationsSpeechRoute
   '/generations/structured-chat': typeof GenerationsStructuredChatRoute
+  '/generations/structured-multi': typeof GenerationsStructuredMultiRoute
   '/generations/structured-output': typeof GenerationsStructuredOutputRoute
   '/generations/summarize': typeof GenerationsSummarizeRoute
   '/generations/transcription': typeof GenerationsTranscriptionRoute
@@ -209,6 +226,7 @@ export interface FileRoutesById {
   '/realtime': typeof RealtimeRoute
   '/api/image-gen': typeof ApiImageGenRoute
   '/api/structured-chat': typeof ApiStructuredChatRoute
+  '/api/structured-multi': typeof ApiStructuredMultiRoute
   '/api/structured-output': typeof ApiStructuredOutputRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tanchat': typeof ApiTanchatRoute
@@ -217,6 +235,7 @@ export interface FileRoutesById {
   '/generations/image': typeof GenerationsImageRoute
   '/generations/speech': typeof GenerationsSpeechRoute
   '/generations/structured-chat': typeof GenerationsStructuredChatRoute
+  '/generations/structured-multi': typeof GenerationsStructuredMultiRoute
   '/generations/structured-output': typeof GenerationsStructuredOutputRoute
   '/generations/summarize': typeof GenerationsSummarizeRoute
   '/generations/transcription': typeof GenerationsTranscriptionRoute
@@ -236,6 +255,7 @@ export interface FileRouteTypes {
     | '/realtime'
     | '/api/image-gen'
     | '/api/structured-chat'
+    | '/api/structured-multi'
     | '/api/structured-output'
     | '/api/summarize'
     | '/api/tanchat'
@@ -244,6 +264,7 @@ export interface FileRouteTypes {
     | '/generations/image'
     | '/generations/speech'
     | '/generations/structured-chat'
+    | '/generations/structured-multi'
     | '/generations/structured-output'
     | '/generations/summarize'
     | '/generations/transcription'
@@ -261,6 +282,7 @@ export interface FileRouteTypes {
     | '/realtime'
     | '/api/image-gen'
     | '/api/structured-chat'
+    | '/api/structured-multi'
     | '/api/structured-output'
     | '/api/summarize'
     | '/api/tanchat'
@@ -269,6 +291,7 @@ export interface FileRouteTypes {
     | '/generations/image'
     | '/generations/speech'
     | '/generations/structured-chat'
+    | '/generations/structured-multi'
     | '/generations/structured-output'
     | '/generations/summarize'
     | '/generations/transcription'
@@ -286,6 +309,7 @@ export interface FileRouteTypes {
     | '/realtime'
     | '/api/image-gen'
     | '/api/structured-chat'
+    | '/api/structured-multi'
     | '/api/structured-output'
     | '/api/summarize'
     | '/api/tanchat'
@@ -294,6 +318,7 @@ export interface FileRouteTypes {
     | '/generations/image'
     | '/generations/speech'
     | '/generations/structured-chat'
+    | '/generations/structured-multi'
     | '/generations/structured-output'
     | '/generations/summarize'
     | '/generations/transcription'
@@ -312,6 +337,7 @@ export interface RootRouteChildren {
   RealtimeRoute: typeof RealtimeRoute
   ApiImageGenRoute: typeof ApiImageGenRoute
   ApiStructuredChatRoute: typeof ApiStructuredChatRoute
+  ApiStructuredMultiRoute: typeof ApiStructuredMultiRoute
   ApiStructuredOutputRoute: typeof ApiStructuredOutputRoute
   ApiSummarizeRoute: typeof ApiSummarizeRoute
   ApiTanchatRoute: typeof ApiTanchatRoute
@@ -320,6 +346,7 @@ export interface RootRouteChildren {
   GenerationsImageRoute: typeof GenerationsImageRoute
   GenerationsSpeechRoute: typeof GenerationsSpeechRoute
   GenerationsStructuredChatRoute: typeof GenerationsStructuredChatRoute
+  GenerationsStructuredMultiRoute: typeof GenerationsStructuredMultiRoute
   GenerationsStructuredOutputRoute: typeof GenerationsStructuredOutputRoute
   GenerationsSummarizeRoute: typeof GenerationsSummarizeRoute
   GenerationsTranscriptionRoute: typeof GenerationsTranscriptionRoute
@@ -383,6 +410,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GenerationsStructuredOutputRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/generations/structured-multi': {
+      id: '/generations/structured-multi'
+      path: '/generations/structured-multi'
+      fullPath: '/generations/structured-multi'
+      preLoaderRoute: typeof GenerationsStructuredMultiRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/generations/structured-chat': {
       id: '/generations/structured-chat'
       path: '/generations/structured-chat'
@@ -437,6 +471,13 @@ declare module '@tanstack/react-router' {
       path: '/api/structured-output'
       fullPath: '/api/structured-output'
       preLoaderRoute: typeof ApiStructuredOutputRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/structured-multi': {
+      id: '/api/structured-multi'
+      path: '/api/structured-multi'
+      fullPath: '/api/structured-multi'
+      preLoaderRoute: typeof ApiStructuredMultiRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/structured-chat': {
@@ -504,6 +545,7 @@ const rootRouteChildren: RootRouteChildren = {
   RealtimeRoute: RealtimeRoute,
   ApiImageGenRoute: ApiImageGenRoute,
   ApiStructuredChatRoute: ApiStructuredChatRoute,
+  ApiStructuredMultiRoute: ApiStructuredMultiRoute,
   ApiStructuredOutputRoute: ApiStructuredOutputRoute,
   ApiSummarizeRoute: ApiSummarizeRoute,
   ApiTanchatRoute: ApiTanchatRoute,
@@ -512,6 +554,7 @@ const rootRouteChildren: RootRouteChildren = {
   GenerationsImageRoute: GenerationsImageRoute,
   GenerationsSpeechRoute: GenerationsSpeechRoute,
   GenerationsStructuredChatRoute: GenerationsStructuredChatRoute,
+  GenerationsStructuredMultiRoute: GenerationsStructuredMultiRoute,
   GenerationsStructuredOutputRoute: GenerationsStructuredOutputRoute,
   GenerationsSummarizeRoute: GenerationsSummarizeRoute,
   GenerationsTranscriptionRoute: GenerationsTranscriptionRoute,

--- a/examples/ts-react-chat/src/routes/api.structured-chat.ts
+++ b/examples/ts-react-chat/src/routes/api.structured-chat.ts
@@ -1,0 +1,87 @@
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  chat,
+  chatParamsFromRequestBody,
+  toServerSentEventsResponse,
+} from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+import type { StreamChunk } from '@tanstack/ai'
+
+// Schema shared by every turn in this conversation. The point of this example
+// is to demonstrate that *every* assistant message carries its own typed
+// structured-output part — old turns don't get blown away by new ones.
+export const RecipeSchema = z.object({
+  title: z.string().describe('A short title for the recipe'),
+  cuisine: z.string().describe('Cuisine label, e.g. "Italian", "Mexican"'),
+  servings: z.number().int().min(1).describe('Number of servings'),
+  estimatedCostUsd: z
+    .number()
+    .min(0)
+    .describe('Rough total grocery cost in USD'),
+  ingredients: z
+    .array(
+      z.object({
+        item: z.string(),
+        amount: z.string().describe('Quantity with unit, e.g. "200 g"'),
+      }),
+    )
+    .min(1),
+  steps: z.array(z.string()).min(1).describe('Numbered cooking steps'),
+  tips: z.array(z.string()).default([]),
+})
+
+export type Recipe = z.infer<typeof RecipeSchema>
+
+const SYSTEM_PROMPT = `You are a chef assistant that always responds with a single recipe matching the provided JSON schema. When the user asks for modifications, produce a new recipe in the same shape that reflects the change. Stay terse — short titles, short steps.`
+
+export const Route = createFileRoute('/api/structured-chat')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (request.signal.aborted) {
+          return new Response(null, { status: 499 })
+        }
+
+        const abortController = new AbortController()
+        request.signal.addEventListener('abort', () => abortController.abort())
+
+        let params
+        try {
+          params = await chatParamsFromRequestBody(await request.json())
+        } catch (error) {
+          return new Response(
+            error instanceof Error ? error.message : 'Bad request',
+            { status: 400 },
+          )
+        }
+
+        try {
+          // Cast to AsyncIterable<StreamChunk> for the SSE serializer; the
+          // structured-output stream variant carries the extra `start` /
+          // `complete` custom events that don't appear in the AGUIEvent
+          // union but are valid StreamChunks at runtime.
+          const stream = chat({
+            adapter: openaiText('gpt-4o'),
+            messages: params.messages,
+            systemPrompts: [SYSTEM_PROMPT],
+            outputSchema: RecipeSchema,
+            stream: true,
+            threadId: params.threadId,
+            runId: params.runId,
+            abortController,
+          }) as AsyncIterable<StreamChunk>
+          return toServerSentEventsResponse(stream, { abortController })
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'An error occurred'
+          console.error('[api/structured-chat] Error:', error)
+          return new Response(JSON.stringify({ error: message }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+      },
+    },
+  },
+})

--- a/examples/ts-react-chat/src/routes/api.structured-multi.ts
+++ b/examples/ts-react-chat/src/routes/api.structured-multi.ts
@@ -1,0 +1,115 @@
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  chat,
+  chatParamsFromRequestBody,
+  toServerSentEventsResponse,
+} from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+import type { StreamChunk } from '@tanstack/ai'
+
+// Two schemas the assistant can produce, picked per turn by the client via
+// `sendMessage(content, { schema: 'recipe' | 'plan' })`. The route looks up
+// the schema by name from `forwardedProps.schemaName` and passes it to
+// `chat({ outputSchema, schemaName })` so the structured-output events
+// carry the discriminator down to the client part.
+
+export const RecipeSchema = z.object({
+  title: z.string(),
+  cuisine: z.string(),
+  servings: z.number().int().min(1),
+  ingredients: z.array(z.object({ item: z.string(), amount: z.string() })),
+  steps: z.array(z.string()),
+})
+export type Recipe = z.infer<typeof RecipeSchema>
+
+export const WeeklyPlanSchema = z.object({
+  title: z.string(),
+  days: z.array(
+    z.object({
+      day: z.string(),
+      focus: z.string(),
+      tasks: z.array(z.string()),
+    }),
+  ),
+})
+export type WeeklyPlan = z.infer<typeof WeeklyPlanSchema>
+
+// The canonical map. Keys are the discriminator strings that round-trip on
+// the wire; values are the schemas the orchestrator uses for validation.
+const SCHEMAS = {
+  recipe: RecipeSchema,
+  plan: WeeklyPlanSchema,
+} as const
+
+export type SchemaName = keyof typeof SCHEMAS
+
+const SYSTEM_PROMPT = `You produce one of two structured artifacts each turn, depending on the user's request: a recipe or a weekly plan. Always emit a single JSON object matching the requested schema. Stay terse.`
+
+export const Route = createFileRoute('/api/structured-multi')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (request.signal.aborted) {
+          return new Response(null, { status: 499 })
+        }
+
+        const abortController = new AbortController()
+        request.signal.addEventListener('abort', () => abortController.abort())
+
+        let params
+        try {
+          params = await chatParamsFromRequestBody(await request.json())
+        } catch (error) {
+          return new Response(
+            error instanceof Error ? error.message : 'Bad request',
+            { status: 400 },
+          )
+        }
+
+        // Pick the schema based on the client-supplied schemaName. Default
+        // to `recipe` if the client didn't specify (e.g. opened the page and
+        // sent a message before picking from the selector). An invalid name
+        // is treated as a 400 so the client knows it asked for something
+        // the route doesn't know how to produce.
+        const rawRequested = params.forwardedProps.schemaName
+        const requested =
+          typeof rawRequested === 'string' ? rawRequested : undefined
+        if (requested && !(requested in SCHEMAS)) {
+          return new Response(
+            JSON.stringify({ error: `unknown schema: ${requested}` }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+        const schemaName: SchemaName =
+          requested && requested in SCHEMAS
+            ? (requested as SchemaName)
+            : 'recipe'
+        const outputSchema = SCHEMAS[schemaName]
+
+        try {
+          const stream = chat({
+            adapter: openaiText('gpt-4o'),
+            messages: params.messages,
+            systemPrompts: [SYSTEM_PROMPT],
+            outputSchema,
+            schemaName,
+            stream: true,
+            threadId: params.threadId,
+            runId: params.runId,
+            abortController,
+          }) as AsyncIterable<StreamChunk>
+          return toServerSentEventsResponse(stream, { abortController })
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'An error occurred'
+          console.error('[api/structured-multi] Error:', error)
+          return new Response(JSON.stringify({ error: message }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+      },
+    },
+  },
+})

--- a/examples/ts-react-chat/src/routes/generations.structured-chat.tsx
+++ b/examples/ts-react-chat/src/routes/generations.structured-chat.tsx
@@ -1,0 +1,245 @@
+import { useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { fetchServerSentEvents, useChat } from '@tanstack/ai-react'
+import type { StructuredOutputPart } from '@tanstack/ai-client'
+import { RecipeSchema, type Recipe } from './api.structured-chat'
+
+const SUGGESTIONS = [
+  'Pasta dinner for two, under $15 total',
+  'Now make it vegan',
+  'Make it gluten-free and add a salad',
+] as const
+
+/**
+ * Multi-turn structured chat. Demonstrates that every assistant message
+ * carries its own typed structured-output part — old turns are still
+ * renderable as history, the latest one streams progressively.
+ *
+ * Reads `messages` directly rather than the hook-level `partial`/`final`
+ * sugar; those two are derived from the latest assistant message's part, so
+ * walking `messages` is the path that exposes history.
+ */
+function StructuredChatPage() {
+  const [input, setInput] = useState('')
+
+  const { messages, sendMessage, isLoading, partial, final } = useChat({
+    outputSchema: RecipeSchema,
+    connection: fetchServerSentEvents('/api/structured-chat'),
+  })
+
+  const handleSubmit = async (text: string) => {
+    if (!text.trim() || isLoading) return
+    setInput('')
+    await sendMessage(text.trim())
+  }
+
+  // Pair each assistant message with the user message that prompted it so
+  // we can render a clean two-column "prompt → recipe" history view.
+  const turns: Array<{
+    userPrompt: string
+    recipePart: StructuredOutputPart | null
+    isLast: boolean
+  }> = []
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i]
+    if (!m || m.role !== 'user') continue
+    const next = messages[i + 1]
+    const promptText = m.parts
+      .filter((p) => p.type === 'text')
+      .map((p) => (p as { content: string }).content)
+      .join('')
+    const recipePart =
+      next && next.role === 'assistant'
+        ? ((next.parts.find((p) => p.type === 'structured-output') as
+            | StructuredOutputPart
+            | undefined) ?? null)
+        : null
+    turns.push({
+      userPrompt: promptText,
+      recipePart,
+      isLast: i === messages.length - 1 || i + 1 === messages.length - 1,
+    })
+  }
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-72px)] bg-gray-900 text-white">
+      <div className="border-b border-orange-500/20 bg-gray-800 px-6 py-4">
+        <h2 className="text-xl font-semibold">Structured Chat</h2>
+        <p className="text-sm text-gray-400 mt-1">
+          Every assistant turn carries its own typed{' '}
+          <code className="text-orange-400">structured-output</code> part on the
+          assistant <code className="text-orange-400">UIMessage</code>. Walk{' '}
+          <code className="text-orange-400">messages</code> to render the full
+          history; the hook-level{' '}
+          <code className="text-orange-400">partial</code> /{' '}
+          <code className="text-orange-400">final</code> are derived from the
+          latest turn.
+        </p>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="max-w-3xl mx-auto space-y-6">
+          {turns.length === 0 && (
+            <div className="text-sm text-gray-500">
+              Try one of:
+              <ul className="mt-2 space-y-1">
+                {SUGGESTIONS.map((s) => (
+                  <li key={s}>
+                    <button
+                      onClick={() => handleSubmit(s)}
+                      className="text-orange-400 hover:text-orange-300 text-left"
+                    >
+                      {s}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {turns.map((turn, idx) => (
+            <div key={idx} className="space-y-2">
+              <div className="text-xs uppercase tracking-wider text-gray-500">
+                You
+              </div>
+              <div className="text-sm text-gray-200">{turn.userPrompt}</div>
+              <div className="text-xs uppercase tracking-wider text-gray-500 mt-3">
+                Recipe
+              </div>
+              {turn.recipePart ? (
+                <RecipeCard part={turn.recipePart} />
+              ) : (
+                <div className="text-sm text-gray-500 italic">
+                  {isLoading ? 'Streaming…' : 'No response yet'}
+                </div>
+              )}
+            </div>
+          ))}
+
+          {turns.length > 0 && (
+            <div className="border-t border-gray-800 pt-4 text-xs text-gray-500">
+              <div>
+                <span className="text-gray-400">Latest `final`:</span>{' '}
+                {final ? final.title : <em>null</em>}
+              </div>
+              <div>
+                <span className="text-gray-400">Latest `partial.title`:</span>{' '}
+                {(partial as { title?: string })?.title ?? <em>—</em>}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="border-t border-orange-500/20 bg-gray-800 px-6 py-4">
+        <div className="max-w-3xl mx-auto flex gap-3">
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                void handleSubmit(input)
+              }
+            }}
+            placeholder='e.g. "pasta dinner for two, under $15"'
+            disabled={isLoading}
+            className="flex-1 rounded-lg border border-orange-500/20 bg-gray-900 px-4 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/50 disabled:opacity-50"
+          />
+          <button
+            onClick={() => handleSubmit(input)}
+            disabled={!input.trim() || isLoading}
+            className="px-5 py-2 bg-orange-600 hover:bg-orange-700 disabled:bg-gray-700 disabled:text-gray-500 text-white rounded-lg text-sm font-medium transition-colors"
+          >
+            {isLoading ? 'Streaming…' : 'Send'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function RecipeCard({ part }: { part: StructuredOutputPart }) {
+  // `partial` is always populated during streaming; `data` lands on complete.
+  // Read whichever is freshest — they converge once `status === 'complete'`.
+  const recipe = (part.data ?? part.partial ?? {}) as Partial<Recipe>
+  const streaming = part.status === 'streaming'
+
+  return (
+    <div
+      className={`rounded-lg border p-4 transition-colors ${
+        streaming
+          ? 'border-orange-500/40 bg-gray-800/50'
+          : part.status === 'error'
+            ? 'border-red-500/40 bg-red-500/5'
+            : 'border-gray-700 bg-gray-800/50'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-lg font-semibold">
+          {recipe.title || (
+            <span className="text-gray-500 italic">Generating…</span>
+          )}
+        </h3>
+        {streaming && (
+          <span className="inline-block w-2 h-2 mt-2 rounded-full bg-orange-400 animate-pulse" />
+        )}
+      </div>
+      {(recipe.cuisine || recipe.servings || recipe.estimatedCostUsd) && (
+        <p className="text-xs text-gray-400 mt-1">
+          {recipe.cuisine}
+          {recipe.servings ? ` · serves ${recipe.servings}` : ''}
+          {recipe.estimatedCostUsd
+            ? ` · ~$${recipe.estimatedCostUsd.toFixed(2)}`
+            : ''}
+        </p>
+      )}
+      {recipe.ingredients && recipe.ingredients.length > 0 && (
+        <div className="mt-3">
+          <p className="text-xs uppercase tracking-wider text-gray-500">
+            Ingredients
+          </p>
+          <ul className="text-sm text-gray-200 mt-1 space-y-0.5">
+            {recipe.ingredients.map((ing, i) => (
+              <li key={i}>
+                {ing?.amount} {ing?.item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {recipe.steps && recipe.steps.length > 0 && (
+        <div className="mt-3">
+          <p className="text-xs uppercase tracking-wider text-gray-500">
+            Steps
+          </p>
+          <ol className="text-sm text-gray-200 mt-1 list-decimal list-inside space-y-1">
+            {recipe.steps.map((step, i) => (
+              <li key={i}>{step}</li>
+            ))}
+          </ol>
+        </div>
+      )}
+      {recipe.tips && recipe.tips.length > 0 && (
+        <div className="mt-3">
+          <p className="text-xs uppercase tracking-wider text-gray-500">Tips</p>
+          <ul className="text-sm text-gray-400 mt-1 list-disc list-inside space-y-0.5">
+            {recipe.tips.map((tip, i) => (
+              <li key={i}>{tip}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {part.status === 'error' && (
+        <p className="text-sm text-red-400 mt-3">
+          {part.errorMessage ?? 'Stream failed'}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/generations/structured-chat')({
+  component: StructuredChatPage,
+})

--- a/examples/ts-react-chat/src/routes/generations.structured-multi.tsx
+++ b/examples/ts-react-chat/src/routes/generations.structured-multi.tsx
@@ -1,0 +1,282 @@
+import { useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { fetchServerSentEvents, useChat } from '@tanstack/ai-react'
+import type { StructuredOutputPart } from '@tanstack/ai-client'
+import {
+  RecipeSchema,
+  WeeklyPlanSchema,
+  type Recipe,
+  type WeeklyPlan,
+  type SchemaName,
+} from './api.structured-multi'
+
+const SCHEMA_OPTIONS: ReadonlyArray<{
+  value: SchemaName
+  label: string
+  prompt: string
+}> = [
+  {
+    value: 'recipe',
+    label: 'Recipe',
+    prompt: 'A weeknight pasta dish for two',
+  },
+  {
+    value: 'plan',
+    label: 'Weekly plan',
+    prompt: 'A focused week for learning TypeScript',
+  },
+]
+
+/**
+ * Phase 2 example: two schemas in one conversation. Each turn picks which
+ * schema the assistant should respond against, and the resulting message's
+ * structured-output part carries the chosen name as the discriminator.
+ *
+ * The render walks `messages` and branches on `part.schemaName`. Using
+ * `getStructuredPart(message, 'recipe' | 'plan')` gives a typed view of the
+ * part — `data` is narrowed against the schema in `outputSchemas`.
+ */
+function StructuredMultiPage() {
+  const [input, setInput] = useState('')
+  const [schema, setSchema] = useState<SchemaName>('recipe')
+
+  const { messages, sendMessage, isLoading, getStructuredPart } = useChat({
+    outputSchemas: { recipe: RecipeSchema, plan: WeeklyPlanSchema },
+    connection: fetchServerSentEvents('/api/structured-multi'),
+  })
+
+  const handleSubmit = async (text: string, withSchema: SchemaName) => {
+    if (!text.trim() || isLoading) return
+    setInput('')
+    await sendMessage(text.trim(), { schema: withSchema })
+  }
+
+  return (
+    <div className="flex h-[calc(100vh-72px)] flex-col bg-gray-900 text-white">
+      <div className="border-b border-orange-500/20 bg-gray-800 px-6 py-4">
+        <h2 className="text-xl font-semibold">
+          Structured Chat — Per-turn Schemas
+        </h2>
+        <p className="mt-1 text-sm text-gray-400">
+          Pick a schema per turn. The assistant message's{' '}
+          <code className="text-orange-400">structured-output</code> part
+          carries the schema name as a discriminator; render code branches on it
+          and reads typed <code className="text-orange-400">data</code> via{' '}
+          <code className="text-orange-400">getStructuredPart</code>.
+        </p>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-3xl space-y-6">
+          {messages.length === 0 && (
+            <div className="text-sm text-gray-500">
+              Try these:
+              <ul className="mt-2 space-y-1">
+                {SCHEMA_OPTIONS.map((opt) => (
+                  <li key={opt.value}>
+                    <button
+                      onClick={() => {
+                        setSchema(opt.value)
+                        void handleSubmit(opt.prompt, opt.value)
+                      }}
+                      className="text-left text-orange-400 hover:text-orange-300"
+                    >
+                      <strong>{opt.label}:</strong> {opt.prompt}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {messages.map((m, i) => {
+            if (m.role === 'user') {
+              const text = m.parts
+                .filter((p) => p.type === 'text')
+                .map((p) => (p as { content: string }).content)
+                .join('')
+              return (
+                <div key={i} className="space-y-1">
+                  <div className="text-xs uppercase tracking-wider text-gray-500">
+                    You
+                  </div>
+                  <div className="text-sm text-gray-200">{text}</div>
+                </div>
+              )
+            }
+            if (m.role !== 'assistant') return null
+
+            const part = m.parts.find((p) => p.type === 'structured-output') as
+              | StructuredOutputPart
+              | undefined
+            if (!part) {
+              return (
+                <div key={i} className="text-sm italic text-gray-500">
+                  {isLoading ? 'Streaming…' : 'No response'}
+                </div>
+              )
+            }
+
+            if (part.schemaName === 'recipe') {
+              const view = getStructuredPart!(m, 'recipe')
+              return (
+                <RecipeCard
+                  key={i}
+                  status={part.status}
+                  recipe={
+                    (view?.data ?? view?.partial ?? {}) as Partial<Recipe>
+                  }
+                />
+              )
+            }
+            if (part.schemaName === 'plan') {
+              const view = getStructuredPart!(m, 'plan')
+              return (
+                <PlanCard
+                  key={i}
+                  status={part.status}
+                  plan={
+                    (view?.data ?? view?.partial ?? {}) as Partial<WeeklyPlan>
+                  }
+                />
+              )
+            }
+            return null
+          })}
+        </div>
+      </div>
+
+      <div className="border-t border-orange-500/20 bg-gray-800 px-6 py-4">
+        <div className="mx-auto flex max-w-3xl gap-3">
+          <select
+            value={schema}
+            onChange={(e) => setSchema(e.target.value as SchemaName)}
+            disabled={isLoading}
+            className="rounded-lg border border-orange-500/20 bg-gray-900 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-orange-500/50 disabled:opacity-50"
+          >
+            {SCHEMA_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                void handleSubmit(input, schema)
+              }
+            }}
+            placeholder="ask for a recipe or a weekly plan…"
+            disabled={isLoading}
+            className="flex-1 rounded-lg border border-orange-500/20 bg-gray-900 px-4 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/50 disabled:opacity-50"
+          />
+          <button
+            onClick={() => handleSubmit(input, schema)}
+            disabled={!input.trim() || isLoading}
+            className="rounded-lg bg-orange-600 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-orange-700 disabled:bg-gray-700 disabled:text-gray-500"
+          >
+            {isLoading ? 'Streaming…' : 'Send'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function RecipeCard({
+  status,
+  recipe,
+}: {
+  status: 'streaming' | 'complete' | 'error'
+  recipe: Partial<Recipe>
+}) {
+  return (
+    <div
+      className={`rounded-lg border p-4 ${
+        status === 'streaming'
+          ? 'border-orange-500/40 bg-gray-800/50'
+          : status === 'error'
+            ? 'border-red-500/40 bg-red-500/5'
+            : 'border-gray-700 bg-gray-800/50'
+      }`}
+    >
+      <p className="mb-1 text-xs uppercase tracking-wider text-orange-400">
+        Recipe
+      </p>
+      <h3 className="text-lg font-semibold">{recipe.title || 'Generating…'}</h3>
+      {recipe.cuisine && (
+        <p className="text-xs text-gray-400">
+          {recipe.cuisine}
+          {recipe.servings ? ` · serves ${recipe.servings}` : ''}
+        </p>
+      )}
+      {recipe.ingredients && recipe.ingredients.length > 0 && (
+        <ul className="mt-3 space-y-0.5 text-sm text-gray-200">
+          {recipe.ingredients.map((ing, i) => (
+            <li key={i}>
+              {ing?.amount} {ing?.item}
+            </li>
+          ))}
+        </ul>
+      )}
+      {recipe.steps && recipe.steps.length > 0 && (
+        <ol className="mt-3 list-inside list-decimal space-y-1 text-sm text-gray-200">
+          {recipe.steps.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ol>
+      )}
+    </div>
+  )
+}
+
+function PlanCard({
+  status,
+  plan,
+}: {
+  status: 'streaming' | 'complete' | 'error'
+  plan: Partial<WeeklyPlan>
+}) {
+  return (
+    <div
+      className={`rounded-lg border p-4 ${
+        status === 'streaming'
+          ? 'border-orange-500/40 bg-gray-800/50'
+          : status === 'error'
+            ? 'border-red-500/40 bg-red-500/5'
+            : 'border-gray-700 bg-gray-800/50'
+      }`}
+    >
+      <p className="mb-1 text-xs uppercase tracking-wider text-orange-400">
+        Weekly plan
+      </p>
+      <h3 className="text-lg font-semibold">{plan.title || 'Generating…'}</h3>
+      {plan.days && plan.days.length > 0 && (
+        <div className="mt-3 space-y-2">
+          {plan.days.map((day, i) => (
+            <div key={i}>
+              <p className="text-sm font-medium text-gray-200">
+                {day?.day} <span className="text-gray-400">— {day?.focus}</span>
+              </p>
+              {day?.tasks && day.tasks.length > 0 && (
+                <ul className="mt-1 list-inside list-disc text-sm text-gray-300">
+                  {day.tasks.map((t, j) => (
+                    <li key={j}>{t}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/generations/structured-multi')({
+  component: StructuredMultiPage,
+})

--- a/packages/typescript/ai-client/src/index.ts
+++ b/packages/typescript/ai-client/src/index.ts
@@ -10,6 +10,7 @@ export type {
   ToolCallPart,
   ToolResultPart,
   ThinkingPart,
+  StructuredOutputPart,
   // Client configuration types
   ChatClientOptions,
   ChatRequestBody,

--- a/packages/typescript/ai-client/src/types.ts
+++ b/packages/typescript/ai-client/src/types.ts
@@ -162,6 +162,27 @@ export interface ThinkingPart {
   content: string
 }
 
+/**
+ * StructuredOutputPart — typed structured response attached to the assistant
+ * message that produced it. `data` and `partial` are intentionally `unknown`
+ * here; the ai-react `useChat<_, TSchema>` hook narrows them via
+ * `InferSchemaType<TSchema>` at the consumption site (the `partial`/`final`
+ * derivation in use-chat.ts). Consumers that need typed access can do the
+ * same narrowing locally.
+ */
+export interface StructuredOutputPart {
+  type: 'structured-output'
+  status: 'streaming' | 'complete' | 'error'
+  /** Progressive parse of `raw` via parsePartialJSON. */
+  partial?: unknown
+  /** Validated final object — only set when `status === 'complete'`. */
+  data?: unknown
+  /** Accumulating JSON buffer. Source of truth for wire round-trip. */
+  raw: string
+  reasoning?: string
+  errorMessage?: string
+}
+
 export type MessagePart<TTools extends ReadonlyArray<AnyClientTool> = any> =
   | TextPart
   | ImagePart
@@ -171,6 +192,7 @@ export type MessagePart<TTools extends ReadonlyArray<AnyClientTool> = any> =
   | ToolCallPart<TTools>
   | ToolResultPart
   | ThinkingPart
+  | StructuredOutputPart
 
 /**
  * UIMessage - Domain-specific message format optimized for building chat UIs

--- a/packages/typescript/ai-client/src/types.ts
+++ b/packages/typescript/ai-client/src/types.ts
@@ -181,6 +181,13 @@ export interface StructuredOutputPart {
   raw: string
   reasoning?: string
   errorMessage?: string
+  /**
+   * Name of the schema that produced this part, when the hook is configured
+   * with `outputSchemas`. Acts as the runtime discriminator: render code
+   * `if (part.schemaName === 'recipe') { ... }` lines up with the typed
+   * variant on `ai-react`'s narrower wrapper types.
+   */
+  schemaName?: string
 }
 
 export type MessagePart<TTools extends ReadonlyArray<AnyClientTool> = any> =

--- a/packages/typescript/ai-react/src/types.ts
+++ b/packages/typescript/ai-react/src/types.ts
@@ -51,9 +51,18 @@ export type DeepPartial<T> =
  * Note: Connection and body changes will recreate the ChatClient instance.
  * To update these options, remount the component or use a key prop.
  */
+/**
+ * A record of named schemas, used to multiplex per-turn structured-output
+ * shapes in one conversation. Each `sendMessage` call can pick which schema
+ * the assistant should respond against; the resulting `structured-output`
+ * part carries the name as `schemaName` so render code can narrow.
+ */
+export type SchemaMap = Record<string, SchemaInput>
+
 export type UseChatOptions<
   TTools extends ReadonlyArray<AnyClientTool> = any,
   TSchema extends SchemaInput | undefined = undefined,
+  TSchemas extends SchemaMap | undefined = undefined,
 > = Omit<
   ChatClientOptions<TTools>,
   | 'onMessagesChange'
@@ -76,6 +85,18 @@ export type UseChatOptions<
    * against the schema passed to `chat({ outputSchema })` on the server route.
    */
   outputSchema?: TSchema
+  /**
+   * Map of named schemas for per-turn structured output. Pair with
+   * `sendMessage(content, { schema: 'name' })` to pick which schema the
+   * assistant should respond against for that turn. The structured-output
+   * part on the resulting assistant message carries `schemaName: 'name'` so
+   * render code can narrow on the discriminator.
+   *
+   * Mutually exclusive with `outputSchema` in practice; if both are set,
+   * `outputSchemas` wins at the type level for narrowing and `sendMessage`'s
+   * `schema` option becomes available.
+   */
+  outputSchemas?: TSchemas
 }
 
 /**
@@ -86,7 +107,8 @@ export type UseChatOptions<
 export type UseChatReturn<
   TTools extends ReadonlyArray<AnyClientTool> = any,
   TSchema extends SchemaInput | undefined = undefined,
-> = BaseUseChatReturn<TTools> &
+  TSchemas extends SchemaMap | undefined = undefined,
+> = BaseUseChatReturn<TTools, TSchemas> &
   (TSchema extends SchemaInput
     ? {
         /**
@@ -105,17 +127,61 @@ export type UseChatReturn<
       }
     : Record<never, never>)
 
-interface BaseUseChatReturn<TTools extends ReadonlyArray<AnyClientTool> = any> {
+/**
+ * Typed view of a `structured-output` part for a specific named schema. The
+ * `partial` and `data` fields are narrowed against the schema's inferred
+ * type, so render code can read them without manual casts.
+ */
+export interface TypedStructuredPart<TSchema extends SchemaInput> {
+  type: 'structured-output'
+  status: 'streaming' | 'complete' | 'error'
+  schemaName: string
+  raw: string
+  reasoning?: string
+  errorMessage?: string
+  partial?: DeepPartial<InferSchemaType<TSchema>>
+  data?: InferSchemaType<TSchema>
+}
+
+interface BaseUseChatReturn<
+  TTools extends ReadonlyArray<AnyClientTool> = any,
+  TSchemas extends SchemaMap | undefined = undefined,
+> {
   /**
    * Current messages in the conversation
    */
   messages: Array<UIMessage<TTools>>
 
   /**
+   * Look up a typed `structured-output` part on a message by its schemaName.
+   * Returns `undefined` if the message has no structured-output part, or if
+   * the part's `schemaName` doesn't match. The returned view's `data` and
+   * `partial` are narrowed against the corresponding schema in `outputSchemas`.
+   *
+   * Only available when `outputSchemas` was supplied at hook creation.
+   */
+  getStructuredPart: TSchemas extends SchemaMap
+    ? <TKey extends keyof TSchemas & string>(
+        message: UIMessage<TTools>,
+        schemaName: TKey,
+      ) => TypedStructuredPart<NonNullable<TSchemas[TKey]>> | undefined
+    : undefined
+
+  /**
    * Send a message and get a response.
    * Can be a simple string or multimodal content with images, audio, etc.
+   *
+   * When the hook was created with `outputSchemas`, pass `{ schema: 'name' }`
+   * to pick which named schema the assistant should respond against for
+   * this turn. The resulting assistant message's `structured-output` part
+   * will carry `schemaName: 'name'`.
    */
-  sendMessage: (content: string | MultimodalContent) => Promise<void>
+  sendMessage: (
+    content: string | MultimodalContent,
+    options?: TSchemas extends SchemaMap
+      ? { schema?: keyof TSchemas & string }
+      : { schema?: never },
+  ) => Promise<void>
 
   /**
    * Append a message to the conversation

--- a/packages/typescript/ai-react/src/use-chat.ts
+++ b/packages/typescript/ai-react/src/use-chat.ts
@@ -1,5 +1,4 @@
 import { ChatClient } from '@tanstack/ai-client'
-import { parsePartialJSON } from '@tanstack/ai'
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import type {
   AnyClientTool,
@@ -8,7 +7,11 @@ import type {
   SchemaInput,
   StreamChunk,
 } from '@tanstack/ai'
-import type { ChatClientState, ConnectionStatus } from '@tanstack/ai-client'
+import type {
+  ChatClientState,
+  ConnectionStatus,
+  StructuredOutputPart,
+} from '@tanstack/ai-client'
 
 import type {
   DeepPartial,
@@ -36,18 +39,8 @@ export function useChat<
     useState<ConnectionStatus>('disconnected')
   const [sessionGenerating, setSessionGenerating] = useState(false)
 
-  // Structured-output state. Only meaningful when `outputSchema` is supplied;
-  // when it isn't, these stay at their initial values and are hidden from the
-  // return type by the conditional in UseChatReturn. Runtime always tracks
-  // them — the type system gates visibility, not the runtime.
   type Partial = DeepPartial<InferSchemaType<NonNullable<TSchema>>>
   type Final = InferSchemaType<NonNullable<TSchema>>
-  const [partial, setPartial] = useState<Partial>({} as Partial)
-  const [final, setFinal] = useState<Final | null>(null)
-  // Raw JSON accumulator for parsePartialJSON. Ref instead of state — partial
-  // JSON parsing happens synchronously inside the chunk handler; we don't want
-  // a re-render per delta solely to track the buffer.
-  const rawJsonRef = useRef('')
 
   // Track current messages in a ref to preserve them when client is recreated
   const messagesRef = useRef<Array<UIMessage<TTools>>>(
@@ -56,7 +49,6 @@ export function useChat<
   const isFirstMountRef = useRef(true)
 
   // Update ref synchronously during render so it's always current when useMemo runs.
-  // A useEffect here would be async and messagesRef could be stale on client recreation.
   messagesRef.current = messages
 
   // Track current options in a ref to avoid recreating client when options change
@@ -64,11 +56,7 @@ export function useChat<
   optionsRef.current = options
 
   // Create ChatClient instance with callbacks to sync state
-  // Note: Options are captured at client creation time.
-  // The connection adapter can use functions for dynamic values (url, headers, etc.)
-  // which are evaluated lazily on each request.
   const client = useMemo(() => {
-    // On first mount, use initialMessages. On subsequent recreations, preserve existing messages.
     const messagesToUse = isFirstMountRef.current
       ? options.initialMessages || []
       : messagesRef.current
@@ -81,34 +69,8 @@ export function useChat<
       initialMessages: messagesToUse,
       body: optionsRef.current.body,
       forwardedProps: optionsRef.current.forwardedProps,
-      // Wrap every callback so the latest options are read at call time.
-      // Capturing the function reference directly would freeze it to whatever
-      // the parent passed on the first render.
       onResponse: (response) => optionsRef.current.onResponse?.(response),
       onChunk: (chunk: StreamChunk) => {
-        // Internal structured-output tracking — runs before the user callback
-        // so user code observes the same state the hook does. Only active when
-        // a schema is supplied; otherwise the branches are no-ops.
-        if (optionsRef.current.outputSchema !== undefined) {
-          if (chunk.type === 'RUN_STARTED') {
-            // New run — reset both views.
-            rawJsonRef.current = ''
-            setPartial({} as Partial)
-            setFinal(null)
-          } else if (chunk.type === 'TEXT_MESSAGE_CONTENT' && chunk.delta) {
-            rawJsonRef.current += chunk.delta
-            const progressive = parsePartialJSON(rawJsonRef.current)
-            if (progressive && typeof progressive === 'object') {
-              setPartial(progressive as Partial)
-            }
-          } else if (
-            chunk.type === 'CUSTOM' &&
-            chunk.name === 'structured-output.complete'
-          ) {
-            const value = chunk.value as { object: unknown }
-            setFinal(value.object as Final)
-          }
-        }
         optionsRef.current.onChunk?.(chunk)
       },
       onFinish: (message: UIMessage<TTools>) => {
@@ -145,11 +107,6 @@ export function useChat<
     })
   }, [clientId])
 
-  // Sync body / forwardedProps changes to the client.
-  // This allows dynamic values (like model selection) to be updated
-  // without recreating the client. Both fields populate the same
-  // wire payload; `forwardedProps` is preferred and `body` is
-  // deprecated but still supported.
   useEffect(() => {
     client.updateOptions({
       body: options.body,
@@ -157,19 +114,14 @@ export function useChat<
     })
   }, [client, options.body, options.forwardedProps])
 
-  // Sync initial messages on mount only
-  // Note: initialMessages are passed to ChatClient constructor, but we also
-  // set them here to ensure React state is in sync
   useEffect(() => {
     if (options.initialMessages && options.initialMessages.length > 0) {
-      // Only set if current messages are empty (initial state)
       if (messages.length === 0) {
         client.setMessagesManually(options.initialMessages)
       }
     }
-  }, []) // Only run on mount - initialMessages are handled by ChatClient constructor
+  }, [])
 
-  // Keep connection lifecycle opt-in and explicit.
   useEffect(() => {
     if (options.live) {
       client.subscribe()
@@ -178,13 +130,8 @@ export function useChat<
     }
   }, [client, options.live])
 
-  // Cleanup on unmount: stop any in-flight requests
-  // Note: We only cleanup when client changes or component unmounts.
-  // DO NOT include isLoading in dependencies - that would cause the cleanup
-  // to run when isLoading changes, aborting continuation requests.
   useEffect(() => {
     return () => {
-      // live mode owns the connection lifecycle; non-live keeps request-only stop.
       if (options.live) {
         client.unsubscribe()
       } else {
@@ -192,9 +139,6 @@ export function useChat<
       }
     }
   }, [client, options.live])
-
-  // All callback options are read through optionsRef at call time, so fresh
-  // closures from each render are picked up without recreating the client.
 
   const sendMessage = useCallback(
     async (content: string | MultimodalContent) => {
@@ -249,10 +193,49 @@ export function useChat<
     [client],
   )
 
-  // partial / final are runtime-tracked unconditionally; the conditional
-  // return type (UseChatReturn<TTools, TSchema>) hides them from callers that
-  // didn't supply `outputSchema`. The `as` cast is the seam between the
-  // unconditional runtime shape and the schema-discriminated public shape.
+  // `partial` and `final` are derived from the active assistant message's
+  // structured-output part. "Active" = the last assistant message whose
+  // position in the array is greater than the last user message — that is,
+  // the assistant message responding to the most recent user turn. Between
+  // sendMessage() and the server's first chunk no such assistant message
+  // exists yet, so `partial` reads as `{}` and `final` as `null` without
+  // any extra state. During streaming the part's `partial` is the progressive
+  // parse; once `structured-output.complete` snaps the part to `complete`,
+  // `final` returns the validated `data`. Historical structured responses on
+  // earlier assistant messages are not exposed through these (consumers walk
+  // `messages` directly for that).
+  const activeStructuredPart = useMemo<StructuredOutputPart | null>(() => {
+    let lastUserIndex = -1
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]!.role === 'user') {
+        lastUserIndex = i
+        break
+      }
+    }
+    for (let i = messages.length - 1; i > lastUserIndex; i--) {
+      const m = messages[i]!
+      if (m.role !== 'assistant') continue
+      const part = m.parts.find(
+        (p): p is StructuredOutputPart => p.type === 'structured-output',
+      )
+      if (part) return part
+    }
+    return null
+  }, [messages])
+
+  const partial = useMemo<Partial>(() => {
+    if (!activeStructuredPart) return {} as Partial
+    const v = activeStructuredPart.partial ?? activeStructuredPart.data
+    return (v ?? {}) as Partial
+  }, [activeStructuredPart])
+
+  const final = useMemo<Final | null>(() => {
+    if (!activeStructuredPart || activeStructuredPart.status !== 'complete') {
+      return null
+    }
+    return activeStructuredPart.data as Final
+  }, [activeStructuredPart])
+
   return {
     messages,
     sendMessage,

--- a/packages/typescript/ai-react/src/use-chat.ts
+++ b/packages/typescript/ai-react/src/use-chat.ts
@@ -16,6 +16,7 @@ import type {
 import type {
   DeepPartial,
   MultimodalContent,
+  SchemaMap,
   UIMessage,
   UseChatOptions,
   UseChatReturn,
@@ -24,7 +25,10 @@ import type {
 export function useChat<
   TTools extends ReadonlyArray<AnyClientTool> = any,
   TSchema extends SchemaInput | undefined = undefined,
->(options: UseChatOptions<TTools, TSchema>): UseChatReturn<TTools, TSchema> {
+  TSchemas extends SchemaMap | undefined = undefined,
+>(
+  options: UseChatOptions<TTools, TSchema, TSchemas>,
+): UseChatReturn<TTools, TSchema, TSchemas> {
   const hookId = useId()
   const clientId = options.id || hookId
 
@@ -52,7 +56,7 @@ export function useChat<
   messagesRef.current = messages
 
   // Track current options in a ref to avoid recreating client when options change
-  const optionsRef = useRef<UseChatOptions<TTools, TSchema>>(options)
+  const optionsRef = useRef<UseChatOptions<TTools, TSchema, TSchemas>>(options)
   optionsRef.current = options
 
   // Create ChatClient instance with callbacks to sync state
@@ -141,8 +145,20 @@ export function useChat<
   }, [client, options.live])
 
   const sendMessage = useCallback(
-    async (content: string | MultimodalContent) => {
-      await client.sendMessage(content)
+    async (
+      content: string | MultimodalContent,
+      sendOptions?: { schema?: string },
+    ) => {
+      // When the caller picks a named schema for this turn, surface it in
+      // forwardedProps.schemaName so the server route can look up the
+      // matching schema and pass it to `chat({ outputSchema, schemaName })`.
+      // The server then tags the structured-output events with this name and
+      // the client processor stamps it onto the resulting part.
+      const body =
+        sendOptions && sendOptions.schema
+          ? { schemaName: sendOptions.schema }
+          : undefined
+      await client.sendMessage(content, body)
     },
     [client],
   )
@@ -236,9 +252,30 @@ export function useChat<
     return activeStructuredPart.data as Final
   }, [activeStructuredPart])
 
+  // Helper for narrowing a structured-output part to a typed view against a
+  // named schema. Returns undefined if the message has no part or the part's
+  // schemaName doesn't match. The runtime branch is identical regardless of
+  // whether `outputSchemas` was provided — the type system gates whether the
+  // helper is exposed (via the conditional on the return shape).
+  const getStructuredPart = useCallback(
+    (message: UIMessage<TTools>, schemaName: string) => {
+      const part = message.parts.find(
+        (p): p is StructuredOutputPart => p.type === 'structured-output',
+      )
+      if (!part || part.schemaName !== schemaName) return undefined
+      return part as unknown as ReturnType<
+        NonNullable<
+          UseChatReturn<TTools, TSchema, TSchemas>['getStructuredPart']
+        >
+      >
+    },
+    [],
+  )
+
   return {
     messages,
     sendMessage,
+    getStructuredPart,
     append,
     reload,
     stop,
@@ -254,5 +291,5 @@ export function useChat<
     addToolApprovalResponse,
     partial,
     final,
-  } as unknown as UseChatReturn<TTools, TSchema>
+  } as unknown as UseChatReturn<TTools, TSchema, TSchemas>
 }

--- a/packages/typescript/ai-react/tests/use-chat-structured-output.test.ts
+++ b/packages/typescript/ai-react/tests/use-chat-structured-output.test.ts
@@ -154,6 +154,293 @@ describe('useChat({ outputSchema }) — runtime', () => {
     expect(result.current.partial).toEqual(personB)
   })
 
+  it('attaches a structured-output part to the assistant message', async () => {
+    // With structured-output.start emitted, the JSON deltas route into a
+    // StructuredOutputPart on the assistant message instead of a TextPart.
+    // History walks `messages` and finds the typed part on each turn.
+    const chunks: Array<StreamChunk> = [
+      {
+        type: 'RUN_STARTED',
+        runId: 'run-x',
+        threadId: 'thread-x',
+        model: 'test',
+        timestamp: Date.now(),
+      } as StreamChunk,
+      {
+        type: 'TEXT_MESSAGE_START',
+        messageId: 'msg-x',
+        role: 'assistant',
+        model: 'test',
+        timestamp: Date.now(),
+      } as StreamChunk,
+      {
+        type: 'CUSTOM',
+        name: 'structured-output.start',
+        value: { messageId: 'msg-x' },
+        model: 'test',
+        timestamp: Date.now(),
+      } as StreamChunk,
+      {
+        type: 'TEXT_MESSAGE_CONTENT',
+        messageId: 'msg-x',
+        delta: json,
+        content: json,
+        model: 'test',
+        timestamp: Date.now(),
+      } as StreamChunk,
+      {
+        type: 'CUSTOM',
+        name: 'structured-output.complete',
+        value: { object: person, raw: json, messageId: 'msg-x' },
+        model: 'test',
+        timestamp: Date.now(),
+      } as StreamChunk,
+      {
+        type: 'RUN_FINISHED',
+        runId: 'run-x',
+        threadId: 'thread-x',
+        model: 'test',
+        timestamp: Date.now(),
+        finishReason: 'stop',
+      } as StreamChunk,
+    ]
+    const adapter = createMockConnectionAdapter({ chunks })
+
+    const { result } = renderHook(() =>
+      useChat({ connection: adapter, outputSchema: personSchema }),
+    )
+
+    await act(async () => {
+      await result.current.sendMessage('Extract')
+    })
+    await waitFor(() => {
+      expect(result.current.final).toEqual(person)
+    })
+
+    // Find the assistant message and the structured-output part on it.
+    const assistant = result.current.messages.find(
+      (m) => m.role === 'assistant',
+    )
+    expect(assistant).toBeDefined()
+    const sop = assistant!.parts.find((p) => p.type === 'structured-output')
+    expect(sop).toBeDefined()
+    expect((sop as any).status).toBe('complete')
+    expect((sop as any).data).toEqual(person)
+    expect((sop as any).raw).toBe(json)
+
+    // With start emitted, no text part should be on the assistant message
+    // (the JSON bytes were routed into the structured-output part).
+    const textPart = assistant!.parts.find((p) => p.type === 'text')
+    expect(textPart).toBeUndefined()
+  })
+
+  it("preserves each turn's structured part across multi-turn history", async () => {
+    const personA: Person = {
+      name: 'Alice',
+      age: 25,
+      email: 'alice@example.com',
+    }
+    const personB: Person = { name: 'Bob', age: 40, email: 'bob@example.com' }
+
+    function streamFor(
+      p: Person,
+      runId: string,
+      messageId: string,
+    ): Array<StreamChunk> {
+      const raw = JSON.stringify(p)
+      return [
+        {
+          type: 'RUN_STARTED',
+          runId,
+          threadId: `thread-${runId}`,
+          model: 'test',
+          timestamp: Date.now(),
+        } as StreamChunk,
+        {
+          type: 'TEXT_MESSAGE_START',
+          messageId,
+          role: 'assistant',
+          model: 'test',
+          timestamp: Date.now(),
+        } as StreamChunk,
+        {
+          type: 'CUSTOM',
+          name: 'structured-output.start',
+          value: { messageId },
+          model: 'test',
+          timestamp: Date.now(),
+        } as StreamChunk,
+        {
+          type: 'TEXT_MESSAGE_CONTENT',
+          messageId,
+          delta: raw,
+          content: raw,
+          model: 'test',
+          timestamp: Date.now(),
+        } as StreamChunk,
+        {
+          type: 'CUSTOM',
+          name: 'structured-output.complete',
+          value: { object: p, raw, messageId },
+          model: 'test',
+          timestamp: Date.now(),
+        } as StreamChunk,
+        {
+          type: 'RUN_FINISHED',
+          runId,
+          threadId: `thread-${runId}`,
+          model: 'test',
+          timestamp: Date.now(),
+          finishReason: 'stop',
+        } as StreamChunk,
+      ]
+    }
+
+    let call = 0
+    const adapter = {
+      async *connect() {
+        const chunks =
+          call === 0
+            ? streamFor(personA, 'run-a', 'msg-a')
+            : streamFor(personB, 'run-b', 'msg-b')
+        call++
+        for (const chunk of chunks) yield chunk
+      },
+    }
+
+    const { result } = renderHook(() =>
+      useChat({ connection: adapter, outputSchema: personSchema }),
+    )
+
+    await act(async () => {
+      await result.current.sendMessage('A')
+    })
+    await waitFor(() => {
+      expect(result.current.final).toEqual(personA)
+    })
+
+    await act(async () => {
+      await result.current.sendMessage('B')
+    })
+    await waitFor(() => {
+      expect(result.current.final).toEqual(personB)
+    })
+
+    // History walk: every assistant message carries its own structured part.
+    const assistants = result.current.messages.filter(
+      (m) => m.role === 'assistant',
+    )
+    expect(assistants.length).toBe(2)
+
+    const partA = assistants[0]!.parts.find(
+      (p) => p.type === 'structured-output',
+    )
+    const partB = assistants[1]!.parts.find(
+      (p) => p.type === 'structured-output',
+    )
+    expect((partA as any)?.data).toEqual(personA)
+    expect((partB as any)?.data).toEqual(personB)
+
+    // `final` reflects the latest, but the earlier turn's data is still
+    // recoverable via the part on the historical message.
+    expect(result.current.final).toEqual(personB)
+  })
+
+  it('reads `final` as null between sendMessage and the first chunk', async () => {
+    // Park the second connect() so no chunks ever arrive for run-b. The
+    // assertion is that, immediately after sendMessage('B'), the latest user
+    // message has no assistant message after it yet, so `final` returns null.
+    const personA: Person = {
+      name: 'Alice',
+      age: 25,
+      email: 'alice@example.com',
+    }
+    let call = 0
+    let releaseSecond: (() => void) | null = null
+    const secondStarted = new Promise<void>((resolve) => {
+      releaseSecond = resolve
+    })
+    const adapter = {
+      async *connect() {
+        if (call === 0) {
+          call++
+          const raw = JSON.stringify(personA)
+          const chunks: Array<StreamChunk> = [
+            {
+              type: 'RUN_STARTED',
+              runId: 'run-a',
+              threadId: 'thread-a',
+              model: 'test',
+              timestamp: Date.now(),
+            } as StreamChunk,
+            {
+              type: 'TEXT_MESSAGE_START',
+              messageId: 'msg-a',
+              role: 'assistant',
+              model: 'test',
+              timestamp: Date.now(),
+            } as StreamChunk,
+            {
+              type: 'CUSTOM',
+              name: 'structured-output.start',
+              value: { messageId: 'msg-a' },
+              model: 'test',
+              timestamp: Date.now(),
+            } as StreamChunk,
+            {
+              type: 'TEXT_MESSAGE_CONTENT',
+              messageId: 'msg-a',
+              delta: raw,
+              content: raw,
+              model: 'test',
+              timestamp: Date.now(),
+            } as StreamChunk,
+            {
+              type: 'CUSTOM',
+              name: 'structured-output.complete',
+              value: { object: personA, raw, messageId: 'msg-a' },
+              model: 'test',
+              timestamp: Date.now(),
+            } as StreamChunk,
+            {
+              type: 'RUN_FINISHED',
+              runId: 'run-a',
+              threadId: 'thread-a',
+              model: 'test',
+              timestamp: Date.now(),
+              finishReason: 'stop',
+            } as StreamChunk,
+          ]
+          for (const c of chunks) yield c
+          return
+        }
+        await secondStarted
+      },
+    }
+
+    const { result } = renderHook(() =>
+      useChat({ connection: adapter, outputSchema: personSchema }),
+    )
+
+    await act(async () => {
+      await result.current.sendMessage('A')
+    })
+    await waitFor(() => {
+      expect(result.current.final).toEqual(personA)
+    })
+
+    act(() => {
+      void result.current.sendMessage('B')
+    })
+
+    await waitFor(() => {
+      expect(result.current.final).toBeNull()
+      expect(result.current.partial).toEqual({})
+    })
+
+    releaseSecond?.()
+  })
+
   it("invokes the user's onChunk callback alongside internal tracking", async () => {
     const chunks = buildStructuredStream(json, person)
     const adapter = createMockConnectionAdapter({ chunks })

--- a/packages/typescript/ai-react/tests/use-chat-structured-output.test.ts
+++ b/packages/typescript/ai-react/tests/use-chat-structured-output.test.ts
@@ -476,6 +476,141 @@ describe('useChat({ outputSchema }) — runtime', () => {
   })
 })
 
+describe('useChat({ outputSchemas }) — per-turn schemas', () => {
+  type Recipe = { title: string; servings: number }
+  type Plan = { day: string; tasks: Array<string> }
+
+  const recipeSchema = {} as StandardJSONSchemaV1<Recipe, Recipe>
+  const planSchema = {} as StandardJSONSchemaV1<Plan, Plan>
+
+  function streamFor(
+    schemaName: 'recipe' | 'plan',
+    obj: unknown,
+    messageId: string,
+    runId: string,
+  ): Array<StreamChunk> {
+    const raw = JSON.stringify(obj)
+    return [
+      {
+        type: 'RUN_STARTED',
+        runId,
+        threadId: `thread-${runId}`,
+        model: 'test',
+        timestamp: Date.now(),
+      } as StreamChunk,
+      {
+        type: 'TEXT_MESSAGE_START',
+        messageId,
+        role: 'assistant',
+        model: 'test',
+        timestamp: Date.now(),
+      } as StreamChunk,
+      {
+        type: 'CUSTOM',
+        name: 'structured-output.start',
+        value: { messageId, schemaName },
+        model: 'test',
+        timestamp: Date.now(),
+      } as StreamChunk,
+      {
+        type: 'TEXT_MESSAGE_CONTENT',
+        messageId,
+        delta: raw,
+        content: raw,
+        model: 'test',
+        timestamp: Date.now(),
+      } as StreamChunk,
+      {
+        type: 'CUSTOM',
+        name: 'structured-output.complete',
+        value: { object: obj, raw, messageId, schemaName },
+        model: 'test',
+        timestamp: Date.now(),
+      } as StreamChunk,
+      {
+        type: 'RUN_FINISHED',
+        runId,
+        threadId: `thread-${runId}`,
+        model: 'test',
+        timestamp: Date.now(),
+        finishReason: 'stop',
+      } as StreamChunk,
+    ]
+  }
+
+  it('stamps schemaName on the part and getStructuredPart narrows by it', async () => {
+    const recipe: Recipe = { title: 'Pasta', servings: 2 }
+    const plan: Plan = { day: 'Mon', tasks: ['walk', 'work'] }
+
+    let call = 0
+    const adapter = {
+      async *connect() {
+        const chunks =
+          call === 0
+            ? streamFor('recipe', recipe, 'msg-a', 'run-a')
+            : streamFor('plan', plan, 'msg-b', 'run-b')
+        call++
+        for (const c of chunks) yield c
+      },
+    }
+
+    const { result } = renderHook(() =>
+      useChat({
+        connection: adapter,
+        outputSchemas: { recipe: recipeSchema, plan: planSchema },
+      }),
+    )
+
+    await act(async () => {
+      await result.current.sendMessage('give me dinner', { schema: 'recipe' })
+    })
+
+    await waitFor(() => {
+      const assistant = result.current.messages.find(
+        (m) => m.role === 'assistant',
+      )
+      const part = assistant?.parts.find(
+        (p) => p.type === 'structured-output',
+      ) as any
+      expect(part?.schemaName).toBe('recipe')
+      expect(part?.data).toEqual(recipe)
+    })
+
+    await act(async () => {
+      await result.current.sendMessage('plan my monday', { schema: 'plan' })
+    })
+
+    await waitFor(() => {
+      const assistants = result.current.messages.filter(
+        (m) => m.role === 'assistant',
+      )
+      expect(assistants).toHaveLength(2)
+      const planPart = assistants[1]!.parts.find(
+        (p) => p.type === 'structured-output',
+      ) as any
+      expect(planPart?.schemaName).toBe('plan')
+      expect(planPart?.data).toEqual(plan)
+    })
+
+    // getStructuredPart returns the typed view when schemaName matches…
+    const assistants = result.current.messages.filter(
+      (m) => m.role === 'assistant',
+    )
+    const recipeView = result.current.getStructuredPart!(
+      assistants[0]!,
+      'recipe',
+    )
+    expect(recipeView?.data).toEqual(recipe)
+
+    const planView = result.current.getStructuredPart!(assistants[1]!, 'plan')
+    expect(planView?.data).toEqual(plan)
+
+    // …and undefined when the schemaName doesn't match.
+    const wrongView = result.current.getStructuredPart!(assistants[0]!, 'plan')
+    expect(wrongView).toBeUndefined()
+  })
+})
+
 describe('useChat() without outputSchema — runtime', () => {
   it('does not break or track structured state when no schema is supplied', async () => {
     const adapter = createMockConnectionAdapter({

--- a/packages/typescript/ai/src/activities/chat/index.ts
+++ b/packages/typescript/ai/src/activities/chat/index.ts
@@ -2045,7 +2045,49 @@ async function* runStreamingStructuredOutputImpl<TSchema extends SchemaInput>(
         outputSchema: jsonSchema,
       })
 
+  // Track the assistant messageId the structured stream is producing so we
+  // can tag both the synthetic `structured-output.start` and the terminal
+  // `structured-output.complete` event with it. Consumers (the client-side
+  // StreamProcessor) use this to route the JSON deltas into a
+  // StructuredOutputPart on the right UIMessage, and to snap that part to
+  // its complete state when the terminal event arrives.
+  let structuredMessageId: string | null = null
+  let startEmitted = false
+
   for await (const chunk of stream) {
+    // Capture the assistant messageId from the first text-message lifecycle
+    // event so the synthetic start carries it.
+    if (!structuredMessageId) {
+      if (chunk.type === EventType.TEXT_MESSAGE_START && 'messageId' in chunk) {
+        structuredMessageId = (chunk as { messageId: string }).messageId
+      } else if (
+        chunk.type === EventType.TEXT_MESSAGE_CONTENT &&
+        'messageId' in chunk
+      ) {
+        structuredMessageId = (chunk as { messageId: string }).messageId
+      }
+    }
+
+    // Emit the synthetic start once, immediately before the first text
+    // content delta would otherwise be routed to a TextPart on the client.
+    if (
+      !startEmitted &&
+      structuredMessageId &&
+      (chunk.type === EventType.TEXT_MESSAGE_START ||
+        chunk.type === EventType.TEXT_MESSAGE_CONTENT)
+    ) {
+      startEmitted = true
+      yield {
+        type: EventType.CUSTOM,
+        name: 'structured-output.start',
+        value: { messageId: structuredMessageId },
+        model: 'model' in chunk ? (chunk.model ?? model) : model,
+        timestamp:
+          'timestamp' in chunk ? (chunk.timestamp ?? Date.now()) : Date.now(),
+        runId,
+      }
+    }
+
     if (
       chunk.type === EventType.CUSTOM &&
       chunk.name === 'structured-output.complete'
@@ -2065,10 +2107,15 @@ async function* runStreamingStructuredOutputImpl<TSchema extends SchemaInput>(
             ...chunk,
             // Forward `reasoning` through schema validation so consumers that
             // only listen for the terminal event don't lose chain-of-thought.
+            // Tag with messageId so the client processor can snap the right
+            // assistant message's structured-output part.
             value: {
               object: validated,
               raw: value.raw,
               ...(value.reasoning ? { reasoning: value.reasoning } : {}),
+              ...(structuredMessageId
+                ? { messageId: structuredMessageId }
+                : {}),
             },
           }
           continue
@@ -2099,6 +2146,18 @@ async function* runStreamingStructuredOutputImpl<TSchema extends SchemaInput>(
           }
           return
         }
+      }
+      // No Standard schema (raw JSONSchema). Still tag the terminal event
+      // with messageId so the client processor can snap the right part.
+      if (structuredMessageId) {
+        yield {
+          ...chunk,
+          value: {
+            ...(chunk.value as Record<string, unknown>),
+            messageId: structuredMessageId,
+          },
+        }
+        continue
       }
       yield chunk
       continue

--- a/packages/typescript/ai/src/activities/chat/index.ts
+++ b/packages/typescript/ai/src/activities/chat/index.ts
@@ -160,6 +160,18 @@ export interface TextActivityOptions<
    */
   outputSchema?: TSchema
   /**
+   * Optional name for the schema used in this run. When set, the synthetic
+   * `structured-output.start` and terminal `structured-output.complete`
+   * events carry this name as `value.schemaName`, and the client-side
+   * StructuredOutputPart inherits it. Useful when the caller is multiplexing
+   * several schemas across turns (Phase 2 `useChat({ outputSchemas })` flow)
+   * so render code can narrow on a discriminator without inspecting the
+   * payload shape.
+   *
+   * Has no effect unless `outputSchema` is also set.
+   */
+  schemaName?: string
+  /**
    * Whether to stream the text result.
    * When true (default), returns an AsyncIterable<StreamChunk> for streaming output.
    * When false, returns a Promise<string> with the collected text content.
@@ -1935,8 +1947,15 @@ async function* runStreamingStructuredOutputImpl<TSchema extends SchemaInput>(
   options: TextActivityOptions<AnyTextAdapter, TSchema, true>,
   jsonSchema: NonNullable<ReturnType<typeof convertSchemaToJsonSchema>>,
 ): StructuredOutputStreamInternal<InferSchemaType<TSchema>> {
-  const { adapter, outputSchema, middleware, context, debug, ...textOptions } =
-    options
+  const {
+    adapter,
+    outputSchema,
+    schemaName,
+    middleware,
+    context,
+    debug,
+    ...textOptions
+  } = options
   const model = adapter.model
   const logger = resolveDebugOption(debug)
   const runId = textOptions.runId
@@ -2080,7 +2099,10 @@ async function* runStreamingStructuredOutputImpl<TSchema extends SchemaInput>(
       yield {
         type: EventType.CUSTOM,
         name: 'structured-output.start',
-        value: { messageId: structuredMessageId },
+        value: {
+          messageId: structuredMessageId,
+          ...(schemaName ? { schemaName } : {}),
+        },
         model: 'model' in chunk ? (chunk.model ?? model) : model,
         timestamp:
           'timestamp' in chunk ? (chunk.timestamp ?? Date.now()) : Date.now(),
@@ -2108,7 +2130,8 @@ async function* runStreamingStructuredOutputImpl<TSchema extends SchemaInput>(
             // Forward `reasoning` through schema validation so consumers that
             // only listen for the terminal event don't lose chain-of-thought.
             // Tag with messageId so the client processor can snap the right
-            // assistant message's structured-output part.
+            // assistant message's structured-output part, and with schemaName
+            // (Phase 2) so it lands as the part's discriminator.
             value: {
               object: validated,
               raw: value.raw,
@@ -2116,6 +2139,7 @@ async function* runStreamingStructuredOutputImpl<TSchema extends SchemaInput>(
               ...(structuredMessageId
                 ? { messageId: structuredMessageId }
                 : {}),
+              ...(schemaName ? { schemaName } : {}),
             },
           }
           continue
@@ -2148,13 +2172,15 @@ async function* runStreamingStructuredOutputImpl<TSchema extends SchemaInput>(
         }
       }
       // No Standard schema (raw JSONSchema). Still tag the terminal event
-      // with messageId so the client processor can snap the right part.
-      if (structuredMessageId) {
+      // with messageId / schemaName so the client processor can snap the
+      // right part and stamp the discriminator.
+      if (structuredMessageId || schemaName) {
         yield {
           ...chunk,
           value: {
             ...(chunk.value as Record<string, unknown>),
-            messageId: structuredMessageId,
+            ...(structuredMessageId ? { messageId: structuredMessageId } : {}),
+            ...(schemaName ? { schemaName } : {}),
           },
         }
         continue

--- a/packages/typescript/ai/src/activities/chat/stream/message-updaters.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/message-updaters.ts
@@ -5,7 +5,9 @@
  * These are used by StreamProcessor to manage the message array.
  */
 
+import { parsePartialJSON } from './json-parser'
 import type {
+  StructuredOutputPart,
   ThinkingPart,
   ToolCallPart,
   ToolResultPart,
@@ -247,6 +249,132 @@ export function updateToolCallApprovalResponse(
       toolCallPart.state = 'approval-responded'
     }
 
+    return { ...msg, parts }
+  })
+}
+
+/**
+ * Append a delta to the structured-output part on `messageId`, or create one
+ * if absent. Progressive parse of the accumulated buffer fills `partial`.
+ * `status` stays `'streaming'` until the terminal complete/error helpers run.
+ */
+export function appendStructuredOutputDelta(
+  messages: Array<UIMessage>,
+  messageId: string,
+  delta: string,
+): Array<UIMessage> {
+  return messages.map((msg) => {
+    if (msg.id !== messageId) {
+      return msg
+    }
+
+    const parts = [...msg.parts]
+    const existingIndex = parts.findIndex(
+      (p): p is StructuredOutputPart => p.type === 'structured-output',
+    )
+    const existing =
+      existingIndex >= 0 ? (parts[existingIndex] as StructuredOutputPart) : null
+
+    const nextRaw = (existing?.raw ?? '') + delta
+    const progressive = parsePartialJSON(nextRaw)
+
+    const nextPart: StructuredOutputPart = {
+      type: 'structured-output',
+      status: 'streaming',
+      raw: nextRaw,
+      ...(progressive !== undefined && progressive !== null
+        ? { partial: progressive }
+        : {}),
+      ...(existing?.reasoning !== undefined
+        ? { reasoning: existing.reasoning }
+        : {}),
+    }
+
+    if (existingIndex >= 0) {
+      parts[existingIndex] = nextPart
+    } else {
+      parts.push(nextPart)
+    }
+
+    return { ...msg, parts }
+  })
+}
+
+/**
+ * Snap the structured-output part on `messageId` to `complete` with the
+ * validated `data`. If no part exists yet (terminal event arrived without
+ * any deltas), one is created — `raw` falls back to the JSON serialization
+ * of `data` so the wire round-trip stays consistent.
+ */
+export function completeStructuredOutputPart(
+  messages: Array<UIMessage>,
+  messageId: string,
+  data: unknown,
+  raw: string,
+  reasoning?: string,
+): Array<UIMessage> {
+  return messages.map((msg) => {
+    if (msg.id !== messageId) {
+      return msg
+    }
+
+    const parts = [...msg.parts]
+    const existingIndex = parts.findIndex(
+      (p): p is StructuredOutputPart => p.type === 'structured-output',
+    )
+
+    const nextPart: StructuredOutputPart = {
+      type: 'structured-output',
+      status: 'complete',
+      data,
+      partial: data,
+      raw:
+        raw ||
+        (existingIndex >= 0
+          ? (parts[existingIndex] as StructuredOutputPart).raw
+          : ''),
+      ...(reasoning !== undefined ? { reasoning } : {}),
+    }
+
+    if (existingIndex >= 0) {
+      parts[existingIndex] = nextPart
+    } else {
+      parts.push(nextPart)
+    }
+
+    return { ...msg, parts }
+  })
+}
+
+/**
+ * Mark any streaming structured-output part on `messageId` as errored.
+ * No-op if no streaming part exists.
+ */
+export function errorStructuredOutputPart(
+  messages: Array<UIMessage>,
+  messageId: string,
+  errorMessage: string,
+): Array<UIMessage> {
+  return messages.map((msg) => {
+    if (msg.id !== messageId) {
+      return msg
+    }
+
+    const parts = [...msg.parts]
+    const existingIndex = parts.findIndex(
+      (p): p is StructuredOutputPart =>
+        p.type === 'structured-output' && p.status === 'streaming',
+    )
+    if (existingIndex < 0) {
+      return msg
+    }
+
+    const existing = parts[existingIndex] as StructuredOutputPart
+    parts[existingIndex] = {
+      ...existing,
+      status: 'error',
+      errorMessage,
+    }
     return { ...msg, parts }
   })
 }

--- a/packages/typescript/ai/src/activities/chat/stream/message-updaters.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/message-updaters.ts
@@ -262,6 +262,7 @@ export function appendStructuredOutputDelta(
   messages: Array<UIMessage>,
   messageId: string,
   delta: string,
+  schemaName?: string,
 ): Array<UIMessage> {
   return messages.map((msg) => {
     if (msg.id !== messageId) {
@@ -277,6 +278,7 @@ export function appendStructuredOutputDelta(
 
     const nextRaw = (existing?.raw ?? '') + delta
     const progressive = parsePartialJSON(nextRaw)
+    const effectiveSchemaName = schemaName ?? existing?.schemaName
 
     const nextPart: StructuredOutputPart = {
       type: 'structured-output',
@@ -287,6 +289,9 @@ export function appendStructuredOutputDelta(
         : {}),
       ...(existing?.reasoning !== undefined
         ? { reasoning: existing.reasoning }
+        : {}),
+      ...(effectiveSchemaName !== undefined
+        ? { schemaName: effectiveSchemaName }
         : {}),
     }
 
@@ -312,6 +317,7 @@ export function completeStructuredOutputPart(
   data: unknown,
   raw: string,
   reasoning?: string,
+  schemaName?: string,
 ): Array<UIMessage> {
   return messages.map((msg) => {
     if (msg.id !== messageId) {
@@ -322,6 +328,9 @@ export function completeStructuredOutputPart(
     const existingIndex = parts.findIndex(
       (p): p is StructuredOutputPart => p.type === 'structured-output',
     )
+    const existing =
+      existingIndex >= 0 ? (parts[existingIndex] as StructuredOutputPart) : null
+    const effectiveSchemaName = schemaName ?? existing?.schemaName
 
     const nextPart: StructuredOutputPart = {
       type: 'structured-output',
@@ -334,6 +343,9 @@ export function completeStructuredOutputPart(
           ? (parts[existingIndex] as StructuredOutputPart).raw
           : ''),
       ...(reasoning !== undefined ? { reasoning } : {}),
+      ...(effectiveSchemaName !== undefined
+        ? { schemaName: effectiveSchemaName }
+        : {}),
     }
 
     if (existingIndex >= 0) {

--- a/packages/typescript/ai/src/activities/chat/stream/processor.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/processor.ts
@@ -20,6 +20,9 @@
 import { generateMessageId, uiMessageToModelMessages } from '../messages.js'
 import { defaultJSONParser } from './json-parser'
 import {
+  appendStructuredOutputDelta,
+  completeStructuredOutputPart,
+  errorStructuredOutputPart,
   updateTextPart,
   updateThinkingPart,
   updateToolCallApproval,
@@ -144,6 +147,12 @@ export class StreamProcessor {
   private toolCallToMessage: Map<string, string> = new Map()
   private pendingManualMessageId: string | null = null
   private pendingThinkingStepId: string | null = null
+
+  // Messages whose TEXT_MESSAGE_CONTENT deltas should be routed into a
+  // StructuredOutputPart instead of a TextPart. Populated by the
+  // `structured-output.start` CUSTOM event; cleared by `structured-output.complete`
+  // / RUN_ERROR / finalize.
+  private structuredMessageIds: Set<string> = new Set()
 
   // Run tracking (for concurrent run safety)
   private activeRuns = new Set<string>()
@@ -395,6 +404,7 @@ export class StreamProcessor {
     this.messageStates.clear()
     this.activeMessageIds.clear()
     this.toolCallToMessage.clear()
+    this.structuredMessageIds.clear()
     this.pendingManualMessageId = null
     this.emitMessagesChange()
   }
@@ -841,6 +851,27 @@ export class StreamProcessor {
     // Content arriving means all current tool calls for this message are complete
     this.completeAllToolCallsForMessage(messageId)
 
+    // Structured-output run: route the delta into the message's
+    // StructuredOutputPart instead of building a TextPart. The server emits
+    // `structured-output.start` ahead of these deltas so we know to redirect.
+    if (this.structuredMessageIds.has(messageId)) {
+      const delta =
+        chunk.delta ||
+        (chunk.content !== undefined && chunk.content !== ''
+          ? chunk.content
+          : '')
+      if (delta !== '') {
+        this.messages = appendStructuredOutputDelta(
+          this.messages,
+          messageId,
+          delta,
+        )
+        state.totalTextContent += delta
+        this.emitMessagesChange()
+      }
+      return
+    }
+
     const previousSegment = state.currentSegmentText
 
     // Detect if this is a NEW text segment (after tool calls) vs continuation
@@ -1192,10 +1223,23 @@ export class StreamProcessor {
     } else {
       this.activeRuns.clear()
     }
-    this.ensureAssistantMessage()
+    const { messageId } = this.ensureAssistantMessage()
     // Prefer spec field `message`; fall back to deprecated `error.message`
     const errorMessage =
       chunk.message || chunk.error?.message || 'An error occurred'
+
+    // Mark any in-flight structured-output part on this message as errored
+    // so consumers can render the partial buffer with a clear error state.
+    if (this.structuredMessageIds.has(messageId)) {
+      this.messages = errorStructuredOutputPart(
+        this.messages,
+        messageId,
+        errorMessage,
+      )
+      this.structuredMessageIds.delete(messageId)
+      this.emitMessagesChange()
+    }
+
     this.events.onError?.(new Error(errorMessage))
   }
 
@@ -1374,6 +1418,42 @@ export class StreamProcessor {
     chunk: Extract<StreamChunk, { type: 'CUSTOM' }>,
   ): void {
     const messageId = this.getActiveAssistantMessageId()
+
+    // Mark a message as carrying structured output. Subsequent
+    // TEXT_MESSAGE_CONTENT deltas for this messageId route into the
+    // StructuredOutputPart instead of building a TextPart.
+    if (chunk.name === 'structured-output.start' && chunk.value) {
+      const v = chunk.value as { messageId?: string }
+      const targetId = v.messageId ?? messageId
+      if (targetId) {
+        this.ensureAssistantMessage(targetId)
+        this.structuredMessageIds.add(targetId)
+      }
+      return
+    }
+
+    // Snap the structured-output part to its validated terminal state.
+    if (chunk.name === 'structured-output.complete' && chunk.value) {
+      const v = chunk.value as {
+        object: unknown
+        raw?: string
+        reasoning?: string
+        messageId?: string
+      }
+      const targetId = v.messageId ?? messageId
+      if (targetId) {
+        this.messages = completeStructuredOutputPart(
+          this.messages,
+          targetId,
+          v.object,
+          v.raw ?? '',
+          v.reasoning,
+        )
+        this.structuredMessageIds.delete(targetId)
+        this.emitMessagesChange()
+      }
+      // Fall through so user `onCustomEvent` callbacks still observe the event.
+    }
 
     // Handle client tool input availability - trigger client-side execution
     if (chunk.name === 'tool-input-available' && chunk.value) {
@@ -1719,6 +1799,7 @@ export class StreamProcessor {
     this.activeMessageIds.clear()
     this.activeRuns.clear()
     this.toolCallToMessage.clear()
+    this.structuredMessageIds.clear()
     this.pendingManualMessageId = null
     this.pendingThinkingStepId = null
     this.finishReason = null

--- a/packages/typescript/ai/src/activities/chat/stream/processor.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/processor.ts
@@ -151,8 +151,9 @@ export class StreamProcessor {
   // Messages whose TEXT_MESSAGE_CONTENT deltas should be routed into a
   // StructuredOutputPart instead of a TextPart. Populated by the
   // `structured-output.start` CUSTOM event; cleared by `structured-output.complete`
-  // / RUN_ERROR / finalize.
-  private structuredMessageIds: Set<string> = new Set()
+  // / RUN_ERROR / finalize. Value is the schemaName the start event carried
+  // (undefined for single-schema flows) so deltas can stamp it onto the part.
+  private structuredMessageIds: Map<string, string | undefined> = new Map()
 
   // Run tracking (for concurrent run safety)
   private activeRuns = new Set<string>()
@@ -861,10 +862,12 @@ export class StreamProcessor {
           ? chunk.content
           : '')
       if (delta !== '') {
+        const schemaName = this.structuredMessageIds.get(messageId)
         this.messages = appendStructuredOutputDelta(
           this.messages,
           messageId,
           delta,
+          schemaName,
         )
         state.totalTextContent += delta
         this.emitMessagesChange()
@@ -1421,13 +1424,14 @@ export class StreamProcessor {
 
     // Mark a message as carrying structured output. Subsequent
     // TEXT_MESSAGE_CONTENT deltas for this messageId route into the
-    // StructuredOutputPart instead of building a TextPart.
+    // StructuredOutputPart instead of building a TextPart. The schemaName
+    // (when present) is stamped on the part so consumers can narrow on it.
     if (chunk.name === 'structured-output.start' && chunk.value) {
-      const v = chunk.value as { messageId?: string }
+      const v = chunk.value as { messageId?: string; schemaName?: string }
       const targetId = v.messageId ?? messageId
       if (targetId) {
         this.ensureAssistantMessage(targetId)
-        this.structuredMessageIds.add(targetId)
+        this.structuredMessageIds.set(targetId, v.schemaName)
       }
       return
     }
@@ -1439,15 +1443,22 @@ export class StreamProcessor {
         raw?: string
         reasoning?: string
         messageId?: string
+        schemaName?: string
       }
       const targetId = v.messageId ?? messageId
       if (targetId) {
+        // Prefer the schemaName from the event; fall back to whatever the
+        // start event stamped (so a server that only emits schemaName once
+        // still works).
+        const schemaName =
+          v.schemaName ?? this.structuredMessageIds.get(targetId)
         this.messages = completeStructuredOutputPart(
           this.messages,
           targetId,
           v.object,
           v.raw ?? '',
           v.reasoning,
+          schemaName,
         )
         this.structuredMessageIds.delete(targetId)
         this.emitMessagesChange()

--- a/packages/typescript/ai/src/types.ts
+++ b/packages/typescript/ai/src/types.ts
@@ -365,6 +365,35 @@ export interface ThinkingPart {
   signature?: string
 }
 
+/**
+ * StructuredOutputPart — a typed structured response attached to the assistant
+ * message that produced it.
+ *
+ * For `useChat({ outputSchema })` and `chat({ outputSchema })`, each assistant
+ * turn that streams a JSON object gets exactly one of these. `partial` updates
+ * per delta via progressive JSON parsing, `data` snaps on the terminal
+ * `structured-output.complete` event, and `raw` is the accumulating JSON
+ * buffer that gets sent back to the LLM as assistant content on the next turn
+ * so multi-turn structured chat stays coherent.
+ *
+ * `data` and `partial` are intentionally untyped at this layer; ai-client /
+ * ai-react narrow them via `InferSchemaType<TSchema>` from the hook surface.
+ */
+export interface StructuredOutputPart {
+  type: 'structured-output'
+  status: 'streaming' | 'complete' | 'error'
+  /** Progressive parse of `raw` via parsePartialJSON — populated while streaming and after complete. */
+  partial?: unknown
+  /** Validated final object — only set when `status === 'complete'`. */
+  data?: unknown
+  /** Accumulating JSON buffer. Source of truth for wire round-trip. */
+  raw: string
+  /** Optional chain-of-thought surfaced by reasoning models alongside the structured output. */
+  reasoning?: string
+  /** Populated when `status === 'error'`. */
+  errorMessage?: string
+}
+
 export type MessagePart =
   | TextPart
   | ImagePart
@@ -374,6 +403,7 @@ export type MessagePart =
   | ToolCallPart
   | ToolResultPart
   | ThinkingPart
+  | StructuredOutputPart
 
 /**
  * UIMessage - Domain-specific message format optimized for building chat UIs
@@ -1115,6 +1145,22 @@ export interface StructuredOutputCompleteEvent<T = unknown> extends Omit<
 }
 
 /**
+ * Emitted at the start of a streaming structured-output run, before the JSON
+ * deltas. Tells consumers that the upcoming `TEXT_MESSAGE_CONTENT` deltas
+ * belong to a structured response so they can route those bytes into a
+ * `StructuredOutputPart` instead of building a `TextPart`. Carries the
+ * `messageId` the deltas will be tagged with so the routing decision can be
+ * made per-message rather than globally.
+ */
+export interface StructuredOutputStartEvent extends Omit<
+  CustomEvent,
+  'name' | 'value'
+> {
+  name: 'structured-output.start'
+  value: { messageId: string }
+}
+
+/**
  * Emitted when a server tool requires approval before execution. The agent
  * loop yields this and pauses — `structured-output.complete` will not fire
  * for that run. The shape is fixed by the orchestrator's tool-approval flow
@@ -1183,6 +1229,7 @@ export interface ToolInputAvailableEvent extends Omit<
  */
 export type StructuredOutputStream<T = unknown> = AsyncIterable<
   | Exclude<StreamChunk, CustomEvent>
+  | StructuredOutputStartEvent
   | StructuredOutputCompleteEvent<T>
   | ApprovalRequestedEvent
   | ToolInputAvailableEvent

--- a/packages/typescript/ai/src/types.ts
+++ b/packages/typescript/ai/src/types.ts
@@ -392,6 +392,13 @@ export interface StructuredOutputPart {
   reasoning?: string
   /** Populated when `status === 'error'`. */
   errorMessage?: string
+  /**
+   * Name of the schema that produced this part. Set when the hook was
+   * configured with `outputSchemas: { [name]: schema }` and `sendMessage`
+   * (or the server) selected this schema for the turn. Undefined for
+   * single-schema flows (`outputSchema`) where there's only one shape.
+   */
+  schemaName?: string
 }
 
 export type MessagePart =
@@ -1141,7 +1148,15 @@ export interface StructuredOutputCompleteEvent<T = unknown> extends Omit<
   'name' | 'value'
 > {
   name: 'structured-output.complete'
-  value: { object: T; raw: string; reasoning?: string }
+  value: {
+    object: T
+    raw: string
+    reasoning?: string
+    /** Set when the originating run was driven by a named schema from
+     *  `outputSchemas`. The client processor stamps this onto the part
+     *  so consumers can narrow `data` against the discriminator. */
+    schemaName?: string
+  }
 }
 
 /**
@@ -1157,7 +1172,7 @@ export interface StructuredOutputStartEvent extends Omit<
   'name' | 'value'
 > {
   name: 'structured-output.start'
-  value: { messageId: string }
+  value: { messageId: string; schemaName?: string }
 }
 
 /**

--- a/packages/typescript/ai/src/utilities/ag-ui-wire.ts
+++ b/packages/typescript/ai/src/utilities/ag-ui-wire.ts
@@ -1,4 +1,4 @@
-import type { ContentPart, MessagePart, TextPart, UIMessage } from '../types'
+import type { ContentPart, MessagePart, UIMessage } from '../types'
 
 type AGUITextInputContent = { type: 'text'; text: string }
 type AGUIInputContent =
@@ -113,10 +113,31 @@ export function uiMessagesToWire(
 }
 
 function collectText(parts: ReadonlyArray<MessagePart>): string {
-  return parts
-    .filter((p): p is TextPart => p.type === 'text')
-    .map((p) => p.content)
-    .join('')
+  // Both `text` parts and the raw JSON of `structured-output` parts contribute
+  // to the assistant's wire `content`. For structured turns the original
+  // streamed JSON is the source of truth — emitting it back lets the LLM see
+  // its own prior structured responses in multi-turn flows. Text and
+  // structured parts are mutually exclusive on a single assistant message in
+  // practice, but the concat is safe either way.
+  const out: Array<string> = []
+  for (const p of parts) {
+    if (p.type === 'text') {
+      out.push(p.content)
+    } else if (p.type === 'structured-output') {
+      // Prefer raw (the streamed JSON), fall back to serializing data if a
+      // terminal-only complete event populated only `data`.
+      if (p.raw !== '') {
+        out.push(p.raw)
+      } else if (p.data !== undefined) {
+        try {
+          out.push(JSON.stringify(p.data))
+        } catch {
+          // Circular or unserializable data: skip rather than throw.
+        }
+      }
+    }
+  }
+  return out.join('')
 }
 
 function collectUserContent(

--- a/packages/typescript/ai/tests/ag-ui-wire.test.ts
+++ b/packages/typescript/ai/tests/ag-ui-wire.test.ts
@@ -141,6 +141,49 @@ describe('uiMessagesToWire', () => {
     expect((wire[0]! as any).parts).toEqual([{ type: 'text', content: 'hi' }])
   })
 
+  it('serializes a structured-output part to assistant content using its raw JSON', () => {
+    // The raw JSON is the byte-identical buffer the model produced. Sending
+    // it back as assistant content keeps multi-turn structured chat coherent
+    // (the LLM sees its own prior structured response).
+    const raw = JSON.stringify({ name: 'Alice', age: 25 })
+    const messages: Array<UIMessage> = [
+      { id: 'u1', role: 'user', parts: [{ type: 'text', content: 'extract' }] },
+      {
+        id: 'a1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'structured-output',
+            status: 'complete',
+            raw,
+            data: { name: 'Alice', age: 25 },
+            partial: { name: 'Alice', age: 25 },
+          },
+        ],
+      },
+    ]
+    const wire = uiMessagesToWire(messages)
+    const assistant = wire.find((m) => m.role === 'assistant') as any
+    expect(assistant).toBeDefined()
+    expect(assistant.content).toBe(raw)
+  })
+
+  it('falls back to JSON.stringify(data) when a structured-output part has no raw buffer', () => {
+    const data = { name: 'Bob', age: 40 }
+    const messages: Array<UIMessage> = [
+      {
+        id: 'a1',
+        role: 'assistant',
+        parts: [
+          { type: 'structured-output', status: 'complete', raw: '', data },
+        ],
+      },
+    ]
+    const wire = uiMessagesToWire(messages)
+    const assistant = wire.find((m) => m.role === 'assistant') as any
+    expect(assistant.content).toBe(JSON.stringify(data))
+  })
+
   it('preserves per-part metadata on multimodal parts (round-trip via parts field)', () => {
     const messages: Array<UIMessage> = [
       {

--- a/packages/typescript/ai/tests/stream-processor.test.ts
+++ b/packages/typescript/ai/tests/stream-processor.test.ts
@@ -3322,4 +3322,117 @@ describe('StreamProcessor', () => {
       expect(toolResultPart.state).toBe('complete')
     })
   })
+
+  describe('Structured output parts', () => {
+    it('routes deltas after structured-output.start into a structured-output part', () => {
+      const processor = new StreamProcessor()
+
+      processor.processChunk(ev.runStarted())
+      processor.processChunk(ev.textStart('msg-1'))
+      processor.processChunk(
+        chunk(EventType.CUSTOM, {
+          name: 'structured-output.start',
+          value: { messageId: 'msg-1' },
+        }),
+      )
+      processor.processChunk(ev.textContent('{"name":', 'msg-1'))
+      processor.processChunk(ev.textContent('"Alice"}', 'msg-1'))
+      processor.processChunk(
+        chunk(EventType.CUSTOM, {
+          name: 'structured-output.complete',
+          value: {
+            object: { name: 'Alice' },
+            raw: '{"name":"Alice"}',
+            messageId: 'msg-1',
+          },
+        }),
+      )
+      processor.processChunk(ev.runFinished('stop'))
+
+      const messages = processor.getMessages()
+      const assistant = messages.find((m) => m.role === 'assistant')
+      expect(assistant).toBeDefined()
+
+      // No text part — the JSON bytes routed into the structured-output part.
+      expect(assistant!.parts.find((p) => p.type === 'text')).toBeUndefined()
+
+      const sop = assistant!.parts.find((p) => p.type === 'structured-output')
+      expect(sop).toBeDefined()
+      expect((sop as any).status).toBe('complete')
+      expect((sop as any).data).toEqual({ name: 'Alice' })
+      expect((sop as any).raw).toBe('{"name":"Alice"}')
+    })
+
+    it('progressively populates partial as JSON deltas arrive', () => {
+      const processor = new StreamProcessor()
+
+      processor.processChunk(ev.runStarted())
+      processor.processChunk(ev.textStart('msg-1'))
+      processor.processChunk(
+        chunk(EventType.CUSTOM, {
+          name: 'structured-output.start',
+          value: { messageId: 'msg-1' },
+        }),
+      )
+      processor.processChunk(ev.textContent('{"name":', 'msg-1'))
+
+      let assistant = processor
+        .getMessages()
+        .find((m) => m.role === 'assistant')
+      let sop = assistant!.parts.find((p) => p.type === 'structured-output')
+      expect((sop as any).status).toBe('streaming')
+
+      processor.processChunk(ev.textContent('"Alice"', 'msg-1'))
+      assistant = processor.getMessages().find((m) => m.role === 'assistant')
+      sop = assistant!.parts.find((p) => p.type === 'structured-output')
+      expect((sop as any).partial).toEqual({ name: 'Alice' })
+
+      processor.processChunk(ev.textContent('}', 'msg-1'))
+      processor.processChunk(
+        chunk(EventType.CUSTOM, {
+          name: 'structured-output.complete',
+          value: {
+            object: { name: 'Alice' },
+            raw: '{"name":"Alice"}',
+            messageId: 'msg-1',
+          },
+        }),
+      )
+      processor.processChunk(ev.runFinished('stop'))
+
+      assistant = processor.getMessages().find((m) => m.role === 'assistant')
+      sop = assistant!.parts.find((p) => p.type === 'structured-output')
+      expect((sop as any).status).toBe('complete')
+      expect((sop as any).data).toEqual({ name: 'Alice' })
+    })
+
+    it('marks a streaming structured-output part as errored on RUN_ERROR', () => {
+      const processor = new StreamProcessor()
+
+      processor.processChunk(ev.runStarted())
+      processor.processChunk(ev.textStart('msg-1'))
+      processor.processChunk(
+        chunk(EventType.CUSTOM, {
+          name: 'structured-output.start',
+          value: { messageId: 'msg-1' },
+        }),
+      )
+      processor.processChunk(ev.textContent('{"name":"Al', 'msg-1'))
+      processor.processChunk(
+        chunk(EventType.RUN_ERROR, {
+          runId: 'run-1',
+          message: 'Stream aborted',
+        }),
+      )
+
+      const assistant = processor
+        .getMessages()
+        .find((m) => m.role === 'assistant')
+      const sop = assistant!.parts.find((p) => p.type === 'structured-output')
+      expect((sop as any).status).toBe('error')
+      expect((sop as any).errorMessage).toBe('Stream aborted')
+      // Partial buffer up to error is preserved for inspection.
+      expect((sop as any).raw).toBe('{"name":"Al')
+    })
+  })
 })

--- a/packages/typescript/ai/tests/stream-processor.test.ts
+++ b/packages/typescript/ai/tests/stream-processor.test.ts
@@ -3406,6 +3406,77 @@ describe('StreamProcessor', () => {
       expect((sop as any).data).toEqual({ name: 'Alice' })
     })
 
+    it('stamps schemaName from structured-output.start onto the part', () => {
+      const processor = new StreamProcessor()
+
+      processor.processChunk(ev.runStarted())
+      processor.processChunk(ev.textStart('msg-1'))
+      processor.processChunk(
+        chunk(EventType.CUSTOM, {
+          name: 'structured-output.start',
+          value: { messageId: 'msg-1', schemaName: 'recipe' },
+        }),
+      )
+      processor.processChunk(ev.textContent('{"title":"Pasta"}', 'msg-1'))
+      processor.processChunk(
+        chunk(EventType.CUSTOM, {
+          name: 'structured-output.complete',
+          value: {
+            object: { title: 'Pasta' },
+            raw: '{"title":"Pasta"}',
+            messageId: 'msg-1',
+            schemaName: 'recipe',
+          },
+        }),
+      )
+      processor.processChunk(ev.runFinished('stop'))
+
+      const assistant = processor
+        .getMessages()
+        .find((m) => m.role === 'assistant')
+      const sop = assistant!.parts.find((p) => p.type === 'structured-output')
+      expect((sop as any).schemaName).toBe('recipe')
+      expect((sop as any).data).toEqual({ title: 'Pasta' })
+    })
+
+    it('preserves schemaName across delta updates even if only start carries it', () => {
+      // Belt-and-suspenders: a server that only sets schemaName on start
+      // (skipping it on complete) must still produce a part with the name.
+      const processor = new StreamProcessor()
+
+      processor.processChunk(ev.runStarted())
+      processor.processChunk(ev.textStart('msg-1'))
+      processor.processChunk(
+        chunk(EventType.CUSTOM, {
+          name: 'structured-output.start',
+          value: { messageId: 'msg-1', schemaName: 'plan' },
+        }),
+      )
+      // Multiple deltas — each call to appendStructuredOutputDelta must keep
+      // the schemaName from the prior part rather than dropping it.
+      processor.processChunk(ev.textContent('{"day"', 'msg-1'))
+      processor.processChunk(ev.textContent(':"Mon"', 'msg-1'))
+      processor.processChunk(ev.textContent('}', 'msg-1'))
+      processor.processChunk(
+        chunk(EventType.CUSTOM, {
+          name: 'structured-output.complete',
+          // Note: no schemaName here — falls back to the start event's value.
+          value: {
+            object: { day: 'Mon' },
+            raw: '{"day":"Mon"}',
+            messageId: 'msg-1',
+          },
+        }),
+      )
+      processor.processChunk(ev.runFinished('stop'))
+
+      const sop = processor
+        .getMessages()
+        .find((m) => m.role === 'assistant')!
+        .parts.find((p) => p.type === 'structured-output')
+      expect((sop as any).schemaName).toBe('plan')
+    })
+
     it('marks a streaming structured-output part as errored on RUN_ERROR', () => {
       const processor = new StreamProcessor()
 


### PR DESCRIPTION
## Summary

Phase 2 of the structured-output redesign. Stacks on #577 — opening against \`feat/use-chat-structured-output-parts\` so the diff is just the Phase 2 delta. Will rebase onto main once #577 lands.

\`useChat\` can now multiplex multiple structured-output schemas in one conversation, picking which the assistant should respond against on a per-turn basis. Each assistant message's structured-output part carries the chosen \`schemaName\` as a runtime discriminator; \`getStructuredPart(message, name)\` gives a type-safe view of the part with \`data\` and \`partial\` narrowed against the matching schema.

## What changed

- **New \`outputSchemas\` option** on \`useChat\`: \`Record<string, SchemaInput>\` map of named schemas.
- **Per-call schema picker:** \`sendMessage(content, { schema: 'recipe' })\`. Typed as \`keyof TSchemas\` when \`outputSchemas\` is set; uninvocable otherwise.
- **New \`getStructuredPart(message, name)\` helper** on the hook return — typed view of a turn's structured part where \`data\`/\`partial\` are narrowed against \`InferSchemaType<TSchemas[name]>\`. Only available when \`outputSchemas\` is configured.
- **Server-side \`chat({ schemaName })\` option** — propagates into the synthetic \`structured-output.start\` and the terminal \`structured-output.complete\` events. Pass it from your server route after looking up the schema by name from \`forwardedProps.schemaName\`.
- **Client processor** records \`schemaName\` from \`structured-output.start\` and persists it through delta updates and on \`complete\`, even when only the start event carries it.
- **New example \`/generations/structured-multi\`** in ts-react-chat: a two-schema conversation (recipe + weekly plan) with a per-message picker, demonstrating type-safe render branching on \`part.schemaName\`.

Single-schema \`outputSchema\` flows from PR #577 continue to work unchanged.

## Test plan

- [x] \`pnpm --filter @tanstack/ai test:lib\` — **810 passing** (2 new processor tests: schemaName persistence from start event, fallback when only start carries it)
- [x] \`pnpm --filter @tanstack/ai-client test:lib\` — 207 passing
- [x] \`pnpm --filter @tanstack/ai-react test:lib\` — **114 passing** (1 new: two-schema flow with getStructuredPart narrowing)
- [x] \`pnpm --filter @tanstack/ai test:eslint\` / \`ai-client\` / \`ai-react\` — clean
- [x] Types green across ai / ai-client / ai-react
- [x] Example builds clean
- [ ] Manual: \`pnpm --filter ts-react-chat dev\`, open \`/generations/structured-multi\`, pick \"Recipe\" and send \"weeknight pasta for two\", then switch to \"Weekly plan\" and send \"focused week for learning TypeScript\". Verify each turn renders against the correct schema. Needs \`OPENAI_API_KEY\`.

## Reviewer notes

- **Stacked on #577.** Diff is Phase-2-only; the base branch carries the foundational MessagePart design.
- **Decision: schema-by-name vs schema-by-value.** Went with the named-map approach because (a) it lets the typed view (\`getStructuredPart\`) narrow against the schema without runtime serialization, and (b) the server has to be in on the schema list anyway for validation. Per-call ad-hoc schemas would require serializing JSON Schema over the wire and was deemed not worth the complexity for this iteration.
- **\`UIMessage<TTools, TSchemas>\` not parameterized.** I considered making the part typed at the message level so \`messages.map(...).find(p => p.type === 'structured-output' && p.schemaName === 'recipe')\` would narrow data automatically. Decided against it — too much ripple for the ergonomic gain when \`getStructuredPart\` covers the same use case with one extra call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)