### PR TITLE
fix(ai): restore StructuredOutputStream assignability to AsyncIterable<StreamChunk>

### DIFF
--- a/.changeset/fix-structured-output-stream-sse-assignability.md
+++ b/.changeset/fix-structured-output-stream-sse-assignability.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/ai": patch
+'@tanstack/ai': patch
 ---
 
 fix(ai): restore `StructuredOutputStream` assignability to `AsyncIterable<StreamChunk>` so it can be passed to `toServerSentEventsResponse`

--- a/.changeset/fix-structured-output-stream-sse-assignability.md
+++ b/.changeset/fix-structured-output-stream-sse-assignability.md
@@ -1,0 +1,9 @@
+---
+"@tanstack/ai": patch
+---
+
+fix(ai): restore `StructuredOutputStream` assignability to `AsyncIterable<StreamChunk>` so it can be passed to `toServerSentEventsResponse`
+
+`StructuredOutputStartEvent`, `StructuredOutputCompleteEvent`, `ApprovalRequestedEvent`, and `ToolInputAvailableEvent` declared their shape with `extends Omit<CustomEvent, 'name' | 'value'>`. Because `CustomEvent` is inferred from a zod `passthrough` schema, it carries a `[k: string]: unknown` index signature, and `Omit` on a type with a `string` index signature collapses every surviving property to `unknown` — including `type: 'CUSTOM'`. That broke union assignability against `AGUIEvent`/`StreamChunk`, so `toServerSentEventsResponse(stream)` failed to typecheck against streams returned by `chat({ outputSchema, stream: true })`.
+
+Switched to `extends CustomEvent` with refined `name`/`value` (allowed: narrower types of declared properties), which keeps `type: 'CUSTOM'` intact and preserves the existing discriminated-narrowing patterns.

--- a/packages/typescript/ai/src/types.ts
+++ b/packages/typescript/ai/src/types.ts
@@ -1146,10 +1146,8 @@ export interface CustomEvent extends AGUICustomEvent {
  * }
  * ```
  */
-export interface StructuredOutputCompleteEvent<T = unknown> extends Omit<
-  CustomEvent,
-  'name' | 'value'
-> {
+export interface StructuredOutputCompleteEvent<T = unknown>
+  extends CustomEvent {
   name: 'structured-output.complete'
   value: { object: T; raw: string; reasoning?: string }
 }
@@ -1162,10 +1160,7 @@ export interface StructuredOutputCompleteEvent<T = unknown> extends Omit<
  * `messageId` the deltas will be tagged with so the routing decision can be
  * made per-message rather than globally.
  */
-export interface StructuredOutputStartEvent extends Omit<
-  CustomEvent,
-  'name' | 'value'
-> {
+export interface StructuredOutputStartEvent extends CustomEvent {
   name: 'structured-output.start'
   value: { messageId: string }
 }
@@ -1177,10 +1172,7 @@ export interface StructuredOutputStartEvent extends Omit<
  * (the agent-loop branch of `runStreamingStructuredOutputImpl` in
  * `activities/chat/index.ts` forwards CUSTOM events from `TextEngine.run()`).
  */
-export interface ApprovalRequestedEvent extends Omit<
-  CustomEvent,
-  'name' | 'value'
-> {
+export interface ApprovalRequestedEvent extends CustomEvent {
   name: 'approval-requested'
   value: {
     toolCallId: string
@@ -1196,10 +1188,7 @@ export interface ApprovalRequestedEvent extends Omit<
  * will not fire for that run. Shape fixed by the agent-loop forwarding in
  * `runStreamingStructuredOutputImpl` in `activities/chat/index.ts`.
  */
-export interface ToolInputAvailableEvent extends Omit<
-  CustomEvent,
-  'name' | 'value'
-> {
+export interface ToolInputAvailableEvent extends CustomEvent {
   name: 'tool-input-available'
   value: {
     toolCallId: string

--- a/packages/typescript/ai/src/types.ts
+++ b/packages/typescript/ai/src/types.ts
@@ -1146,8 +1146,9 @@ export interface CustomEvent extends AGUICustomEvent {
  * }
  * ```
  */
-export interface StructuredOutputCompleteEvent<T = unknown>
-  extends CustomEvent {
+export interface StructuredOutputCompleteEvent<
+  T = unknown,
+> extends CustomEvent {
   name: 'structured-output.complete'
   value: { object: T; raw: string; reasoning?: string }
 }

--- a/packages/typescript/ai/tests/chat-result-types.test.ts
+++ b/packages/typescript/ai/tests/chat-result-types.test.ts
@@ -81,9 +81,9 @@ describe('chat() return type', () => {
 
   describe('StructuredOutputStream assignability', () => {
     it('is assignable to AsyncIterable<StreamChunk> (toServerSentEventsResponse input)', () => {
-      expectTypeOf<
-        StructuredOutputStream<Person>
-      >().toMatchTypeOf<AsyncIterable<StreamChunk>>()
+      expectTypeOf<StructuredOutputStream<Person>>().toMatchTypeOf<
+        AsyncIterable<StreamChunk>
+      >()
     })
   })
 

--- a/packages/typescript/ai/tests/chat-result-types.test.ts
+++ b/packages/typescript/ai/tests/chat-result-types.test.ts
@@ -79,6 +79,14 @@ describe('chat() return type', () => {
     })
   })
 
+  describe('StructuredOutputStream assignability', () => {
+    it('is assignable to AsyncIterable<StreamChunk> (toServerSentEventsResponse input)', () => {
+      expectTypeOf<
+        StructuredOutputStream<Person>
+      >().toMatchTypeOf<AsyncIterable<StreamChunk>>()
+    })
+  })
+
   describe('without outputSchema', () => {
     it('stream: true → AsyncIterable<StreamChunk>', () => {
       expectTypeOf<TextActivityResult<undefined, true>>().toEqualTypeOf<


### PR DESCRIPTION
## Summary

- `StructuredOutputStartEvent`, `StructuredOutputCompleteEvent`, `ApprovalRequestedEvent`, and `ToolInputAvailableEvent` declared their shape with `extends Omit<CustomEvent, 'name' | 'value'>`. Because `CustomEvent` is inferred from a zod `passthrough` schema, it carries a `[k: string]: unknown` index signature, and `Omit` on a type with a `string` index signature collapses every surviving property to `unknown` — including `type: 'CUSTOM'`. That broke union assignability against `AGUIEvent` / `StreamChunk`, so `toServerSentEventsResponse(stream)` failed to typecheck against the stream returned by `chat({ outputSchema, stream: true })` — the exact pattern documented in `docs/structured-outputs/streaming.md`.
- Switched the four interfaces to `extends CustomEvent` with refined `name`/`value` (narrower types of inherited properties are allowed). `type: 'CUSTOM'` is preserved and existing discriminated-narrowing (`chunk.type === 'CUSTOM' && chunk.name === '...'`) continues to give a fully typed `value`.
- Added a type-level regression assertion in `chat-result-types.test.ts` that pins `StructuredOutputStream<T>` to `AsyncIterable<StreamChunk>` so this can't silently regress again.

## Reproducer

Before the fix:

```ts
import { chat, toServerSentEventsResponse } from '@tanstack/ai'

const stream = chat({ adapter, messages, outputSchema, stream: true })
return toServerSentEventsResponse(stream)
// TS2345: Argument of type 'StructuredOutputStream<{...}>' is not
// assignable to parameter of type 'AsyncIterable<AGUIEvent>'.
//   Type 'StructuredOutputStartEvent' is missing the following
//   properties from type 'ReasoningEncryptedValueEvent': type,
//   subtype, entityId, encryptedValue
```

After the fix this compiles. Runtime behaviour is unchanged — this is a pure type-level bug fix.

## Test plan

- [x] `pnpm test:lib` — 832 tests pass in `@tanstack/ai`
- [x] `pnpm test:types` — 32 projects pass
- [x] New regression assertion exercises `StructuredOutputStream<Person>` ⊂ `AsyncIterable<StreamChunk>`
- [x] Verified discrimination still works on `structured-output.complete`, `structured-output.start`, `approval-requested`, `tool-input-available`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript type assignability issues when using structured output streaming with the chat API, ensuring proper type compatibility for stream chunks with strict type checking enabled.

* **Tests**
  * Added type-level test to verify structured output stream assignability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->