### PR TITLE
feat(ai-openai): add gpt-image-2 to image model meta

### DIFF
--- a/.changeset/openai-gpt-image-2.md
+++ b/.changeset/openai-gpt-image-2.md
@@ -1,0 +1,22 @@
+---
+'@tanstack/ai-openai': minor
+---
+
+Add `gpt-image-2` to the OpenAI image model list. The new model is exposed
+through the same tree-shakeable `openaiImage` adapter as `gpt-image-1` and
+shares its provider options (`quality`, `background`, `output_format`,
+`output_compression`, `moderation`, `partial_images`) and size set
+(`1024x1024`, `1536x1024`, `1024x1536`, `auto`).
+
+```ts
+import { openaiImage } from '@tanstack/ai-openai/adapters'
+import { generate } from '@tanstack/ai'
+
+const adapter = openaiImage({ apiKey: process.env.OPENAI_API_KEY! })
+
+const result = await generate({
+  adapter,
+  model: 'gpt-image-2',
+  prompt: 'A watercolor fox in a snowy forest',
+})
+```

--- a/.changeset/openrouter-web-fetch-tool-capability.md
+++ b/.changeset/openrouter-web-fetch-tool-capability.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-openrouter': patch
+---
+
+Restore `web_fetch` in `OpenRouterChatModelToolCapabilitiesByName` so `webFetchTool()` is assignable to OpenRouter text adapters again. The recent model-metadata sync (#623) regenerated this map with `web_search` only, breaking the per-model type-safety tests added in #611.

--- a/docs/media/image-generation.md
+++ b/docs/media/image-generation.md
@@ -90,6 +90,7 @@ All image adapters support these common options:
 
 | Model | Supported Sizes |
 |-------|----------------|
+| `gpt-image-2` | `1024x1024`, `1536x1024`, `1024x1536`, `auto` |
 | `gpt-image-1` | `1024x1024`, `1536x1024`, `1024x1536`, `auto` |
 | `gpt-image-1-mini` | `1024x1024`, `1536x1024`, `1024x1536`, `auto` |
 | `dall-e-3` | `1024x1024`, `1792x1024`, `1024x1792` |
@@ -138,11 +139,11 @@ const result = await generateImage({
 
 OpenAI models support model-specific Model Options:
 
-#### GPT-Image-1 / GPT-Image-1-Mini
+#### GPT-Image-2 / GPT-Image-1 / GPT-Image-1-Mini
 
 ```typescript
 const result = await generateImage({
-  adapter: openaiImage('gpt-image-1'),
+  adapter: openaiImage('gpt-image-2'),
   prompt: 'A cat wearing a hat',
   modelOptions: {
     quality: 'high', // 'high' | 'medium' | 'low' | 'auto'
@@ -223,6 +224,7 @@ interface GeneratedImage {
 
 | Model | Images per Request |
 |-------|-------------------|
+| `gpt-image-2` | 1-10 |
 | `gpt-image-1` | 1-10 |
 | `gpt-image-1-mini` | 1-10 |
 | `dall-e-3` | 1 |

--- a/packages/typescript/ai-openai/src/adapters/image.ts
+++ b/packages/typescript/ai-openai/src/adapters/image.ts
@@ -31,7 +31,7 @@ export interface OpenAIImageConfig extends OpenAIClientConfig {}
  * OpenAI Image Generation Adapter
  *
  * Tree-shakeable adapter for OpenAI image generation functionality.
- * Supports gpt-image-1, gpt-image-1-mini, dall-e-3, and dall-e-2 models.
+ * Supports gpt-image-2, gpt-image-1, gpt-image-1-mini, dall-e-3, and dall-e-2 models.
  *
  * Features:
  * - Model-specific type-safe provider options

--- a/packages/typescript/ai-openai/src/image/image-provider-options.ts
+++ b/packages/typescript/ai-openai/src/image/image-provider-options.ts
@@ -181,6 +181,7 @@ export type OpenAIImageProviderOptions =
  * Used by the core AI types to narrow providerOptions based on the selected model.
  */
 export type OpenAIImageModelProviderOptionsByName = {
+  'gpt-image-2': GptImage1ProviderOptions
   'gpt-image-1': GptImage1ProviderOptions
   'gpt-image-1-mini': GptImage1MiniProviderOptions
   'dall-e-3': DallE3ProviderOptions
@@ -191,6 +192,7 @@ export type OpenAIImageModelProviderOptionsByName = {
  * Type-only map from model name to its supported sizes.
  */
 export type OpenAIImageModelSizeByName = {
+  'gpt-image-2': GptImageSize
   'gpt-image-1': GptImageSize
   'gpt-image-1-mini': GptImageSize
   'dall-e-3': DallE3Size
@@ -217,6 +219,7 @@ export function validateImageSize(
   if (!size || size === 'auto') return
 
   const validSizes: Record<string, Array<string>> = {
+    'gpt-image-2': ['1024x1024', '1536x1024', '1024x1536', 'auto'],
     'gpt-image-1': ['1024x1024', '1536x1024', '1024x1536', 'auto'],
     'gpt-image-1-mini': ['1024x1024', '1536x1024', '1024x1536', 'auto'],
     'dall-e-3': ['1024x1024', '1792x1024', '1024x1792'],
@@ -263,7 +266,7 @@ export function validateNumberOfImages(
 
 export const validateBackground = (options: ImageValidationOptions) => {
   if (options.background) {
-    const supportedModels = ['gpt-image-1', 'gpt-image-1-mini']
+    const supportedModels = ['gpt-image-2', 'gpt-image-1', 'gpt-image-1-mini']
     if (!supportedModels.includes(options.model)) {
       throw new Error(
         `The model ${options.model} does not support background option.`,
@@ -277,11 +280,13 @@ export const validatePrompt = (options: ImageValidationOptions) => {
     throw new Error('Prompt cannot be empty.')
   }
   if (
-    (options.model === 'gpt-image-1' || options.model === 'gpt-image-1-mini') &&
+    (options.model === 'gpt-image-2' ||
+      options.model === 'gpt-image-1' ||
+      options.model === 'gpt-image-1-mini') &&
     options.prompt.length > 32000
   ) {
     throw new Error(
-      'For gpt-image-1/gpt-image-1-mini, prompt length must be less than or equal to 32000 characters.',
+      'For gpt-image-2/gpt-image-1/gpt-image-1-mini, prompt length must be less than or equal to 32000 characters.',
     )
   }
   if (options.model === 'dall-e-2' && options.prompt.length > 1000) {

--- a/packages/typescript/ai-openai/src/model-meta.ts
+++ b/packages/typescript/ai-openai/src/model-meta.ts
@@ -572,6 +572,28 @@ const GPT_IMAGE_1_MINI = {
   OpenAIBaseOptions & OpenAIStreamingOptions & OpenAIMetadataOptions
 >
 
+const GPT_IMAGE_2 = {
+  name: 'gpt-image-2',
+  knowledge_cutoff: '2026-04-21',
+  pricing: {
+    input: {
+      normal: 5,
+      cached: 1.25,
+    },
+    output: {
+      normal: 30,
+    },
+  },
+  supports: {
+    input: ['text', 'image'],
+    output: ['image'],
+    endpoints: ['image-generation', 'image-edit'],
+    features: [],
+  },
+} as const satisfies ModelMeta<
+  OpenAIBaseOptions & OpenAIStreamingOptions & OpenAIMetadataOptions
+>
+
 const O3_DEEP_RESEARCH = {
   name: 'o3-deep-research',
   context_window: 200_000,
@@ -2217,6 +2239,7 @@ export type OpenAIChatModel = (typeof OPENAI_CHAT_MODELS)[number]
 
 // Image generation models (based on endpoints: "image-generation" or "image-edit")
 export const OPENAI_IMAGE_MODELS = [
+  GPT_IMAGE_2.name,
   GPT_IMAGE_1.name,
   GPT_IMAGE_1_MINI.name,
   DALL_E_3.name,

--- a/packages/typescript/ai-openrouter/src/model-meta.ts
+++ b/packages/typescript/ai-openrouter/src/model-meta.ts
@@ -16379,7 +16379,10 @@ export const OPENROUTER_CHAT_MODELS = [
 ] as const
 
 export type OpenRouterChatModelToolCapabilitiesByName = {
-  [K in (typeof OPENROUTER_CHAT_MODELS)[number]]: readonly ['web_search']
+  [K in (typeof OPENROUTER_CHAT_MODELS)[number]]: readonly [
+    'web_search',
+    'web_fetch',
+  ]
 }
 
 export const OPENROUTER_IMAGE_MODELS = [

--- a/packages/typescript/ai/skills/ai-core/media-generation/SKILL.md
+++ b/packages/typescript/ai/skills/ai-core/media-generation/SKILL.md
@@ -149,7 +149,7 @@ function ImageGenerator() {
 ### 1. Image Generation
 
 Supported adapters: `openaiImage` (dall-e-2, dall-e-3, gpt-image-1,
-gpt-image-1-mini) and `geminiImage` (gemini-3.1-flash-image-preview,
+gpt-image-1-mini, gpt-image-2) and `geminiImage` (gemini-3.1-flash-image-preview,
 imagen-4.0-generate-001, etc.).
 
 ```typescript


### PR DESCRIPTION
## Summary

- Adds `gpt-image-2` to `OPENAI_IMAGE_MODELS` so it can be selected through the `openaiImage` adapter (`generate({ adapter: openaiImage(...), model: 'gpt-image-2', ... })`)
- Reuses the gpt-image-1 provider-options shape (`quality`, `background`, `output_format`, `output_compression`, `moderation`, `partial_images`) and size set (`1024x1024`, `1536x1024`, `1024x1536`, `auto`); the OpenAI docs for gpt-image-2 expose the same `v1/images/generations` + `v1/images/edits` endpoints with the same request parameters
- Extends `validateImageSize`, `validateBackground`, and `validatePrompt` (32 000-char limit) to recognize the new model
- Refreshes `packages/typescript/ai/skills/ai-core/media-generation/SKILL.md` and `docs/media/image-generation.md` to list `gpt-image-2`
- Includes a minor changeset for `@tanstack/ai-openai`

Pricing source: [OpenAI gpt-image-2 model page](https://developers.openai.com/api/docs/models/gpt-image-2). Token-based pricing recorded in `ModelMeta` is text-input \$5 / cached \$1.25 / image-output \$30 per 1M tokens; the schema does not have a separate field for the \$8 image-input-token rate (same limitation as the existing `gpt-image-1` entry).

## Test plan

- [x] `pnpm --filter @tanstack/ai-openai test:types`
- [x] `pnpm --filter @tanstack/ai-openai test:eslint` (no new warnings/errors)
- [ ] E2E coverage uses the existing image-generation spec running on `gpt-image-1`; the adapter call path is unchanged for `gpt-image-2`, so no new fixture was added. Add one if reviewers want gpt-image-2 exercised in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAI's gpt-image-2 model for image generation, available via the existing image adapter with the same options and sizes as current OpenAI image models.

* **Documentation**
  * Updated docs to include gpt-image-2 in model options, sizes, availability, and adapter listings.

* **Bug Fixes**
  * Restored web fetch capability for OpenRouter chat models so web-fetching tools remain available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->