### PR TITLE
chore(eslint): adopt @tanstack/eslint-config@0.4.0 and prune local overrides

### DIFF
--- a/.changeset/eslint-config-0-4-0.md
+++ b/.changeset/eslint-config-0-4-0.md
@@ -1,0 +1,22 @@
+---
+'@tanstack/ai': patch
+'@tanstack/ai-code-mode': patch
+'@tanstack/ai-code-mode-skills': patch
+'@tanstack/ai-elevenlabs': patch
+'@tanstack/ai-fal': patch
+'@tanstack/ai-gemini': patch
+'@tanstack/ai-grok': patch
+'@tanstack/ai-openai': patch
+'@tanstack/ai-openrouter': patch
+'@tanstack/ai-react-ui': patch
+---
+
+Adopt `@tanstack/eslint-config@0.4.0` and clean up the local override layer.
+
+- Bump `@tanstack/eslint-config` from `0.3.3` to `0.4.0`.
+- Drop dead `pnpm/enforce-catalog` and `pnpm/json-enforce-catalog` disables (upstream removed `eslint-plugin-pnpm` in `0.3.1`).
+- Drop the `no-case-declarations: off` override — no current source actually violates it.
+- Drop the `no-shadow: off` override — upstream sets it to `warn`, so it surfaces in editors without blocking CI.
+- Remove ~25 unnecessary type assertions across the publishable packages that the upgraded `typescript-eslint` now catches via `no-unnecessary-type-assertion`. One deliberately defensive cast in `ag-ui-wire.ts` is preserved with an inline opt-out and a reason comment.
+
+No public-API or runtime-behavior changes.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,11 +12,7 @@ const config = [
       'unused-imports': unusedImports,
     },
     rules: {
-      'no-case-declarations': 'off',
-      'no-shadow': 'off',
       'unused-imports/no-unused-imports': 'warn',
-      'pnpm/enforce-catalog': 'off',
-      'pnpm/json-enforce-catalog': 'off',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@changesets/cli": "^2.30.0",
     "@faker-js/faker": "^10.1.0",
     "@svitejs/changesets-changelog-github-compact": "^1.2.0",
-    "@tanstack/eslint-config": "0.3.3",
+    "@tanstack/eslint-config": "0.4.0",
     "@tanstack/typedoc-config": "0.3.1",
     "@tanstack/vite-config": "0.4.1",
     "@types/node": "^24.10.1",

--- a/packages/typescript/ai-code-mode-skills/src/generate-skill-types.ts
+++ b/packages/typescript/ai-code-mode-skills/src/generate-skill-types.ts
@@ -116,7 +116,7 @@ export function generateSkillTypes(skills: Array<Skill>): string {
     if (
       skill.inputSchema.type === 'object' &&
       skill.inputSchema.properties &&
-      Object.keys(skill.inputSchema.properties as object).length > 0
+      Object.keys(skill.inputSchema.properties).length > 0
     ) {
       declarations.push(`interface ${inputTypeName} ${inputType}`)
     }
@@ -126,7 +126,7 @@ export function generateSkillTypes(skills: Array<Skill>): string {
     if (
       skill.outputSchema.type === 'object' &&
       skill.outputSchema.properties &&
-      Object.keys(skill.outputSchema.properties as object).length > 0
+      Object.keys(skill.outputSchema.properties).length > 0
     ) {
       declarations.push(`interface ${outputTypeName} ${outputType}`)
     }
@@ -135,14 +135,14 @@ export function generateSkillTypes(skills: Array<Skill>): string {
     const inputRef =
       skill.inputSchema.type === 'object' &&
       skill.inputSchema.properties &&
-      Object.keys(skill.inputSchema.properties as object).length > 0
+      Object.keys(skill.inputSchema.properties).length > 0
         ? inputTypeName
         : inputType
 
     const outputRef =
       skill.outputSchema.type === 'object' &&
       skill.outputSchema.properties &&
-      Object.keys(skill.outputSchema.properties as object).length > 0
+      Object.keys(skill.outputSchema.properties).length > 0
         ? outputTypeName
         : outputType
 

--- a/packages/typescript/ai-code-mode/src/type-generator/json-schema-to-ts.ts
+++ b/packages/typescript/ai-code-mode/src/type-generator/json-schema-to-ts.ts
@@ -84,7 +84,7 @@ export function jsonSchemaToTypeScript(
   if (
     schema.type === 'object' &&
     schema.properties &&
-    Object.keys(schema.properties as object).length > 0
+    Object.keys(schema.properties).length > 0
   ) {
     return {
       name: typeName,

--- a/packages/typescript/ai-elevenlabs/src/realtime/adapter.ts
+++ b/packages/typescript/ai-elevenlabs/src/realtime/adapter.ts
@@ -8,7 +8,6 @@ import type {
   RealtimeMessage,
   RealtimeMode,
   RealtimeSessionConfig,
-  RealtimeStatus,
   RealtimeToken,
 } from '@tanstack/ai'
 import type { InternalLogger } from '@tanstack/ai/adapter-internals'
@@ -119,7 +118,7 @@ async function createElevenLabsConnection(
       logger.provider(`provider=elevenlabs direction=in type=connect`, {
         frame: { type: 'connect' },
       })
-      emit('status_change', { status: 'connected' as RealtimeStatus })
+      emit('status_change', { status: 'connected' })
       emit('mode_change', { mode: 'listening' })
     },
 
@@ -127,7 +126,7 @@ async function createElevenLabsConnection(
       logger.provider(`provider=elevenlabs direction=in type=disconnect`, {
         frame: { type: 'disconnect' },
       })
-      emit('status_change', { status: 'idle' as RealtimeStatus })
+      emit('status_change', { status: 'idle' })
       emit('mode_change', { mode: 'idle' })
     },
 
@@ -205,7 +204,7 @@ async function createElevenLabsConnection(
         await conversation.endSession()
         conversation = null
       }
-      emit('status_change', { status: 'idle' as RealtimeStatus })
+      emit('status_change', { status: 'idle' })
     },
 
     async startAudioCapture() {

--- a/packages/typescript/ai-fal/src/adapters/image.ts
+++ b/packages/typescript/ai-fal/src/adapters/image.ts
@@ -135,7 +135,7 @@ export class FalImageAdapter<TModel extends FalModel> extends BaseImageAdapter<
       img &&
       typeof img === 'object' &&
       'url' in img &&
-      typeof (img as { url: unknown }).url === 'string'
+      typeof img.url === 'string'
     ) {
       url = (img as { url: string }).url
     } else {

--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -750,7 +750,7 @@ export class GeminiTextAdapter<
             response: {
               content: msg.content || '',
             },
-          } as any,
+          },
         })
       }
 
@@ -829,8 +829,7 @@ export class GeminiTextAdapter<
     // local `thinkingLevel?: keyof typeof ThinkingLevel` type doesn't leak
     // into the SDK config object via the `...modelOpts` spread — we re-add a
     // properly-typed `ThinkingConfig` below.
-    const { thinkingConfig, ...modelOpts } =
-      options.modelOptions ?? ({} as GeminiTextProviderOptions)
+    const { thinkingConfig, ...modelOpts } = options.modelOptions ?? {}
     // Build the thinkingConfig payload only when the caller actually supplied
     // one. Our local `thinkingLevel` is typed as `keyof typeof ThinkingLevel`
     // (string union) so users can pass plain strings; the SDK target is the

--- a/packages/typescript/ai-grok/src/adapters/tts.ts
+++ b/packages/typescript/ai-grok/src/adapters/tts.ts
@@ -5,7 +5,6 @@ import type { GrokTTSModel } from '../model-meta'
 import type {
   GrokTTSCodec,
   GrokTTSProviderOptions,
-  GrokTTSVoice,
 } from '../audio/tts-provider-options'
 
 const DEFAULT_GROK_BASE_URL = 'https://api.x.ai/v1'
@@ -155,7 +154,7 @@ export function buildTTSRequestBody(options: {
 
   const body: Record<string, unknown> = {
     text,
-    voice_id: (voice as GrokTTSVoice | undefined) ?? 'eve',
+    voice_id: voice ?? 'eve',
     language: modelOptions?.language ?? 'en',
     output_format: outputFormat,
   }

--- a/packages/typescript/ai-grok/src/realtime/adapter.ts
+++ b/packages/typescript/ai-grok/src/realtime/adapter.ts
@@ -7,7 +7,6 @@ import type {
   RealtimeMessage,
   RealtimeMode,
   RealtimeSessionConfig,
-  RealtimeStatus,
   RealtimeToken,
 } from '@tanstack/ai'
 import type { InternalLogger } from '@tanstack/ai/adapter-internals'
@@ -210,7 +209,7 @@ async function createWebRTCConnection(
       // don't attempt a redundant reject on an already-settled promise.
       rejectDataChannelReady = null
       flushPendingEvents()
-      emit('status_change', { status: 'connected' as RealtimeStatus })
+      emit('status_change', { status: 'connected' })
       resolve()
     }
   })
@@ -297,10 +296,7 @@ async function createWebRTCConnection(
       // guard listeners would see two `idle` events per disconnect.
       if (!isTornDown) {
         emit('status_change', {
-          status:
-            state === 'failed'
-              ? ('error' as RealtimeStatus)
-              : ('idle' as RealtimeStatus),
+          status: state === 'failed' ? 'error' : 'idle',
         })
       }
       if (!dataChannelOpened) {
@@ -961,7 +957,7 @@ async function createWebRTCConnection(
       // every cleanup site stays in sync (input analyser, output analyser,
       // output source, audio element, etc.).
       await teardownConnection()
-      emit('status_change', { status: 'idle' as RealtimeStatus })
+      emit('status_change', { status: 'idle' })
     },
 
     async startAudioCapture() {

--- a/packages/typescript/ai-openai/src/adapters/transcription.ts
+++ b/packages/typescript/ai-openai/src/adapters/transcription.ts
@@ -186,7 +186,7 @@ export class OpenAITranscriptionAdapter<
     format?: 'json' | 'text' | 'srt' | 'verbose_json' | 'vtt',
   ): OpenAI_SDK.Audio.TranscriptionCreateParams['response_format'] {
     if (!format) return 'json'
-    return format as OpenAI_SDK.Audio.TranscriptionCreateParams['response_format']
+    return format
   }
 }
 

--- a/packages/typescript/ai-openai/src/adapters/tts.ts
+++ b/packages/typescript/ai-openai/src/adapters/tts.ts
@@ -65,7 +65,7 @@ export class OpenAITTSAdapter<
     const request: OpenAI_SDK.Audio.SpeechCreateParams = {
       model,
       input: text,
-      voice: (voice || 'alloy') as OpenAI_SDK.Audio.SpeechCreateParams['voice'],
+      voice: voice || 'alloy',
       response_format: format,
       ...(speed !== undefined && { speed }),
       ...(modelOptions ?? {}),

--- a/packages/typescript/ai-openai/src/adapters/video.ts
+++ b/packages/typescript/ai-openai/src/adapters/video.ts
@@ -100,9 +100,7 @@ export class OpenAIVideoAdapter<
     // `VideoCreateParams.size` is `size?: VideoSize` (no `| undefined`), so we
     // narrow before assignment instead of casting from a `T | undefined` source.
     if (size) {
-      request.size = size as NonNullable<
-        OpenAI_SDK.Videos.VideoCreateParams['size']
-      >
+      request.size = size
     } else if (modelOptions?.size) {
       request.size = modelOptions.size
     }

--- a/packages/typescript/ai-openai/src/realtime/adapter.ts
+++ b/packages/typescript/ai-openai/src/realtime/adapter.ts
@@ -7,7 +7,6 @@ import type {
   RealtimeMessage,
   RealtimeMode,
   RealtimeSessionConfig,
-  RealtimeStatus,
   RealtimeToken,
 } from '@tanstack/ai'
 import type { InternalLogger } from '@tanstack/ai/adapter-internals'
@@ -127,7 +126,7 @@ async function createWebRTCConnection(
   const dataChannelReady = new Promise<void>((resolve) => {
     channel.onopen = () => {
       flushPendingEvents()
-      emit('status_change', { status: 'connected' as RealtimeStatus })
+      emit('status_change', { status: 'connected' })
       resolve()
     }
   })
@@ -510,7 +509,7 @@ async function createWebRTCConnection(
         audioContext = null
       }
 
-      emit('status_change', { status: 'idle' as RealtimeStatus })
+      emit('status_change', { status: 'idle' })
     },
 
     async startAudioCapture() {

--- a/packages/typescript/ai-openrouter/src/adapters/responses-text.ts
+++ b/packages/typescript/ai-openrouter/src/adapters/responses-text.ts
@@ -1823,9 +1823,7 @@ function normalizeStreamEvent(event: StreamEvents): NormalizedStreamEvent {
     }
     if ('part' in raw) out.part = raw.part
     out.type =
-      typeof raw['type'] === 'string'
-        ? raw['type']
-        : (e.type as string) || 'unknown'
+      typeof raw['type'] === 'string' ? raw['type'] : e.type || 'unknown'
     // eslint-disable-next-line no-restricted-syntax -- NormalizedStreamEvent is a discriminated union built field-by-field from Record<string, unknown>; TS can't narrow the variant from construction.
     return out as unknown as NormalizedStreamEvent
   }

--- a/packages/typescript/ai-openrouter/src/tools/web-search-tool.ts
+++ b/packages/typescript/ai-openrouter/src/tools/web-search-tool.ts
@@ -57,7 +57,7 @@ export function convertWebSearchToolToAdapterFormat(
   }
   return {
     type: 'web_search',
-    web_search: metadata.web_search as WebSearchToolConfig['web_search'],
+    web_search: metadata.web_search,
   }
 }
 

--- a/packages/typescript/ai-react-ui/src/chat-input.tsx
+++ b/packages/typescript/ai-react-ui/src/chat-input.tsx
@@ -105,7 +105,7 @@ export function ChatInput({
         ref={inputRef as React.RefObject<HTMLInputElement>}
         type="text"
         value={value}
-        onChange={(e) => setValue((e.target as HTMLInputElement).value)}
+        onChange={(e) => setValue(e.target.value)}
         onKeyDown={(e) => {
           if (submitOnEnter && e.key === 'Enter') {
             e.preventDefault()
@@ -127,15 +127,12 @@ export function ChatInput({
           transition: 'all 0.2s',
         }}
         onFocus={(e) => {
-          ;(e.target as HTMLInputElement).style.borderColor =
-            'rgba(249, 115, 22, 0.4)'
-          ;(e.target as HTMLInputElement).style.boxShadow =
-            '0 0 0 2px rgba(249, 115, 22, 0.2)'
+          e.target.style.borderColor = 'rgba(249, 115, 22, 0.4)'
+          e.target.style.boxShadow = '0 0 0 2px rgba(249, 115, 22, 0.2)'
         }}
         onBlur={(e) => {
-          ;(e.target as HTMLInputElement).style.borderColor =
-            'rgba(255, 255, 255, 0.1)'
-          ;(e.target as HTMLInputElement).style.boxShadow = 'none'
+          e.target.style.borderColor = 'rgba(255, 255, 255, 0.1)'
+          e.target.style.boxShadow = 'none'
         }}
       />
       <button

--- a/packages/typescript/ai/src/activities/chat/index.ts
+++ b/packages/typescript/ai/src/activities/chat/index.ts
@@ -54,7 +54,6 @@ import type {
   ChatMiddleware,
   ChatMiddlewareConfig,
   ChatMiddlewareContext,
-  ChatMiddlewarePhase,
 } from './middleware/types'
 import type { SystemPrompt } from '../../system-prompts'
 import type { InternalLogger } from '../../logger/internal-logger'
@@ -375,9 +374,7 @@ class TextEngine<
 
     // Convert messages to ModelMessage format (handles both UIMessage and ModelMessage input)
     // This ensures consistent internal format regardless of what the client sends
-    this.messages = convertMessagesToModelMessages(
-      config.params.messages as Array<any>,
-    )
+    this.messages = convertMessagesToModelMessages(config.params.messages)
 
     // Initialize lazy tool manager after messages are converted (needs message history for scanning)
     this.lazyToolManager = new LazyToolManager(
@@ -410,7 +407,7 @@ class TextEngine<
     // `DevtoolsChatMiddleware` (defined in `@tanstack/ai-event-client` to
     // avoid a circular dep). Cast it to `ChatMiddleware` for the runner.
     const allMiddleware: Array<ChatMiddleware> = [
-      devtoolsMiddleware() as ChatMiddleware,
+      devtoolsMiddleware(),
       ...(config.middleware || []),
       stripToSpecMiddleware(),
     ]
@@ -423,7 +420,7 @@ class TextEngine<
       // Legacy alias kept on the ctx so middleware that reads
       // `ctx.conversationId` keeps working. Always equals `threadId`.
       conversationId: this.threadId,
-      phase: 'init' as ChatMiddlewarePhase,
+      phase: 'init',
       iteration: 0,
       chunkIndex: 0,
       signal: this.effectiveSignal,

--- a/packages/typescript/ai/src/activities/chat/messages.ts
+++ b/packages/typescript/ai/src/activities/chat/messages.ts
@@ -114,7 +114,7 @@ export function convertMessagesToModelMessages(
       modelMessages.push({
         role: 'system' as ModelMessage['role'],
         content: (msg as { content: string }).content,
-      } as ModelMessage)
+      })
       continue
     }
 

--- a/packages/typescript/ai/src/activities/chat/middleware/compose.ts
+++ b/packages/typescript/ai/src/activities/chat/middleware/compose.ts
@@ -71,7 +71,7 @@ export class MiddlewareRunner {
           current = { ...current, ...result }
           if (!skip) {
             this.logger.config(
-              `middleware=${mw.name ?? 'unnamed'} keys=${Object.keys(result as object).join(',')}`,
+              `middleware=${mw.name ?? 'unnamed'} keys=${Object.keys(result).join(',')}`,
               {
                 middleware: mw.name ?? 'unnamed',
                 changes: result,
@@ -94,7 +94,7 @@ export class MiddlewareRunner {
               ...base,
               middlewareName: mw.name || 'unnamed',
               iteration: ctx.iteration,
-              changes: result as Record<string, unknown>,
+              changes: result,
             })
           }
         }
@@ -152,7 +152,7 @@ export class MiddlewareRunner {
       const nextChunks: Array<StreamChunk> = []
       for (const c of chunks) {
         // Cast: @ag-ui/core Zod passthrough types prevent direct `.type` access
-        const chunkType = (c as StreamChunk & { type: string }).type
+        const chunkType = c.type
         if (!skip) {
           this.logger.middleware(
             `hook=onChunk middleware=${mw.name ?? 'unnamed'} in=${chunkType}`,
@@ -188,7 +188,7 @@ export class MiddlewareRunner {
           nextChunks.push(...result)
           if (!skip) {
             this.logger.middleware(
-              `hook=onChunk middleware=${mw.name ?? 'unnamed'} in=${chunkType} out=[${result.map((r: StreamChunk) => (r as StreamChunk & { type: string }).type).join(',')}]`,
+              `hook=onChunk middleware=${mw.name ?? 'unnamed'} in=${chunkType} out=[${result.map((r: StreamChunk) => r.type).join(',')}]`,
               {
                 middleware: mw.name ?? 'unnamed',
                 hook: 'onChunk',
@@ -209,7 +209,7 @@ export class MiddlewareRunner {
           nextChunks.push(result)
           if (!skip) {
             this.logger.middleware(
-              `hook=onChunk middleware=${mw.name ?? 'unnamed'} in=${chunkType} out=${(result as StreamChunk & { type: string }).type}`,
+              `hook=onChunk middleware=${mw.name ?? 'unnamed'} in=${chunkType} out=${result.type}`,
               {
                 middleware: mw.name ?? 'unnamed',
                 hook: 'onChunk',

--- a/packages/typescript/ai/src/activities/chat/stream/processor.ts
+++ b/packages/typescript/ai/src/activities/chat/stream/processor.ts
@@ -216,7 +216,7 @@ export class StreamProcessor {
         ? [{ type: 'text', content }]
         : content.map((part) => {
             // ContentPart types (text, image, audio, video, document) are compatible with MessagePart
-            return part as MessagePart
+            return part
           })
 
     const userMessage: UIMessage = {
@@ -479,7 +479,7 @@ export class StreamProcessor {
 
     // Cast needed: @ag-ui/core Zod passthrough types add `& { [k: string]: unknown }`
     // which prevents TypeScript from narrowing the `type` discriminant in switch.
-    const c = chunk as StreamChunk & { type: string }
+    const c = chunk
     // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- AG-UI EventType enum members vs string-literal case labels; default branch handles untraced events.
     switch (c.type) {
       // AG-UI Events

--- a/packages/typescript/ai/src/activities/chat/tools/schema-converter.ts
+++ b/packages/typescript/ai/src/activities/chat/tools/schema-converter.ts
@@ -58,7 +58,6 @@ export function isStandardSchema(schema: unknown): schema is StandardSchemaV1 {
     typeof schema['~standard'] === 'object' &&
     schema['~standard'] !== null &&
     'version' in schema['~standard'] &&
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard for caller-provided unknown; in-operator narrows but doesn't validate the wire payload
     schema['~standard'].version === 1 &&
     'validate' in schema['~standard'] &&
     typeof schema['~standard'].validate === 'function'

--- a/packages/typescript/ai/src/activities/generateImage/index.ts
+++ b/packages/typescript/ai/src/activities/generateImage/index.ts
@@ -210,7 +210,7 @@ async function runGenerateImage<
     prompt: rest.prompt,
     numberOfImages: rest.numberOfImages,
     size: rest.size,
-    modelOptions: rest.modelOptions as Record<string, unknown> | undefined,
+    modelOptions: rest.modelOptions,
     timestamp: startTime,
   })
 
@@ -237,7 +237,7 @@ async function runGenerateImage<
         b64Json: image.b64Json,
       })),
       duration,
-      modelOptions: rest.modelOptions as Record<string, unknown> | undefined,
+      modelOptions: rest.modelOptions,
       timestamp: Date.now(),
     })
 
@@ -246,7 +246,7 @@ async function runGenerateImage<
         requestId,
         model,
         usage: result.usage,
-        modelOptions: rest.modelOptions as Record<string, unknown> | undefined,
+        modelOptions: rest.modelOptions,
         timestamp: Date.now(),
       })
     }

--- a/packages/typescript/ai/src/extend-adapter.ts
+++ b/packages/typescript/ai/src/extend-adapter.ts
@@ -65,7 +65,7 @@ export function createModel<
   return {
     name,
     input,
-    modelOptions: {} as unknown,
+    modelOptions: {},
   }
 }
 

--- a/packages/typescript/ai/src/middlewares/content-guard.ts
+++ b/packages/typescript/ai/src/middlewares/content-guard.ts
@@ -151,7 +151,7 @@ function createDeltaStrategy(
       return {
         ...rest,
         delta: filtered,
-      } as StreamChunk
+      }
     },
   }
 }

--- a/packages/typescript/ai/src/middlewares/otel.ts
+++ b/packages/typescript/ai/src/middlewares/otel.ts
@@ -256,10 +256,7 @@ export function otelMiddleware(options: OtelMiddlewareOptions): ChatMiddleware {
     const span = state.currentIterationSpan
     const iteration = state.iterationCount - 1
     safeCall('otel.onSpanEnd', () =>
-      onSpanEnd?.(
-        { kind: 'iteration', ctx, iteration } as OtelSpanInfo<'iteration'>,
-        span,
-      ),
+      onSpanEnd?.({ kind: 'iteration', ctx, iteration }, span),
     )
     span.end()
     state.currentIterationSpan = null
@@ -676,7 +673,7 @@ export function otelMiddleware(options: OtelMiddlewareOptions): ChatMiddleware {
               toolName: info.toolName,
               toolCallId: info.toolCallId,
               iteration: state.iterationCount - 1,
-            } as OtelSpanInfo<'tool'>,
+            },
             toolSpan,
           ),
         )
@@ -709,7 +706,7 @@ export function otelMiddleware(options: OtelMiddlewareOptions): ChatMiddleware {
                 kind: 'iteration',
                 ctx,
                 iteration: state.iterationCount - 1,
-              } as OtelSpanInfo<'iteration'>,
+              },
               iterationSpan,
             ),
           )
@@ -729,7 +726,7 @@ export function otelMiddleware(options: OtelMiddlewareOptions): ChatMiddleware {
                 toolCallId: id,
                 toolName,
                 iteration: state.iterationCount - 1,
-              } as OtelSpanInfo<'tool'>,
+              },
               span,
             ),
           )
@@ -782,7 +779,7 @@ export function otelMiddleware(options: OtelMiddlewareOptions): ChatMiddleware {
                 kind: 'iteration',
                 ctx,
                 iteration: state.iterationCount - 1,
-              } as OtelSpanInfo<'iteration'>,
+              },
               iterationSpan,
             ),
           )
@@ -800,7 +797,7 @@ export function otelMiddleware(options: OtelMiddlewareOptions): ChatMiddleware {
                 toolCallId: id,
                 toolName,
                 iteration: state.iterationCount - 1,
-              } as OtelSpanInfo<'tool'>,
+              },
               span,
             ),
           )
@@ -845,7 +842,7 @@ export function otelMiddleware(options: OtelMiddlewareOptions): ChatMiddleware {
                 toolCallId: id,
                 toolName,
                 iteration: state.iterationCount - 1,
-              } as OtelSpanInfo<'tool'>,
+              },
               span,
             ),
           )

--- a/packages/typescript/ai/src/strip-to-spec-middleware.ts
+++ b/packages/typescript/ai/src/strip-to-spec-middleware.ts
@@ -12,10 +12,7 @@ import type { StreamChunk } from './types'
  */
 export function stripToSpec(chunk: StreamChunk): StreamChunk {
   // Only strip the deprecated nested error object from RUN_ERROR
-  if (
-    (chunk as StreamChunk & { type: string }).type === 'RUN_ERROR' &&
-    'error' in chunk
-  ) {
+  if (chunk.type === 'RUN_ERROR' && 'error' in chunk) {
     const { error: _deprecated, ...rest } = chunk as Record<string, unknown>
     return rest as StreamChunk
   }

--- a/packages/typescript/ai/src/utilities/ag-ui-wire.ts
+++ b/packages/typescript/ai/src/utilities/ag-ui-wire.ts
@@ -53,6 +53,7 @@ export function uiMessagesToWire(
     // Defensive: if parts is missing (ModelMessage-shaped input), pass through as-is.
     // UIMessage always has parts; ModelMessage uses content directly.
     const parts: ReadonlyArray<MessagePart> =
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- runtime input may be ModelMessage-shaped (no `parts`); cast forces the optional-chain fallback below to remain in scope
       (msg.parts as ReadonlyArray<MessagePart> | undefined) ?? []
 
     if (msg.role === 'system') {
@@ -161,7 +162,7 @@ function collectUserContent(
       p.type === 'video' ||
       p.type === 'document'
     ) {
-      out.push(p as AGUIInputContent)
+      out.push(p)
     }
   }
   return out

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@tanstack/eslint-config':
-        specifier: 0.3.3
-        version: 0.3.3(@typescript-eslint/utils@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 0.4.0
+        version: 0.4.0(@typescript-eslint/utils@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@tanstack/typedoc-config':
         specifier: 0.3.1
         version: 0.3.1(typescript@5.9.3)
@@ -40,7 +40,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)
       eslint-plugin-unused-imports:
         specifier: ^4.3.0
-        version: 4.3.0(@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
+        version: 4.3.0(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
       happy-dom:
         specifier: ^20.0.10
         version: 20.0.11
@@ -3268,6 +3268,15 @@ packages:
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
   '@eslint/js@9.39.1':
     resolution: {integrity: sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5657,11 +5666,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@stylistic/eslint-plugin@5.6.1':
-    resolution: {integrity: sha512-JCs+MqoXfXrRPGbGmho/zGS/jMcn3ieKl/A8YImqib76C8kjgZwq5uUFzc30lJkMvcchuRn6/v8IApLxli3Jyw==}
+  '@stylistic/eslint-plugin@5.10.0':
+    resolution: {integrity: sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: '>=9.0.0'
+      eslint: ^9.0.0 || ^10.0.0
 
   '@sveltejs/acorn-typescript@1.0.8':
     resolution: {integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==}
@@ -5910,9 +5919,11 @@ packages:
     peerDependencies:
       vite: '>=6.0.0 || >=7.0.0'
 
-  '@tanstack/eslint-config@0.3.3':
-    resolution: {integrity: sha512-8VFyAaIFV9onJcfc5yVj5WWl6DmN3W4m+t0Mb+nZrQmqHy+kDndw5O5Xv2BHVWRRPTqnhlJYh6wHWGh0R81ZzQ==}
+  '@tanstack/eslint-config@0.4.0':
+    resolution: {integrity: sha512-V+Cd81W/f65dqKJKpytbwTGx9R+IwxKAHsG/uJ3nSLYEh36hlAr54lRpstUhggQB8nf/cP733cIw8DuD2dzQUg==}
     engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
 
   '@tanstack/history@1.131.2':
     resolution: {integrity: sha512-cs1WKawpXIe+vSTeiZUuSBy8JFjEuDgdMKZFRLKwQysKo8y2q6Q1HvS74Yw+m5IhOW1nTZooa6rlgdfXcgFAaw==}
@@ -6553,20 +6564,20 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.49.0':
-    resolution: {integrity: sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==}
+  '@typescript-eslint/eslint-plugin@8.59.4':
+    resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.49.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      '@typescript-eslint/parser': ^8.59.4
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.49.0':
-    resolution: {integrity: sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==}
+  '@typescript-eslint/parser@8.59.4':
+    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/project-service@8.49.0':
     resolution: {integrity: sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==}
@@ -6574,8 +6585,18 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/project-service@8.59.4':
+    resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.49.0':
     resolution: {integrity: sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.59.4':
+    resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.49.0':
@@ -6584,15 +6605,25 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/type-utils@8.49.0':
-    resolution: {integrity: sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==}
+  '@typescript-eslint/tsconfig-utils@8.59.4':
+    resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.4':
+    resolution: {integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/types@8.49.0':
     resolution: {integrity: sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.59.4':
+    resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.49.0':
@@ -6601,6 +6632,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/typescript-estree@8.59.4':
+    resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/utils@8.49.0':
     resolution: {integrity: sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -6608,8 +6645,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/utils@8.59.4':
+    resolution: {integrity: sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.49.0':
     resolution: {integrity: sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -7147,6 +7195,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
     peerDependencies:
@@ -7242,6 +7294,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -8074,8 +8130,8 @@ packages:
       eslint-import-resolver-node:
         optional: true
 
-  eslint-plugin-n@17.23.1:
-    resolution: {integrity: sha512-68PealUpYoHOBh332JLLD9Sj7OQUDkFpmcfqt8R9sySfFSeuGJjMTJQvCRRB96zO3A/PELRLkPrzsHmzEFQQ5A==}
+  eslint-plugin-n@17.24.0:
+    resolution: {integrity: sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.23.0'
@@ -8107,6 +8163,10 @@ packages:
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@9.39.1:
     resolution: {integrity: sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==}
@@ -8486,8 +8546,8 @@ packages:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
-  globals@16.5.0:
-    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
   globby@11.1.0:
@@ -9618,6 +9678,10 @@ packages:
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.0.8:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
@@ -11202,6 +11266,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-debounce@4.0.0:
     resolution: {integrity: sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==}
 
@@ -11328,12 +11398,12 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x
 
-  typescript-eslint@8.49.0:
-    resolution: {integrity: sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==}
+  typescript-eslint@8.59.4:
+    resolution: {integrity: sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
@@ -12031,11 +12101,11 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-eslint-parser@10.2.0:
-    resolution: {integrity: sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==}
+  vue-eslint-parser@10.4.0:
+    resolution: {integrity: sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
   vue-router@4.6.4:
     resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
@@ -13329,6 +13399,11 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.1(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
@@ -13387,6 +13462,10 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@eslint/js@10.0.1(eslint@9.39.1(jiti@2.6.1))':
+    optionalDependencies:
+      eslint: 9.39.1(jiti@2.6.1)
 
   '@eslint/js@9.39.1': {}
 
@@ -13709,8 +13788,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.7.1
-      '@emnapi/runtime': 1.7.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -15454,10 +15533,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@stylistic/eslint-plugin@5.6.1(eslint@9.39.1(jiti@2.6.1))':
+  '@stylistic/eslint-plugin@5.10.0(eslint@9.39.1(jiti@2.6.1))':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
-      '@typescript-eslint/types': 8.49.0
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1))
+      '@typescript-eslint/types': 8.59.4
       eslint: 9.39.1(jiti@2.6.1)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -15760,18 +15839,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/eslint-config@0.3.3(@typescript-eslint/utils@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@tanstack/eslint-config@0.4.0(@typescript-eslint/utils@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint/js': 9.39.1
-      '@stylistic/eslint-plugin': 5.6.1(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-n: 17.23.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      globals: 16.5.0
-      typescript-eslint: 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      vue-eslint-parser: 10.2.0(eslint@9.39.1(jiti@2.6.1))
+      '@eslint/js': 10.0.1(eslint@9.39.1(jiti@2.6.1))
+      '@stylistic/eslint-plugin': 5.10.0(eslint@9.39.1(jiti@2.6.1))
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-n: 17.24.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      globals: 17.6.0
+      typescript-eslint: 8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      vue-eslint-parser: 10.4.0(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
-      - eslint
       - eslint-import-resolver-node
       - supports-color
       - typescript
@@ -17111,28 +17190,28 @@ snapshots:
       '@types/node': 24.10.3
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.49.0
-      '@typescript-eslint/type-utils': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.49.0
+      '@typescript-eslint/parser': 8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/type-utils': 8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
       eslint: 9.39.1(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.3)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.49.0
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.49.0
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
       debug: 4.4.3
       eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.9.3
@@ -17148,28 +17227,48 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.59.4(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.4
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.49.0':
     dependencies:
       '@typescript-eslint/types': 8.49.0
       '@typescript-eslint/visitor-keys': 8.49.0
 
+  '@typescript-eslint/scope-manager@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+
   '@typescript-eslint/tsconfig-utils@8.49.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.1(jiti@2.6.1)
-      ts-api-utils: 2.1.0(typescript@5.9.3)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.49.0': {}
+
+  '@typescript-eslint/types@8.59.4': {}
 
   '@typescript-eslint/typescript-estree@8.49.0(typescript@5.9.3)':
     dependencies:
@@ -17186,13 +17285,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.49.0
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
-      eslint: 9.39.1(jiti@2.6.1)
+      '@typescript-eslint/project-service': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -17208,10 +17311,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      eslint: 9.39.1(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.49.0':
     dependencies:
       '@typescript-eslint/types': 8.49.0
       eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -17423,13 +17542,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.0.14(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.14(vite@7.3.3(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.14
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.3(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.0.15(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -17871,6 +17990,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.8.2: {}
 
   bare-fs@4.5.5:
@@ -17981,6 +18102,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -18843,12 +18968,12 @@ snapshots:
 
   eslint-plugin-es-x@7.8.0(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       eslint: 9.39.1(jiti@2.6.1)
       eslint-compat-utils: 0.5.1(eslint@9.39.1(jiti@2.6.1))
 
-  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@typescript-eslint/types': 8.49.0
       comment-parser: 1.4.1
@@ -18861,13 +18986,13 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-n@17.23.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
+  eslint-plugin-n@17.24.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1))
       enhanced-resolve: 5.18.4
       eslint: 9.39.1(jiti@2.6.1)
       eslint-plugin-es-x: 7.8.0(eslint@9.39.1(jiti@2.6.1))
@@ -18893,11 +19018,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unused-imports@4.3.0(@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-unused-imports@4.3.0(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -18907,6 +19032,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.39.1(jiti@2.6.1):
     dependencies:
@@ -19385,7 +19512,7 @@ snapshots:
 
   globals@15.15.0: {}
 
-  globals@16.5.0: {}
+  globals@17.6.0: {}
 
   globby@11.1.0:
     dependencies:
@@ -20794,6 +20921,10 @@ snapshots:
   minimatch@10.1.1:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
 
   minimatch@3.0.8:
     dependencies:
@@ -22955,6 +23086,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-debounce@4.0.0: {}
 
   ts-declaration-location@1.0.7(typescript@5.9.3):
@@ -23090,12 +23225,12 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.8.2
 
-  typescript-eslint@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -23620,7 +23755,7 @@ snapshots:
   vitest@4.0.14(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(happy-dom@20.0.11)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.9))(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.14
-      '@vitest/mocker': 4.0.14(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.14(vite@7.3.3(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.14
       '@vitest/runner': 4.0.14
       '@vitest/snapshot': 4.0.14
@@ -23637,7 +23772,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.3(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -23731,14 +23866,14 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-eslint-parser@10.2.0(eslint@9.39.1(jiti@2.6.1)):
+  vue-eslint-parser@10.4.0(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 4.4.3
       eslint: 9.39.1(jiti@2.6.1)
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
-      esquery: 1.6.0
+      esquery: 1.7.0
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

- Bumps `@tanstack/eslint-config` from `0.3.3` to `0.4.0`.
- Removes the local override layer that has either gone dead upstream or no longer corresponds to real violations.
- Cleans up ~25 unnecessary type assertions that the upgraded `typescript-eslint` (via `no-unnecessary-type-assertion`) now catches.

## Changes to `eslint.config.js`

Before:
```js
rules: {
  'no-case-declarations': 'off',
  'no-shadow': 'off',
  'unused-imports/no-unused-imports': 'warn',
  'pnpm/enforce-catalog': 'off',
  'pnpm/json-enforce-catalog': 'off',
},
```

After:
```js
rules: {
  'unused-imports/no-unused-imports': 'warn',
},
```

- **`pnpm/*`** — dead. `eslint-plugin-pnpm` was removed upstream in `0.3.1`.
- **`no-case-declarations`** — no current source actually violates the upstream `error` setting.
- **`no-shadow`** — upstream is `warn`, not `error`. One legitimate shadow surfaces as a warning in `activities/chat/index.ts`; left as-is (warn-only, doesn't block CI).

The additive typed-linting and `no-double-as` blocks from #564 are untouched.

## Source-file fixes

The upgrade surfaced 26 `no-unnecessary-type-assertion` errors across 10 publishable packages. All but one were resolved by `eslint --fix` (purely removing redundant `as X`). The remaining one — `utilities/ag-ui-wire.ts` — was a *deliberately* defensive cast handling `ModelMessage`-shaped runtime input that doesn't match the declared `UIMessage.parts` type; preserved with a targeted `eslint-disable-next-line` plus a reason comment.

No public-API or runtime-behavior changes.

## Test plan

- [x] `pnpm nx run-many --target=test:eslint --exclude=examples/**,testing/**` — 45/45 pass
- [x] `pnpm nx run-many --target=test:types --exclude=examples/**,testing/**` — 49/49 pass
- [x] `pnpm nx run-many --target=build --exclude=examples/**,testing/**` — 31/31 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration to version 0.4.0.
  * Removed unnecessary TypeScript type assertions across the codebase for improved type safety and code quality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->