### PR TITLE
fix(ai-vue): preserve UIMessage discrimination in useChat refs

### DIFF
--- a/.changeset/vue-messages-discrimination.md
+++ b/.changeset/vue-messages-discrimination.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-vue': patch
+---
+
+Fix `useChat` in Vue: `messages`, `partial`, and `final` now use `Readonly<ShallowRef<X>>` instead of `DeepReadonly<ShallowRef<X>>`. The deep-readonly wrapper was contradictory over a shallow ref and silently collapsed the `MessagePart` discriminated union, breaking `parts.find(p => p.type === 'structured-output')?.data` narrowing in consumer code. The runtime behavior is unchanged.

--- a/packages/typescript/ai-vue/src/types.ts
+++ b/packages/typescript/ai-vue/src/types.ts
@@ -91,12 +91,12 @@ export type UseChatReturn<
          * latest assistant message's structured-output part — updates as
          * `TEXT_MESSAGE_CONTENT` deltas accumulate into that part.
          */
-        partial: DeepReadonly<ShallowRef<DeepPartial<InferSchemaType<TSchema>>>>
+        partial: Readonly<ShallowRef<DeepPartial<InferSchemaType<TSchema>>>>
         /**
          * Final, schema-validated structured output. `null` until the latest
          * assistant turn's structured-output part transitions to `complete`.
          */
-        final: DeepReadonly<ShallowRef<InferSchemaType<TSchema> | null>>
+        final: Readonly<ShallowRef<InferSchemaType<TSchema> | null>>
       }
     : Record<never, never>)
 
@@ -109,7 +109,7 @@ interface BaseUseChatReturn<
    * `messages[i].parts.find(p => p.type === 'structured-output')` is typed
    * by the schema — `data: T`, `partial: DeepPartial<T>`.
    */
-  messages: DeepReadonly<ShallowRef<Array<UIMessage<TTools, TData>>>>
+  messages: Readonly<ShallowRef<Array<UIMessage<TTools, TData>>>>
 
   /**
    * Send a message and get a response.

--- a/packages/typescript/ai-vue/tests/use-chat-types.test.ts
+++ b/packages/typescript/ai-vue/tests/use-chat-types.test.ts
@@ -7,7 +7,7 @@ import { describe, expectTypeOf, it } from 'vitest'
 import type { StandardJSONSchemaV1 } from '@standard-schema/spec'
 import type { AnyClientTool } from '@tanstack/ai'
 import type { StructuredOutputPart } from '@tanstack/ai-client'
-import type { DeepReadonly, ShallowRef } from 'vue'
+import type { ShallowRef } from 'vue'
 import type { DeepPartial, UseChatOptions, UseChatReturn } from '../src/types'
 
 type Person = { name: string; age: number; email: string }
@@ -19,10 +19,10 @@ describe('useChat() return type (vue)', () => {
     it('exposes typed partial + final refs', () => {
       type R = UseChatReturn<NoTools, PersonSchema>
       expectTypeOf<R['partial']>().toEqualTypeOf<
-        DeepReadonly<ShallowRef<DeepPartial<Person>>>
+        Readonly<ShallowRef<DeepPartial<Person>>>
       >()
       expectTypeOf<R['final']>().toEqualTypeOf<
-        DeepReadonly<ShallowRef<Person | null>>
+        Readonly<ShallowRef<Person | null>>
       >()
     })
 
@@ -39,7 +39,7 @@ describe('useChat() return type (vue)', () => {
       // structured-output part on each assistant message carries `data:
       // Person` (and `partial: DeepPartial<Person>`). No cast needed.
       type Messages =
-        R['messages'] extends DeepReadonly<ShallowRef<infer A>> ? A : never
+        R['messages'] extends Readonly<ShallowRef<infer A>> ? A : never
       type Part = Messages[number]['parts'][number]
       type StructuredPart = Extract<Part, { type: 'structured-output' }>
       expectTypeOf<StructuredPart>().toEqualTypeOf<
@@ -61,7 +61,7 @@ describe('useChat() return type (vue)', () => {
     it('messages.parts structured-output variant defaults to unknown', () => {
       type R = UseChatReturn<NoTools>
       type Messages =
-        R['messages'] extends DeepReadonly<ShallowRef<infer A>> ? A : never
+        R['messages'] extends Readonly<ShallowRef<infer A>> ? A : never
       type Part = Messages[number]['parts'][number]
       type StructuredPart = Extract<Part, { type: 'structured-output' }>
       expectTypeOf<StructuredPart['data']>().toEqualTypeOf<


### PR DESCRIPTION
## Summary

`@tanstack/ai-vue:test:types` started failing on `main` for `tests/use-chat-types.test.ts` (lines 22 / 25 / 46 / 48 / 68). The failure has been present since #577 but was hidden behind Nx Cloud cache hits on prior runs.

**Root cause:** `useChat` typed its refs as `DeepReadonly<ShallowRef<X>>`. Vue's `DeepReadonly` is a recursive mapped type that — when applied to an `Array<UIMessage<TTools, Person>>` — collapses the `MessagePart` discriminated union: every variant's fields become optional and the `type` literals merge. That means consumer code like

```ts
const { messages } = useChat({ outputSchema: personSchema })
messages.value[0].parts.find(p => p.type === 'structured-output')?.data
//                                                              ^? supposed to be Person | undefined
```

doesn't narrow to `Person` anymore. The probe-style typecheck I ran during diagnosis confirmed the part union was being flattened (every part field showed up as optional, `type` became a union of all literals).

`DeepReadonly<ShallowRef<X>>` was also semantically incoherent in the first place: `ShallowRef` is shallow by definition, so layering deep-readonly enforcement over it added no reactivity guarantee — only the type mangling.

**Fix:** in `packages/typescript/ai-vue/src/types.ts`, change `messages`, `partial`, and `final` from `DeepReadonly<ShallowRef<X>>` to `Readonly<ShallowRef<X>>`. `Readonly` only makes the outer ref's `.value` setter readonly without re-mapping `X`, so the inner discriminated union survives. The runtime stays `readonly(messages)` — the `as unknown as UseChatReturn<…>` cast in `use-chat.ts` already bridges the type and the deep-readonly proxy at runtime, so nested mutations still throw.

Tests updated to match the corrected public type.

## Test plan

- [x] `pnpm nx run @tanstack/ai-vue:test:types --skip-nx-cache` — passes
- [x] `pnpm nx run @tanstack/ai-vue:test:lib` — 94/94 pass (1 pre-existing skip)
- [x] `pnpm nx run @tanstack/ai-vue:build` — passes
- [x] `pnpm nx run @tanstack/ai-vue:test:eslint` — clean
- [x] `pnpm nx run @tanstack/ai-vue-ui:test:types` — passes (downstream consumer)
- [x] `pnpm nx run ts-vue-chat:build` — passes (example)
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript typing for Vue's `useChat` composable to properly preserve type narrowing for structured output parts. This resolves a type-level issue that could prevent accurate type inference when using discriminated unions with AI responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->