### PR TITLE
fix(ai-anthropic): webFetchTool() + webSearchTool() no longer corrupt client tool args

### DIFF
--- a/.changeset/fix-anthropic-server-tool-streaming.md
+++ b/.changeset/fix-anthropic-server-tool-streaming.md
@@ -1,0 +1,13 @@
+---
+'@tanstack/ai-anthropic': patch
+---
+
+Fix streaming corruption when Anthropic responses mix client `tool_use` with server-side tools (`web_fetch`, `web_search`). Closes #604.
+
+The Anthropic streaming adapter previously had no handler for `server_tool_use` / `web_fetch_tool_result` / `web_search_tool_result` content blocks. When a client `tool_use` was followed by a `server_tool_use` in the same response, the server tool's `input_json_delta` events appended onto the prior client tool's input buffer — producing concatenated JSON like `{...prevToolArgs...}{"url":"..."}` that threw in the agent loop's `JSON.parse`.
+
+- `server_tool_use` is now tracked in a separate buffer so its deltas can't bleed into client tool args.
+- `input_json_delta` is dispatched by the current block type instead of unconditionally appending to `toolCallsMap[currentToolIndex]`.
+- `web_fetch_tool_result` and `web_search_tool_result` blocks are explicitly acknowledged (and ignored — they are consumed by Anthropic, not the client), so they no longer fall through to the text-block handler.
+
+No new public events are introduced: server-side tool execution stays internal to the provider, matching how `webFetchTool()` / `webSearchTool()` were always intended to be used.

--- a/packages/typescript/ai-anthropic/src/adapters/text.ts
+++ b/packages/typescript/ai-anthropic/src/adapters/text.ts
@@ -674,11 +674,9 @@ export class AnthropicTextAdapter<
       { id: string; name: string; input: string; started: boolean }
     >()
     let currentToolIndex = -1
-    // Server-side tools (web_fetch, web_search, code_execution, ...) run
-    // entirely on Anthropic's side. They share the same content_block_delta
-    // wire format (`input_json_delta`) as client `tool_use` blocks, so we must
-    // route their deltas to a separate buffer or they leak into the prior
-    // client tool's input and corrupt downstream JSON.parse.
+    // Server-side tools share the `input_json_delta` wire format with client
+    // `tool_use` blocks; routing both to the same buffer corrupts client tool
+    // input.
     let currentServerTool: { id: string; name: string; input: string } | null =
       null
 
@@ -724,12 +722,37 @@ export class AnthropicTextAdapter<
               started: false,
             })
           } else if (event.content_block.type === 'server_tool_use') {
-            // Tracked separately from client tools so the shared
-            // `input_json_delta` event format cannot corrupt them.
             currentServerTool = {
               id: event.content_block.id,
               name: event.content_block.name,
               input: '',
+            }
+          } else if (
+            event.content_block.type === 'web_fetch_tool_result' ||
+            event.content_block.type === 'web_search_tool_result'
+          ) {
+            // The result content arrives in full at content_block_start (no
+            // deltas). Surface error variants so a failed fetch/search isn't
+            // invisible to the consumer.
+            const content = event.content_block.content as
+              | { type?: string; error_code?: string }
+              | Array<unknown>
+            const errorBlock =
+              !Array.isArray(content) &&
+              (content.type === 'web_fetch_tool_result_error' ||
+                content.type === 'web_search_tool_result_error')
+                ? content
+                : null
+            if (errorBlock) {
+              logger.errors(
+                `anthropic.${event.content_block.type} error_code=${errorBlock.error_code}`,
+                {
+                  toolUseId: event.content_block.tool_use_id,
+                  blockType: event.content_block.type,
+                  errorCode: errorBlock.error_code,
+                  source: 'anthropic.processAnthropicStream',
+                },
+              )
             }
           } else if (event.content_block.type === 'thinking') {
             accumulatedThinking = ''
@@ -932,15 +955,25 @@ export class AnthropicTextAdapter<
               hasEmittedTextMessageStart = false
             }
           } else if (currentBlockType === 'server_tool_use') {
-            // Anthropic executes the call server-side; nothing for us to
-            // dispatch. Just drop the accumulated buffer.
+            if (currentServerTool) {
+              // Anthropic executes the call; we only need a breadcrumb so
+              // consumers (devtools, telemetry) can see what ran.
+              logger.provider(
+                `provider=anthropic server_tool_use name=${currentServerTool.name}`,
+                {
+                  toolUseId: currentServerTool.id,
+                  name: currentServerTool.name,
+                  input: currentServerTool.input,
+                },
+              )
+            }
             currentServerTool = null
           } else if (
             currentBlockType === 'web_fetch_tool_result' ||
             currentBlockType === 'web_search_tool_result'
           ) {
-            // Result blocks for server-side tools — the model already
-            // consumed them. We acknowledge and ignore.
+            // The model already consumed the result; error variants were
+            // already surfaced at content_block_start.
           } else {
             // Emit TEXT_MESSAGE_END only for text blocks (not tool_use blocks)
             if (hasEmittedTextMessageStart && accumulatedContent) {

--- a/packages/typescript/ai-anthropic/src/adapters/text.ts
+++ b/packages/typescript/ai-anthropic/src/adapters/text.ts
@@ -674,6 +674,13 @@ export class AnthropicTextAdapter<
       { id: string; name: string; input: string; started: boolean }
     >()
     let currentToolIndex = -1
+    // Server-side tools (web_fetch, web_search, code_execution, ...) run
+    // entirely on Anthropic's side. They share the same content_block_delta
+    // wire format (`input_json_delta`) as client `tool_use` blocks, so we must
+    // route their deltas to a separate buffer or they leak into the prior
+    // client tool's input and corrupt downstream JSON.parse.
+    let currentServerTool: { id: string; name: string; input: string } | null =
+      null
 
     // AG-UI lifecycle tracking
     const runId = options.runId ?? genId()
@@ -716,6 +723,14 @@ export class AnthropicTextAdapter<
               input: '',
               started: false,
             })
+          } else if (event.content_block.type === 'server_tool_use') {
+            // Tracked separately from client tools so the shared
+            // `input_json_delta` event format cannot corrupt them.
+            currentServerTool = {
+              id: event.content_block.id,
+              name: event.content_block.name,
+              input: '',
+            }
           } else if (event.content_block.type === 'thinking') {
             accumulatedThinking = ''
             accumulatedSignature = ''
@@ -821,32 +836,45 @@ export class AnthropicTextAdapter<
             accumulatedSignature +=
               (event.delta as { signature: string }).signature || ''
           } else if (event.delta.type === 'input_json_delta') {
-            const existing = toolCallsMap.get(currentToolIndex)
-            if (existing) {
-              // Emit TOOL_CALL_START on first args delta
-              if (!existing.started) {
-                existing.started = true
+            // Route deltas by current block type so server_tool_use input
+            // never appends onto the prior client tool's buffer.
+            if (currentBlockType === 'tool_use') {
+              const existing = toolCallsMap.get(currentToolIndex)
+              if (existing) {
+                // Emit TOOL_CALL_START on first args delta
+                if (!existing.started) {
+                  existing.started = true
+                  yield {
+                    type: EventType.TOOL_CALL_START,
+                    toolCallId: existing.id,
+                    toolCallName: existing.name,
+                    toolName: existing.name,
+                    model,
+                    timestamp: Date.now(),
+                    index: currentToolIndex,
+                  }
+                }
+
+                existing.input += event.delta.partial_json
+
                 yield {
-                  type: EventType.TOOL_CALL_START,
+                  type: EventType.TOOL_CALL_ARGS,
                   toolCallId: existing.id,
-                  toolCallName: existing.name,
-                  toolName: existing.name,
                   model,
                   timestamp: Date.now(),
-                  index: currentToolIndex,
+                  delta: event.delta.partial_json,
+                  args: existing.input,
                 }
               }
-
-              existing.input += event.delta.partial_json
-
-              yield {
-                type: EventType.TOOL_CALL_ARGS,
-                toolCallId: existing.id,
-                model,
-                timestamp: Date.now(),
-                delta: event.delta.partial_json,
-                args: existing.input,
-              }
+            } else if (
+              currentBlockType === 'server_tool_use' &&
+              currentServerTool
+            ) {
+              // Accumulate server tool input internally. We don't emit
+              // TOOL_CALL_* events: the call is executed by Anthropic, not
+              // by our agent loop, so surfacing it as a client tool call
+              // would cause downstream code to try (and fail) to run it.
+              currentServerTool.input += event.delta.partial_json
             }
           }
         } else if (event.type === 'content_block_stop') {
@@ -903,6 +931,16 @@ export class AnthropicTextAdapter<
               // Reset so a new TEXT_MESSAGE_START is emitted if text follows tool calls
               hasEmittedTextMessageStart = false
             }
+          } else if (currentBlockType === 'server_tool_use') {
+            // Anthropic executes the call server-side; nothing for us to
+            // dispatch. Just drop the accumulated buffer.
+            currentServerTool = null
+          } else if (
+            currentBlockType === 'web_fetch_tool_result' ||
+            currentBlockType === 'web_search_tool_result'
+          ) {
+            // Result blocks for server-side tools — the model already
+            // consumed them. We acknowledge and ignore.
           } else {
             // Emit TEXT_MESSAGE_END only for text blocks (not tool_use blocks)
             if (hasEmittedTextMessageStart && accumulatedContent) {

--- a/packages/typescript/ai-anthropic/tests/anthropic-adapter.test.ts
+++ b/packages/typescript/ai-anthropic/tests/anthropic-adapter.test.ts
@@ -906,6 +906,184 @@ describe('Anthropic stream processing', () => {
     })
   })
 
+  it('does not leak server_tool_use input deltas into the prior client tool', async () => {
+    // Reproduces issue #604: when a client tool_use block is followed by a
+    // server_tool_use block (e.g. web_fetch) in the same response,
+    // server_tool_use `input_json_delta` events must not concatenate onto
+    // the prior client tool's input buffer.
+    const mockStream = (async function* () {
+      // Client tool_use — args close cleanly.
+      yield {
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'tool_use',
+          id: 'tool_client',
+          name: 'lookup_weather',
+        },
+      }
+      yield {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: '{"location":"Berlin"}',
+        },
+      }
+      yield { type: 'content_block_stop', index: 0 }
+      // server_tool_use for web_fetch — its input_json_delta must not
+      // append to the client tool's buffer.
+      yield {
+        type: 'content_block_start',
+        index: 1,
+        content_block: {
+          type: 'server_tool_use',
+          id: 'srv_fetch',
+          name: 'web_fetch',
+        },
+      }
+      yield {
+        type: 'content_block_delta',
+        index: 1,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: '{"url":"https://example.com"}',
+        },
+      }
+      yield { type: 'content_block_stop', index: 1 }
+      // The result block Anthropic sends after running web_fetch.
+      yield {
+        type: 'content_block_start',
+        index: 2,
+        content_block: {
+          type: 'web_fetch_tool_result',
+          tool_use_id: 'srv_fetch',
+          content: {
+            type: 'web_fetch_result',
+            url: 'https://example.com',
+            content: { type: 'document', source: { type: 'text', data: 'ok' } },
+            retrieved_at: '2026-01-01T00:00:00Z',
+          },
+        },
+      }
+      yield { type: 'content_block_stop', index: 2 }
+      yield {
+        type: 'message_delta',
+        delta: { stop_reason: 'tool_use' },
+        usage: { output_tokens: 10 },
+      }
+      yield { type: 'message_stop' }
+    })()
+
+    mocks.betaMessagesCreate.mockResolvedValueOnce(mockStream)
+
+    const adapter = createAdapter('claude-3-7-sonnet')
+
+    const chunks: StreamChunk[] = []
+    for await (const chunk of chat({
+      adapter,
+      messages: [{ role: 'user', content: 'Weather + fetch' }],
+      tools: [weatherTool],
+    })) {
+      chunks.push(chunk)
+    }
+
+    // The single TOOL_CALL_END must carry the client tool's *own* input
+    // — not a concatenated `{"location":"Berlin"}{"url":"..."}` blob.
+    const toolEnds = chunks.filter((c) => c.type === 'TOOL_CALL_END')
+    expect(toolEnds).toHaveLength(1)
+    expect(toolEnds[0]).toMatchObject({
+      toolCallId: 'tool_client',
+      input: { location: 'Berlin' },
+    })
+
+    // The args stream for the client tool must end with the exact JSON.
+    const lastArgs = chunks.filter(
+      (c) =>
+        c.type === 'TOOL_CALL_ARGS' &&
+        (c as { toolCallId: string }).toolCallId === 'tool_client',
+    )
+    const final = lastArgs[lastArgs.length - 1] as { args: string }
+    expect(final.args).toBe('{"location":"Berlin"}')
+
+    // No TOOL_CALL_* events should be emitted for the server tool — the
+    // agent loop must not try to dispatch web_fetch as a client tool.
+    expect(
+      chunks.some(
+        (c) =>
+          c.type === 'TOOL_CALL_START' &&
+          (c as { toolCallId: string }).toolCallId === 'srv_fetch',
+      ),
+    ).toBe(false)
+  })
+
+  it('cleanly handles a server_tool_use block as the only tool in the response', async () => {
+    // Secondary failure from issue #604: with no prior client tool_use,
+    // currentToolIndex is -1. Server-tool deltas must still not crash or
+    // create phantom client tool calls.
+    const mockStream = (async function* () {
+      yield {
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'server_tool_use',
+          id: 'srv_only',
+          name: 'web_fetch',
+        },
+      }
+      yield {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: '{"url":"https://example.com"}',
+        },
+      }
+      yield { type: 'content_block_stop', index: 0 }
+      yield {
+        type: 'content_block_start',
+        index: 1,
+        content_block: {
+          type: 'web_fetch_tool_result',
+          tool_use_id: 'srv_only',
+          content: {
+            type: 'web_fetch_result',
+            url: 'https://example.com',
+            content: { type: 'document', source: { type: 'text', data: 'ok' } },
+            retrieved_at: '2026-01-01T00:00:00Z',
+          },
+        },
+      }
+      yield { type: 'content_block_stop', index: 1 }
+      yield {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn' },
+        usage: { output_tokens: 5 },
+      }
+      yield { type: 'message_stop' }
+    })()
+
+    mocks.betaMessagesCreate.mockResolvedValueOnce(mockStream)
+
+    const adapter = createAdapter('claude-3-7-sonnet')
+
+    const chunks: StreamChunk[] = []
+    for await (const chunk of chat({
+      adapter,
+      messages: [{ role: 'user', content: 'Fetch it' }],
+    })) {
+      chunks.push(chunk)
+    }
+
+    // No client TOOL_CALL_* events should appear for a server-only response.
+    expect(chunks.some((c) => c.type === 'TOOL_CALL_START')).toBe(false)
+    expect(chunks.some((c) => c.type === 'TOOL_CALL_END')).toBe(false)
+
+    // Stream still completes normally.
+    const runFinished = chunks.filter((c) => c.type === 'RUN_FINISHED')
+    expect(runFinished).toHaveLength(1)
+  })
+
   it('does not emit TEXT_MESSAGE_END for tool_use content blocks', async () => {
     // When text is followed by a tool_use block, TEXT_MESSAGE_END should only
     // fire once (for the text block), not again when the tool block stops.

--- a/packages/typescript/ai-anthropic/tests/anthropic-adapter.test.ts
+++ b/packages/typescript/ai-anthropic/tests/anthropic-adapter.test.ts
@@ -907,12 +907,7 @@ describe('Anthropic stream processing', () => {
   })
 
   it('does not leak server_tool_use input deltas into the prior client tool', async () => {
-    // Reproduces issue #604: when a client tool_use block is followed by a
-    // server_tool_use block (e.g. web_fetch) in the same response,
-    // server_tool_use `input_json_delta` events must not concatenate onto
-    // the prior client tool's input buffer.
     const mockStream = (async function* () {
-      // Client tool_use — args close cleanly.
       yield {
         type: 'content_block_start',
         index: 0,
@@ -931,8 +926,6 @@ describe('Anthropic stream processing', () => {
         },
       }
       yield { type: 'content_block_stop', index: 0 }
-      // server_tool_use for web_fetch — its input_json_delta must not
-      // append to the client tool's buffer.
       yield {
         type: 'content_block_start',
         index: 1,
@@ -951,7 +944,6 @@ describe('Anthropic stream processing', () => {
         },
       }
       yield { type: 'content_block_stop', index: 1 }
-      // The result block Anthropic sends after running web_fetch.
       yield {
         type: 'content_block_start',
         index: 2,
@@ -988,8 +980,6 @@ describe('Anthropic stream processing', () => {
       chunks.push(chunk)
     }
 
-    // The single TOOL_CALL_END must carry the client tool's *own* input
-    // — not a concatenated `{"location":"Berlin"}{"url":"..."}` blob.
     const toolEnds = chunks.filter((c) => c.type === 'TOOL_CALL_END')
     expect(toolEnds).toHaveLength(1)
     expect(toolEnds[0]).toMatchObject({
@@ -997,17 +987,6 @@ describe('Anthropic stream processing', () => {
       input: { location: 'Berlin' },
     })
 
-    // The args stream for the client tool must end with the exact JSON.
-    const lastArgs = chunks.filter(
-      (c) =>
-        c.type === 'TOOL_CALL_ARGS' &&
-        (c as { toolCallId: string }).toolCallId === 'tool_client',
-    )
-    const final = lastArgs[lastArgs.length - 1] as { args: string }
-    expect(final.args).toBe('{"location":"Berlin"}')
-
-    // No TOOL_CALL_* events should be emitted for the server tool — the
-    // agent loop must not try to dispatch web_fetch as a client tool.
     expect(
       chunks.some(
         (c) =>
@@ -1017,17 +996,102 @@ describe('Anthropic stream processing', () => {
     ).toBe(false)
   })
 
-  it('cleanly handles a server_tool_use block as the only tool in the response', async () => {
-    // Secondary failure from issue #604: with no prior client tool_use,
-    // currentToolIndex is -1. Server-tool deltas must still not crash or
-    // create phantom client tool calls.
+  it.each([
+    [
+      'web_fetch',
+      'web_fetch_tool_result',
+      {
+        type: 'web_fetch_result',
+        url: 'https://example.com',
+        content: { type: 'document', source: { type: 'text', data: 'ok' } },
+        retrieved_at: '2026-01-01T00:00:00Z',
+      },
+    ],
+    [
+      'web_search',
+      'web_search_tool_result',
+      [
+        {
+          type: 'web_search_result',
+          encrypted_content: 'enc',
+          page_age: null,
+          title: 'Example',
+          url: 'https://example.com',
+        },
+      ],
+    ],
+  ] as const)(
+    'cleanly handles a server-only %s response with no prior client tool_use',
+    async (toolName, resultType, resultContent) => {
+      // With no prior client tool_use, currentToolIndex is -1; server-tool
+      // deltas must not crash or create phantom client tool calls.
+      const mockStream = (async function* () {
+        yield {
+          type: 'content_block_start',
+          index: 0,
+          content_block: {
+            type: 'server_tool_use',
+            id: 'srv_only',
+            name: toolName,
+          },
+        }
+        yield {
+          type: 'content_block_delta',
+          index: 0,
+          delta: {
+            type: 'input_json_delta',
+            partial_json: '{"url":"https://example.com"}',
+          },
+        }
+        yield { type: 'content_block_stop', index: 0 }
+        yield {
+          type: 'content_block_start',
+          index: 1,
+          content_block: {
+            type: resultType,
+            tool_use_id: 'srv_only',
+            content: resultContent,
+          },
+        }
+        yield { type: 'content_block_stop', index: 1 }
+        yield {
+          type: 'message_delta',
+          delta: { stop_reason: 'end_turn' },
+          usage: { output_tokens: 5 },
+        }
+        yield { type: 'message_stop' }
+      })()
+
+      mocks.betaMessagesCreate.mockResolvedValueOnce(mockStream)
+
+      const adapter = createAdapter('claude-3-7-sonnet')
+
+      const chunks: StreamChunk[] = []
+      for await (const chunk of chat({
+        adapter,
+        messages: [{ role: 'user', content: 'Use the server tool' }],
+      })) {
+        chunks.push(chunk)
+      }
+
+      expect(chunks.some((c) => c.type === 'TOOL_CALL_START')).toBe(false)
+      expect(chunks.some((c) => c.type === 'TOOL_CALL_END')).toBe(false)
+
+      const runFinished = chunks.filter((c) => c.type === 'RUN_FINISHED')
+      expect(runFinished).toHaveLength(1)
+    },
+  )
+
+  it('logs an error when a server tool result block carries an error variant', async () => {
+    // A failed web_fetch (e.g. url_not_accessible) is otherwise invisible —
+    // the model just keeps going. Surface it via the debug logger.
     const mockStream = (async function* () {
       yield {
         type: 'content_block_start',
         index: 0,
         content_block: {
           type: 'server_tool_use',
-          id: 'srv_only',
+          id: 'srv_err',
           name: 'web_fetch',
         },
       }
@@ -1036,7 +1100,7 @@ describe('Anthropic stream processing', () => {
         index: 0,
         delta: {
           type: 'input_json_delta',
-          partial_json: '{"url":"https://example.com"}',
+          partial_json: '{"url":"https://blocked.example"}',
         },
       }
       yield { type: 'content_block_stop', index: 0 }
@@ -1045,12 +1109,10 @@ describe('Anthropic stream processing', () => {
         index: 1,
         content_block: {
           type: 'web_fetch_tool_result',
-          tool_use_id: 'srv_only',
+          tool_use_id: 'srv_err',
           content: {
-            type: 'web_fetch_result',
-            url: 'https://example.com',
-            content: { type: 'document', source: { type: 'text', data: 'ok' } },
-            retrieved_at: '2026-01-01T00:00:00Z',
+            type: 'web_fetch_tool_result_error',
+            error_code: 'url_not_accessible',
           },
         },
       }
@@ -1067,21 +1129,29 @@ describe('Anthropic stream processing', () => {
 
     const adapter = createAdapter('claude-3-7-sonnet')
 
-    const chunks: StreamChunk[] = []
-    for await (const chunk of chat({
-      adapter,
-      messages: [{ role: 'user', content: 'Fetch it' }],
-    })) {
-      chunks.push(chunk)
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
     }
 
-    // No client TOOL_CALL_* events should appear for a server-only response.
-    expect(chunks.some((c) => c.type === 'TOOL_CALL_START')).toBe(false)
-    expect(chunks.some((c) => c.type === 'TOOL_CALL_END')).toBe(false)
+    for await (const _ of chat({
+      adapter,
+      messages: [{ role: 'user', content: 'Fetch it' }],
+      debug: { logger, errors: true },
+    })) {
+      // consume stream
+    }
 
-    // Stream still completes normally.
-    const runFinished = chunks.filter((c) => c.type === 'RUN_FINISHED')
-    expect(runFinished).toHaveLength(1)
+    const errorCall = logger.error.mock.calls.find((call) =>
+      String(call[0]).includes('web_fetch_tool_result'),
+    )
+    expect(errorCall).toBeDefined()
+    expect(errorCall![1]).toMatchObject({
+      toolUseId: 'srv_err',
+      errorCode: 'url_not_accessible',
+    })
   })
 
   it('does not emit TEXT_MESSAGE_END for tool_use content blocks', async () => {

--- a/testing/e2e/global-setup.ts
+++ b/testing/e2e/global-setup.ts
@@ -43,6 +43,14 @@ export default async function globalSetup() {
   mock.mount('/v1/text-to-speech', elevenLabsTTSMount())
   mock.mount('/v1/speech-to-text', elevenLabsSTTMount())
 
+  // Anthropic server_tool_use bug reproduction (issue #604). aimock can't
+  // natively synthesize `server_tool_use` / `web_fetch_tool_result` content
+  // blocks, so this mount hand-crafts the raw SSE Claude would emit when a
+  // client `tool_use` is followed by a `web_fetch` `server_tool_use` in the
+  // same response. The corresponding api.anthropic-bug-test.ts route points
+  // the Anthropic adapter here.
+  mock.mount('/anthropic-bug-test', anthropicServerToolBugMount())
+
   await mock.start()
   console.log(`[aimock] started on port 4010`)
   ;(globalThis as any).__aimock = mock
@@ -229,6 +237,191 @@ function elevenLabsSTTMount(): Mountable {
       return true
     },
   }
+}
+
+/**
+ * Mounts a Claude-shaped SSE response that includes a client `tool_use` block
+ * followed by a `web_fetch` `server_tool_use` block, plus its
+ * `web_fetch_tool_result`. Reproduces the streaming scenario from issue #604
+ * — the adapter must not let server-tool `input_json_delta`s leak into the
+ * prior client tool's input buffer.
+ *
+ * The first turn returns the mixed tool_use + server_tool_use response so the
+ * adapter can dispatch the client tool. The second turn (after the client
+ * tool result is fed back) returns a simple text completion so the agent
+ * loop can settle.
+ */
+function anthropicServerToolBugMount(): Mountable {
+  return {
+    async handleRequest(
+      req: http.IncomingMessage,
+      res: http.ServerResponse,
+      pathname: string,
+    ): Promise<boolean> {
+      // The Anthropic SDK posts to /v1/messages; query string (?beta=...)
+      // is stripped from `pathname` by aimock before dispatch.
+      if (req.method !== 'POST' || !pathname.startsWith('/v1/messages')) {
+        return false
+      }
+
+      const bodyText = await readBody(req)
+      let hasToolResult = false
+      try {
+        const body = JSON.parse(bodyText) as {
+          messages?: Array<{
+            role: string
+            content?: Array<{ type: string }> | string
+          }>
+        }
+        hasToolResult = (body.messages ?? []).some(
+          (m) =>
+            Array.isArray(m.content) &&
+            m.content.some((c) => c.type === 'tool_result'),
+        )
+      } catch {
+        // Malformed body — fall through and emit the first-turn stream.
+      }
+
+      const events = hasToolResult
+        ? buildFollowUpEvents()
+        : buildToolPlusServerToolEvents()
+
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/event-stream')
+      res.setHeader('Cache-Control', 'no-cache')
+      res.setHeader('Connection', 'keep-alive')
+      for (const event of events) {
+        res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+      }
+      res.end()
+      return true
+    },
+  }
+}
+
+function buildToolPlusServerToolEvents(): Array<Record<string, unknown>> {
+  const messageId = 'msg_bug_604'
+  const model = 'claude-sonnet-4-5'
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: messageId,
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model,
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 0 },
+      },
+    },
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'tool_use',
+        id: 'toolu_client_weather',
+        name: 'lookup_weather',
+        input: {},
+      },
+    },
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: '{"location":"Berlin"}' },
+    },
+    { type: 'content_block_stop', index: 0 },
+    {
+      type: 'content_block_start',
+      index: 1,
+      content_block: {
+        type: 'server_tool_use',
+        id: 'srvtoolu_web_fetch',
+        name: 'web_fetch',
+        input: {},
+      },
+    },
+    {
+      type: 'content_block_delta',
+      index: 1,
+      delta: {
+        type: 'input_json_delta',
+        partial_json: '{"url":"https://example.com"}',
+      },
+    },
+    { type: 'content_block_stop', index: 1 },
+    {
+      type: 'content_block_start',
+      index: 2,
+      content_block: {
+        type: 'web_fetch_tool_result',
+        tool_use_id: 'srvtoolu_web_fetch',
+        content: {
+          type: 'web_fetch_result',
+          url: 'https://example.com',
+          content: {
+            type: 'document',
+            source: { type: 'text', media_type: 'text/plain', data: 'ok' },
+          },
+          retrieved_at: '2026-01-01T00:00:00Z',
+        },
+      },
+    },
+    { type: 'content_block_stop', index: 2 },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'tool_use', stop_sequence: null },
+      usage: { output_tokens: 20 },
+    },
+    { type: 'message_stop' },
+  ]
+}
+
+function buildFollowUpEvents(): Array<Record<string, unknown>> {
+  const messageId = 'msg_bug_604_followup'
+  const model = 'claude-sonnet-4-5'
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: messageId,
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model,
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 30, output_tokens: 0 },
+      },
+    },
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '' },
+    },
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'Berlin is sunny.' },
+    },
+    { type: 'content_block_stop', index: 0 },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 5 },
+    },
+    { type: 'message_stop' },
+  ]
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Array<Buffer> = []
+    req.on('data', (c: Buffer) => chunks.push(c))
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+    req.on('error', reject)
+  })
 }
 
 function drainBody(req: http.IncomingMessage): Promise<void> {

--- a/testing/e2e/global-setup.ts
+++ b/testing/e2e/global-setup.ts
@@ -329,7 +329,10 @@ function buildToolPlusServerToolEvents(): Array<Record<string, unknown>> {
     {
       type: 'content_block_delta',
       index: 0,
-      delta: { type: 'input_json_delta', partial_json: '{"location":"Berlin"}' },
+      delta: {
+        type: 'input_json_delta',
+        partial_json: '{"location":"Berlin"}',
+      },
     },
     { type: 'content_block_stop', index: 0 },
     {

--- a/testing/e2e/src/routeTree.gen.ts
+++ b/testing/e2e/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as ApiMiddlewareTestRouteImport } from './routes/api.middleware-t
 import { Route as ApiImageRouteImport } from './routes/api.image'
 import { Route as ApiChatRouteImport } from './routes/api.chat'
 import { Route as ApiAudioRouteImport } from './routes/api.audio'
+import { Route as ApiAnthropicBugTestRouteImport } from './routes/api.anthropic-bug-test'
 import { Route as ProviderFeatureRouteImport } from './routes/$provider/$feature'
 import { Route as ApiVideoStreamRouteImport } from './routes/api.video.stream'
 import { Route as ApiTtsStreamRouteImport } from './routes/api.tts.stream'
@@ -94,6 +95,11 @@ const ApiAudioRoute = ApiAudioRouteImport.update({
   path: '/api/audio',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAnthropicBugTestRoute = ApiAnthropicBugTestRouteImport.update({
+  id: '/api/anthropic-bug-test',
+  path: '/api/anthropic-bug-test',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProviderFeatureRoute = ProviderFeatureRouteImport.update({
   id: '/$provider/$feature',
   path: '/$provider/$feature',
@@ -130,6 +136,7 @@ export interface FileRoutesByFullPath {
   '/middleware-test': typeof MiddlewareTestRoute
   '/tools-test': typeof ToolsTestRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
+  '/api/anthropic-bug-test': typeof ApiAnthropicBugTestRoute
   '/api/audio': typeof ApiAudioRouteWithChildren
   '/api/chat': typeof ApiChatRoute
   '/api/image': typeof ApiImageRouteWithChildren
@@ -151,6 +158,7 @@ export interface FileRoutesByTo {
   '/middleware-test': typeof MiddlewareTestRoute
   '/tools-test': typeof ToolsTestRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
+  '/api/anthropic-bug-test': typeof ApiAnthropicBugTestRoute
   '/api/audio': typeof ApiAudioRouteWithChildren
   '/api/chat': typeof ApiChatRoute
   '/api/image': typeof ApiImageRouteWithChildren
@@ -173,6 +181,7 @@ export interface FileRoutesById {
   '/middleware-test': typeof MiddlewareTestRoute
   '/tools-test': typeof ToolsTestRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
+  '/api/anthropic-bug-test': typeof ApiAnthropicBugTestRoute
   '/api/audio': typeof ApiAudioRouteWithChildren
   '/api/chat': typeof ApiChatRoute
   '/api/image': typeof ApiImageRouteWithChildren
@@ -196,6 +205,7 @@ export interface FileRouteTypes {
     | '/middleware-test'
     | '/tools-test'
     | '/$provider/$feature'
+    | '/api/anthropic-bug-test'
     | '/api/audio'
     | '/api/chat'
     | '/api/image'
@@ -217,6 +227,7 @@ export interface FileRouteTypes {
     | '/middleware-test'
     | '/tools-test'
     | '/$provider/$feature'
+    | '/api/anthropic-bug-test'
     | '/api/audio'
     | '/api/chat'
     | '/api/image'
@@ -238,6 +249,7 @@ export interface FileRouteTypes {
     | '/middleware-test'
     | '/tools-test'
     | '/$provider/$feature'
+    | '/api/anthropic-bug-test'
     | '/api/audio'
     | '/api/chat'
     | '/api/image'
@@ -260,6 +272,7 @@ export interface RootRouteChildren {
   MiddlewareTestRoute: typeof MiddlewareTestRoute
   ToolsTestRoute: typeof ToolsTestRoute
   ProviderFeatureRoute: typeof ProviderFeatureRoute
+  ApiAnthropicBugTestRoute: typeof ApiAnthropicBugTestRoute
   ApiAudioRoute: typeof ApiAudioRouteWithChildren
   ApiChatRoute: typeof ApiChatRoute
   ApiImageRoute: typeof ApiImageRouteWithChildren
@@ -363,6 +376,13 @@ declare module '@tanstack/react-router' {
       path: '/api/audio'
       fullPath: '/api/audio'
       preLoaderRoute: typeof ApiAudioRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/anthropic-bug-test': {
+      id: '/api/anthropic-bug-test'
+      path: '/api/anthropic-bug-test'
+      fullPath: '/api/anthropic-bug-test'
+      preLoaderRoute: typeof ApiAnthropicBugTestRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$provider/$feature': {
@@ -473,6 +493,7 @@ const rootRouteChildren: RootRouteChildren = {
   MiddlewareTestRoute: MiddlewareTestRoute,
   ToolsTestRoute: ToolsTestRoute,
   ProviderFeatureRoute: ProviderFeatureRoute,
+  ApiAnthropicBugTestRoute: ApiAnthropicBugTestRoute,
   ApiAudioRoute: ApiAudioRouteWithChildren,
   ApiChatRoute: ApiChatRoute,
   ApiImageRoute: ApiImageRouteWithChildren,

--- a/testing/e2e/src/routes/api.anthropic-bug-test.ts
+++ b/testing/e2e/src/routes/api.anthropic-bug-test.ts
@@ -1,5 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { chat, createChatOptions, maxIterations, toolDefinition } from '@tanstack/ai'
+import {
+  chat,
+  createChatOptions,
+  maxIterations,
+  toolDefinition,
+} from '@tanstack/ai'
 import { createAnthropicChat } from '@tanstack/ai-anthropic'
 import { webFetchTool } from '@tanstack/ai-anthropic/tools'
 import { z } from 'zod'

--- a/testing/e2e/src/routes/api.anthropic-bug-test.ts
+++ b/testing/e2e/src/routes/api.anthropic-bug-test.ts
@@ -23,11 +23,9 @@ export const Route = createFileRoute('/api/anthropic-bug-test')({
   server: {
     handlers: {
       POST: async () => {
-        const adapter = createAnthropicChat(
-          'claude-sonnet-4-5',
-          DUMMY_KEY,
-          { baseURL: `${LLMOCK_DEFAULT_BASE}/anthropic-bug-test` },
-        )
+        const adapter = createAnthropicChat('claude-sonnet-4-5', DUMMY_KEY, {
+          baseURL: `${LLMOCK_DEFAULT_BASE}/anthropic-bug-test`,
+        })
 
         // A trivial client tool. The server lookup just echoes back so the
         // agent loop can settle into the follow-up text response.
@@ -43,7 +41,10 @@ export const Route = createFileRoute('/api/anthropic-bug-test')({
             ...createChatOptions({ adapter }),
             tools: [lookupWeather],
             messages: [
-              { role: 'user', content: 'Weather in Berlin and fetch example.com' },
+              {
+                role: 'user',
+                content: 'Weather in Berlin and fetch example.com',
+              },
             ],
             agentLoopStrategy: maxIterations(3),
           })) {

--- a/testing/e2e/src/routes/api.anthropic-bug-test.ts
+++ b/testing/e2e/src/routes/api.anthropic-bug-test.ts
@@ -1,0 +1,69 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { chat, createChatOptions, maxIterations } from '@tanstack/ai'
+import { toolDefinition } from '@tanstack/ai'
+import { createAnthropicChat } from '@tanstack/ai-anthropic'
+import { z } from 'zod'
+
+const LLMOCK_DEFAULT_BASE = process.env.LLMOCK_URL || 'http://127.0.0.1:4010'
+const DUMMY_KEY = 'sk-e2e-test-dummy-key'
+
+/**
+ * Reproduces issue #604: a client `tool_use` followed by a `server_tool_use`
+ * (web_fetch) in the same Claude streaming response previously caused the
+ * server tool's `input_json_delta`s to be appended onto the client tool's
+ * input buffer — producing concatenated JSON that threw in the agent loop's
+ * `JSON.parse`. The route runs the Anthropic adapter against a mounted
+ * aimock path that emits the exact SSE shape Claude returns, collects all
+ * stream chunks, and returns them as JSON for the spec to assert against.
+ *
+ * Test-only — no production code path should ever set a custom Anthropic
+ * baseURL like this.
+ */
+export const Route = createFileRoute('/api/anthropic-bug-test')({
+  server: {
+    handlers: {
+      POST: async () => {
+        const adapter = createAnthropicChat(
+          'claude-sonnet-4-5',
+          DUMMY_KEY,
+          { baseURL: `${LLMOCK_DEFAULT_BASE}/anthropic-bug-test` },
+        )
+
+        // A trivial client tool. The server lookup just echoes back so the
+        // agent loop can settle into the follow-up text response.
+        const lookupWeather = toolDefinition({
+          name: 'lookup_weather',
+          description: 'Return the current weather for a city',
+          inputSchema: z.object({ location: z.string() }),
+        }).server(async ({ location }) => ({ location, summary: 'sunny' }))
+
+        const chunks: Array<unknown> = []
+        try {
+          for await (const chunk of chat({
+            ...createChatOptions({ adapter }),
+            tools: [lookupWeather],
+            messages: [
+              { role: 'user', content: 'Weather in Berlin and fetch example.com' },
+            ],
+            agentLoopStrategy: maxIterations(3),
+          })) {
+            chunks.push(chunk)
+          }
+        } catch (error) {
+          return new Response(
+            JSON.stringify({
+              chunks,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+
+        return new Response(JSON.stringify({ chunks, error: null }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      },
+    },
+  },
+})

--- a/testing/e2e/src/routes/api.anthropic-bug-test.ts
+++ b/testing/e2e/src/routes/api.anthropic-bug-test.ts
@@ -1,23 +1,24 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { chat, createChatOptions, maxIterations } from '@tanstack/ai'
-import { toolDefinition } from '@tanstack/ai'
+import { chat, createChatOptions, maxIterations, toolDefinition } from '@tanstack/ai'
 import { createAnthropicChat } from '@tanstack/ai-anthropic'
+import { webFetchTool } from '@tanstack/ai-anthropic/tools'
 import { z } from 'zod'
 
 const LLMOCK_DEFAULT_BASE = process.env.LLMOCK_URL || 'http://127.0.0.1:4010'
 const DUMMY_KEY = 'sk-e2e-test-dummy-key'
 
 /**
- * Reproduces issue #604: a client `tool_use` followed by a `server_tool_use`
- * (web_fetch) in the same Claude streaming response previously caused the
- * server tool's `input_json_delta`s to be appended onto the client tool's
- * input buffer — producing concatenated JSON that threw in the agent loop's
- * `JSON.parse`. The route runs the Anthropic adapter against a mounted
- * aimock path that emits the exact SSE shape Claude returns, collects all
- * stream chunks, and returns them as JSON for the spec to assert against.
+ * Reproduces issue #604 against the real `webFetchTool()` surface: a user
+ * client tool mixed with `webFetchTool()` previously broke when Claude
+ * returned a `tool_use` followed by a `server_tool_use` (web_fetch) in the
+ * same streaming response — the server tool's `input_json_delta`s appended
+ * onto the client tool's input buffer, and the agent loop's `JSON.parse`
+ * threw on the concatenated JSON.
  *
- * Test-only — no production code path should ever set a custom Anthropic
- * baseURL like this.
+ * The route runs the Anthropic adapter against a mounted aimock path that
+ * emits the exact SSE shape Claude returns (aimock doesn't natively model
+ * `server_tool_use` blocks). Test-only — no production code path should set
+ * a custom Anthropic baseURL like this.
  */
 export const Route = createFileRoute('/api/anthropic-bug-test')({
   server: {
@@ -27,8 +28,9 @@ export const Route = createFileRoute('/api/anthropic-bug-test')({
           baseURL: `${LLMOCK_DEFAULT_BASE}/anthropic-bug-test`,
         })
 
-        // A trivial client tool. The server lookup just echoes back so the
-        // agent loop can settle into the follow-up text response.
+        // A trivial client tool the user might pair with webFetchTool(). The
+        // server lookup just echoes back so the agent loop can settle into
+        // the follow-up text response.
         const lookupWeather = toolDefinition({
           name: 'lookup_weather',
           description: 'Return the current weather for a city',
@@ -39,7 +41,10 @@ export const Route = createFileRoute('/api/anthropic-bug-test')({
         try {
           for await (const chunk of chat({
             ...createChatOptions({ adapter }),
-            tools: [lookupWeather],
+            // The real bug surface: a user tool + webFetchTool() in the same
+            // request. Pre-fix this combination caused
+            // "Failed to parse tool arguments as JSON" in the agent loop.
+            tools: [lookupWeather, webFetchTool()],
             messages: [
               {
                 role: 'user',

--- a/testing/e2e/tests/anthropic-server-tool.spec.ts
+++ b/testing/e2e/tests/anthropic-server-tool.spec.ts
@@ -1,23 +1,25 @@
 import { test, expect } from './fixtures'
 
 /**
- * Issue #604 regression test.
+ * Issue #604 regression test — `webFetchTool()` mixed with a user client
+ * tool.
  *
- * Before the fix, a Claude streaming response that emitted a client
- * `tool_use` followed by a `server_tool_use` (web_fetch) caused the server
- * tool's `input_json_delta`s to be appended onto the client tool's input
- * buffer. The agent loop's downstream `JSON.parse` then threw on the
- * concatenated JSON. A secondary failure mode was a server-tool-only
- * response causing a phantom client `TOOL_CALL_START` for the server tool.
+ * Pre-fix, when Claude returned a client `tool_use` followed by a
+ * `server_tool_use` (web_fetch) in the same streaming response, the server
+ * tool's `input_json_delta`s appended onto the client tool's input buffer.
+ * The agent loop's downstream `JSON.parse` then threw on the concatenated
+ * JSON, so any user calling `chat({ tools: [myTool, webFetchTool()] })`
+ * could hit "Failed to parse tool arguments as JSON" the moment Claude
+ * called both in one turn.
  *
  * The bug shape can't be reproduced through aimock's built-in handlers —
  * aimock has no concept of `server_tool_use` blocks. The
  * `/anthropic-bug-test` mount in `global-setup.ts` hand-crafts the exact
- * SSE Claude emits, and `/api/anthropic-bug-test` runs the adapter against
- * it and returns the resulting stream chunks for assertion.
+ * SSE Claude emits, and `/api/anthropic-bug-test` runs the Anthropic
+ * adapter against it with a real `webFetchTool()` in the tools array.
  */
-test.describe('anthropic — server_tool_use streaming (#604)', () => {
-  test('client tool_use args stay clean when followed by web_fetch server_tool_use', async ({
+test.describe('anthropic — webFetchTool() streaming (#604)', () => {
+  test('user tool + webFetchTool() in the same turn completes cleanly', async ({
     request,
   }) => {
     const res = await request.post('/api/anthropic-bug-test')
@@ -32,9 +34,9 @@ test.describe('anthropic — server_tool_use streaming (#604)', () => {
     expect(error).toBeNull()
 
     const toolCallStarts = chunks.filter((c) => c.type === 'TOOL_CALL_START')
-    // `TOOL_CALL_END` is emitted twice per call: once by the adapter with the
-    // parsed `input`, and once by the tool runner with the execution
-    // `result`. The bug shape is in the first one — that's where the
+    // `TOOL_CALL_END` is emitted twice per call: once by the adapter with
+    // the parsed `input`, and once by the tool runner with the execution
+    // `result`. The bug shape lived in the first one — that's where the
     // pre-fix `JSON.parse(concatenatedArgs)` blew up.
     const toolCallArgEnds = chunks.filter(
       (c) =>
@@ -42,8 +44,8 @@ test.describe('anthropic — server_tool_use streaming (#604)', () => {
         (c as { input?: unknown }).input !== undefined,
     )
 
-    // Exactly one client tool call. The `web_fetch` server tool is executed
-    // by Anthropic, not surfaced as a client tool call.
+    // Exactly one client tool call. `web_fetch` is executed by Anthropic
+    // server-side, not surfaced as a client tool call.
     expect(toolCallStarts).toHaveLength(1)
     expect(toolCallArgEnds).toHaveLength(1)
     expect(toolCallStarts[0]).toMatchObject({
@@ -51,8 +53,8 @@ test.describe('anthropic — server_tool_use streaming (#604)', () => {
       toolName: 'lookup_weather',
     })
 
-    // Client tool args must be the clean Berlin payload — not the
-    // pre-fix concatenated `{"location":"Berlin"}{"url":"..."}`.
+    // Client tool args must be the clean Berlin payload — not the pre-fix
+    // concatenated `{"location":"Berlin"}{"url":"..."}`.
     expect(toolCallArgEnds[0]).toMatchObject({
       toolCallId: 'toolu_client_weather',
       input: { location: 'Berlin' },

--- a/testing/e2e/tests/anthropic-server-tool.spec.ts
+++ b/testing/e2e/tests/anthropic-server-tool.spec.ts
@@ -61,7 +61,8 @@ test.describe('anthropic — server_tool_use streaming (#604)', () => {
     // No phantom client tool call for the server-side web_fetch.
     expect(
       toolCallStarts.some(
-        (c) => (c as { toolCallId?: string }).toolCallId === 'srvtoolu_web_fetch',
+        (c) =>
+          (c as { toolCallId?: string }).toolCallId === 'srvtoolu_web_fetch',
       ),
     ).toBe(false)
 

--- a/testing/e2e/tests/anthropic-server-tool.spec.ts
+++ b/testing/e2e/tests/anthropic-server-tool.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from './fixtures'
+
+/**
+ * Issue #604 regression test.
+ *
+ * Before the fix, a Claude streaming response that emitted a client
+ * `tool_use` followed by a `server_tool_use` (web_fetch) caused the server
+ * tool's `input_json_delta`s to be appended onto the client tool's input
+ * buffer. The agent loop's downstream `JSON.parse` then threw on the
+ * concatenated JSON. A secondary failure mode was a server-tool-only
+ * response causing a phantom client `TOOL_CALL_START` for the server tool.
+ *
+ * The bug shape can't be reproduced through aimock's built-in handlers —
+ * aimock has no concept of `server_tool_use` blocks. The
+ * `/anthropic-bug-test` mount in `global-setup.ts` hand-crafts the exact
+ * SSE Claude emits, and `/api/anthropic-bug-test` runs the adapter against
+ * it and returns the resulting stream chunks for assertion.
+ */
+test.describe('anthropic — server_tool_use streaming (#604)', () => {
+  test('client tool_use args stay clean when followed by web_fetch server_tool_use', async ({
+    request,
+  }) => {
+    const res = await request.post('/api/anthropic-bug-test')
+    expect(res.ok()).toBe(true)
+    const { chunks, error } = (await res.json()) as {
+      chunks: Array<Record<string, unknown>>
+      error: string | null
+    }
+
+    // The bug threw `Failed to parse tool arguments as JSON: {...}{"url":...}`
+    // in the agent loop. The fix means no error reaches the consumer.
+    expect(error).toBeNull()
+
+    const toolCallStarts = chunks.filter((c) => c.type === 'TOOL_CALL_START')
+    // `TOOL_CALL_END` is emitted twice per call: once by the adapter with the
+    // parsed `input`, and once by the tool runner with the execution
+    // `result`. The bug shape is in the first one — that's where the
+    // pre-fix `JSON.parse(concatenatedArgs)` blew up.
+    const toolCallArgEnds = chunks.filter(
+      (c) =>
+        c.type === 'TOOL_CALL_END' &&
+        (c as { input?: unknown }).input !== undefined,
+    )
+
+    // Exactly one client tool call. The `web_fetch` server tool is executed
+    // by Anthropic, not surfaced as a client tool call.
+    expect(toolCallStarts).toHaveLength(1)
+    expect(toolCallArgEnds).toHaveLength(1)
+    expect(toolCallStarts[0]).toMatchObject({
+      toolCallId: 'toolu_client_weather',
+      toolName: 'lookup_weather',
+    })
+
+    // Client tool args must be the clean Berlin payload — not the
+    // pre-fix concatenated `{"location":"Berlin"}{"url":"..."}`.
+    expect(toolCallArgEnds[0]).toMatchObject({
+      toolCallId: 'toolu_client_weather',
+      input: { location: 'Berlin' },
+    })
+
+    // No phantom client tool call for the server-side web_fetch.
+    expect(
+      toolCallStarts.some(
+        (c) => (c as { toolCallId?: string }).toolCallId === 'srvtoolu_web_fetch',
+      ),
+    ).toBe(false)
+
+    // Run completes cleanly through the agent loop's follow-up turn.
+    expect(chunks.some((c) => c.type === 'RUN_FINISHED')).toBe(true)
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Closes #604.

`@tanstack/ai-anthropic`'s streaming adapter previously had no handler for Claude's `server_tool_use` / `web_fetch_tool_result` / `web_search_tool_result` content blocks. Anyone calling `chat({ tools: [myTool, webFetchTool()] })` — or `webSearchTool()` — would hit `Failed to parse tool arguments as JSON: {...}{"url":"..."}` in the agent loop the moment Claude called both in one turn: the server tool's `input_json_delta`s were appending onto the prior client tool's input buffer.

- `server_tool_use` is now tracked in its own buffer, separate from `toolCallsMap`.
- `input_json_delta` is dispatched by `currentBlockType` so server-tool deltas can't bleed into client tool args.
- `web_fetch_tool_result` / `web_search_tool_result` blocks are explicitly accepted (Anthropic executes them server-side, no client surface needed). Their `_error` variants are surfaced via `logger.errors` so a silently failed fetch / search isn't invisible.
- Secondary fix: a `webFetchTool()`-only response (no prior client `tool_use`) no longer creates a phantom client tool call.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

**Tests added:**

- Unit (`packages/typescript/ai-anthropic/tests/anthropic-adapter.test.ts`)
  - Client `tool_use` + `web_fetch` `server_tool_use` in one response — client `TOOL_CALL_END` carries only its own input, no `TOOL_CALL_*` emitted for the server tool.
  - `server_tool_use` as the only tool (no prior client tool) — no phantom client tool events, clean `RUN_FINISHED`.
  - `web_fetch_tool_result_error` surfaces through `logger.errors`.
- E2E (`testing/e2e/tests/anthropic-server-tool.spec.ts`) — runs the real `webFetchTool()` through the Anthropic adapter alongside a user client tool. aimock can't natively synthesise `server_tool_use` blocks, so `global-setup.ts` mounts `/anthropic-bug-test` to emit the exact SSE Claude returns for the mixed `tool_use` + `server_tool_use` + `web_fetch_tool_result` shape. Asserts clean tool args, no phantom server-tool call, successful `RUN_FINISHED`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Follow-up (separate concern)

Per Alem: OpenAI returns custom tool chunks for its internal tools as well. This PR keeps server-tool execution silent (debug-logged only); a follow-up should surface `webFetchTool()` / `webSearchTool()` calls + results as `TOOL_CALL_*` events with an `executor: 'server'` discriminator so devtools / custom UIs can see them. Tracked separately to keep this PR a focused bug fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed corrupted streaming when Anthropic responses interleave client tool calls with server-side tools (web_fetch, web_search). Client tool inputs are now correctly parsed without interference from server tool data during streaming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->