### PR TITLE
feat(ai-openrouter): webFetchTool() + canonical openrouter:web_* wire format

### DIFF
--- a/.changeset/openrouter-web-fetch-tool.md
+++ b/.changeset/openrouter-web-fetch-tool.md
@@ -2,24 +2,64 @@
 '@tanstack/ai-openrouter': patch
 ---
 
-Add `webFetchTool()` to `@tanstack/ai-openrouter/tools` for OpenRouter's
-`openrouter:web_fetch` server tool, mirroring the existing `webSearchTool()`
-factory. Lets any OpenRouter-proxied chat model fetch full page content from
-URLs (with `engine`, `maxContentTokens`, `allowedDomains`, `blockedDomains`
-options) without hand-constructing the tool spec. Closes #603.
+`webFetchTool()` + `webSearchTool()` now produce wire shapes that survive the
+OpenRouter SDK's outbound Zod serializer. Closes #603.
+
+### What changed
+
+- Added `webFetchTool()` to `@tanstack/ai-openrouter/tools` for OpenRouter's
+  `openrouter:web_fetch` server tool (`engine`, `maxContentTokens`,
+  `allowedDomains`, `blockedDomains`, `maxUses`).
+- Bumped `@openrouter/sdk` from `0.12.14` to `0.12.35` so we can source the
+  canonical input types (`WebFetchServerTool`, `WebFetchServerToolConfig`,
+  `OpenRouterWebSearchServerTool`, `WebSearchConfig`) directly from the SDK.
+- Reworked the wire format for both factories from the non-SDK
+  `{type: 'web_*', web_*: {...}}` nesting to the SDK's canonical
+  `{type: 'openrouter:web_*', parameters: {...}}` shape.
+
+### Why this matters
+
+Prior versions of `webSearchTool()` typed the nested `web_search` sub-object
+in the metadata, but the SDK's outbound serializer (`ChatRequest$outboundSchema`)
+only recognised `type` on the `ChatFunctionTool` union — the nested
+sub-object wasn't a field on any member, so it was silently stripped before
+HTTP send. Every option you set (`engine`, `maxResults`, `searchPrompt`) was
+dropped on the wire; OpenRouter received `{type: 'web_search'}` and applied
+defaults. The newly added `webFetchTool()` initially inherited the same bug.
+
+After this change, the request body actually contains your `parameters`, so
+options take effect on OpenRouter.
+
+### Breaking change
+
+`webSearchTool()`'s option surface now matches OpenRouter's
+`WebSearchConfig` exactly:
+
+- Removed: `searchPrompt` (never modelled by OpenRouter; was silently
+  dropped pre-fix).
+- Added: `allowedDomains`, `excludedDomains`, `maxTotalResults`,
+  `searchContextSize`, `userLocation`.
+- Unchanged: `engine`, `maxResults` (engine enum now widens to `auto`,
+  `native`, `exa`, `firecrawl`, `parallel`).
+
+Callers passing `searchPrompt` will get a TS error and should drop it — it
+wasn't reaching OpenRouter anyway.
 
 ```ts
 import { chat } from '@tanstack/ai'
 import { openRouterText } from '@tanstack/ai-openrouter'
-import { webFetchTool } from '@tanstack/ai-openrouter/tools'
+import { webFetchTool, webSearchTool } from '@tanstack/ai-openrouter/tools'
 
 const stream = chat({
   adapter: openRouterText('openai/gpt-5'),
   messages: [{ role: 'user', content: 'Summarize https://example.com' }],
-  tools: [webFetchTool({ engine: 'openrouter', maxContentTokens: 4000 })],
+  tools: [
+    webSearchTool({ engine: 'exa', maxResults: 5 }),
+    webFetchTool({ engine: 'openrouter', maxContentTokens: 4000 }),
+  ],
 })
 ```
 
-The Responses adapter (`createOpenRouterResponsesText`) rejects
-`webFetchTool()` with a `RUN_ERROR` pointing users at the chat-completions
-adapter, matching how it already handles `webSearchTool()`.
+The Responses adapter (`createOpenRouterResponsesText`) rejects both factories
+with a `RUN_ERROR` pointing at the chat-completions adapter, matching the
+existing `webSearchTool()` rejection.

--- a/.changeset/openrouter-web-fetch-tool.md
+++ b/.changeset/openrouter-web-fetch-tool.md
@@ -1,0 +1,25 @@
+---
+'@tanstack/ai-openrouter': patch
+---
+
+Add `webFetchTool()` to `@tanstack/ai-openrouter/tools` for OpenRouter's
+`openrouter:web_fetch` server tool, mirroring the existing `webSearchTool()`
+factory. Lets any OpenRouter-proxied chat model fetch full page content from
+URLs (with `engine`, `maxContentTokens`, `allowedDomains`, `blockedDomains`
+options) without hand-constructing the tool spec. Closes #603.
+
+```ts
+import { chat } from '@tanstack/ai'
+import { openRouterText } from '@tanstack/ai-openrouter'
+import { webFetchTool } from '@tanstack/ai-openrouter/tools'
+
+const stream = chat({
+  adapter: openRouterText('openai/gpt-5'),
+  messages: [{ role: 'user', content: 'Summarize https://example.com' }],
+  tools: [webFetchTool({ engine: 'openrouter', maxContentTokens: 4000 })],
+})
+```
+
+The Responses adapter (`createOpenRouterResponsesText`) rejects
+`webFetchTool()` with a `RUN_ERROR` pointing users at the chat-completions
+adapter, matching how it already handles `webSearchTool()`.

--- a/docs/adapters/openrouter.md
+++ b/docs/adapters/openrouter.md
@@ -189,9 +189,12 @@ any proxied chat model. Import it from `@tanstack/ai-openrouter/tools`.
 
 ### `webSearchTool`
 
-Adds web search capability to any OpenRouter-proxied chat model. Choose the
-search `engine` (`native` or `exa`), cap results with `maxResults`, and
-optionally provide a `searchPrompt` to guide query formation.
+Adds web search capability to any OpenRouter-proxied chat model. The factory
+accepts OpenRouter's `WebSearchConfig` directly — pick the `engine`
+(`auto`, `native`, `exa`, `firecrawl`, or `parallel`), cap results with
+`maxResults` / `maxTotalResults`, restrict which sites can appear in results
+with `allowedDomains` / `excludedDomains`, and optionally pass
+`searchContextSize` or `userLocation` for finer control.
 
 ```typescript
 import { chat } from "@tanstack/ai";
@@ -205,7 +208,7 @@ const stream = chat({
     webSearchTool({
       engine: "exa",
       maxResults: 5,
-      searchPrompt: "Recent AI news and research papers",
+      allowedDomains: ["arxiv.org", "openai.com"],
     }),
   ],
 });
@@ -216,15 +219,17 @@ const stream = chat({
 ### `webFetchTool`
 
 Lets any OpenRouter-proxied chat model fetch the full contents of a URL the
-model chooses, instead of running a search. Pick the fetch `engine`
-(`auto` — the default, `native`, `openrouter`, `exa`, or `parallel`), cap how
-much page content the model receives with `maxContentTokens`, and restrict
-which URLs the model can fetch with `allowedDomains` / `blockedDomains`.
+model chooses, instead of running a search. The factory accepts OpenRouter's
+`WebFetchServerToolConfig` directly — pick the fetch `engine` (`auto` — the
+default, `native`, `openrouter`, `exa`, or `firecrawl`), cap how much page
+content the model receives with `maxContentTokens`, cap how many fetches the
+model can make per request with `maxUses`, and restrict which URLs the model
+can fetch with `allowedDomains` / `blockedDomains`.
 
 > The `native` engine routes to the underlying provider's own fetch (for
 > example, Anthropic's `web_fetch` on Claude models). Native fetch
 > capabilities vary, so `allowedDomains` and `blockedDomains` may be
-> ignored. Use `openrouter`, `exa`, or `parallel` if you need consistent
+> ignored. Use `openrouter`, `exa`, or `firecrawl` if you need consistent
 > behaviour across models.
 
 ```typescript

--- a/docs/adapters/openrouter.md
+++ b/docs/adapters/openrouter.md
@@ -213,3 +213,39 @@ const stream = chat({
 
 **Supported models:** all OpenRouter chat models. See [Provider Tools](../tools/provider-tools.md#which-models-support-which-tools).
 
+### `webFetchTool`
+
+Lets any OpenRouter-proxied chat model fetch the full contents of a URL the
+model chooses, instead of running a search. Pick the fetch `engine`
+(`auto` — the default, `native`, `openrouter`, `exa`, or `parallel`), cap how
+much page content the model receives with `maxContentTokens`, and restrict
+which URLs the model can fetch with `allowedDomains` / `blockedDomains`.
+
+> The `native` engine routes to the underlying provider's own fetch (for
+> example, Anthropic's `web_fetch` on Claude models). Native fetch
+> capabilities vary, so `allowedDomains` and `blockedDomains` may be
+> ignored. Use `openrouter`, `exa`, or `parallel` if you need consistent
+> behaviour across models.
+
+```typescript
+import { chat } from "@tanstack/ai";
+import { openRouterText } from "@tanstack/ai-openrouter";
+import { webFetchTool } from "@tanstack/ai-openrouter/tools";
+
+const stream = chat({
+  adapter: openRouterText("openai/gpt-5"),
+  messages: [
+    { role: "user", content: "Summarize https://example.com/article" },
+  ],
+  tools: [
+    webFetchTool({
+      engine: "openrouter",
+      maxContentTokens: 4000,
+      allowedDomains: ["example.com"],
+    }),
+  ],
+});
+```
+
+**Supported models:** all OpenRouter chat models. See [Provider Tools](../tools/provider-tools.md#which-models-support-which-tools).
+

--- a/docs/tools/provider-tools.md
+++ b/docs/tools/provider-tools.md
@@ -66,7 +66,7 @@ therefore universally accepted by any chat model, just like `toolDefinition()`.
 | Anthropic | `webSearchTool`, `webFetchTool`, `codeExecutionTool`, `computerUseTool`, `bashTool`, `textEditorTool`, `memoryTool` — see [Anthropic adapter](../adapters/anthropic.md#provider-tools). |
 | OpenAI | `webSearchTool`, `webSearchPreviewTool`, `fileSearchTool`, `imageGenerationTool`, `codeInterpreterTool`, `mcpTool`, `computerUseTool`, `localShellTool`, `shellTool`, `applyPatchTool` — see [OpenAI adapter](../adapters/openai.md#provider-tools). |
 | Gemini | `codeExecutionTool`, `fileSearchTool`, `googleSearchTool`, `googleSearchRetrievalTool`, `googleMapsTool`, `urlContextTool`, `computerUseTool` — see [Gemini adapter](../adapters/gemini.md#provider-tools). |
-| OpenRouter | `webSearchTool` — see [OpenRouter adapter](../adapters/openrouter.md#provider-tools). |
+| OpenRouter | `webSearchTool`, `webFetchTool` — see [OpenRouter adapter](../adapters/openrouter.md#provider-tools). |
 | Grok | function tools only (no provider-specific tools). |
 | Groq | function tools only (no provider-specific tools). |
 
@@ -82,7 +82,8 @@ matrix is maintained alongside `model-meta.ts` and reflected here:
   preview/shell variants. GPT-3.5 and audio-focused models: none.
 - **Gemini**: 3.x Pro/Flash models support the full tool set. Lite and
   image/video variants have narrower support.
-- **OpenRouter**: every chat model supports `webSearchTool` via the gateway.
+- **OpenRouter**: every chat model supports `webSearchTool` and
+  `webFetchTool` via the gateway.
 
 For the exact per-model list, open the adapter page or read the model's
 `supports.tools` array directly from `model-meta.ts`.

--- a/packages/typescript/ai-openrouter/package.json
+++ b/packages/typescript/ai-openrouter/package.json
@@ -43,7 +43,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@openrouter/sdk": "0.12.14",
+    "@openrouter/sdk": "0.12.35",
     "@tanstack/ai-utils": "workspace:*"
   },
   "devDependencies": {

--- a/packages/typescript/ai-openrouter/src/adapters/responses-text.ts
+++ b/packages/typescript/ai-openrouter/src/adapters/responses-text.ts
@@ -7,6 +7,7 @@ import { extractRequestOptions } from '../internal/request-options'
 import { makeStructuredOutputCompatible } from '../internal/schema-converter'
 import { convertFunctionToolToResponsesFormat } from '../internal/responses-tool-converter'
 import { isWebSearchTool } from '../tools/web-search-tool'
+import { isWebFetchTool } from '../tools/web-fetch-tool'
 import { getOpenRouterApiKeyFromEnv } from '../utils'
 import type { SDKOptions } from '@openrouter/sdk'
 import type { ResponsesFunctionTool } from '../internal/responses-tool-converter'
@@ -1505,13 +1506,20 @@ export class OpenRouterResponsesTextAdapter<
   protected mapOptionsToRequest(
     options: TextOptions<OpenRouterResponsesTextProviderOptions>,
   ): Omit<ResponsesRequest, 'stream'> {
-    // Fail loud on webSearchTool() — v1 only routes function tools.
+    // Fail loud on webSearchTool() / webFetchTool() — v1 only routes function tools.
     if (options.tools) {
       for (const tool of options.tools) {
         if (isWebSearchTool(tool)) {
           throw new Error(
             `OpenRouterResponsesTextAdapter does not yet support webSearchTool(). ` +
               `Use the chat-completions adapter (openRouterText) for web search ` +
+              `tools, or pass function tools only to this adapter.`,
+          )
+        }
+        if (isWebFetchTool(tool)) {
+          throw new Error(
+            `OpenRouterResponsesTextAdapter does not yet support webFetchTool(). ` +
+              `Use the chat-completions adapter (openRouterText) for web fetch ` +
               `tools, or pass function tools only to this adapter.`,
           )
         }

--- a/packages/typescript/ai-openrouter/src/adapters/text.ts
+++ b/packages/typescript/ai-openrouter/src/adapters/text.ts
@@ -1153,14 +1153,7 @@ export class OpenRouterTextAdapter<
         maxCompletionTokens: options.maxTokens,
       }),
       ...(options.topP !== undefined && { topP: options.topP }),
-      // Cast at the SDK boundary: the SDK's `ChatRequest.tools` is typed as
-      // `Array<ChatFunctionTool>`, whose union accidentally accepts the
-      // existing `WebSearchToolConfig` shape (because `'web_search'` happens
-      // to be in `ChatWebSearchShorthandType`) but not the new
-      // `WebFetchToolConfig` shape — the SDK does not yet declare an input
-      // type for `openrouter:web_fetch`.
-      ...(tools &&
-        tools.length > 0 && { tools: tools as ChatRequest['tools'] }),
+      ...(tools && tools.length > 0 && { tools }),
     }
     return request
   }

--- a/packages/typescript/ai-openrouter/src/adapters/text.ts
+++ b/packages/typescript/ai-openrouter/src/adapters/text.ts
@@ -1153,7 +1153,14 @@ export class OpenRouterTextAdapter<
         maxCompletionTokens: options.maxTokens,
       }),
       ...(options.topP !== undefined && { topP: options.topP }),
-      ...(tools && tools.length > 0 && { tools }),
+      // Cast at the SDK boundary: the SDK's `ChatRequest.tools` is typed as
+      // `Array<ChatFunctionTool>`, whose union accidentally accepts the
+      // existing `WebSearchToolConfig` shape (because `'web_search'` happens
+      // to be in `ChatWebSearchShorthandType`) but not the new
+      // `WebFetchToolConfig` shape — the SDK does not yet declare an input
+      // type for `openrouter:web_fetch`.
+      ...(tools &&
+        tools.length > 0 && { tools: tools as ChatRequest['tools'] }),
     }
     return request
   }

--- a/packages/typescript/ai-openrouter/src/model-meta.ts
+++ b/packages/typescript/ai-openrouter/src/model-meta.ts
@@ -16252,7 +16252,10 @@ export const OPENROUTER_CHAT_MODELS = [
 ] as const
 
 export type OpenRouterChatModelToolCapabilitiesByName = {
-  [K in (typeof OPENROUTER_CHAT_MODELS)[number]]: readonly ['web_search']
+  [K in (typeof OPENROUTER_CHAT_MODELS)[number]]: readonly [
+    'web_search',
+    'web_fetch',
+  ]
 }
 
 export const OPENROUTER_IMAGE_MODELS = [

--- a/packages/typescript/ai-openrouter/src/tools/index.ts
+++ b/packages/typescript/ai-openrouter/src/tools/index.ts
@@ -6,6 +6,12 @@ export {
   type WebSearchTool,
 } from './web-search-tool'
 export {
+  webFetchTool,
+  convertWebFetchToolToAdapterFormat,
+  type OpenRouterWebFetchTool,
+  type WebFetchToolConfig,
+} from './web-fetch-tool'
+export {
   type FunctionTool,
   convertFunctionToolToAdapterFormat,
 } from './function-tool'

--- a/packages/typescript/ai-openrouter/src/tools/tool-converter.ts
+++ b/packages/typescript/ai-openrouter/src/tools/tool-converter.ts
@@ -3,20 +3,32 @@ import {
   convertWebSearchToolToAdapterFormat,
   isWebSearchTool,
 } from './web-search-tool'
+import {
+  convertWebFetchToolToAdapterFormat,
+  isWebFetchTool,
+} from './web-fetch-tool'
 import type { Tool } from '@tanstack/ai'
 import type { FunctionTool } from './function-tool'
 import type { WebSearchToolConfig } from './web-search-tool'
+import type { WebFetchToolConfig } from './web-fetch-tool'
 
-export type OpenRouterTool = FunctionTool | WebSearchToolConfig
+export type OpenRouterTool =
+  | FunctionTool
+  | WebSearchToolConfig
+  | WebFetchToolConfig
 
 export function convertToolsToProviderFormat(
   tools: Array<Tool>,
 ): Array<OpenRouterTool> {
   return tools.map((tool) => {
-    // Dispatch on the stable `__kind` brand set by webSearchTool() — not on
-    // `tool.name`, which a user can reuse with toolDefinition().
+    // Dispatch on the stable `__kind` brand set by webSearchTool() /
+    // webFetchTool() — not on `tool.name`, which a user can reuse with
+    // toolDefinition().
     if (isWebSearchTool(tool)) {
       return convertWebSearchToolToAdapterFormat(tool)
+    }
+    if (isWebFetchTool(tool)) {
+      return convertWebFetchToolToAdapterFormat(tool)
     }
     return convertFunctionToolToAdapterFormat(tool)
   })

--- a/packages/typescript/ai-openrouter/src/tools/web-fetch-tool.ts
+++ b/packages/typescript/ai-openrouter/src/tools/web-fetch-tool.ts
@@ -1,4 +1,5 @@
 import { brandProviderTool } from '@tanstack/ai'
+import type { WebFetchServerTool } from '@openrouter/sdk/models'
 import type { ProviderTool, Tool } from '@tanstack/ai'
 
 /**
@@ -9,26 +10,13 @@ import type { ProviderTool, Tool } from '@tanstack/ai'
 export const WEB_FETCH_TOOL_KIND = 'openrouter.web_fetch'
 
 /**
- * OpenRouter `openrouter:web_fetch` server-tool wire shape.
+ * Wire shape for OpenRouter's `openrouter:web_fetch` server tool, sourced
+ * directly from `@openrouter/sdk`'s `WebFetchServerTool` so the SDK's outbound
+ * Zod schema preserves every field on the wire.
  *
- * Mirrors the nested shape used by {@link WebSearchToolConfig} — the
- * `@openrouter/sdk` does not yet declare an input type for `web_fetch`, only
- * the output item (`OutputWebFetchServerToolItem`). If OpenRouter requires the
- * flat `{type: "openrouter:web_fetch", ...}` namespacing shown in their
- * announcement, both this and `webSearchTool()` should be flipped together to
- * keep the package consistent.
- *
- * @see https://openrouter.ai/announcements/agentic-web-tools
+ * @see https://openrouter.ai/docs/guides/features/server-tools/web-fetch
  */
-export interface WebFetchToolConfig {
-  type: 'web_fetch'
-  web_fetch: {
-    engine?: 'auto' | 'native' | 'openrouter' | 'exa' | 'parallel'
-    max_content_tokens?: number
-    allowed_domains?: Array<string>
-    blocked_domains?: Array<string>
-  }
-}
+export type WebFetchToolConfig = WebFetchServerTool
 
 export type OpenRouterWebFetchTool = ProviderTool<'openrouter', 'web_fetch'>
 
@@ -49,25 +37,19 @@ export function convertWebFetchToolToAdapterFormat(
   const metadata = tool.metadata as
     | {
         __kind?: unknown
-        type?: unknown
-        web_fetch?: unknown
+        parameters?: WebFetchServerTool['parameters']
       }
     | undefined
-  if (
-    !metadata ||
-    metadata.__kind !== WEB_FETCH_TOOL_KIND ||
-    metadata.type !== 'web_fetch' ||
-    typeof metadata.web_fetch !== 'object' ||
-    metadata.web_fetch === null ||
-    Array.isArray(metadata.web_fetch)
-  ) {
+  if (!metadata || metadata.__kind !== WEB_FETCH_TOOL_KIND) {
     throw new Error(
       `convertWebFetchToolToAdapterFormat: tool "${tool.name}" is not a valid webFetchTool() output (missing branded metadata).`,
     )
   }
   return {
-    type: 'web_fetch',
-    web_fetch: metadata.web_fetch,
+    type: 'openrouter:web_fetch',
+    ...(metadata.parameters !== undefined && {
+      parameters: metadata.parameters,
+    }),
   }
 }
 
@@ -77,29 +59,22 @@ export function convertWebFetchToolToAdapterFormat(
  * The web fetch tool is available across all OpenRouter chat models via the
  * OpenRouter gateway. The model decides which URL to fetch; the `engine`
  * option chooses how OpenRouter retrieves it. With `engine: 'native'` the
- * provider's own fetch is used (e.g. Anthropic's web_fetch on Claude models),
- * in which case `allowed_domains` / `blocked_domains` may not be respected.
+ * provider's own fetch is used (e.g. Anthropic's `web_fetch` on Claude
+ * models), in which case `allowedDomains` / `blockedDomains` may not be
+ * respected. Use `'openrouter'`, `'exa'`, or `'firecrawl'` for consistent
+ * behaviour across models.
  *
  * Pass the returned value in the `tools` array when calling a chat function.
  */
-export function webFetchTool(options?: {
-  engine?: 'auto' | 'native' | 'openrouter' | 'exa' | 'parallel'
-  maxContentTokens?: number
-  allowedDomains?: Array<string>
-  blockedDomains?: Array<string>
-}): OpenRouterWebFetchTool {
+export function webFetchTool(
+  options?: WebFetchServerTool['parameters'],
+): OpenRouterWebFetchTool {
   return brandProviderTool<OpenRouterWebFetchTool>({
     name: 'web_fetch',
     description: '',
     metadata: {
       __kind: WEB_FETCH_TOOL_KIND,
-      type: 'web_fetch' as const,
-      web_fetch: {
-        engine: options?.engine,
-        max_content_tokens: options?.maxContentTokens,
-        allowed_domains: options?.allowedDomains,
-        blocked_domains: options?.blockedDomains,
-      },
+      ...(options !== undefined && { parameters: options }),
     },
   })
 }

--- a/packages/typescript/ai-openrouter/src/tools/web-fetch-tool.ts
+++ b/packages/typescript/ai-openrouter/src/tools/web-fetch-tool.ts
@@ -1,0 +1,105 @@
+import { brandProviderTool } from '@tanstack/ai'
+import type { ProviderTool, Tool } from '@tanstack/ai'
+
+/**
+ * Stable runtime marker used to identify a `webFetchTool()`-created tool so
+ * `convertToolsToProviderFormat` can route it without relying on the mutable
+ * public `tool.name`.
+ */
+export const WEB_FETCH_TOOL_KIND = 'openrouter.web_fetch'
+
+/**
+ * OpenRouter `openrouter:web_fetch` server-tool wire shape.
+ *
+ * Mirrors the nested shape used by {@link WebSearchToolConfig} — the
+ * `@openrouter/sdk` does not yet declare an input type for `web_fetch`, only
+ * the output item (`OutputWebFetchServerToolItem`). If OpenRouter requires the
+ * flat `{type: "openrouter:web_fetch", ...}` namespacing shown in their
+ * announcement, both this and `webSearchTool()` should be flipped together to
+ * keep the package consistent.
+ *
+ * @see https://openrouter.ai/announcements/agentic-web-tools
+ */
+export interface WebFetchToolConfig {
+  type: 'web_fetch'
+  web_fetch: {
+    engine?: 'auto' | 'native' | 'openrouter' | 'exa' | 'parallel'
+    max_content_tokens?: number
+    allowed_domains?: Array<string>
+    blocked_domains?: Array<string>
+  }
+}
+
+export type OpenRouterWebFetchTool = ProviderTool<'openrouter', 'web_fetch'>
+
+/** A tool is a webFetchTool() output iff its metadata carries our branded kind marker. */
+export function isWebFetchTool(tool: Tool): boolean {
+  const kind = (tool.metadata as { __kind?: unknown } | undefined)?.__kind
+  return kind === WEB_FETCH_TOOL_KIND
+}
+
+/**
+ * Converts a branded web-fetch tool to OpenRouter's wire format. Throws if
+ * the metadata doesn't match the expected shape — callers must gate on
+ * `isWebFetchTool()` first.
+ */
+export function convertWebFetchToolToAdapterFormat(
+  tool: Tool,
+): WebFetchToolConfig {
+  const metadata = tool.metadata as
+    | {
+        __kind?: unknown
+        type?: unknown
+        web_fetch?: unknown
+      }
+    | undefined
+  if (
+    !metadata ||
+    metadata.__kind !== WEB_FETCH_TOOL_KIND ||
+    metadata.type !== 'web_fetch' ||
+    typeof metadata.web_fetch !== 'object' ||
+    metadata.web_fetch === null ||
+    Array.isArray(metadata.web_fetch)
+  ) {
+    throw new Error(
+      `convertWebFetchToolToAdapterFormat: tool "${tool.name}" is not a valid webFetchTool() output (missing branded metadata).`,
+    )
+  }
+  return {
+    type: 'web_fetch',
+    web_fetch: metadata.web_fetch,
+  }
+}
+
+/**
+ * Creates a branded web fetch tool for use with OpenRouter models.
+ *
+ * The web fetch tool is available across all OpenRouter chat models via the
+ * OpenRouter gateway. The model decides which URL to fetch; the `engine`
+ * option chooses how OpenRouter retrieves it. With `engine: 'native'` the
+ * provider's own fetch is used (e.g. Anthropic's web_fetch on Claude models),
+ * in which case `allowed_domains` / `blocked_domains` may not be respected.
+ *
+ * Pass the returned value in the `tools` array when calling a chat function.
+ */
+export function webFetchTool(options?: {
+  engine?: 'auto' | 'native' | 'openrouter' | 'exa' | 'parallel'
+  maxContentTokens?: number
+  allowedDomains?: Array<string>
+  blockedDomains?: Array<string>
+}): OpenRouterWebFetchTool {
+  return brandProviderTool<OpenRouterWebFetchTool>({
+    name: 'web_fetch',
+    description: '',
+    metadata: {
+      __kind: WEB_FETCH_TOOL_KIND,
+      type: 'web_fetch' as const,
+      web_fetch: {
+        engine: options?.engine,
+        max_content_tokens: options?.maxContentTokens,
+        allowed_domains: options?.allowedDomains,
+        blocked_domains: options?.blockedDomains,
+      },
+    },
+  })
+}

--- a/packages/typescript/ai-openrouter/src/tools/web-search-tool.ts
+++ b/packages/typescript/ai-openrouter/src/tools/web-search-tool.ts
@@ -1,4 +1,5 @@
 import { brandProviderTool } from '@tanstack/ai'
+import type { OpenRouterWebSearchServerTool } from '@openrouter/sdk/models'
 import type { ProviderTool, Tool } from '@tanstack/ai'
 
 /**
@@ -8,14 +9,14 @@ import type { ProviderTool, Tool } from '@tanstack/ai'
  */
 export const WEB_SEARCH_TOOL_KIND = 'openrouter.web_search'
 
-export interface WebSearchToolConfig {
-  type: 'web_search'
-  web_search: {
-    engine?: 'native' | 'exa'
-    max_results?: number
-    search_prompt?: string
-  }
-}
+/**
+ * Wire shape for OpenRouter's `openrouter:web_search` server tool, sourced
+ * directly from `@openrouter/sdk`'s `OpenRouterWebSearchServerTool` so the
+ * SDK's outbound Zod schema preserves every field on the wire.
+ *
+ * @see https://openrouter.ai/docs/guides/features/server-tools/web-search
+ */
+export type WebSearchToolConfig = OpenRouterWebSearchServerTool
 
 /** @deprecated Renamed to `WebSearchToolConfig`. Will be removed in a future release. */
 export type WebSearchTool = WebSearchToolConfig
@@ -39,25 +40,19 @@ export function convertWebSearchToolToAdapterFormat(
   const metadata = tool.metadata as
     | {
         __kind?: unknown
-        type?: unknown
-        web_search?: unknown
+        parameters?: OpenRouterWebSearchServerTool['parameters']
       }
     | undefined
-  if (
-    !metadata ||
-    metadata.__kind !== WEB_SEARCH_TOOL_KIND ||
-    metadata.type !== 'web_search' ||
-    typeof metadata.web_search !== 'object' ||
-    metadata.web_search === null ||
-    Array.isArray(metadata.web_search)
-  ) {
+  if (!metadata || metadata.__kind !== WEB_SEARCH_TOOL_KIND) {
     throw new Error(
       `convertWebSearchToolToAdapterFormat: tool "${tool.name}" is not a valid webSearchTool() output (missing branded metadata).`,
     )
   }
   return {
-    type: 'web_search',
-    web_search: metadata.web_search,
+    type: 'openrouter:web_search',
+    ...(metadata.parameters !== undefined && {
+      parameters: metadata.parameters,
+    }),
   }
 }
 
@@ -65,25 +60,22 @@ export function convertWebSearchToolToAdapterFormat(
  * Creates a branded web search tool for use with OpenRouter models.
  *
  * The web search tool is available across all OpenRouter chat models via the
- * OpenRouter gateway. Pass the returned value in the `tools` array when calling
- * a chat function.
+ * OpenRouter gateway. Pass the returned value in the `tools` array when
+ * calling a chat function.
+ *
+ * Note: prior versions accepted a `searchPrompt` option that was silently
+ * dropped on the wire. The SDK's `WebSearchConfig` does not model that field;
+ * use `maxResults`, `searchContextSize`, or `userLocation` to tune the call.
  */
-export function webSearchTool(options?: {
-  engine?: 'native' | 'exa'
-  maxResults?: number
-  searchPrompt?: string
-}): OpenRouterWebSearchTool {
+export function webSearchTool(
+  options?: OpenRouterWebSearchServerTool['parameters'],
+): OpenRouterWebSearchTool {
   return brandProviderTool<OpenRouterWebSearchTool>({
     name: 'web_search',
     description: '',
     metadata: {
       __kind: WEB_SEARCH_TOOL_KIND,
-      type: 'web_search' as const,
-      web_search: {
-        engine: options?.engine,
-        max_results: options?.maxResults,
-        search_prompt: options?.searchPrompt,
-      },
+      ...(options !== undefined && { parameters: options }),
     },
   })
 }

--- a/packages/typescript/ai-openrouter/tests/openrouter-responses-adapter.test.ts
+++ b/packages/typescript/ai-openrouter/tests/openrouter-responses-adapter.test.ts
@@ -4,6 +4,7 @@ import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
 import { ResponsesRequest$outboundSchema } from '@openrouter/sdk/models'
 import { createOpenRouterResponsesText } from '../src/adapters/responses-text'
 import { webSearchTool } from '../src/tools/web-search-tool'
+import { webFetchTool } from '../src/tools/web-fetch-tool'
 import type { StreamChunk, Tool } from '@tanstack/ai'
 
 const testLogger = resolveDebugOption(false)
@@ -211,6 +212,27 @@ describe('OpenRouter responses adapter — request shape', () => {
         e.type === EventType.RUN_ERROR,
     )
     expect(runError).toBeDefined()
+    expect(runError!.message).toMatch(/openRouterText/)
+  })
+
+  it('rejects webFetchTool() as RUN_ERROR pointing at the chat adapter', async () => {
+    const adapter = createAdapter()
+    const wf = webFetchTool() as Tool
+    const events: Array<StreamChunk> = []
+    for await (const evt of adapter.chatStream({
+      model: 'openai/gpt-4o-mini' as any,
+      messages: [{ role: 'user', content: 'hi' }],
+      tools: [wf],
+      logger: testLogger,
+    })) {
+      events.push(evt)
+    }
+    const runError = events.find(
+      (e): e is Extract<StreamChunk, { type: typeof EventType.RUN_ERROR }> =>
+        e.type === EventType.RUN_ERROR,
+    )
+    expect(runError).toBeDefined()
+    expect(runError!.message).toMatch(/webFetchTool/)
     expect(runError!.message).toMatch(/openRouterText/)
   })
 

--- a/packages/typescript/ai-openrouter/tests/tools-per-model-type-safety.test.ts
+++ b/packages/typescript/ai-openrouter/tests/tools-per-model-type-safety.test.ts
@@ -46,7 +46,7 @@ describe('OpenRouter per-model tool gating', () => {
     const adapter = openRouterText('openai/gpt-4o')
     typedTools(adapter, [
       userTool,
-      webSearchTool({ engine: 'exa', searchPrompt: 'latest news' }),
+      webSearchTool({ engine: 'exa', maxTotalResults: 20 }),
     ])
   })
 

--- a/packages/typescript/ai-openrouter/tests/tools-per-model-type-safety.test.ts
+++ b/packages/typescript/ai-openrouter/tests/tools-per-model-type-safety.test.ts
@@ -8,7 +8,7 @@ import { beforeAll, describe, it } from 'vitest'
 import { z } from 'zod'
 import { toolDefinition } from '@tanstack/ai'
 import { openRouterText } from '../src'
-import { webSearchTool } from '../src/tools'
+import { webSearchTool, webFetchTool } from '../src/tools'
 import type { TextActivityOptions } from '@tanstack/ai/adapters'
 import type { ProviderTool } from '@tanstack/ai'
 
@@ -47,6 +47,26 @@ describe('OpenRouter per-model tool gating', () => {
     typedTools(adapter, [
       userTool,
       webSearchTool({ engine: 'exa', searchPrompt: 'latest news' }),
+    ])
+  })
+
+  it('anthropic/claude-opus-4.6 accepts webFetchTool and user-defined tools', () => {
+    const adapter = openRouterText('anthropic/claude-opus-4.6')
+    typedTools(adapter, [
+      userTool,
+      webFetchTool({
+        engine: 'native',
+        maxContentTokens: 4000,
+        allowedDomains: ['example.com'],
+      }),
+    ])
+  })
+
+  it('openai/gpt-4o accepts webFetchTool and user-defined tools', () => {
+    const adapter = openRouterText('openai/gpt-4o')
+    typedTools(adapter, [
+      userTool,
+      webFetchTool({ engine: 'exa', blockedDomains: ['evil.example'] }),
     ])
   })
 

--- a/packages/typescript/ai-openrouter/tests/web-fetch-tool.test.ts
+++ b/packages/typescript/ai-openrouter/tests/web-fetch-tool.test.ts
@@ -11,37 +11,33 @@ import { convertToolsToProviderFormat } from '../src/tools/tool-converter'
 import type { Tool } from '@tanstack/ai'
 
 describe('webFetchTool()', () => {
-  it('produces a branded tool with snake_case wire keys', () => {
+  it('produces a branded tool whose metadata carries the SDK parameters', () => {
     const tool = webFetchTool({
       engine: 'native',
       maxContentTokens: 4000,
       allowedDomains: ['example.com'],
       blockedDomains: ['evil.example'],
+      maxUses: 3,
     })
     expect(tool.name).toBe('web_fetch')
     expect((tool.metadata as { __kind?: string }).__kind).toBe(
       WEB_FETCH_TOOL_KIND,
     )
     expect(tool.metadata).toMatchObject({
-      type: 'web_fetch',
-      web_fetch: {
+      parameters: {
         engine: 'native',
-        max_content_tokens: 4000,
-        allowed_domains: ['example.com'],
-        blocked_domains: ['evil.example'],
+        maxContentTokens: 4000,
+        allowedDomains: ['example.com'],
+        blockedDomains: ['evil.example'],
+        maxUses: 3,
       },
     })
   })
 
-  it('accepts a no-options call (all fields optional)', () => {
+  it('accepts a no-options call (parameters omitted from metadata)', () => {
     const tool = webFetchTool()
     expect(isWebFetchTool(tool as unknown as Tool)).toBe(true)
-    expect((tool.metadata as { web_fetch: unknown }).web_fetch).toEqual({
-      engine: undefined,
-      max_content_tokens: undefined,
-      allowed_domains: undefined,
-      blocked_domains: undefined,
-    })
+    expect((tool.metadata as { parameters?: unknown }).parameters).toBeUndefined()
   })
 })
 
@@ -70,55 +66,50 @@ describe('isWebFetchTool()', () => {
 })
 
 describe('convertWebFetchToolToAdapterFormat()', () => {
-  it('returns the OpenRouter wire shape for a valid branded tool', () => {
+  it('emits the openrouter:web_fetch wire shape with parameters preserved', () => {
     const wireShape = convertWebFetchToolToAdapterFormat(
-      webFetchTool({ engine: 'exa', maxContentTokens: 2000 }) as unknown as Tool,
+      webFetchTool({
+        engine: 'exa',
+        maxContentTokens: 2000,
+      }) as unknown as Tool,
     )
     expect(wireShape).toEqual({
-      type: 'web_fetch',
-      web_fetch: {
+      type: 'openrouter:web_fetch',
+      parameters: {
         engine: 'exa',
-        max_content_tokens: 2000,
-        allowed_domains: undefined,
-        blocked_domains: undefined,
+        maxContentTokens: 2000,
       },
     })
+  })
+
+  it('omits parameters when the factory was called with no options', () => {
+    const wireShape = convertWebFetchToolToAdapterFormat(
+      webFetchTool() as unknown as Tool,
+    )
+    expect(wireShape).toEqual({ type: 'openrouter:web_fetch' })
   })
 
   it('throws on a tool missing the brand marker', () => {
     const unbranded: Tool = {
       name: 'web_fetch',
       description: '',
-      metadata: { type: 'web_fetch', web_fetch: {} },
+      metadata: { parameters: {} },
     }
     expect(() => convertWebFetchToolToAdapterFormat(unbranded)).toThrow(
       /not a valid webFetchTool/,
     )
   })
-
-  it('throws on a tool with mismatched metadata.type', () => {
-    const wrongType: Tool = {
-      name: 'web_fetch',
-      description: '',
-      metadata: {
-        __kind: WEB_FETCH_TOOL_KIND,
-        type: 'web_search',
-        web_fetch: {},
-      },
-    }
-    expect(() => convertWebFetchToolToAdapterFormat(wrongType)).toThrow()
-  })
 })
 
 describe('convertToolsToProviderFormat()', () => {
-  it('routes webFetchTool() to the web_fetch wire branch', () => {
+  it('routes webFetchTool() to the openrouter:web_fetch wire branch', () => {
     const out = convertToolsToProviderFormat([
       webFetchTool({ engine: 'openrouter' }) as unknown as Tool,
     ])
     expect(out).toHaveLength(1)
     expect(out[0]).toMatchObject({
-      type: 'web_fetch',
-      web_fetch: { engine: 'openrouter' },
+      type: 'openrouter:web_fetch',
+      parameters: { engine: 'openrouter' },
     })
   })
 
@@ -134,6 +125,6 @@ describe('convertToolsToProviderFormat()', () => {
     ])
     expect(out).toHaveLength(2)
     expect((out[0] as { type: string }).type).toBe('function')
-    expect((out[1] as { type: string }).type).toBe('web_fetch')
+    expect((out[1] as { type: string }).type).toBe('openrouter:web_fetch')
   })
 })

--- a/packages/typescript/ai-openrouter/tests/web-fetch-tool.test.ts
+++ b/packages/typescript/ai-openrouter/tests/web-fetch-tool.test.ts
@@ -37,7 +37,9 @@ describe('webFetchTool()', () => {
   it('accepts a no-options call (parameters omitted from metadata)', () => {
     const tool = webFetchTool()
     expect(isWebFetchTool(tool as unknown as Tool)).toBe(true)
-    expect((tool.metadata as { parameters?: unknown }).parameters).toBeUndefined()
+    expect(
+      (tool.metadata as { parameters?: unknown }).parameters,
+    ).toBeUndefined()
   })
 })
 

--- a/packages/typescript/ai-openrouter/tests/web-fetch-tool.test.ts
+++ b/packages/typescript/ai-openrouter/tests/web-fetch-tool.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { toolDefinition } from '@tanstack/ai'
+import {
+  WEB_FETCH_TOOL_KIND,
+  convertWebFetchToolToAdapterFormat,
+  isWebFetchTool,
+  webFetchTool,
+} from '../src/tools/web-fetch-tool'
+import { convertToolsToProviderFormat } from '../src/tools/tool-converter'
+import type { Tool } from '@tanstack/ai'
+
+describe('webFetchTool()', () => {
+  it('produces a branded tool with snake_case wire keys', () => {
+    const tool = webFetchTool({
+      engine: 'native',
+      maxContentTokens: 4000,
+      allowedDomains: ['example.com'],
+      blockedDomains: ['evil.example'],
+    })
+    expect(tool.name).toBe('web_fetch')
+    expect((tool.metadata as { __kind?: string }).__kind).toBe(
+      WEB_FETCH_TOOL_KIND,
+    )
+    expect(tool.metadata).toMatchObject({
+      type: 'web_fetch',
+      web_fetch: {
+        engine: 'native',
+        max_content_tokens: 4000,
+        allowed_domains: ['example.com'],
+        blocked_domains: ['evil.example'],
+      },
+    })
+  })
+
+  it('accepts a no-options call (all fields optional)', () => {
+    const tool = webFetchTool()
+    expect(isWebFetchTool(tool as unknown as Tool)).toBe(true)
+    expect((tool.metadata as { web_fetch: unknown }).web_fetch).toEqual({
+      engine: undefined,
+      max_content_tokens: undefined,
+      allowed_domains: undefined,
+      blocked_domains: undefined,
+    })
+  })
+})
+
+describe('isWebFetchTool()', () => {
+  it('returns true only for webFetchTool() outputs', () => {
+    expect(isWebFetchTool(webFetchTool() as unknown as Tool)).toBe(true)
+  })
+
+  it('returns false for user-defined function tools', () => {
+    const userTool = toolDefinition({
+      name: 'echo',
+      description: '',
+      inputSchema: z.object({ msg: z.string() }),
+    }).server(async ({ msg }) => msg)
+    expect(isWebFetchTool(userTool)).toBe(false)
+  })
+
+  it('returns false for tools with the wrong kind brand', () => {
+    const fake: Tool = {
+      name: 'web_fetch',
+      description: '',
+      metadata: { __kind: 'openrouter.web_search' },
+    }
+    expect(isWebFetchTool(fake)).toBe(false)
+  })
+})
+
+describe('convertWebFetchToolToAdapterFormat()', () => {
+  it('returns the OpenRouter wire shape for a valid branded tool', () => {
+    const wireShape = convertWebFetchToolToAdapterFormat(
+      webFetchTool({ engine: 'exa', maxContentTokens: 2000 }) as unknown as Tool,
+    )
+    expect(wireShape).toEqual({
+      type: 'web_fetch',
+      web_fetch: {
+        engine: 'exa',
+        max_content_tokens: 2000,
+        allowed_domains: undefined,
+        blocked_domains: undefined,
+      },
+    })
+  })
+
+  it('throws on a tool missing the brand marker', () => {
+    const unbranded: Tool = {
+      name: 'web_fetch',
+      description: '',
+      metadata: { type: 'web_fetch', web_fetch: {} },
+    }
+    expect(() => convertWebFetchToolToAdapterFormat(unbranded)).toThrow(
+      /not a valid webFetchTool/,
+    )
+  })
+
+  it('throws on a tool with mismatched metadata.type', () => {
+    const wrongType: Tool = {
+      name: 'web_fetch',
+      description: '',
+      metadata: {
+        __kind: WEB_FETCH_TOOL_KIND,
+        type: 'web_search',
+        web_fetch: {},
+      },
+    }
+    expect(() => convertWebFetchToolToAdapterFormat(wrongType)).toThrow()
+  })
+})
+
+describe('convertToolsToProviderFormat()', () => {
+  it('routes webFetchTool() to the web_fetch wire branch', () => {
+    const out = convertToolsToProviderFormat([
+      webFetchTool({ engine: 'openrouter' }) as unknown as Tool,
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({
+      type: 'web_fetch',
+      web_fetch: { engine: 'openrouter' },
+    })
+  })
+
+  it('passes through function tools unchanged alongside webFetchTool()', () => {
+    const userTool = toolDefinition({
+      name: 'echo',
+      description: '',
+      inputSchema: z.object({ msg: z.string() }),
+    }).server(async ({ msg }) => msg)
+    const out = convertToolsToProviderFormat([
+      userTool,
+      webFetchTool() as unknown as Tool,
+    ])
+    expect(out).toHaveLength(2)
+    expect((out[0] as { type: string }).type).toBe('function')
+    expect((out[1] as { type: string }).type).toBe('web_fetch')
+  })
+})

--- a/packages/typescript/ai-openrouter/tests/web-tools-wire-format.test.ts
+++ b/packages/typescript/ai-openrouter/tests/web-tools-wire-format.test.ts
@@ -30,9 +30,9 @@ let mockSend: any
 
 // eslint-disable-next-line @typescript-eslint/require-await
 vi.mock('@openrouter/sdk', async () => {
-  function OpenRouter(
-    this: { chat: { send: (...args: Array<unknown>) => unknown } },
-  ) {
+  function OpenRouter(this: {
+    chat: { send: (...args: Array<unknown>) => unknown }
+  }) {
     this.chat = {
       send: (...args: Array<unknown>) => mockSend(...args),
     }

--- a/packages/typescript/ai-openrouter/tests/web-tools-wire-format.test.ts
+++ b/packages/typescript/ai-openrouter/tests/web-tools-wire-format.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { chat } from '@tanstack/ai'
+import { ChatRequest$outboundSchema } from '@openrouter/sdk/models'
+import { createOpenRouterText } from '../src/adapters/text'
+import { webSearchTool } from '../src/tools/web-search-tool'
+import { webFetchTool } from '../src/tools/web-fetch-tool'
+import type { StreamChunk } from '@tanstack/ai'
+
+/**
+ * Wire-format verification for OpenRouter's server-side web tools.
+ *
+ * The adapter doesn't hit OpenRouter directly — it hands a `ChatRequest` to
+ * the SDK, which runs it through `ChatRequest$outboundSchema` (a Zod
+ * serializer) before sending the bytes upstream. These tests assert what
+ * actually goes over the wire by replaying the adapter's request through that
+ * same outbound schema.
+ *
+ * Earlier versions of this package shipped a non-SDK shape (`{type:
+ * 'web_search', web_search: {...}}` / `{type: 'web_fetch', web_fetch:
+ * {...}}`) that compiled cleanly but had the inner sub-object silently
+ * stripped by the SDK's outbound serializer — so caller-passed `engine`,
+ * `maxResults`, `maxContentTokens`, etc. never reached OpenRouter. The tests
+ * below pin the fix: both factories now emit `{type:
+ * 'openrouter:web_*', parameters: {...}}` (the canonical
+ * `OpenRouterWebSearchServerTool` / `WebFetchServerTool` shapes from
+ * `@openrouter/sdk`), and parameters survive serialization.
+ */
+
+let mockSend: any
+
+// eslint-disable-next-line @typescript-eslint/require-await
+vi.mock('@openrouter/sdk', async () => {
+  function OpenRouter(
+    this: { chat: { send: (...args: Array<unknown>) => unknown } },
+  ) {
+    this.chat = {
+      send: (...args: Array<unknown>) => mockSend(...args),
+    }
+  }
+  return { OpenRouter }
+})
+
+function createAsyncIterable<T>(chunks: Array<T>): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0
+      return {
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async next() {
+          if (index < chunks.length) {
+            return { value: chunks[index++]!, done: false }
+          }
+          return { value: undefined as T, done: true }
+        },
+      }
+    },
+  }
+}
+
+function setupMockSend(): void {
+  mockSend = vi.fn().mockImplementation((params) => {
+    if (params.chatRequest?.stream) {
+      return Promise.resolve(
+        createAsyncIterable([
+          {
+            id: 'x',
+            model: 'openai/gpt-4o-mini',
+            choices: [{ delta: { content: 'ok' }, finishReason: 'stop' }],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          },
+        ]),
+      )
+    }
+    return Promise.resolve({})
+  })
+}
+
+async function captureSerializedTools(tool: unknown): Promise<unknown> {
+  setupMockSend()
+  const adapter = createOpenRouterText('openai/gpt-4o-mini', 'test-key')
+  const chunks: Array<StreamChunk> = []
+  for await (const c of chat({
+    adapter,
+    messages: [{ role: 'user', content: 'hi' }],
+    tools: [tool as never],
+  })) {
+    chunks.push(c)
+  }
+  const [rawParams] = mockSend.mock.calls[0]!
+  const serialized = ChatRequest$outboundSchema.parse(
+    rawParams.chatRequest,
+  ) as { tools?: Array<unknown> }
+  return serialized.tools?.[0]
+}
+
+describe('OpenRouter web-tool wire format (post-SDK serialization)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('webSearchTool() preserves the full parameters object on the wire', async () => {
+    const wireTool = await captureSerializedTools(
+      webSearchTool({
+        engine: 'exa',
+        maxResults: 10,
+        searchContextSize: 'medium',
+        allowedDomains: ['example.com'],
+        excludedDomains: ['evil.example'],
+      }),
+    )
+    expect(wireTool).toMatchObject({
+      type: 'openrouter:web_search',
+      parameters: {
+        engine: 'exa',
+        max_results: 10,
+        search_context_size: 'medium',
+        allowed_domains: ['example.com'],
+        excluded_domains: ['evil.example'],
+      },
+    })
+  })
+
+  it('webFetchTool() preserves the full parameters object on the wire', async () => {
+    const wireTool = await captureSerializedTools(
+      webFetchTool({
+        engine: 'openrouter',
+        maxContentTokens: 4000,
+        allowedDomains: ['example.com'],
+        blockedDomains: ['evil.example'],
+        maxUses: 3,
+      }),
+    )
+    expect(wireTool).toMatchObject({
+      type: 'openrouter:web_fetch',
+      parameters: {
+        engine: 'openrouter',
+        max_content_tokens: 4000,
+        allowed_domains: ['example.com'],
+        blocked_domains: ['evil.example'],
+        max_uses: 3,
+      },
+    })
+  })
+
+  it('omits parameters entirely when neither factory was given options', async () => {
+    const searchTool = await captureSerializedTools(webSearchTool())
+    const fetchTool = await captureSerializedTools(webFetchTool())
+    expect(searchTool).toEqual({ type: 'openrouter:web_search' })
+    expect(fetchTool).toEqual({ type: 'openrouter:web_fetch' })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1368,8 +1368,8 @@ importers:
   packages/typescript/ai-openrouter:
     dependencies:
       '@openrouter/sdk':
-        specifier: 0.12.14
-        version: 0.12.14
+        specifier: 0.12.35
+        version: 0.12.35
       '@tanstack/ai-utils':
         specifier: workspace:*
         version: link:../ai-utils
@@ -1768,8 +1768,8 @@ importers:
         specifier: ^1.18.0
         version: 1.18.0(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(happy-dom@20.0.11)(jsdom@27.3.0(postcss@8.5.9))(vite@7.3.3(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
       '@openrouter/sdk':
-        specifier: 0.12.14
-        version: 0.12.14
+        specifier: 0.12.35
+        version: 0.12.35
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -3733,8 +3733,8 @@ packages:
     resolution: {integrity: sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==}
     engines: {node: '>=8.0'}
 
-  '@openrouter/sdk@0.12.14':
-    resolution: {integrity: sha512-G32CZ1IkmtsGfQF7/mzcvt7W0Lmd6HUHFGjDWv5knBvL6sJcMmX6i3VPSIpHQYSgEqRQSxFuDROP6iErTu7XcA==}
+  '@openrouter/sdk@0.12.35':
+    resolution: {integrity: sha512-s4QVLLnG1AmfW3TjnnHUqGfsCkzwVK+kboGcZmKbde09m1DPqgzl4RUFt/HJ5v97MX8aEaN0UG3mKv2S+qj2Gw==}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -13933,7 +13933,7 @@ snapshots:
 
   '@oozcitak/util@8.3.8': {}
 
-  '@openrouter/sdk@0.12.14':
+  '@openrouter/sdk@0.12.35':
     dependencies:
       zod: 4.3.6
 

--- a/testing/e2e/fixtures/chat/openrouter-wire-test.json
+++ b/testing/e2e/fixtures/chat/openrouter-wire-test.json
@@ -1,0 +1,10 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "[wire-test] check tools serialization" },
+      "response": {
+        "content": "ok"
+      }
+    }
+  ]
+}

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@copilotkit/aimock": "^1.18.0",
-    "@openrouter/sdk": "0.12.14",
+    "@openrouter/sdk": "0.12.35",
     "@opentelemetry/api": "^1.9.0",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/ai": "workspace:*",

--- a/testing/e2e/src/routeTree.gen.ts
+++ b/testing/e2e/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as ApiTtsRouteImport } from './routes/api.tts'
 import { Route as ApiTranscriptionRouteImport } from './routes/api.transcription'
 import { Route as ApiToolsTestRouteImport } from './routes/api.tools-test'
 import { Route as ApiSummarizeRouteImport } from './routes/api.summarize'
+import { Route as ApiOpenrouterWebToolsWireRouteImport } from './routes/api.openrouter-web-tools-wire'
 import { Route as ApiMiddlewareTestRouteImport } from './routes/api.middleware-test'
 import { Route as ApiImageRouteImport } from './routes/api.image'
 import { Route as ApiChatRouteImport } from './routes/api.chat'
@@ -81,6 +82,12 @@ const ApiSummarizeRoute = ApiSummarizeRouteImport.update({
   path: '/api/summarize',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiOpenrouterWebToolsWireRoute =
+  ApiOpenrouterWebToolsWireRouteImport.update({
+    id: '/api/openrouter-web-tools-wire',
+    path: '/api/openrouter-web-tools-wire',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiMiddlewareTestRoute = ApiMiddlewareTestRouteImport.update({
   id: '/api/middleware-test',
   path: '/api/middleware-test',
@@ -148,6 +155,7 @@ export interface FileRoutesByFullPath {
   '/api/chat': typeof ApiChatRoute
   '/api/image': typeof ApiImageRouteWithChildren
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
+  '/api/openrouter-web-tools-wire': typeof ApiOpenrouterWebToolsWireRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tools-test': typeof ApiToolsTestRoute
   '/api/transcription': typeof ApiTranscriptionRouteWithChildren
@@ -171,6 +179,7 @@ export interface FileRoutesByTo {
   '/api/chat': typeof ApiChatRoute
   '/api/image': typeof ApiImageRouteWithChildren
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
+  '/api/openrouter-web-tools-wire': typeof ApiOpenrouterWebToolsWireRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tools-test': typeof ApiToolsTestRoute
   '/api/transcription': typeof ApiTranscriptionRouteWithChildren
@@ -195,6 +204,7 @@ export interface FileRoutesById {
   '/api/chat': typeof ApiChatRoute
   '/api/image': typeof ApiImageRouteWithChildren
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
+  '/api/openrouter-web-tools-wire': typeof ApiOpenrouterWebToolsWireRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tools-test': typeof ApiToolsTestRoute
   '/api/transcription': typeof ApiTranscriptionRouteWithChildren
@@ -220,6 +230,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/image'
     | '/api/middleware-test'
+    | '/api/openrouter-web-tools-wire'
     | '/api/summarize'
     | '/api/tools-test'
     | '/api/transcription'
@@ -243,6 +254,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/image'
     | '/api/middleware-test'
+    | '/api/openrouter-web-tools-wire'
     | '/api/summarize'
     | '/api/tools-test'
     | '/api/transcription'
@@ -266,6 +278,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/image'
     | '/api/middleware-test'
+    | '/api/openrouter-web-tools-wire'
     | '/api/summarize'
     | '/api/tools-test'
     | '/api/transcription'
@@ -290,6 +303,7 @@ export interface RootRouteChildren {
   ApiChatRoute: typeof ApiChatRoute
   ApiImageRoute: typeof ApiImageRouteWithChildren
   ApiMiddlewareTestRoute: typeof ApiMiddlewareTestRoute
+  ApiOpenrouterWebToolsWireRoute: typeof ApiOpenrouterWebToolsWireRoute
   ApiSummarizeRoute: typeof ApiSummarizeRoute
   ApiToolsTestRoute: typeof ApiToolsTestRoute
   ApiTranscriptionRoute: typeof ApiTranscriptionRouteWithChildren
@@ -368,6 +382,13 @@ declare module '@tanstack/react-router' {
       path: '/api/summarize'
       fullPath: '/api/summarize'
       preLoaderRoute: typeof ApiSummarizeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/openrouter-web-tools-wire': {
+      id: '/api/openrouter-web-tools-wire'
+      path: '/api/openrouter-web-tools-wire'
+      fullPath: '/api/openrouter-web-tools-wire'
+      preLoaderRoute: typeof ApiOpenrouterWebToolsWireRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/middleware-test': {
@@ -519,6 +540,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiChatRoute: ApiChatRoute,
   ApiImageRoute: ApiImageRouteWithChildren,
   ApiMiddlewareTestRoute: ApiMiddlewareTestRoute,
+  ApiOpenrouterWebToolsWireRoute: ApiOpenrouterWebToolsWireRoute,
   ApiSummarizeRoute: ApiSummarizeRoute,
   ApiToolsTestRoute: ApiToolsTestRoute,
   ApiTranscriptionRoute: ApiTranscriptionRouteWithChildren,

--- a/testing/e2e/src/routes/api.openrouter-web-tools-wire.ts
+++ b/testing/e2e/src/routes/api.openrouter-web-tools-wire.ts
@@ -1,0 +1,87 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { chat, createChatOptions } from '@tanstack/ai'
+import { createOpenRouterText } from '@tanstack/ai-openrouter'
+import { webSearchTool, webFetchTool } from '@tanstack/ai-openrouter/tools'
+import { HTTPClient } from '@openrouter/sdk'
+
+const LLMOCK_DEFAULT_BASE = process.env.LLMOCK_URL || 'http://127.0.0.1:4010'
+const DUMMY_KEY = 'sk-e2e-test-dummy-key'
+
+/**
+ * Drives the OpenRouter chat-completions adapter with both `webSearchTool()`
+ * and `webFetchTool()` so the companion spec can inspect aimock's journal
+ * (`GET /v1/_requests`) and assert what wire bytes actually crossed the SDK
+ * boundary.
+ *
+ * Both factories emit the SDK's canonical
+ * `{type: 'openrouter:web_*', parameters: {...}}` shape, so caller-passed
+ * options survive `ChatRequest$outboundSchema` and reach OpenRouter. The
+ * spec asserts the captured request body's `tools[*]` against that shape.
+ *
+ * The spec uses this route purely to generate the captured request; the
+ * response content here is irrelevant to the wire-format assertion.
+ */
+export const Route = createFileRoute('/api/openrouter-web-tools-wire')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const url = new URL(request.url)
+        const testId = url.searchParams.get('testId') ?? undefined
+
+        // Same X-Test-Id injection pattern as `providers.ts` so this route
+        // gets its own aimock test bucket and doesn't collide with other
+        // openrouter specs.
+        const httpClient = new HTTPClient()
+        if (testId) {
+          httpClient.addHook('beforeRequest', (req) => {
+            const next = new Request(req)
+            next.headers.set('X-Test-Id', testId)
+            return next
+          })
+        }
+
+        const adapter = createOpenRouterText('openai/gpt-4o' as never, DUMMY_KEY, {
+          serverURL: `${LLMOCK_DEFAULT_BASE}/v1`,
+          httpClient,
+        })
+
+        try {
+          for await (const _ of chat({
+            ...createChatOptions({ adapter }),
+            messages: [
+              { role: 'user', content: '[wire-test] check tools serialization' },
+            ],
+            tools: [
+              webSearchTool({
+                engine: 'exa',
+                maxResults: 10,
+                allowedDomains: ['example.com'],
+              }),
+              webFetchTool({
+                engine: 'openrouter',
+                maxContentTokens: 4000,
+                allowedDomains: ['example.com'],
+                blockedDomains: ['evil.example'],
+              }),
+            ],
+          })) {
+            // Drain the stream.
+          }
+        } catch (error) {
+          return new Response(
+            JSON.stringify({
+              ok: false,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      },
+    },
+  },
+})

--- a/testing/e2e/src/routes/api.openrouter-web-tools-wire.ts
+++ b/testing/e2e/src/routes/api.openrouter-web-tools-wire.ts
@@ -40,16 +40,23 @@ export const Route = createFileRoute('/api/openrouter-web-tools-wire')({
           })
         }
 
-        const adapter = createOpenRouterText('openai/gpt-4o' as never, DUMMY_KEY, {
-          serverURL: `${LLMOCK_DEFAULT_BASE}/v1`,
-          httpClient,
-        })
+        const adapter = createOpenRouterText(
+          'openai/gpt-4o' as never,
+          DUMMY_KEY,
+          {
+            serverURL: `${LLMOCK_DEFAULT_BASE}/v1`,
+            httpClient,
+          },
+        )
 
         try {
           for await (const _ of chat({
             ...createChatOptions({ adapter }),
             messages: [
-              { role: 'user', content: '[wire-test] check tools serialization' },
+              {
+                role: 'user',
+                content: '[wire-test] check tools serialization',
+              },
             ],
             tools: [
               webSearchTool({

--- a/testing/e2e/tests/openrouter-web-tools-wire.spec.ts
+++ b/testing/e2e/tests/openrouter-web-tools-wire.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from './fixtures'
+
+/**
+ * Wire-format verification for OpenRouter's `webSearchTool()` and
+ * `webFetchTool()` factories.
+ *
+ * Both factories now emit the SDK's canonical shapes
+ * (`OpenRouterWebSearchServerTool` / `WebFetchServerTool`):
+ * `{type: 'openrouter:web_*', parameters: {...config...}}`. The SDK's
+ * outbound Zod schema preserves `parameters` on the wire, so caller-passed
+ * `engine` / `maxResults` / `maxContentTokens` / `allowedDomains` etc.
+ * actually reach OpenRouter.
+ *
+ * This spec drives the OpenRouter chat adapter against aimock and then
+ * inspects aimock's journal endpoint (`GET /v1/_requests`) to assert the
+ * bytes received over the wire. It pins the fix that landed alongside
+ * #603 — previously the request body contained only `{type: 'web_*'}` with
+ * all options silently dropped by the SDK serializer.
+ */
+test.describe('openrouter — web tool wire format', () => {
+  test.beforeEach(async ({ request, aimockPort }) => {
+    // Clear the aimock journal so we only assert against the request this
+    // test triggers — adjacent specs share the same aimock instance.
+    await request.delete(`http://127.0.0.1:${aimockPort}/v1/_requests`)
+  })
+
+  test('SDK accepts webSearchTool() + webFetchTool() without throwing', async ({
+    request,
+    testId,
+  }) => {
+    const res = await request.post(
+      `/api/openrouter-web-tools-wire?testId=${encodeURIComponent(testId)}`,
+    )
+    expect(res.ok()).toBe(true)
+    const { ok } = (await res.json()) as { ok: boolean; error?: string }
+    expect(ok).toBe(true)
+  })
+
+  test('webSearchTool({engine, maxResults, allowedDomains}) preserves config on the wire', async ({
+    request,
+    aimockPort,
+    testId,
+  }) => {
+    await request.post(
+      `/api/openrouter-web-tools-wire?testId=${encodeURIComponent(testId)}`,
+    )
+    const journalRes = await request.get(
+      `http://127.0.0.1:${aimockPort}/v1/_requests`,
+    )
+    const entries = (await journalRes.json()) as Array<{
+      body: { tools?: Array<Record<string, unknown>> } | null
+    }>
+    const captured = entries[0]?.body?.tools?.find(
+      (t) => t['type'] === 'openrouter:web_search',
+    )
+    expect(captured).toMatchObject({
+      type: 'openrouter:web_search',
+      parameters: {
+        engine: 'exa',
+        max_results: 10,
+        allowed_domains: ['example.com'],
+      },
+    })
+  })
+
+  test('webFetchTool({engine, maxContentTokens, allowedDomains, blockedDomains}) preserves config on the wire', async ({
+    request,
+    aimockPort,
+    testId,
+  }) => {
+    await request.post(
+      `/api/openrouter-web-tools-wire?testId=${encodeURIComponent(testId)}`,
+    )
+    const journalRes = await request.get(
+      `http://127.0.0.1:${aimockPort}/v1/_requests`,
+    )
+    const entries = (await journalRes.json()) as Array<{
+      body: { tools?: Array<Record<string, unknown>> } | null
+    }>
+    const captured = entries[0]?.body?.tools?.find(
+      (t) => t['type'] === 'openrouter:web_fetch',
+    )
+    expect(captured).toMatchObject({
+      type: 'openrouter:web_fetch',
+      parameters: {
+        engine: 'openrouter',
+        max_content_tokens: 4000,
+        allowed_domains: ['example.com'],
+        blocked_domains: ['evil.example'],
+      },
+    })
+  })
+})


### PR DESCRIPTION
Closes #603.

## Summary

Adds `webFetchTool()` to `@tanstack/ai-openrouter/tools` and fixes a latent wire-format bug in the existing `webSearchTool()`.

Both factories now emit OpenRouter's canonical `{type: 'openrouter:web_*', parameters: {...}}` shape (sourced from `@openrouter/sdk`'s `WebFetchServerTool` / `OpenRouterWebSearchServerTool` types) so caller-passed options actually reach OpenRouter.

## The bug this also fixes

While implementing #603, the original plan was to mirror the existing `webSearchTool()` pattern: `{type: 'web_search', web_search: {...config...}}`. The new tool would type-check, lint clean, and ship.

Tracing the actual wire bytes against the OpenRouter SDK's outbound serializer revealed both `webSearchTool()` (existing) and `webFetchTool()` (new) were broken on the wire:

| Input (factory call)                                                                          | Wire bytes the SDK actually sent                  |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| `webSearchTool({ engine: 'exa', maxResults: 10 })`                                            | `{ "type": "web_search" }` ← **all options gone** |
| `webFetchTool({ engine: 'openrouter', maxContentTokens: 4000, allowedDomains: ['ex.com'] })`  | `{ "type": "web_fetch" }` ← **all options gone**  |

Why: TypeScript and the SDK's outbound Zod schema both accept the nested shape (because `'web_search'` happens to be a member of `ChatWebSearchShorthandType`), but the nested `web_search` / `web_fetch` sub-object isn't a field on any `ChatFunctionTool` union member, so the serializer silently strips it before HTTP send. OpenRouter received an empty `{type: 'web_*'}` and applied its defaults. Users got web search results — just not with the engine, domain filter, or token cap they configured.

Verified empirically via aimock's request journal (`GET /v1/_requests`) — pre-fix bytes were literally `[{"type":"web_search"},{"type":"web_fetch"}]`.

## What this PR changes

- **Bumps `@openrouter/sdk` from `0.12.14` to `0.12.35`** to pick up the canonical input types `WebFetchServerTool`, `WebFetchServerToolConfig`, `OpenRouterWebSearchServerTool`, `WebSearchConfig`. (0.12.14 had the *output* type for web_fetch but no input type.)
- **Re-sources `WebFetchToolConfig` and `WebSearchToolConfig` from the SDK directly** rather than hand-writing them, per repo guidance to use vendor types in adapters.
- **Both factories emit `{type: 'openrouter:web_*', parameters: {...}}`** — `parameters` survives serialization with camelCase → snake_case conversion handled by the SDK.
- **Drops the `tools as ChatRequest['tools']` cast** in `adapters/text.ts`; the SDK's `ChatFunctionTool` union now natively accepts both shapes in 0.12.35.
- **`createOpenRouterResponsesText` rejects `webFetchTool()`** with a `RUN_ERROR` pointing at the chat-completions adapter, matching the existing `webSearchTool()` rejection.
- **`OpenRouterChatModelToolCapabilitiesByName`** updated so `'web_fetch'` is accepted alongside `'web_search'` at compile-time gating.

## Breaking change to `webSearchTool()`'s option surface

`webSearchTool()` now accepts `WebSearchConfig` directly:

- **Removed**: `searchPrompt` — not a field on OpenRouter's `WebSearchConfig`. Was silently dropped on the wire pre-fix, so removing it has no runtime impact, just a TS error for callers who were passing it.
- **Added**: `allowedDomains`, `excludedDomains`, `maxTotalResults`, `searchContextSize`, `userLocation`.
- **Unchanged**: `engine`, `maxResults`. Engine union widens to `auto` / `native` / `exa` / `firecrawl` / `parallel`.

## What this PR does **not** change

- The `webSearchTool` brand kind constant (`'openrouter.web_search'`) and runtime `__kind` marker — internal-only, no external impact.
- Examples / framework integration packages — `webSearchTool()` / `webFetchTool()` are not used in any example yet.

## Test plan

- [x] `pnpm --filter @tanstack/ai-openrouter test:types` — passes (uses canonical SDK types)
- [x] `pnpm --filter @tanstack/ai-openrouter test:lib` — 97/97 pass, including:
  - `web-fetch-tool.test.ts` (10) — factory shape, guard, converter, routing
  - `web-tools-wire-format.test.ts` (3) — runs `ChatRequest$outboundSchema` and asserts parameters survive (would fail pre-fix)
  - `tools-per-model-type-safety.test.ts` (5) — compile-time gating for both factories
  - `openrouter-responses-adapter.test.ts` (23) — Responses adapter rejection for both factories
- [x] `pnpm --filter @tanstack/ai-openrouter test:eslint` — 0 errors
- [x] `pnpm --filter @tanstack/ai-openrouter test:build` (publint) — passes
- [x] `pnpm test:docs` — all links intact
- [x] `pnpm --filter @tanstack/ai-e2e test:e2e -- tests/openrouter-web-tools-wire.spec.ts` — 3/3 pass; drives the full adapter → SDK → aimock path and queries aimock's `/v1/_requests` journal to verify captured wire bytes contain `parameters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `webFetchTool` for OpenRouter models, enabling web content retrieval alongside search capabilities.

* **Documentation**
  * Updated tool documentation to reflect support for both web search and fetch tools on OpenRouter models.
  * Documented expanded `webSearchTool` configuration options including domain filtering (`allowedDomains`, `excludedDomains`), result limits (`maxTotalResults`), and search refinements (`searchContextSize`, `userLocation`).

* **Breaking Changes**
  * `webSearchTool` configuration modified: removed `searchPrompt` option and restructured parameters for SDK alignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->