### PR TITLE
docs: refresh README and package metadata

### DIFF
--- a/.changeset/openrouter-web-fetch-tool-types.md
+++ b/.changeset/openrouter-web-fetch-tool-types.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-openrouter': patch
+---
+
+Fix OpenRouter provider tool type metadata to include `webFetchTool`.

--- a/.changeset/refresh-readme-package-metadata.md
+++ b/.changeset/refresh-readme-package-metadata.md
@@ -1,0 +1,35 @@
+---
+'@tanstack/ai': patch
+'@tanstack/ai-anthropic': patch
+'@tanstack/ai-client': patch
+'@tanstack/ai-code-mode': patch
+'@tanstack/ai-code-mode-skills': patch
+'@tanstack/ai-devtools-core': patch
+'@tanstack/ai-elevenlabs': patch
+'@tanstack/ai-event-client': patch
+'@tanstack/ai-fal': patch
+'@tanstack/ai-gemini': patch
+'@tanstack/ai-grok': patch
+'@tanstack/ai-groq': patch
+'@tanstack/ai-isolate-cloudflare': patch
+'@tanstack/ai-isolate-node': patch
+'@tanstack/ai-isolate-quickjs': patch
+'@tanstack/ai-ollama': patch
+'@tanstack/ai-openai': patch
+'@tanstack/ai-openrouter': patch
+'@tanstack/ai-preact': patch
+'@tanstack/ai-react': patch
+'@tanstack/ai-react-ui': patch
+'@tanstack/ai-solid': patch
+'@tanstack/ai-solid-ui': patch
+'@tanstack/ai-svelte': patch
+'@tanstack/ai-utils': patch
+'@tanstack/ai-vue': patch
+'@tanstack/ai-vue-ui': patch
+'@tanstack/openai-base': patch
+'@tanstack/preact-ai-devtools': patch
+'@tanstack/react-ai-devtools': patch
+'@tanstack/solid-ai-devtools': patch
+---
+
+Refresh package README content and npm metadata for better discoverability.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/README.md
+++ b/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "generate:models:fetch": "tsx scripts/fetch-openrouter-models.ts",
     "regenerate:models": "tsx scripts/convert-openrouter-models.ts",
     "sync-docs-config": "node scripts/sync-docs-config.ts",
-    "copy:readme": "cp README.md packages/typescript/ai/README.md && cp README.md packages/typescript/ai-devtools/README.md && cp README.md packages/typescript/preact-ai-devtools/README.md && cp README.md packages/typescript/ai-client/README.md && cp README.md packages/typescript/ai-gemini/README.md && cp README.md packages/typescript/ai-ollama/README.md && cp README.md packages/typescript/ai-openai/README.md && cp README.md packages/typescript/ai-react/README.md && cp README.md packages/typescript/ai-react-ui/README.md && cp README.md packages/typescript/react-ai-devtools/README.md && cp README.md packages/typescript/solid-ai-devtools/README.md",
+    "copy:readme": "node scripts/copy-readme.js",
     "changeset": "changeset",
     "changeset:publish": "changeset publish",
     "changeset:version": "changeset version && pnpm install --no-frozen-lockfile && pnpm format"

--- a/packages/typescript/ai-anthropic/package.json
+++ b/packages/typescript/ai-anthropic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-anthropic",
   "version": "0.10.2",
-  "description": "Anthropic Claude adapter for TanStack AI",
+  "description": "Anthropic Claude adapter for TanStack AI chat, tool calling, thinking, and structured outputs.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -11,10 +11,16 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
     "anthropic",
     "claude",
-    "tanstack",
-    "adapter"
+    "adapter",
+    "chat",
+    "tool-calling",
+    "structured-outputs",
+    "thinking"
   ],
   "type": "module",
   "module": "./dist/esm/index.js",

--- a/packages/typescript/ai-client/README.md
+++ b/packages/typescript/ai-client/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-client/README.md
+++ b/packages/typescript/ai-client/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-client/package.json
+++ b/packages/typescript/ai-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-client",
   "version": "0.11.5",
-  "description": "Framework-agnostic headless client for TanStack AI",
+  "description": "Framework-agnostic headless client for TanStack AI chat, realtime sessions, streaming transports, and media generations.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -11,11 +11,17 @@
   },
   "keywords": [
     "ai",
-    "client",
-    "headless",
+    "ai-sdk",
+    "typescript",
     "tanstack",
+    "headless",
+    "client",
     "chat",
-    "streaming"
+    "streaming",
+    "realtime",
+    "generative-ai",
+    "tool-calling",
+    "structured-outputs"
   ],
   "type": "module",
   "module": "./dist/esm/index.js",

--- a/packages/typescript/ai-code-mode-skills/package.json
+++ b/packages/typescript/ai-code-mode-skills/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-code-mode-skills",
   "version": "0.1.18",
-  "description": "Persistent skill library for TanStack AI Code Mode - LLM-created reusable code snippets",
+  "description": "Persistent runtime skill library for TanStack AI Code Mode agents and sandboxed tool orchestration.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -50,11 +50,16 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
     "tanstack",
     "code-mode",
     "skills",
+    "agents",
     "llm",
-    "sandbox"
+    "sandbox",
+    "tool-calling",
+    "tanstack-intent"
   ],
   "dependencies": {
     "@tanstack/ai": "workspace:*",

--- a/packages/typescript/ai-code-mode/package.json
+++ b/packages/typescript/ai-code-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-code-mode",
   "version": "0.1.18",
-  "description": "Code Mode for TanStack AI - LLM-driven code execution in secure sandboxes",
+  "description": "Secure TypeScript Code Mode for TanStack AI agents to execute sandboxed tool orchestration programs.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -39,11 +39,16 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
     "tanstack",
     "code-mode",
+    "agents",
     "llm",
+    "tool-calling",
     "sandbox",
     "isolate",
+    "code-execution",
     "tanstack-intent"
   ],
   "dependencies": {

--- a/packages/typescript/ai-devtools/README.md
+++ b/packages/typescript/ai-devtools/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-devtools/README.md
+++ b/packages/typescript/ai-devtools/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-devtools/package.json
+++ b/packages/typescript/ai-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-devtools-core",
   "version": "0.3.35",
-  "description": "Core TanStack AI Devtools",
+  "description": "Core TanStack AI Devtools plugin for inspecting chat messages, tool calls, streams, and errors.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -71,11 +71,15 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
     "tanstack",
-    "sdk",
-    "llm",
+    "devtools",
+    "debugging",
+    "observability",
     "chat",
-    "embeddings"
+    "tool-calling",
+    "streaming"
   ],
   "dependencies": {
     "@tanstack/ai": "workspace:*",

--- a/packages/typescript/ai-elevenlabs/package.json
+++ b/packages/typescript/ai-elevenlabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-elevenlabs",
   "version": "0.2.9",
-  "description": "ElevenLabs adapter for TanStack AI realtime voice",
+  "description": "ElevenLabs adapter for TanStack AI realtime voice, text-to-speech, transcription, music, and sound effects.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -11,18 +11,20 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
     "elevenlabs",
+    "adapter",
     "voice",
     "realtime",
-    "tanstack",
-    "adapter",
-    "tts",
     "text-to-speech",
+    "tts",
+    "transcription",
+    "speech-to-text",
     "audio-generation",
     "music",
-    "sound-effects",
-    "transcription",
-    "speech-to-text"
+    "sound-effects"
   ],
   "type": "module",
   "module": "./dist/esm/index.js",

--- a/packages/typescript/ai-event-client/package.json
+++ b/packages/typescript/ai-event-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-event-client",
   "version": "0.3.8",
-  "description": "Event client for TanStack AI devtools integration",
+  "description": "Typed event client for TanStack AI devtools, observability, and streamed runtime events.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -41,5 +41,16 @@
   },
   "devDependencies": {
     "@vitest/coverage-v8": "4.0.14"
-  }
+  },
+  "keywords": [
+    "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
+    "events",
+    "devtools",
+    "observability",
+    "streaming",
+    "chat"
+  ]
 }

--- a/packages/typescript/ai-fal/package.json
+++ b/packages/typescript/ai-fal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-fal",
   "version": "0.7.11",
-  "description": "fal.ai adapter for TanStack AI",
+  "description": "fal.ai adapter for TanStack AI image, video, audio, speech, and transcription generation.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -34,8 +34,11 @@
   },
   "keywords": [
     "ai",
-    "fal",
+    "ai-sdk",
+    "typescript",
     "tanstack",
+    "fal",
+    "fal-ai",
     "adapter",
     "image-generation",
     "video-generation",
@@ -43,7 +46,8 @@
     "text-to-speech",
     "speech-to-text",
     "tts",
-    "transcription"
+    "transcription",
+    "media-generation"
   ],
   "dependencies": {
     "@fal-ai/client": "^1.10.1",

--- a/packages/typescript/ai-gemini/README.md
+++ b/packages/typescript/ai-gemini/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-gemini/README.md
+++ b/packages/typescript/ai-gemini/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-gemini/package.json
+++ b/packages/typescript/ai-gemini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-gemini",
   "version": "0.10.9",
-  "description": "Google Gemini adapter for TanStack AI",
+  "description": "Google Gemini adapter for TanStack AI chat, images, speech, audio generation, and structured outputs.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -38,10 +38,18 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
     "gemini",
     "google",
-    "tanstack",
-    "adapter"
+    "adapter",
+    "chat",
+    "tool-calling",
+    "structured-outputs",
+    "image-generation",
+    "audio-generation",
+    "text-to-speech"
   ],
   "dependencies": {
     "@google/genai": "^1.43.0",

--- a/packages/typescript/ai-grok/package.json
+++ b/packages/typescript/ai-grok/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-grok",
   "version": "0.8.6",
-  "description": "Grok (xAI) adapter for TanStack AI",
+  "description": "xAI Grok adapter for TanStack AI chat, image generation, realtime, and structured outputs.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -38,10 +38,17 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
     "grok",
     "xai",
-    "tanstack",
-    "adapter"
+    "adapter",
+    "chat",
+    "tool-calling",
+    "structured-outputs",
+    "image-generation",
+    "realtime"
   ],
   "dependencies": {
     "@tanstack/ai-utils": "workspace:*",

--- a/packages/typescript/ai-groq/package.json
+++ b/packages/typescript/ai-groq/package.json
@@ -2,7 +2,7 @@
   "name": "@tanstack/ai-groq",
   "version": "0.2.5",
   "type": "module",
-  "description": "Groq adapter for TanStack AI",
+  "description": "Groq adapter for TanStack AI low-latency chat, tool calling, and structured outputs.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -38,9 +38,16 @@
   },
   "keywords": [
     "ai",
-    "groq",
+    "ai-sdk",
+    "typescript",
     "tanstack",
-    "adapter"
+    "groq",
+    "adapter",
+    "llm",
+    "chat",
+    "low-latency",
+    "tool-calling",
+    "structured-outputs"
   ],
   "devDependencies": {
     "@vitest/coverage-v8": "4.0.14",

--- a/packages/typescript/ai-isolate-cloudflare/package.json
+++ b/packages/typescript/ai-isolate-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-isolate-cloudflare",
   "version": "0.2.9",
-  "description": "Cloudflare Workers driver for TanStack AI Code Mode - execute code on the edge",
+  "description": "Cloudflare Workers sandbox driver for TanStack AI Code Mode TypeScript execution at the edge.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -46,12 +46,16 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
     "tanstack",
     "code-mode",
     "cloudflare",
     "workers",
     "edge",
-    "isolate"
+    "isolate",
+    "sandbox",
+    "code-execution"
   ],
   "dependencies": {
     "@tanstack/ai-code-mode": "workspace:*"

--- a/packages/typescript/ai-isolate-node/package.json
+++ b/packages/typescript/ai-isolate-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-isolate-node",
   "version": "0.1.18",
-  "description": "Node.js isolated-vm driver for TanStack AI Code Mode",
+  "description": "Node.js isolated-vm sandbox driver for TanStack AI Code Mode TypeScript execution.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -38,11 +38,15 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
     "tanstack",
     "code-mode",
+    "nodejs",
+    "isolated-vm",
     "isolate",
     "sandbox",
-    "isolated-vm"
+    "code-execution"
   ],
   "dependencies": {
     "isolated-vm": "^6.0.2"

--- a/packages/typescript/ai-isolate-quickjs/package.json
+++ b/packages/typescript/ai-isolate-quickjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-isolate-quickjs",
   "version": "0.1.18",
-  "description": "QuickJS WASM driver for TanStack AI Code Mode - runs everywhere",
+  "description": "QuickJS WASM sandbox driver for TanStack AI Code Mode TypeScript execution across runtimes.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -35,12 +35,15 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
     "tanstack",
     "code-mode",
+    "quickjs",
+    "wasm",
     "isolate",
     "sandbox",
-    "quickjs",
-    "wasm"
+    "code-execution"
   ],
   "dependencies": {
     "quickjs-emscripten": "^0.31.0"

--- a/packages/typescript/ai-ollama/README.md
+++ b/packages/typescript/ai-ollama/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-ollama/README.md
+++ b/packages/typescript/ai-ollama/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-ollama/package.json
+++ b/packages/typescript/ai-ollama/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-ollama",
   "version": "0.6.20",
-  "description": "Ollama adapter for TanStack AI",
+  "description": "Ollama adapter for TanStack AI local LLM chat, tool calling, and structured outputs.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -34,11 +34,17 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
     "ollama",
+    "local-llm",
     "llama",
     "mistral",
-    "tanstack",
-    "adapter"
+    "adapter",
+    "chat",
+    "tool-calling",
+    "structured-outputs"
   ],
   "dependencies": {
     "@tanstack/ai-utils": "workspace:*",

--- a/packages/typescript/ai-openai/README.md
+++ b/packages/typescript/ai-openai/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-openai/README.md
+++ b/packages/typescript/ai-openai/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-openai/package.json
+++ b/packages/typescript/ai-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-openai",
   "version": "0.9.6",
-  "description": "OpenAI adapter for TanStack AI",
+  "description": "OpenAI adapter for TanStack AI chat, tools, images, video, speech, transcription, realtime, and structured outputs.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -38,10 +38,20 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
     "openai",
     "gpt",
-    "tanstack",
-    "adapter"
+    "adapter",
+    "chat",
+    "tool-calling",
+    "structured-outputs",
+    "image-generation",
+    "video-generation",
+    "text-to-speech",
+    "transcription",
+    "realtime"
   ],
   "dependencies": {
     "@tanstack/ai-utils": "workspace:*",

--- a/packages/typescript/ai-openrouter/README.md
+++ b/packages/typescript/ai-openrouter/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-openrouter/README.md
+++ b/packages/typescript/ai-openrouter/README.md
@@ -1,92 +1,254 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Multimodal content support** - Send images, audio, video, and documents
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</b></a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Bonus: TanStack Start Integration
+## Start Here
 
-TanStack AI works with **any** framework (Next.js, Express, Remix, etc.).
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
 
-**With TanStack Start**, you get a bonus: share implementations between AI tools and server functions with `createServerFnTool`:
+## What You Can Build
 
-```typescript
-import { createServerFnTool } from '@tanstack/ai-react'
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
 
-// Define once, get AI tool AND server function (TanStack Start only)
-const getProducts = createServerFnTool({
-  name: 'getProducts',
-  inputSchema: z.object({ query: z.string() }),
-  execute: async ({ query }) => db.products.search(query),
-})
+## Install
 
-// Use in AI chat
-chat({ tools: [getProducts.server] })
+Install the core package and the provider/framework packages your app uses:
 
-// Call directly from components (no API endpoint needed!)
-const products = await getProducts.serverFn({ query: 'laptop' })
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
 ```
 
-No duplicate logic, full type safety, automatic validation. The `serverFn` feature requires TanStack Start. See [docs](https://tanstack.com/ai) for details.
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
+
+```typescript
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+
+export async function POST(request: Request) {
+  const body = await request.json()
+
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
+
+  return toServerSentEventsResponse(stream)
+}
+```
+
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" height="40" />
-          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
       </a>
@@ -94,9 +256,9 @@ No duplicate logic, full type safety, automatic validation. The `serverFn` featu
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" />
-          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" height="60" />
-          <img src="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" height="60" alt="Cloudflare" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
+          <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
       </a>
     </td>
@@ -104,28 +266,39 @@ No duplicate logic, full type safety, automatic validation. The `serverFn` featu
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-openrouter/package.json
+++ b/packages/typescript/ai-openrouter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-openrouter",
   "version": "0.9.6",
-  "description": "OpenRouter adapter for TanStack AI",
+  "description": "TanStack AI adapter for OpenRouter chat, provider tools, structured outputs, and access to hundreds of LLMs.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -38,9 +38,18 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
+    "llm",
+    "generative-ai",
     "openrouter",
     "tanstack",
-    "adapter"
+    "adapter",
+    "chat",
+    "streaming",
+    "tool-calling",
+    "structured-outputs",
+    "model-router"
   ],
   "dependencies": {
     "@openrouter/sdk": "0.12.35",

--- a/packages/typescript/ai-openrouter/src/model-meta.ts
+++ b/packages/typescript/ai-openrouter/src/model-meta.ts
@@ -16379,7 +16379,10 @@ export const OPENROUTER_CHAT_MODELS = [
 ] as const
 
 export type OpenRouterChatModelToolCapabilitiesByName = {
-  [K in (typeof OPENROUTER_CHAT_MODELS)[number]]: readonly ['web_search']
+  [K in (typeof OPENROUTER_CHAT_MODELS)[number]]: readonly [
+    'web_search',
+    'web_fetch',
+  ]
 }
 
 export const OPENROUTER_IMAGE_MODELS = [

--- a/packages/typescript/ai-preact/README.md
+++ b/packages/typescript/ai-preact/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-preact/README.md
+++ b/packages/typescript/ai-preact/README.md
@@ -1,92 +1,254 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</b></a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" height="40" />
-          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
       </a>
@@ -94,9 +256,9 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" />
-          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" height="60" />
-          <img src="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" height="60" alt="Cloudflare" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
+          <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
       </a>
     </td>
@@ -104,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-preact/package.json
+++ b/packages/typescript/ai-preact/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-preact",
   "version": "0.6.30",
-  "description": "Preact hooks for TanStack AI",
+  "description": "Preact hooks for TanStack AI streaming chat and typed messages.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -34,11 +34,14 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
     "preact",
     "hooks",
-    "tanstack",
     "chat",
-    "streaming"
+    "streaming",
+    "tool-calling"
   ],
   "dependencies": {
     "@tanstack/ai-client": "workspace:*"

--- a/packages/typescript/ai-react-ui/README.md
+++ b/packages/typescript/ai-react-ui/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-react-ui/README.md
+++ b/packages/typescript/ai-react-ui/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-react-ui/package.json
+++ b/packages/typescript/ai-react-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-react-ui",
   "version": "0.8.0",
-  "description": "Headless React components for building AI chat interfaces",
+  "description": "Headless React components for building TanStack AI chat interfaces with streamed message parts.",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
   "type": "module",
@@ -29,13 +29,17 @@
     "test:types": "tsc"
   },
   "keywords": [
-    "tanstack",
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
     "react",
     "chat",
     "ui",
     "headless",
-    "components"
+    "components",
+    "streaming",
+    "generative-ai"
   ],
   "dependencies": {
     "react-markdown": "^10.1.0",

--- a/packages/typescript/ai-react/README.md
+++ b/packages/typescript/ai-react/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-react/README.md
+++ b/packages/typescript/ai-react/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-react/package.json
+++ b/packages/typescript/ai-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-react",
   "version": "0.11.5",
-  "description": "React hooks for TanStack AI",
+  "description": "React hooks for TanStack AI streaming chat, realtime voice, structured outputs, and media generation.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -34,11 +34,17 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
     "react",
     "hooks",
-    "tanstack",
     "chat",
-    "streaming"
+    "streaming",
+    "realtime",
+    "tool-calling",
+    "structured-outputs",
+    "media-generation"
   ],
   "dependencies": {
     "@tanstack/ai-client": "workspace:*"

--- a/packages/typescript/ai-solid-ui/README.md
+++ b/packages/typescript/ai-solid-ui/README.md
@@ -1,65 +1,254 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Type-safe tools with server/client execution
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</b></a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
+
+## Start Here
+
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
+
+```typescript
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+
+export async function POST(request: Request) {
+  const body = await request.json()
+
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
+
+  return toServerSentEventsResponse(stream)
+}
+```
+
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" height="40" />
-          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
       </a>
@@ -67,9 +256,9 @@ A powerful, type-safe AI SDK for building AI-powered applications.
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" />
-          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" height="60" />
-          <img src="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" height="60" alt="Cloudflare" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
+          <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
       </a>
     </td>
@@ -77,28 +266,39 @@ A powerful, type-safe AI SDK for building AI-powered applications.
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools">TanStack Devtools</a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-solid-ui/README.md
+++ b/packages/typescript/ai-solid-ui/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-solid-ui/package.json
+++ b/packages/typescript/ai-solid-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-solid-ui",
   "version": "0.7.0",
-  "description": "Headless Solid components for building AI chat interfaces",
+  "description": "Headless Solid components for building TanStack AI chat interfaces with streamed message parts.",
   "module": "./src/index.ts",
   "types": "./src/index.ts",
   "type": "module",
@@ -31,14 +31,18 @@
     "test:types": "tsc"
   },
   "keywords": [
-    "tanstack",
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
     "solid",
     "solidjs",
     "chat",
     "ui",
     "headless",
-    "components"
+    "components",
+    "streaming",
+    "generative-ai"
   ],
   "dependencies": {
     "rehype-highlight": "^7.0.2",

--- a/packages/typescript/ai-solid/package.json
+++ b/packages/typescript/ai-solid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-solid",
   "version": "0.10.5",
-  "description": "Solid hooks for TanStack AI",
+  "description": "Solid hooks for TanStack AI streaming chat, structured outputs, and media generation.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -32,11 +32,17 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
+    "solid",
     "solidjs",
     "hooks",
-    "tanstack",
     "chat",
-    "streaming"
+    "streaming",
+    "tool-calling",
+    "structured-outputs",
+    "media-generation"
   ],
   "dependencies": {
     "@tanstack/ai-client": "workspace:*"

--- a/packages/typescript/ai-svelte/package.json
+++ b/packages/typescript/ai-svelte/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-svelte",
   "version": "0.10.5",
-  "description": "Svelte bindings for TanStack AI",
+  "description": "Svelte 5 bindings for TanStack AI streaming chat, structured outputs, and media generation.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -36,11 +36,16 @@
   },
   "keywords": [
     "ai",
-    "svelte",
-    "hooks",
+    "ai-sdk",
+    "typescript",
     "tanstack",
+    "svelte",
+    "svelte5",
     "chat",
-    "streaming"
+    "streaming",
+    "tool-calling",
+    "structured-outputs",
+    "media-generation"
   ],
   "dependencies": {
     "@tanstack/ai-client": "workspace:*"

--- a/packages/typescript/ai-utils/package.json
+++ b/packages/typescript/ai-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-utils",
   "version": "0.2.0",
-  "description": "Shared utilities for TanStack AI adapter packages",
+  "description": "Shared TypeScript utilities for TanStack AI provider adapters and runtime packages.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -34,8 +34,12 @@
   },
   "keywords": [
     "ai",
-    "utils",
-    "tanstack"
+    "ai-sdk",
+    "typescript",
+    "tanstack",
+    "utilities",
+    "adapter",
+    "provider-adapter"
   ],
   "devDependencies": {
     "@types/node": "^24.10.1",

--- a/packages/typescript/ai-vue-ui/README.md
+++ b/packages/typescript/ai-vue-ui/README.md
@@ -1,65 +1,254 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Type-safe tools with server/client execution
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</b></a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
+
+## Start Here
+
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
+
+```typescript
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+
+export async function POST(request: Request) {
+  const body = await request.json()
+
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
+
+  return toServerSentEventsResponse(stream)
+}
+```
+
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" height="40" />
-          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
       </a>
@@ -67,9 +256,9 @@ A powerful, type-safe AI SDK for building AI-powered applications.
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" />
-          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" height="60" />
-          <img src="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" height="60" alt="Cloudflare" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
+          <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
       </a>
     </td>
@@ -77,28 +266,39 @@ A powerful, type-safe AI SDK for building AI-powered applications.
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools">TanStack Devtools</a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-vue-ui/README.md
+++ b/packages/typescript/ai-vue-ui/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-vue-ui/package.json
+++ b/packages/typescript/ai-vue-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-vue-ui",
   "version": "0.2.1",
-  "description": "Headless Vue components for building AI chat interfaces",
+  "description": "Headless Vue components for building TanStack AI chat interfaces with streamed message parts.",
   "module": "./src/index.ts",
   "types": "./src/index.ts",
   "type": "module",
@@ -30,13 +30,17 @@
     "test:types": "vue-tsc --noEmit"
   },
   "keywords": [
-    "tanstack",
     "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
     "vue",
     "chat",
     "ui",
     "headless",
-    "components"
+    "components",
+    "streaming",
+    "generative-ai"
   ],
   "dependencies": {
     "@crazydos/vue-markdown": "^1.1.4",

--- a/packages/typescript/ai-vue/README.md
+++ b/packages/typescript/ai-vue/README.md
@@ -1,65 +1,254 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Type-safe tools with server/client execution
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</b></a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
+
+## Start Here
+
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
+
+```typescript
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+
+export async function POST(request: Request) {
+  const body = await request.json()
+
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
+
+  return toServerSentEventsResponse(stream)
+}
+```
+
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" height="40" />
-          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
       </a>
@@ -67,9 +256,9 @@ A powerful, type-safe AI SDK for building AI-powered applications.
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" />
-          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" height="60" />
-          <img src="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" height="60" alt="Cloudflare" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
+          <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
       </a>
     </td>
@@ -77,28 +266,39 @@ A powerful, type-safe AI SDK for building AI-powered applications.
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools">TanStack Devtools</a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai-vue/README.md
+++ b/packages/typescript/ai-vue/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai-vue/package.json
+++ b/packages/typescript/ai-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai-vue",
   "version": "0.10.6",
-  "description": "Vue hooks for TanStack AI",
+  "description": "Vue composables for TanStack AI streaming chat, structured outputs, and media generation.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -32,11 +32,17 @@
   },
   "keywords": [
     "ai",
-    "vue",
-    "hooks",
+    "ai-sdk",
+    "typescript",
     "tanstack",
+    "vue",
+    "vue3",
+    "composables",
     "chat",
-    "streaming"
+    "streaming",
+    "tool-calling",
+    "structured-outputs",
+    "media-generation"
   ],
   "dependencies": {
     "@tanstack/ai-client": "workspace:*"

--- a/packages/typescript/ai/README.md
+++ b/packages/typescript/ai/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/ai/README.md
+++ b/packages/typescript/ai/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/ai/package.json
+++ b/packages/typescript/ai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/ai",
   "version": "0.21.1",
-  "description": "Core TanStack AI library - Open source AI SDK",
+  "description": "Type-safe TypeScript AI SDK for streaming chat, tool calling, agents, structured outputs, and multimodal generation.",
   "author": "Tanner Linsley",
   "license": "MIT",
   "repository": {
@@ -57,11 +57,19 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
     "tanstack",
-    "sdk",
     "llm",
+    "generative-ai",
     "chat",
-    "embeddings",
+    "streaming",
+    "tool-calling",
+    "function-calling",
+    "agents",
+    "structured-outputs",
+    "multimodal",
+    "zod",
     "tanstack-intent"
   ],
   "dependencies": {

--- a/packages/typescript/openai-base/package.json
+++ b/packages/typescript/openai-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/openai-base",
   "version": "0.3.5",
-  "description": "Shared base adapters for OpenAI-SDK-backed providers in TanStack AI (Chat Completions and Responses)",
+  "description": "Shared OpenAI SDK base adapters for TanStack AI providers using Chat Completions and Responses APIs.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -34,9 +34,15 @@
   },
   "keywords": [
     "ai",
-    "openai",
+    "ai-sdk",
+    "typescript",
     "tanstack",
-    "adapter"
+    "openai",
+    "adapter",
+    "provider-adapter",
+    "chat-completions",
+    "responses-api",
+    "structured-outputs"
   ],
   "dependencies": {
     "@tanstack/ai-utils": "workspace:*",

--- a/packages/typescript/preact-ai-devtools/README.md
+++ b/packages/typescript/preact-ai-devtools/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/preact-ai-devtools/README.md
+++ b/packages/typescript/preact-ai-devtools/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/preact-ai-devtools/package.json
+++ b/packages/typescript/preact-ai-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/preact-ai-devtools",
   "version": "0.1.39",
-  "description": "Preact Devtools for TanStack AI.",
+  "description": "Preact Devtools plugin for inspecting TanStack AI chat messages, tool calls, streams, and errors.",
   "author": "tannerlinsley",
   "license": "MIT",
   "homepage": "https://tanstack.com/ai",
@@ -57,5 +57,17 @@
   },
   "peerDependencies": {
     "preact": "^10.0.0"
-  }
+  },
+  "keywords": [
+    "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
+    "preact",
+    "devtools",
+    "debugging",
+    "observability",
+    "chat",
+    "tool-calling"
+  ]
 }

--- a/packages/typescript/react-ai-devtools/README.md
+++ b/packages/typescript/react-ai-devtools/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/react-ai-devtools/README.md
+++ b/packages/typescript/react-ai-devtools/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/react-ai-devtools/package.json
+++ b/packages/typescript/react-ai-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/react-ai-devtools",
   "version": "0.2.39",
-  "description": "React Devtools for TanStack AI.",
+  "description": "React Devtools plugin for inspecting TanStack AI chat messages, tool calls, streams, and errors.",
   "author": "tannerlinsley",
   "license": "MIT",
   "homepage": "https://tanstack.com/ai",
@@ -60,5 +60,17 @@
     "@vitest/coverage-v8": "4.0.14",
     "react": "^19.2.3",
     "vite": "^7.3.3"
-  }
+  },
+  "keywords": [
+    "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
+    "react",
+    "devtools",
+    "debugging",
+    "observability",
+    "chat",
+    "tool-calling"
+  ]
 }

--- a/packages/typescript/solid-ai-devtools/README.md
+++ b/packages/typescript/solid-ai-devtools/README.md
@@ -33,7 +33,7 @@ provider or switch between many. Import only chat, or add image, audio, video,
 speech, transcription, summarization, realtime, Code Mode, devtools, and
 framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs -></a>
+## <a href="https://tanstack.com/ai">Read the docs -></a>
 
 ## Start Here
 
@@ -292,7 +292,7 @@ on.
   range and slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
   type-safe routing, caching, and URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> -
   full-stack SSR and streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
   reactive data store

--- a/packages/typescript/solid-ai-devtools/README.md
+++ b/packages/typescript/solid-ai-devtools/README.md
@@ -1,93 +1,253 @@
 <div align="center">
-  <img src="./media/header_ai.png" >
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
 </div>
 
 <br />
 
 <div align="center">
-<a href="https://npmjs.com/package/@tanstack/ai" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
-</a>
-<a href="https://github.com/TanStack/ai" target="\_parent">
-	  <img alt="" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" alt="GitHub stars" />
-</a>
-<a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="\_parent">
-  <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
-</a>
-</div>
-
-<div align="center">
-<a href="#badge">
-  <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
-</a>
-	<a href="#badge">
-		<img src="https://img.shields.io/github/v/release/tanstack/ai" alt="Release"/>
-	</a>
-<a href="https://twitter.com/tan_stack">
-  <img src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" alt="Follow @TanStack"/>
-</a>
-</div>
-
-<div align="center">
-  
-### [Become a Sponsor!](https://github.com/sponsors/tannerlinsley/)
+  <a href="https://npmjs.com/package/@tanstack/ai" target="_parent">
+    <img alt="NPM downloads" src="https://img.shields.io/npm/dm/@tanstack/ai.svg" />
+  </a>
+  <a href="https://github.com/TanStack/ai" target="_parent">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/TanStack/ai.svg?style=social&label=Star" />
+  </a>
+  <a href="https://github.com/TanStack/ai/releases" target="_parent">
+    <img alt="Release" src="https://img.shields.io/github/v/release/tanstack/ai" />
+  </a>
+  <a href="https://bundlephobia.com/result?p=@tanstack/ai@latest" target="_parent">
+    <img alt="Bundle size" src="https://badgen.net/bundlephobia/minzip/@tanstack/ai@latest" />
+  </a>
+  <a href="https://twitter.com/tan_stack">
+    <img alt="Follow @TanStack" src="https://img.shields.io/twitter/follow/tan_stack.svg?style=social" />
+  </a>
 </div>
 
 # TanStack AI
 
-A powerful, type-safe AI SDK for building AI-powered applications.
+Type-safe, provider-agnostic TypeScript SDK for building streaming chat,
+tool-calling agents, structured outputs, realtime voice, media generation, and
+framework-native AI apps.
 
-- Provider-agnostic adapters (OpenAI, Anthropic, Gemini, Ollama, etc.)
-- **Tree-shakeable adapters** - Import only what you need for smaller bundles
-- **Multimodal content support** - Send images, audio, video, and documents
-- **Image generation** - Generate images with OpenAI DALL-E/GPT-Image and Gemini Imagen
-- Chat completion, streaming, and agent loop strategies
-- Headless chat state management with adapters (SSE, HTTP stream, custom)
-- Isomorphic type-safe tools with server/client execution
-- **Enhanced integration with TanStack Start** - Share implementations between AI tools and server functions
-- **Observability events** - Structured, typed events for text, tools, image, speech, transcription, and video ([docs](./docs/guides/observability.md))
+TanStack AI is built from composable activities and provider adapters. Use one
+provider or switch between many. Import only chat, or add image, audio, video,
+speech, transcription, summarization, realtime, Code Mode, devtools, and
+framework bindings as your app needs them.
 
-### <a href="https://tanstack.com/ai">Read the docs →</a>
+### <a href="https://tanstack.com/ai">Read the docs -></a>
 
-## Tree-Shakeable Adapters
+## Start Here
 
-Import only the functionality you need for smaller bundle sizes:
+- [Overview](https://tanstack.com/ai/latest/docs/getting-started/overview) -
+  what TanStack AI is and how the packages fit together.
+- [Quick Start: React](https://tanstack.com/ai/latest/docs/getting-started/quick-start) -
+  add streaming chat to a React app.
+- [Quick Start: Vue](https://tanstack.com/ai/latest/docs/getting-started/quick-start-vue) -
+  build with Vue composables.
+- [Quick Start: Svelte](https://tanstack.com/ai/latest/docs/getting-started/quick-start-svelte) -
+  build with Svelte 5 runes.
+- [Quick Start: Server Only](https://tanstack.com/ai/latest/docs/getting-started/quick-start-server) -
+  use TanStack AI from a server endpoint, script, or backend service.
+- [TanStack AI vs Vercel AI SDK](https://tanstack.com/ai/latest/docs/comparison/vercel-ai-sdk) -
+  compare architecture, feature coverage, and tradeoffs.
+
+## What You Can Build
+
+- Streaming chat experiences with typed messages, tool calls, reasoning parts,
+  and configurable connection adapters.
+- Type-safe tools that can run on the server or client from one shared
+  `toolDefinition()` contract.
+- Structured output flows backed by JSON Schema, Zod, ArkType, Valibot, or
+  plain JSON Schema.
+- Multimodal prompts and responses that include text, images, audio, video, and
+  documents.
+- Image, audio, video, speech, transcription, and summarization workflows using
+  a shared generation client pattern.
+- Realtime voice chat with provider adapters for realtime sessions and token
+  minting.
+- Code Mode agents that let an LLM write and execute TypeScript in an isolated
+  sandbox to orchestrate tools with loops, branches, and parallel calls.
+- Devtools and observability pipelines for inspecting messages, tool calls,
+  stream chunks, errors, usage, and OpenTelemetry traces.
+- Framework-native clients for React, Solid, Vue, Svelte, and Preact, plus a
+  headless client for custom runtimes.
+
+## Install
+
+Install the core package and the provider/framework packages your app uses:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openai
+```
+
+For a React chat UI:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-client @tanstack/ai-react @tanstack/ai-openai
+```
+
+OpenRouter is also a good starting point if you want access to many providers
+through one API key:
+
+```bash
+pnpm add @tanstack/ai @tanstack/ai-openrouter
+```
+
+## Streaming Chat
 
 ```typescript
-// Only chat functionality - no summarization code bundled
-import { openaiText } from '@tanstack/ai-openai/adapters'
-import { generate } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
 
-const textAdapter = openaiText()
+export async function POST(request: Request) {
+  const body = await request.json()
 
-const result = generate({
-  adapter: textAdapter,
-  model: 'gpt-4o',
-  messages: [{ role: 'user', content: [{ type: 'text', content: 'Hello!' }] }],
-})
+  const stream = chat({
+    adapter: openaiText('gpt-5.2'),
+    messages: body.messages,
+  })
 
-for await (const chunk of result) {
-  console.log(chunk)
+  return toServerSentEventsResponse(stream)
 }
 ```
 
-Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicText`, `geminiText`, `ollamaText`, and more.
+Learn more in the
+[Chat & Streaming docs](https://tanstack.com/ai/latest/docs/chat/streaming) and
+[Connection Adapters docs](https://tanstack.com/ai/latest/docs/chat/connection-adapters).
+
+## Type-Safe Tools
+
+Define a tool once, then attach a server or client implementation with the same
+input and output types:
+
+```typescript
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+const getProducts = toolDefinition({
+  name: 'getProducts',
+  description: 'Search the product catalog',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+}).server(async ({ query }) => {
+  return db.products.search(query)
+})
+```
+
+Learn more in the
+[Tools docs](https://tanstack.com/ai/latest/docs/tools/tools),
+[Tool Approval Flow docs](https://tanstack.com/ai/latest/docs/tools/tool-approval),
+and
+[Lazy Tool Discovery docs](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery).
+
+## Structured Outputs
+
+Use `outputSchema` when you need typed objects instead of freeform text:
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+import { z } from 'zod'
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+const person = await chat({
+  adapter: openaiText('gpt-5.2'),
+  messages: [{ role: 'user', content: 'Ada Lovelace, 36' }],
+  outputSchema: Person,
+})
+```
+
+Learn more in the
+[Structured Outputs docs](https://tanstack.com/ai/latest/docs/structured-outputs/overview).
+
+## Media, Realtime, and Code Mode
+
+- [Generations](https://tanstack.com/ai/latest/docs/media/generations) - one
+  pattern for image generation, text-to-speech, transcription, summarization,
+  audio generation, and video generation.
+- [Realtime Voice Chat](https://tanstack.com/ai/latest/docs/media/realtime-chat) -
+  build low-latency realtime voice experiences.
+- [Code Mode](https://tanstack.com/ai/latest/docs/code-mode/code-mode) - let
+  models write and execute TypeScript inside a secure isolate.
+- [Code Mode with Skills](https://tanstack.com/ai/latest/docs/code-mode/code-mode-with-skills) -
+  give Code Mode reusable runtime capabilities.
+
+## Providers
+
+Official adapters include:
+
+| Package                                                                              | Use it for                                                                     |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) | 300+ models through one OpenRouter API                                         |
+| [`@tanstack/ai-openai`](https://tanstack.com/ai/latest/docs/adapters/openai)         | OpenAI chat, image, video, speech, transcription, realtime, and provider tools |
+| [`@tanstack/ai-anthropic`](https://tanstack.com/ai/latest/docs/adapters/anthropic)   | Anthropic Claude chat, thinking, tools, and structured outputs                 |
+| [`@tanstack/ai-gemini`](https://tanstack.com/ai/latest/docs/adapters/gemini)         | Google Gemini chat, image, speech, and audio generation                        |
+| [`@tanstack/ai-ollama`](https://tanstack.com/ai/latest/docs/adapters/ollama)         | Local Ollama models                                                            |
+| [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
+| [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
+| [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
+
+The adapter system is tree-shakeable by activity. Import `openaiText` for chat,
+`openaiImage` for images, `falVideo` for video, `geminiSpeech` for TTS, and so
+on.
+
+## Framework Packages
+
+| Package                                                                    | What it provides                                                         |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`@tanstack/ai-client`](https://tanstack.com/ai/latest/docs/api/ai-client) | Headless chat, realtime, and generation clients                          |
+| [`@tanstack/ai-react`](https://tanstack.com/ai/latest/docs/api/ai-react)   | React hooks including `useChat`, `useRealtimeChat`, and generation hooks |
+| [`@tanstack/ai-solid`](https://tanstack.com/ai/latest/docs/api/ai-solid)   | Solid hooks for chat and generations                                     |
+| [`@tanstack/ai-vue`](https://tanstack.com/ai/latest/docs/api/ai-vue)       | Vue composables for chat and generations                                 |
+| [`@tanstack/ai-svelte`](https://tanstack.com/ai/latest/docs/api/ai-svelte) | Svelte 5 factories for chat and generations                              |
+| [`@tanstack/ai-preact`](https://tanstack.com/ai/latest/docs/api/ai-preact) | Preact hooks for chat                                                    |
+| `@tanstack/ai-react-ui`, `@tanstack/ai-solid-ui`, `@tanstack/ai-vue-ui`    | Headless UI components for chat interfaces                               |
+
+## Advanced Docs
+
+- [Middleware](https://tanstack.com/ai/latest/docs/advanced/middleware) - hook
+  into chat configuration, chunks, tool calls, usage, errors, and structured
+  outputs.
+- [OpenTelemetry](https://tanstack.com/ai/latest/docs/advanced/otel) - emit
+  vendor-neutral GenAI traces and metrics.
+- [Observability](https://tanstack.com/ai/latest/docs/advanced/observability) -
+  subscribe to typed TanStack AI events.
+- [Per-Model Type Safety](https://tanstack.com/ai/latest/docs/advanced/per-model-type-safety) -
+  narrow model options and content modalities to the selected model.
+- [Runtime Adapter Switching](https://tanstack.com/ai/latest/docs/advanced/runtime-adapter-switching) -
+  switch providers at runtime.
+- [Tree-Shaking](https://tanstack.com/ai/latest/docs/advanced/tree-shaking) -
+  ship only the activities and adapters you use.
+- [Agent Skills](https://tanstack.com/ai/latest/docs/getting-started/agent-skills) -
+  install TanStack AI skills into Claude Code, Cursor, GitHub Copilot, Codex,
+  and other coding agents with TanStack Intent.
 
 ## Get Involved
 
-- We welcome issues and pull requests!
-- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions)
-- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ)
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions
+- Read the [docs](https://tanstack.com/ai).
+- Participate in [GitHub discussions](https://github.com/TanStack/ai/discussions).
+- Chat with the community on [Discord](https://discord.com/invite/WrRKjPJ).
+- See [CONTRIBUTING.md](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md)
+  for setup instructions.
+- [Become a sponsor](https://github.com/sponsors/tannerlinsley/).
 
 ## Partners
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS" >
+      <a href="https://www.coderabbit.ai/?via=tanstack&dub_id=aCcEEdAOqqutX6OS">
         <picture>
-         <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/coderabbit-dark-D643Zkrv.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" />
           <img src="https://tanstack.com/assets/coderabbit-light-CIzGLYU_.svg" height="40" alt="CodeRabbit" />
         </picture>
@@ -96,7 +256,7 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
     <td>
       <a href="https://www.cloudflare.com?utm_source=tanstack">
         <picture>
-           <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" />
           <source media="(prefers-color-scheme: light)" srcset="https://tanstack.com/assets/cloudflare-black-6Ojsn8yh.svg" />
           <img src="https://tanstack.com/assets/cloudflare-white-Co-Tyjbl.svg" height="60" alt="Cloudflare" />
         </picture>
@@ -106,28 +266,39 @@ Available adapters: `openaiText`, `openaiEmbed`, `openaiSummarize`, `anthropicTe
 </table>
 
 <div align="center">
-<img src="./media/partner_logo.svg" alt="AI & you?" height="65">
-<p>
-We're looking for TanStack AI Partners to join our mission! Partner with us to push the boundaries of TanStack AI and build amazing things together.
-</p>
-<a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
+  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/partner_logo.svg" alt="AI and you?" height="65" />
+  <p>
+    We're looking for TanStack AI partners to join our mission. Partner with us
+    to push the boundaries of TanStack AI and build amazing things together.
+  </p>
+  <a href="mailto:partners@tanstack.com?subject=TanStack AI Partnership"><b>LET'S CHAT</b></a>
 </div>
 
 ## Explore the TanStack Ecosystem
 
-- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> – Tooling for JS/TS packages
-- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> – Reactive sync client store
-- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> – Unified devtools panel
-- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> – Type‑safe form state
-- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> – Debouncing, throttling, batching
-- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
-- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
-- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
-- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
-- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> – Headless datagrids
-- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
+- <a href="https://github.com/tanstack/config"><b>TanStack Config</b></a> -
+  tooling for JS/TS packages
+- <a href="https://github.com/tanstack/db"><b>TanStack DB</b></a> - reactive
+  sync client store
+- <a href="https://github.com/tanstack/devtools"><b>TanStack Devtools</b></a> -
+  unified devtools panel
+- <a href="https://github.com/tanstack/form"><b>TanStack Form</b></a> -
+  type-safe form state
+- <a href="https://github.com/tanstack/pacer"><b>TanStack Pacer</b></a> -
+  debouncing, throttling, batching
+- <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> -
+  async state and caching
+- <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> -
+  range and slider primitives
+- <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> -
+  type-safe routing, caching, and URL state
+- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> -
+  full-stack SSR and streaming
+- <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> -
+  reactive data store
+- <a href="https://github.com/tanstack/table"><b>TanStack Table</b></a> -
+  headless datagrids
+- <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> -
+  virtualized rendering
 
-… and more at <a href="https://tanstack.com"><b>TanStack.com »</b></a>
-
-<!-- USE THE FORCE LUKE -->
+...and more at <a href="https://tanstack.com"><b>TanStack.com</b></a>.

--- a/packages/typescript/solid-ai-devtools/package.json
+++ b/packages/typescript/solid-ai-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/solid-ai-devtools",
   "version": "0.2.39",
-  "description": "Solid TanStack AI Devtools",
+  "description": "Solid Devtools plugin for inspecting TanStack AI chat messages, tool calls, streams, and errors.",
   "author": "",
   "license": "MIT",
   "repository": {
@@ -40,11 +40,16 @@
   },
   "keywords": [
     "ai",
+    "ai-sdk",
+    "typescript",
     "tanstack",
-    "sdk",
-    "llm",
+    "solid",
+    "solidjs",
+    "devtools",
+    "debugging",
+    "observability",
     "chat",
-    "embeddings"
+    "tool-calling"
   ],
   "dependencies": {
     "@tanstack/ai-devtools-core": "workspace:*",

--- a/scripts/copy-readme.js
+++ b/scripts/copy-readme.js
@@ -1,0 +1,28 @@
+import { copyFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+const targets = [
+  'packages/typescript/ai/README.md',
+  'packages/typescript/ai-client/README.md',
+  'packages/typescript/ai-devtools/README.md',
+  'packages/typescript/ai-gemini/README.md',
+  'packages/typescript/ai-ollama/README.md',
+  'packages/typescript/ai-openai/README.md',
+  'packages/typescript/ai-openrouter/README.md',
+  'packages/typescript/ai-preact/README.md',
+  'packages/typescript/ai-react/README.md',
+  'packages/typescript/ai-react-ui/README.md',
+  'packages/typescript/ai-solid-ui/README.md',
+  'packages/typescript/ai-vue/README.md',
+  'packages/typescript/ai-vue-ui/README.md',
+  'packages/typescript/preact-ai-devtools/README.md',
+  'packages/typescript/react-ai-devtools/README.md',
+  'packages/typescript/solid-ai-devtools/README.md',
+]
+
+for (const target of targets) {
+  copyFileSync(join(rootDir, 'README.md'), join(rootDir, target))
+}


### PR DESCRIPTION
## Changes

- Refresh the README around current TanStack AI capabilities: streaming chat, type-safe tools, structured outputs, media generation, realtime voice, Code Mode, devtools, providers, framework packages, and current docs entry points.
- Use absolute GitHub raw URLs for README-local assets and an absolute GitHub URL for CONTRIBUTING so copied package READMEs do not contain broken relative links.
- Copy the refreshed root README into the package README files that use the root README content, and replace the Unix-only `copy:readme` command with a small Node script.
- Update TypeScript package descriptions and npm keywords so the core, provider, framework, UI, devtools, and utility packages are easier to find on npm and GitHub.
- Add a patch changeset for the changed publishable packages so the README and metadata updates are released.
- Align OpenRouter model tool metadata with the existing `webFetchTool` support and include a patch changeset.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

- `pnpm --dir F:\projects\tanstack\ai\.claude\worktrees\docs-github-discoverability-readme run copy:readme`
- `pnpm --dir F:\projects\tanstack\ai\.claude\worktrees\docs-github-discoverability-readme exec prettier --write README.md package.json scripts/copy-readme.js .changeset/refresh-readme-package-metadata.md .changeset/openrouter-web-fetch-tool-types.md "packages/typescript/*/README.md" "packages/typescript/*/package.json" packages/typescript/ai-openrouter/src/model-meta.ts`
- `pnpm --dir F:\projects\tanstack\ai\.claude\worktrees\docs-github-discoverability-readme test:docs`
- `pnpm --dir F:\projects\tanstack\ai\.claude\worktrees\docs-github-discoverability-readme test:sherif`
- `pnpm --dir F:\projects\tanstack\ai\.claude\worktrees\docs-github-discoverability-readme test:pr`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Comprehensive README refresh across TanStack AI packages: reorganized hero, expanded "Start Here", feature guides, examples, providers, and partners.

* **Bug Fixes**
  * Fixed OpenRouter provider tool type metadata to include webFetchTool.

* **Chores**
  * Updated npm package metadata (descriptions/keywords) across packages for better discoverability.
  * Replaced manual README copy with an automated script for propagating docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->