### PR TITLE
fix(ai): move @standard-schema/spec to dependencies (closes #602)

### DIFF
--- a/.changeset/standard-schema-spec-dependency.md
+++ b/.changeset/standard-schema-spec-dependency.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai': patch
+---
+
+Move `@standard-schema/spec` from `devDependencies` to `dependencies`. Closes #602.
+
+The package's published `.d.ts` files (`types.d.ts`, `activities/chat/tools/tool-definition.d.ts`, `activities/chat/tools/schema-converter.d.ts`) import types from `@standard-schema/spec`, so consumers need it installed for type resolution to succeed. With `skipLibCheck: true`, `tsc` silently ignored the unresolved module, but type-aware tools like `@typescript-eslint` (with `recommendedTypeChecked` / `projectService: true`) failed to resolve return types — surfacing as `Unsafe assignment of an error typed value` on `useChat()` destructuring and cascading errors through downstream usages.

--- a/packages/typescript/ai/package.json
+++ b/packages/typescript/ai/package.json
@@ -66,6 +66,7 @@
   ],
   "dependencies": {
     "@ag-ui/core": "^0.0.52",
+    "@standard-schema/spec": "^1.1.0",
     "@tanstack/ai-event-client": "workspace:*",
     "partial-json": "^0.1.7"
   },
@@ -79,7 +80,6 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@standard-schema/spec": "^1.1.0",
     "@vitest/coverage-v8": "4.0.14",
     "zod": "^4.2.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,6 +953,9 @@ importers:
       '@ag-ui/core':
         specifier: ^0.0.52
         version: 0.0.52
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@tanstack/ai-event-client':
         specifier: workspace:*
         version: link:../ai-event-client
@@ -963,9 +966,6 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
-      '@standard-schema/spec':
-        specifier: ^1.1.0
-        version: 1.1.0
       '@vitest/coverage-v8':
         specifier: 4.0.14
         version: 4.0.14(vitest@4.0.14(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(happy-dom@20.0.11)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.9))(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))


### PR DESCRIPTION
## Summary

- Move `@standard-schema/spec` from `devDependencies` to `dependencies` in `@tanstack/ai`.
- Published `.d.ts` files (`types.d.ts`, `activities/chat/tools/tool-definition.d.ts`, `activities/chat/tools/schema-converter.d.ts`) `import type` from `@standard-schema/spec`, so consumers need it installed for type resolution to succeed.

## Why this matters

With `skipLibCheck: true`, `tsc` silently ignores the unresolved module reference inside `.d.ts` files. But type-aware tools like `@typescript-eslint` (with `recommendedTypeChecked` / `projectService: true`) follow the full type chain. When it hits the missing module, the entire type resolution for `useChat()` fails, producing an "error type" that cascades through all usages:

```
Unsafe assignment of an error typed value
```

The dep is also pulled in transitively by all framework packages (`ai-react`, `ai-solid`, `ai-svelte`, `ai-vue`, `ai-client`) since they re-export types from `@tanstack/ai`.

## Test plan

- [x] `pnpm test:sherif` — workspace dep consistency passes
- [x] `pnpm test:knip` — no unused dep flagged
- [x] `pnpm --filter @tanstack/ai test:types` — type check passes
- [x] `pnpm --filter @tanstack/ai test:lib` — 899 tests pass
- [x] `pnpm --filter @tanstack/ai test:build` — publint passes
- [x] `pnpm test:eslint` — lint passes across affected projects

No behavior change — packaging fix only.

Closes #602.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * `@standard-schema/spec` (v1.1.0+) has been moved from dev dependencies to runtime dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->