### PR TITLE
feat(ai-*-ui): markdown plugin customization on TextPart

### DIFF
--- a/.changeset/markdown-plugin-customization.md
+++ b/.changeset/markdown-plugin-customization.md
@@ -17,7 +17,6 @@ with a single prop:
 
 ```tsx
 import remarkCjkFriendly from 'remark-cjk-friendly'
-
 ;<TextPart content={content} remarkPlugins={[remarkCjkFriendly]} />
 ```
 

--- a/.changeset/markdown-plugin-customization.md
+++ b/.changeset/markdown-plugin-customization.md
@@ -1,0 +1,30 @@
+---
+'@tanstack/ai-react-ui': minor
+'@tanstack/ai-solid-ui': minor
+'@tanstack/ai-vue-ui': minor
+---
+
+`TextPart` now accepts `remarkPlugins`, `rehypePlugins`, and (React/Solid)
+`components` props, plus a `disableDefaultPlugins` escape hatch. User plugins
+merge with the secure defaults — `rehype-sanitize` continues to run last
+unless defaults are disabled.
+
+This fixes [#164](https://github.com/TanStack/ai/issues/164): bold and
+emphasis in Japanese, Chinese, and Korean text rendered incorrectly because
+of a CommonMark spec defect. Consumers can now drop in
+[`remark-cjk-friendly`](https://www.npmjs.com/package/remark-cjk-friendly)
+with a single prop:
+
+```tsx
+import remarkCjkFriendly from 'remark-cjk-friendly'
+
+;<TextPart content={content} remarkPlugins={[remarkCjkFriendly]} />
+```
+
+Also fixes a latent bug in `@tanstack/ai-react-ui` where `remark-gfm` was
+passed inside the rehype plugin array, silently disabling GFM features
+(tables, strikethrough, task lists) in the React `TextPart`.
+
+`@tanstack/ai-vue-ui` omits the `components` prop because its underlying
+renderer (`@crazydos/vue-markdown`) does not expose component overrides;
+use that library's slot API for custom rendering.

--- a/packages/typescript/ai-react-ui/src/markdown-plugins.ts
+++ b/packages/typescript/ai-react-ui/src/markdown-plugins.ts
@@ -1,0 +1,48 @@
+import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize from 'rehype-sanitize'
+import rehypeHighlight from 'rehype-highlight'
+import type { Options as ReactMarkdownOptions } from 'react-markdown'
+
+export type PluggableList = NonNullable<ReactMarkdownOptions['remarkPlugins']>
+
+export const DEFAULT_REMARK_PLUGINS: PluggableList = [remarkGfm]
+export const DEFAULT_REHYPE_PLUGINS_BEFORE_USER: PluggableList = [
+  rehypeRaw,
+  rehypeHighlight,
+]
+export const DEFAULT_REHYPE_PLUGINS_AFTER_USER: PluggableList = [rehypeSanitize]
+
+export interface ResolveMarkdownPluginsOptions {
+  remarkPlugins?: PluggableList
+  rehypePlugins?: PluggableList
+  disableDefaultPlugins?: boolean
+}
+
+export interface ResolvedMarkdownPlugins {
+  remarkPlugins: PluggableList
+  rehypePlugins: PluggableList
+}
+
+export function resolveMarkdownPlugins(
+  options: ResolveMarkdownPluginsOptions,
+): ResolvedMarkdownPlugins {
+  const userRemark = options.remarkPlugins ?? []
+  const userRehype = options.rehypePlugins ?? []
+
+  if (options.disableDefaultPlugins) {
+    return {
+      remarkPlugins: [...userRemark],
+      rehypePlugins: [...userRehype],
+    }
+  }
+
+  return {
+    remarkPlugins: [...DEFAULT_REMARK_PLUGINS, ...userRemark],
+    rehypePlugins: [
+      ...DEFAULT_REHYPE_PLUGINS_BEFORE_USER,
+      ...userRehype,
+      ...DEFAULT_REHYPE_PLUGINS_AFTER_USER,
+    ],
+  }
+}

--- a/packages/typescript/ai-react-ui/src/text-part.tsx
+++ b/packages/typescript/ai-react-ui/src/text-part.tsx
@@ -1,8 +1,7 @@
 import ReactMarkdown from 'react-markdown'
-import rehypeRaw from 'rehype-raw'
-import rehypeSanitize from 'rehype-sanitize'
-import rehypeHighlight from 'rehype-highlight'
-import remarkGfm from 'remark-gfm'
+import { resolveMarkdownPlugins } from './markdown-plugins'
+import type { Components } from 'react-markdown'
+import type { PluggableList } from './markdown-plugins'
 
 export interface TextPartProps {
   /** The text content to render */
@@ -15,16 +14,31 @@ export interface TextPartProps {
   userClassName?: string
   /** Additional className for assistant messages (also used for system messages) */
   assistantClassName?: string
+  /**
+   * Additional remark plugins, appended after the defaults
+   * (or replacing them when `disableDefaultPlugins` is true).
+   */
+  remarkPlugins?: PluggableList
+  /**
+   * Additional rehype plugins. Inserted between the built-in
+   * `rehypeRaw`/`rehypeHighlight` and the trailing `rehypeSanitize`
+   * so sanitization always runs last. When `disableDefaultPlugins`
+   * is true, replaces the entire chain.
+   */
+  rehypePlugins?: PluggableList
+  /** react-markdown `components` overrides (e.g. custom `a`, `code`). */
+  components?: Components
+  /**
+   * Drop the built-in plugin defaults entirely. The consumer becomes
+   * responsible for syntax highlighting, GFM, raw HTML handling, and
+   * sanitization. Use with care — disabling defaults removes the
+   * built-in XSS sanitizer.
+   */
+  disableDefaultPlugins?: boolean
 }
 
 /**
- * TextPart component - renders markdown text with syntax highlighting
- *
- * Features:
- * - Full markdown support with GFM (tables, strikethrough, etc.)
- * - Syntax highlighting for code blocks
- * - Sanitized HTML rendering
- * - Role-based styling (user vs assistant)
+ * TextPart component - renders markdown text with syntax highlighting.
  *
  * @example Standalone usage
  * ```tsx
@@ -37,22 +51,11 @@ export interface TextPartProps {
  * />
  * ```
  *
- * @example Usage in partRenderers
+ * @example Add a markdown plugin (e.g. CJK bold/emphasis support)
  * ```tsx
- * <ChatMessage
- *   message={message}
- *   partRenderers={{
- *     text: ({ content }) => (
- *       <TextPart
- *         content={content}
- *         role={message.role}
- *         className="px-5 py-3 rounded-2xl"
- *         userClassName="bg-orange-500 text-white"
- *         assistantClassName="bg-gray-800 text-white"
- *       />
- *     )
- *   }}
- * />
+ * import remarkCjkFriendly from 'remark-cjk-friendly'
+ *
+ * <TextPart content={content} remarkPlugins={[remarkCjkFriendly]} />
  * ```
  */
 export function TextPart({
@@ -61,8 +64,11 @@ export function TextPart({
   className = '',
   userClassName = '',
   assistantClassName = '',
+  remarkPlugins,
+  rehypePlugins,
+  components,
+  disableDefaultPlugins,
 }: TextPartProps) {
-  // Combine classes based on role
   const roleClassName =
     role === 'user'
       ? userClassName
@@ -71,10 +77,18 @@ export function TextPart({
         : ''
   const combinedClassName = [className, roleClassName].filter(Boolean).join(' ')
 
+  const resolved = resolveMarkdownPlugins({
+    remarkPlugins,
+    rehypePlugins,
+    disableDefaultPlugins,
+  })
+
   return (
     <div className={combinedClassName || undefined}>
       <ReactMarkdown
-        rehypePlugins={[rehypeRaw, rehypeSanitize, rehypeHighlight, remarkGfm]}
+        remarkPlugins={resolved.remarkPlugins}
+        rehypePlugins={resolved.rehypePlugins}
+        components={components}
       >
         {content}
       </ReactMarkdown>

--- a/packages/typescript/ai-react-ui/tests/markdown-plugins.test.ts
+++ b/packages/typescript/ai-react-ui/tests/markdown-plugins.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize from 'rehype-sanitize'
+import rehypeHighlight from 'rehype-highlight'
+import {
+  DEFAULT_REHYPE_PLUGINS_AFTER_USER,
+  DEFAULT_REHYPE_PLUGINS_BEFORE_USER,
+  DEFAULT_REMARK_PLUGINS,
+  resolveMarkdownPlugins,
+} from '../src/markdown-plugins'
+
+const userRemark = () => () => {}
+const userRehype = () => () => {}
+
+describe('resolveMarkdownPlugins', () => {
+  it('returns defaults when no user plugins are supplied', () => {
+    const { remarkPlugins, rehypePlugins } = resolveMarkdownPlugins({})
+    expect(remarkPlugins).toEqual([remarkGfm])
+    expect(rehypePlugins).toEqual([rehypeRaw, rehypeHighlight, rehypeSanitize])
+  })
+
+  it('appends user remark plugins after defaults', () => {
+    const { remarkPlugins } = resolveMarkdownPlugins({
+      remarkPlugins: [userRemark],
+    })
+    expect(remarkPlugins).toEqual([remarkGfm, userRemark])
+  })
+
+  it('inserts user rehype plugins before rehype-sanitize so sanitize always runs last', () => {
+    const { rehypePlugins } = resolveMarkdownPlugins({
+      rehypePlugins: [userRehype],
+    })
+    expect(rehypePlugins).toEqual([
+      rehypeRaw,
+      rehypeHighlight,
+      userRehype,
+      rehypeSanitize,
+    ])
+  })
+
+  it('drops defaults entirely when disableDefaultPlugins is true', () => {
+    const { remarkPlugins, rehypePlugins } = resolveMarkdownPlugins({
+      remarkPlugins: [userRemark],
+      rehypePlugins: [userRehype],
+      disableDefaultPlugins: true,
+    })
+    expect(remarkPlugins).toEqual([userRemark])
+    expect(rehypePlugins).toEqual([userRehype])
+  })
+
+  it('returns empty arrays when defaults disabled and no user plugins given', () => {
+    const { remarkPlugins, rehypePlugins } = resolveMarkdownPlugins({
+      disableDefaultPlugins: true,
+    })
+    expect(remarkPlugins).toEqual([])
+    expect(rehypePlugins).toEqual([])
+  })
+
+  it('does not mutate the user-supplied arrays', () => {
+    const userR = [userRemark]
+    const userH = [userRehype]
+    resolveMarkdownPlugins({ remarkPlugins: userR, rehypePlugins: userH })
+    expect(userR).toEqual([userRemark])
+    expect(userH).toEqual([userRehype])
+  })
+
+  it('exposes default constants for documentation/reuse', () => {
+    expect(DEFAULT_REMARK_PLUGINS).toEqual([remarkGfm])
+    expect(DEFAULT_REHYPE_PLUGINS_BEFORE_USER).toEqual([
+      rehypeRaw,
+      rehypeHighlight,
+    ])
+    expect(DEFAULT_REHYPE_PLUGINS_AFTER_USER).toEqual([rehypeSanitize])
+  })
+})

--- a/packages/typescript/ai-solid-ui/src/markdown-plugins.ts
+++ b/packages/typescript/ai-solid-ui/src/markdown-plugins.ts
@@ -1,0 +1,48 @@
+import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize from 'rehype-sanitize'
+import rehypeHighlight from 'rehype-highlight'
+import type { SolidMarkdownOptions } from 'solid-markdown'
+
+export type PluggableList = SolidMarkdownOptions['remarkPlugins']
+
+export const DEFAULT_REMARK_PLUGINS: PluggableList = [remarkGfm]
+export const DEFAULT_REHYPE_PLUGINS_BEFORE_USER: PluggableList = [
+  rehypeRaw,
+  rehypeHighlight,
+]
+export const DEFAULT_REHYPE_PLUGINS_AFTER_USER: PluggableList = [rehypeSanitize]
+
+export interface ResolveMarkdownPluginsOptions {
+  remarkPlugins?: PluggableList
+  rehypePlugins?: PluggableList
+  disableDefaultPlugins?: boolean
+}
+
+export interface ResolvedMarkdownPlugins {
+  remarkPlugins: PluggableList
+  rehypePlugins: PluggableList
+}
+
+export function resolveMarkdownPlugins(
+  options: ResolveMarkdownPluginsOptions,
+): ResolvedMarkdownPlugins {
+  const userRemark = options.remarkPlugins ?? []
+  const userRehype = options.rehypePlugins ?? []
+
+  if (options.disableDefaultPlugins) {
+    return {
+      remarkPlugins: [...userRemark],
+      rehypePlugins: [...userRehype],
+    }
+  }
+
+  return {
+    remarkPlugins: [...DEFAULT_REMARK_PLUGINS, ...userRemark],
+    rehypePlugins: [
+      ...DEFAULT_REHYPE_PLUGINS_BEFORE_USER,
+      ...userRehype,
+      ...DEFAULT_REHYPE_PLUGINS_AFTER_USER,
+    ],
+  }
+}

--- a/packages/typescript/ai-solid-ui/src/text-part.tsx
+++ b/packages/typescript/ai-solid-ui/src/text-part.tsx
@@ -1,9 +1,7 @@
 import { SolidMarkdown } from 'solid-markdown'
-import remarkGfm from 'remark-gfm'
-
-import rehypeRaw from 'rehype-raw'
-import rehypeSanitize from 'rehype-sanitize'
-import rehypeHighlight from 'rehype-highlight'
+import { resolveMarkdownPlugins } from './markdown-plugins'
+import type { SolidMarkdownComponents } from 'solid-markdown'
+import type { PluggableList } from './markdown-plugins'
 
 export interface TextPartProps {
   /** The text content to render */
@@ -16,48 +14,33 @@ export interface TextPartProps {
   userClass?: string
   /** Additional class for assistant messages (also used for system messages) */
   assistantClass?: string
+  /** Additional remark plugins, appended after the defaults. */
+  remarkPlugins?: PluggableList
+  /**
+   * Additional rehype plugins. Inserted before the trailing
+   * `rehypeSanitize` so sanitization always runs last.
+   */
+  rehypePlugins?: PluggableList
+  /** solid-markdown `components` overrides. */
+  components?: SolidMarkdownComponents
+  /**
+   * Drop the built-in plugin defaults entirely. Disables the XSS
+   * sanitizer; the caller becomes responsible for sanitization.
+   */
+  disableDefaultPlugins?: boolean
 }
 
 /**
- * TextPart component - renders markdown text with syntax highlighting
+ * TextPart component - renders markdown text with syntax highlighting.
  *
- * Features:
- * - Full markdown support with GFM (tables, strikethrough, etc.)
- * - Syntax highlighting for code blocks
- * - Sanitized HTML rendering
- * - Role-based styling (user vs assistant)
- *
- * @example Standalone usage
+ * @example Add a markdown plugin (e.g. CJK bold/emphasis support)
  * ```tsx
- * <TextPart
- *   content="Hello **world**!"
- *   role="user"
- *   class="p-4 rounded"
- *   userClass="bg-blue-500"
- *   assistantClass="bg-gray-500"
- * />
- * ```
+ * import remarkCjkFriendly from 'remark-cjk-friendly'
  *
- * @example Usage in partRenderers
- * ```tsx
- * <ChatMessage
- *   message={message}
- *   partRenderers={{
- *     text: ({ content }) => (
- *       <TextPart
- *         content={content}
- *         role={message.role}
- *         class="px-5 py-3 rounded-2xl"
- *         userClass="bg-orange-500 text-white"
- *         assistantClass="bg-gray-800 text-white"
- *       />
- *     )
- *   }}
- * />
+ * <TextPart content={content} remarkPlugins={[remarkCjkFriendly]} />
  * ```
  */
 export function TextPart(props: TextPartProps) {
-  // Combine classes based on role
   const roleClass = () =>
     props.role === 'user'
       ? (props.userClass ?? '')
@@ -67,11 +50,19 @@ export function TextPart(props: TextPartProps) {
   const combinedClass = () =>
     [props.class ?? '', roleClass()].filter(Boolean).join(' ')
 
+  const resolved = () =>
+    resolveMarkdownPlugins({
+      remarkPlugins: props.remarkPlugins,
+      rehypePlugins: props.rehypePlugins,
+      disableDefaultPlugins: props.disableDefaultPlugins,
+    })
+
   return (
     <div class={combinedClass() || undefined}>
       <SolidMarkdown
-        remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw, rehypeSanitize, rehypeHighlight]}
+        remarkPlugins={resolved().remarkPlugins}
+        rehypePlugins={resolved().rehypePlugins}
+        components={props.components}
       >
         {props.content}
       </SolidMarkdown>

--- a/packages/typescript/ai-solid-ui/tests/markdown-plugins.test.ts
+++ b/packages/typescript/ai-solid-ui/tests/markdown-plugins.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize from 'rehype-sanitize'
+import rehypeHighlight from 'rehype-highlight'
+import {
+  DEFAULT_REHYPE_PLUGINS_AFTER_USER,
+  DEFAULT_REHYPE_PLUGINS_BEFORE_USER,
+  DEFAULT_REMARK_PLUGINS,
+  resolveMarkdownPlugins,
+} from '../src/markdown-plugins'
+
+const userRemark = () => () => {}
+const userRehype = () => () => {}
+
+describe('resolveMarkdownPlugins (solid)', () => {
+  it('returns defaults when no user plugins are supplied', () => {
+    const { remarkPlugins, rehypePlugins } = resolveMarkdownPlugins({})
+    expect(remarkPlugins).toEqual([remarkGfm])
+    expect(rehypePlugins).toEqual([rehypeRaw, rehypeHighlight, rehypeSanitize])
+  })
+
+  it('appends user remark plugins after defaults', () => {
+    const { remarkPlugins } = resolveMarkdownPlugins({
+      remarkPlugins: [userRemark],
+    })
+    expect(remarkPlugins).toEqual([remarkGfm, userRemark])
+  })
+
+  it('inserts user rehype plugins before rehype-sanitize so sanitize always runs last', () => {
+    const { rehypePlugins } = resolveMarkdownPlugins({
+      rehypePlugins: [userRehype],
+    })
+    expect(rehypePlugins).toEqual([
+      rehypeRaw,
+      rehypeHighlight,
+      userRehype,
+      rehypeSanitize,
+    ])
+  })
+
+  it('drops defaults entirely when disableDefaultPlugins is true', () => {
+    const { remarkPlugins, rehypePlugins } = resolveMarkdownPlugins({
+      remarkPlugins: [userRemark],
+      rehypePlugins: [userRehype],
+      disableDefaultPlugins: true,
+    })
+    expect(remarkPlugins).toEqual([userRemark])
+    expect(rehypePlugins).toEqual([userRehype])
+  })
+
+  it('returns empty arrays when defaults disabled and no user plugins given', () => {
+    const { remarkPlugins, rehypePlugins } = resolveMarkdownPlugins({
+      disableDefaultPlugins: true,
+    })
+    expect(remarkPlugins).toEqual([])
+    expect(rehypePlugins).toEqual([])
+  })
+
+  it('does not mutate the user-supplied arrays', () => {
+    const userR = [userRemark]
+    const userH = [userRehype]
+    resolveMarkdownPlugins({ remarkPlugins: userR, rehypePlugins: userH })
+    expect(userR).toEqual([userRemark])
+    expect(userH).toEqual([userRehype])
+  })
+
+  it('exposes default constants for documentation/reuse', () => {
+    expect(DEFAULT_REMARK_PLUGINS).toEqual([remarkGfm])
+    expect(DEFAULT_REHYPE_PLUGINS_BEFORE_USER).toEqual([
+      rehypeRaw,
+      rehypeHighlight,
+    ])
+    expect(DEFAULT_REHYPE_PLUGINS_AFTER_USER).toEqual([rehypeSanitize])
+  })
+})

--- a/packages/typescript/ai-vue-ui/package.json
+++ b/packages/typescript/ai-vue-ui/package.json
@@ -43,7 +43,6 @@
     "@tanstack/ai-vue": "workspace:*",
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
-    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1"
   },
   "peerDependencies": {

--- a/packages/typescript/ai-vue-ui/src/markdown-plugins.ts
+++ b/packages/typescript/ai-vue-ui/src/markdown-plugins.ts
@@ -1,0 +1,49 @@
+import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
+import rehypeHighlight from 'rehype-highlight'
+import type { PluggableList as UnifiedPluggableList } from '@crazydos/vue-markdown'
+
+/**
+ * @crazydos/vue-markdown applies `rehype-sanitize` automatically when its
+ * `sanitize` prop is true. The helper therefore does NOT add `rehype-sanitize`
+ * itself — instead, `<TextPart>` toggles the renderer's `sanitize` prop based
+ * on `disableDefaultPlugins`.
+ */
+
+export type PluggableList = UnifiedPluggableList
+
+export const DEFAULT_REMARK_PLUGINS: PluggableList = [remarkGfm]
+export const DEFAULT_REHYPE_PLUGINS: PluggableList = [
+  rehypeRaw,
+  rehypeHighlight,
+]
+
+export interface ResolveMarkdownPluginsOptions {
+  remarkPlugins?: PluggableList
+  rehypePlugins?: PluggableList
+  disableDefaultPlugins?: boolean
+}
+
+export interface ResolvedMarkdownPlugins {
+  remarkPlugins: PluggableList
+  rehypePlugins: PluggableList
+}
+
+export function resolveMarkdownPlugins(
+  options: ResolveMarkdownPluginsOptions,
+): ResolvedMarkdownPlugins {
+  const userRemark = options.remarkPlugins ?? []
+  const userRehype = options.rehypePlugins ?? []
+
+  if (options.disableDefaultPlugins) {
+    return {
+      remarkPlugins: [...userRemark],
+      rehypePlugins: [...userRehype],
+    }
+  }
+
+  return {
+    remarkPlugins: [...DEFAULT_REMARK_PLUGINS, ...userRemark],
+    rehypePlugins: [...DEFAULT_REHYPE_PLUGINS, ...userRehype],
+  }
+}

--- a/packages/typescript/ai-vue-ui/src/text-part.vue
+++ b/packages/typescript/ai-vue-ui/src/text-part.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { VueMarkdown } from '@crazydos/vue-markdown'
-import remarkGfm from 'remark-gfm'
-import rehypeRaw from 'rehype-raw'
-import rehypeSanitize from 'rehype-sanitize'
-import rehypeHighlight from 'rehype-highlight'
+import { resolveMarkdownPlugins } from './markdown-plugins'
 import type { TextPartProps } from './types'
 
 const props = defineProps<TextPartProps>()
@@ -21,15 +18,28 @@ const roleClass = computed(() =>
 const combinedClass = computed(() =>
   [props.class ?? '', roleClass.value].filter(Boolean).join(' '),
 )
+
+const resolved = computed(() =>
+  resolveMarkdownPlugins({
+    remarkPlugins: props.remarkPlugins,
+    rehypePlugins: props.rehypePlugins,
+    disableDefaultPlugins: props.disableDefaultPlugins,
+  }),
+)
+
+// @crazydos/vue-markdown applies rehype-sanitize automatically when `sanitize`
+// is true. Disabling defaults also disables sanitize so the caller owns the
+// chain.
+const sanitize = computed(() => !props.disableDefaultPlugins)
 </script>
 
 <template>
   <div :class="combinedClass || undefined">
     <VueMarkdown
       :markdown="content"
-      :remark-plugins="[remarkGfm]"
-      :rehype-plugins="[rehypeRaw, rehypeSanitize, rehypeHighlight]"
-      sanitize
+      :remark-plugins="resolved.remarkPlugins"
+      :rehype-plugins="resolved.rehypePlugins"
+      :sanitize="sanitize"
     />
   </div>
 </template>

--- a/packages/typescript/ai-vue-ui/src/types.ts
+++ b/packages/typescript/ai-vue-ui/src/types.ts
@@ -1,4 +1,5 @@
 import type { ConnectionAdapter, UIMessage } from '@tanstack/ai-vue'
+import type { PluggableList } from '@crazydos/vue-markdown'
 
 export interface ChatProps {
   /** CSS class name for the root element */
@@ -89,6 +90,15 @@ export interface TextPartProps {
   userClass?: string
   /** Additional class for assistant messages (also used for system messages) */
   assistantClass?: string
+  /** Additional remark plugins, appended after the defaults. */
+  remarkPlugins?: PluggableList
+  /** Additional rehype plugins, appended after the defaults. */
+  rehypePlugins?: PluggableList
+  /**
+   * Drop the built-in plugin defaults and disable the renderer's built-in
+   * sanitizer. The caller becomes responsible for sanitization.
+   */
+  disableDefaultPlugins?: boolean
 }
 
 export interface ToolApprovalProps {

--- a/packages/typescript/ai-vue-ui/tests/markdown-plugins.test.ts
+++ b/packages/typescript/ai-vue-ui/tests/markdown-plugins.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
+import rehypeHighlight from 'rehype-highlight'
+import {
+  DEFAULT_REHYPE_PLUGINS,
+  DEFAULT_REMARK_PLUGINS,
+  resolveMarkdownPlugins,
+} from '../src/markdown-plugins'
+
+const userRemark = () => () => {}
+const userRehype = () => () => {}
+
+describe('resolveMarkdownPlugins (vue)', () => {
+  it('returns defaults when no user plugins are supplied', () => {
+    const { remarkPlugins, rehypePlugins } = resolveMarkdownPlugins({})
+    expect(remarkPlugins).toEqual([remarkGfm])
+    // @crazydos/vue-markdown adds rehype-sanitize on top automatically when
+    // its `sanitize` prop is true.
+    expect(rehypePlugins).toEqual([rehypeRaw, rehypeHighlight])
+  })
+
+  it('appends user remark plugins after defaults', () => {
+    const { remarkPlugins } = resolveMarkdownPlugins({
+      remarkPlugins: [userRemark],
+    })
+    expect(remarkPlugins).toEqual([remarkGfm, userRemark])
+  })
+
+  it('appends user rehype plugins after defaults', () => {
+    const { rehypePlugins } = resolveMarkdownPlugins({
+      rehypePlugins: [userRehype],
+    })
+    expect(rehypePlugins).toEqual([rehypeRaw, rehypeHighlight, userRehype])
+  })
+
+  it('drops defaults entirely when disableDefaultPlugins is true', () => {
+    const { remarkPlugins, rehypePlugins } = resolveMarkdownPlugins({
+      remarkPlugins: [userRemark],
+      rehypePlugins: [userRehype],
+      disableDefaultPlugins: true,
+    })
+    expect(remarkPlugins).toEqual([userRemark])
+    expect(rehypePlugins).toEqual([userRehype])
+  })
+
+  it('returns empty arrays when defaults disabled and no user plugins given', () => {
+    const { remarkPlugins, rehypePlugins } = resolveMarkdownPlugins({
+      disableDefaultPlugins: true,
+    })
+    expect(remarkPlugins).toEqual([])
+    expect(rehypePlugins).toEqual([])
+  })
+
+  it('does not mutate the user-supplied arrays', () => {
+    const userR = [userRemark]
+    const userH = [userRehype]
+    resolveMarkdownPlugins({ remarkPlugins: userR, rehypePlugins: userH })
+    expect(userR).toEqual([userRemark])
+    expect(userH).toEqual([userRehype])
+  })
+
+  it('exposes default constants for documentation/reuse', () => {
+    expect(DEFAULT_REMARK_PLUGINS).toEqual([remarkGfm])
+    expect(DEFAULT_REHYPE_PLUGINS).toEqual([rehypeRaw, rehypeHighlight])
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1657,9 +1657,6 @@ importers:
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
-      rehype-sanitize:
-        specifier: ^6.0.0
-        version: 6.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1842,6 +1842,9 @@ importers:
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
+      remark-cjk-friendly:
+        specifier: ^2.0.1
+        version: 2.0.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -8427,6 +8430,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -9486,6 +9493,25 @@ packages:
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
+  micromark-extension-cjk-friendly-util@3.0.1:
+    resolution: {integrity: sha512-GcbXqTTHOsiZHyF753oIddP/J2eH8j9zpyQPhkof6B2JNxfEJabnQqxbCgzJNuNes0Y2jTNJ3LiYPSXr6eJA8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      micromark-util-types: '*'
+    peerDependenciesMeta:
+      micromark-util-types:
+        optional: true
+
+  micromark-extension-cjk-friendly@2.0.1:
+    resolution: {integrity: sha512-OkzoYVTL1ChbvQ8Cc1ayTIz7paFQz8iS9oIYmewncweUSwmWR+hkJF9spJ1lxB90XldJl26A1F4IkPOKS3bDXw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      micromark: ^4.0.0
+      micromark-util-types: ^2.0.0
+    peerDependenciesMeta:
+      micromark-util-types:
+        optional: true
+
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
 
@@ -10483,6 +10509,16 @@ packages:
 
   rehype-sanitize@6.0.0:
     resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
+  remark-cjk-friendly@2.0.1:
+    resolution: {integrity: sha512-6WwkoQyZf/4j5k53zdFYrR8Ca+UVn992jXdLUSBDZR4eBpFhKyVxmA4gUHra/5fesjGIxrDhHesNr/sVoiiysA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/mdast': ^4.0.0
+      unified: ^11.0.0
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -17423,13 +17459,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.0.14(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.14(vite@7.3.3(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.14
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.3(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.0.15(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -19309,6 +19345,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -20578,6 +20616,25 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-cjk-friendly-util@3.0.1(micromark-util-types@2.0.2):
+    dependencies:
+      get-east-asian-width: 1.6.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-cjk-friendly@2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2):
+    dependencies:
+      devlop: 1.1.0
+      micromark: 4.0.2
+      micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
+      micromark-util-chunked: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
       micromark-util-types: 2.0.2
 
   micromark-extension-gfm-autolink-literal@2.1.0:
@@ -22080,6 +22137,16 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       hast-util-sanitize: 5.0.2
+
+  remark-cjk-friendly@2.0.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5):
+    dependencies:
+      micromark-extension-cjk-friendly: 2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2)
+      unified: 11.0.5
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark
+      - micromark-util-types
 
   remark-gfm@4.0.1:
     dependencies:
@@ -23620,7 +23687,7 @@ snapshots:
   vitest@4.0.14(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(happy-dom@20.0.11)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.9))(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.14
-      '@vitest/mocker': 4.0.14(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.14(vite@7.3.3(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.14
       '@vitest/runner': 4.0.14
       '@vitest/snapshot': 4.0.14
@@ -23637,7 +23704,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.3(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -36,6 +36,7 @@
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
+    "remark-cjk-friendly": "^2.0.1",
     "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.1.18",
     "vite-tsconfig-paths": "^5.1.4",

--- a/testing/e2e/src/routeTree.gen.ts
+++ b/testing/e2e/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ToolsTestRouteImport } from './routes/tools-test'
 import { Route as MiddlewareTestRouteImport } from './routes/middleware-test'
+import { Route as MarkdownCjkRouteImport } from './routes/markdown-cjk'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProviderIndexRouteImport } from './routes/$provider/index'
 import { Route as ApiVideoRouteImport } from './routes/api.video'
@@ -37,6 +38,11 @@ const ToolsTestRoute = ToolsTestRouteImport.update({
 const MiddlewareTestRoute = MiddlewareTestRouteImport.update({
   id: '/middleware-test',
   path: '/middleware-test',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MarkdownCjkRoute = MarkdownCjkRouteImport.update({
+  id: '/markdown-cjk',
+  path: '/markdown-cjk',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -127,6 +133,7 @@ const ApiAudioStreamRoute = ApiAudioStreamRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/markdown-cjk': typeof MarkdownCjkRoute
   '/middleware-test': typeof MiddlewareTestRoute
   '/tools-test': typeof ToolsTestRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
@@ -148,6 +155,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/markdown-cjk': typeof MarkdownCjkRoute
   '/middleware-test': typeof MiddlewareTestRoute
   '/tools-test': typeof ToolsTestRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
@@ -170,6 +178,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/markdown-cjk': typeof MarkdownCjkRoute
   '/middleware-test': typeof MiddlewareTestRoute
   '/tools-test': typeof ToolsTestRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
@@ -193,6 +202,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/markdown-cjk'
     | '/middleware-test'
     | '/tools-test'
     | '/$provider/$feature'
@@ -214,6 +224,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/markdown-cjk'
     | '/middleware-test'
     | '/tools-test'
     | '/$provider/$feature'
@@ -235,6 +246,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/markdown-cjk'
     | '/middleware-test'
     | '/tools-test'
     | '/$provider/$feature'
@@ -257,6 +269,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  MarkdownCjkRoute: typeof MarkdownCjkRoute
   MiddlewareTestRoute: typeof MiddlewareTestRoute
   ToolsTestRoute: typeof ToolsTestRoute
   ProviderFeatureRoute: typeof ProviderFeatureRoute
@@ -286,6 +299,13 @@ declare module '@tanstack/react-router' {
       path: '/middleware-test'
       fullPath: '/middleware-test'
       preLoaderRoute: typeof MiddlewareTestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/markdown-cjk': {
+      id: '/markdown-cjk'
+      path: '/markdown-cjk'
+      fullPath: '/markdown-cjk'
+      preLoaderRoute: typeof MarkdownCjkRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -470,6 +490,7 @@ const ApiVideoRouteWithChildren = ApiVideoRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  MarkdownCjkRoute: MarkdownCjkRoute,
   MiddlewareTestRoute: MiddlewareTestRoute,
   ToolsTestRoute: ToolsTestRoute,
   ProviderFeatureRoute: ProviderFeatureRoute,

--- a/testing/e2e/src/routes/markdown-cjk.tsx
+++ b/testing/e2e/src/routes/markdown-cjk.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { TextPart } from '@tanstack/ai-react-ui'
+import remarkCjkFriendly from 'remark-cjk-friendly'
+
+export const Route = createFileRoute('/markdown-cjk')({
+  component: MarkdownCjkPage,
+})
+
+// CommonMark refuses to close `**` when the closing delimiter is preceded by
+// full-width punctuation (e.g. `。`) and followed by a CJK letter, because the
+// right-flanking rule fails. remark-cjk-friendly relaxes that rule for CJK
+// text, so the bold parses correctly.
+const CJK_CONTENT = '**この文は太字になりません。**この文のせいで。'
+
+function MarkdownCjkPage() {
+  return (
+    <div className="p-6 max-w-2xl mx-auto space-y-8">
+      <h1 className="text-xl font-semibold">CJK bold rendering</h1>
+      <section data-testid="without-plugin">
+        <h2 className="font-medium mb-2">Without remark-cjk-friendly</h2>
+        <TextPart content={CJK_CONTENT} />
+      </section>
+      <section data-testid="with-plugin">
+        <h2 className="font-medium mb-2">With remark-cjk-friendly</h2>
+        <TextPart content={CJK_CONTENT} remarkPlugins={[remarkCjkFriendly]} />
+      </section>
+    </div>
+  )
+}

--- a/testing/e2e/tests/markdown-cjk.spec.ts
+++ b/testing/e2e/tests/markdown-cjk.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('markdown CJK bold rendering', () => {
+  test('without remark-cjk-friendly, CJK bold does NOT render as <strong>', async ({
+    page,
+  }) => {
+    await page.goto('/markdown-cjk')
+    const without = page.getByTestId('without-plugin')
+    // The literal "**" should still be visible because the bold parser fails.
+    await expect(without).toContainText('**')
+    // No <strong> should appear inside the without-plugin section.
+    await expect(without.locator('strong')).toHaveCount(0)
+  })
+
+  test('with remark-cjk-friendly, CJK bold renders as <strong>', async ({
+    page,
+  }) => {
+    await page.goto('/markdown-cjk')
+    const withPlugin = page.getByTestId('with-plugin')
+    // The literal "**" should be consumed by the bold parser.
+    await expect(withPlugin).not.toContainText('**')
+    // The Japanese run should now be inside a <strong>.
+    const strong = withPlugin.locator('strong')
+    await expect(strong).toHaveCount(1)
+    await expect(strong).toHaveText('この文は太字になりません。')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `remarkPlugins`, `rehypePlugins`, `components` (React/Solid only), and `disableDefaultPlugins` props to `TextPart` across `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, and `@tanstack/ai-vue-ui`. User plugins merge with the defaults; `rehype-sanitize` continues to run last unless `disableDefaultPlugins` is set.
- Fixes the reported CJK bold/emphasis issue ([#164](https://github.com/TanStack/ai/issues/164)) by letting consumers pass `remark-cjk-friendly` (or any other unified plugin) without forking `TextPart`.
- Fixes a latent bug: in the React `TextPart`, `remark-gfm` was passed inside the `rehypePlugins` array, silently no-opping GFM features (tables, strikethrough, task lists). Now correctly wired as a remark plugin.
- Vue's underlying renderer (`@crazydos/vue-markdown`) does not expose a `components` prop, so the Vue `TextPart` omits it. Renderer's built-in `sanitize` is wired to `!disableDefaultPlugins`.

## Test plan
- [x] Unit tests for the merge helper across all three UI packages (`pnpm test:lib`, 7 tests each)
- [x] Type checks (`pnpm test:types`)
- [x] Lint (`pnpm test:eslint`)
- [x] Build + publint (`pnpm build`, `pnpm test:build`)
- [x] E2E spec: `testing/e2e/tests/markdown-cjk.spec.ts` renders the public-API surface with an offending CJK bold string both without and with `remark-cjk-friendly`, asserting `<strong>` count and absence of literal `**`

Closes #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable markdown rendering: supply remark/rehype plugins (React, Solid, Vue) and optionally disable defaults.
  * Demo page showing CJK markdown behavior.

* **Bug Fixes**
  * Corrected bold/emphasis rendering for CJK text.
  * Fixed markdown plugin handling in React UI.

* **Tests**
  * Added unit tests for plugin resolution and e2e tests for CJK rendering (including remark-cjk-friendly).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->