### PR TITLE
chore: enforce pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@11.1.1",
   "type": "module",
   "engines": {
-    "pnpm": ">=10.17.0"
+    "pnpm": ">=11.0.0"
   },
   "scripts": {
     "clean": "pnpm --filter \"./packages/**\" run clean",


### PR DESCRIPTION
Adds `engines.pnpm >=11.0.0` to TanStack/ai.

| Scenario | Result |
|---|---|
| `pnpm@11+ install` | Allowed |
| `pnpm@11+ run ...` | Allowed |
| `pnpm@9 install` | Blocked by `engines.pnpm` |
| `pnpm@9 run ...` | Blocked by `engines.pnpm` |
| `pnpm@10 install` with default pnpm version management | Usually hands off to `packageManager` and runs as the declared pnpm version |
| `pnpm@10 run ...` with default pnpm version management | Usually hands off to `packageManager` and runs as the declared pnpm version |
| `pnpm@10 install` with version handoff disabled | Blocked by `engines.pnpm` |
| `pnpm@10 run ...` with version handoff disabled | Blocked by `engines.pnpm` |
| `pnpm@9/10 list` | Not blocked |
| `pnpm@9/10 exec ...` | Not blocked |

| Field | What It Does |
|---|---|
| `packageManager` | Helps tools/newer pnpm select or hand off to the declared pnpm version |
| `engines.pnpm: ">=11.0.0"` | Fails important project workflows when an older pnpm is actually executing them |
| `engines.pnpm` | Does not intercept every pnpm subcommand |