### PR TITLE
fix(ai-openrouter): restore OpenRouterChatModelToolCapabilitiesByName

### DIFF
--- a/.changeset/openrouter-restore-tool-capabilities.md
+++ b/.changeset/openrouter-restore-tool-capabilities.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-openrouter': patch
+---
+
+Restore `OpenRouterChatModelToolCapabilitiesByName` export in `model-meta.ts` and emit it from the OpenRouter model generator so future syncs don't drop it.

--- a/packages/typescript/ai-openrouter/src/model-meta.ts
+++ b/packages/typescript/ai-openrouter/src/model-meta.ts
@@ -16251,6 +16251,10 @@ export const OPENROUTER_CHAT_MODELS = [
   'openrouter/auto',
 ] as const
 
+export type OpenRouterChatModelToolCapabilitiesByName = {
+  [K in (typeof OPENROUTER_CHAT_MODELS)[number]]: readonly ['web_search']
+}
+
 export const OPENROUTER_IMAGE_MODELS = [
   GOOGLE_GEMINI_2_5_FLASH_IMAGE.id,
   GOOGLE_GEMINI_3_PRO_IMAGE_PREVIEW.id,

--- a/scripts/convert-openrouter-models.ts
+++ b/scripts/convert-openrouter-models.ts
@@ -64,6 +64,19 @@ function generateChatModelsArray(): string {
     .join('\n')}\n] as const`
 }
 
+/**
+ * OpenRouter's web_search plugin works across all chat models via the gateway,
+ * so the tool-capability map is structural and identical for every chat model.
+ * Emitted as a mapped type to stay in sync with OPENROUTER_CHAT_MODELS without
+ * touching each model constant.
+ */
+function generateChatToolCapabilitiesType(): string {
+  if (chatModels.size === 0) {
+    return ''
+  }
+  return `export type OpenRouterChatModelToolCapabilitiesByName = {\n  [K in (typeof OPENROUTER_CHAT_MODELS)[number]]: readonly ['web_search']\n}`
+}
+
 function generateImageModelsArray(): string {
   const modelIds = Array.from(imageModels)
   if (modelIds.length === 0) {
@@ -306,6 +319,8 @@ ${createPerModelModelOptions()}
 ${createPerModelInputModalities()}
 
 ${generateChatModelsArray()}
+
+${generateChatToolCapabilitiesType()}
 ${generateVideoModelsArray()}
 ${generateImageModelsArray()}
 `


### PR DESCRIPTION
## Summary

Restores the `OpenRouterChatModelToolCapabilitiesByName` mapped type whose disappearance broke `main` in [run 26098355252](https://github.com/TanStack/ai/actions/runs/26098355252) (the release that should have shipped #580's version bumps).

**Root cause:** the type was hand-added to `packages/typescript/ai-openrouter/src/model-meta.ts` in #466 but never wired into `scripts/convert-openrouter-models.ts`. PR #581's wholesale regeneration of `model-meta.ts` dropped it, and `src/index.ts`, `src/adapters/text.ts`, and `src/adapters/responses-text.ts` all still import it — so `@tanstack/ai-openrouter:build` and `@tanstack/ai-openrouter:test:types` both failed, aborting the release before changesets could publish.

- Add `generateChatToolCapabilitiesType()` to the generator and emit it after `OPENROUTER_CHAT_MODELS`, so future syncs preserve the type.
- Restore the missing block in `model-meta.ts` (identical to what the fixed generator now produces) so the current `main` build goes green.

The cascade type errors at `text.ts:123/207/360/1177` and `responses-text.ts:373/1525` (including the implicit-`any` on `tool`/`tc`) all resolve automatically once the type import works again — they were artifacts of TS giving up on the broken generic.

## Test plan

- [x] `pnpm nx run @tanstack/ai-openrouter:build` — passes
- [x] `pnpm nx run @tanstack/ai-openrouter:test:types` — passes
- [x] `pnpm nx run @tanstack/ai-openrouter:test:lib` — 80/80 pass
- [x] `pnpm nx run @tanstack/ai-openrouter:test:eslint` — clean
- [ ] CI green on this PR
- [ ] Once merged, the next push to `main` should let the Release workflow proceed past the Run Tests step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `OpenRouterChatModelToolCapabilitiesByName` type export that clearly documents which OpenRouter chat models support web search capabilities, improving developer experience with better type safety and IDE autocompletion.

## Chores
* Enhanced the model code generator to automatically create and maintain tool capability type definitions during synchronization, preventing loss of type information on future model updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->