### PR TITLE
fix(ai): report finalization-call usage on synthesized RUN_FINISHED

### DIFF
--- a/.changeset/structured-output-finalization-usage.md
+++ b/.changeset/structured-output-finalization-usage.md
@@ -1,0 +1,11 @@
+---
+'@tanstack/ai': patch
+'@tanstack/ai-anthropic': patch
+'@tanstack/ai-gemini': patch
+'@tanstack/ai-ollama': patch
+'@tanstack/ai-openrouter': patch
+---
+
+Adapters now report token `usage` from the non-streaming `structuredOutput()` call, and `fallbackStructuredOutputStream` forwards it onto the synthesized `RUN_FINISHED` event. Previously the legacy finalization round-trip was invisible to the chat middleware `onUsage` hook — any cost-tracking middleware silently under-counted by exactly one call whenever an adapter without a native `structuredOutputStream` (Anthropic, Gemini, Ollama, OpenRouter) ran agentic structured output through the legacy path.
+
+`StructuredOutputResult` gains an optional `usage: { promptTokens, completionTokens, totalTokens }` field. Adapters without a token count on the wire (or that fail before usage is known) leave it `undefined`, which the engine treats as "no usage to report" — same as before. No consumer-visible behavior change beyond accurate `onUsage` totals.

--- a/packages/typescript/ai-anthropic/src/adapters/text.ts
+++ b/packages/typescript/ai-anthropic/src/adapters/text.ts
@@ -276,9 +276,16 @@ export class AnthropicTextAdapter<
         }
       }
 
+      const inputTokens = response.usage?.input_tokens ?? 0
+      const outputTokens = response.usage?.output_tokens ?? 0
       return {
         data: parsed,
         rawText,
+        usage: {
+          promptTokens: inputTokens,
+          completionTokens: outputTokens,
+          totalTokens: inputTokens + outputTokens,
+        },
       }
     } catch (error: unknown) {
       const err = error as Error

--- a/packages/typescript/ai-gemini/src/adapters/text.ts
+++ b/packages/typescript/ai-gemini/src/adapters/text.ts
@@ -196,9 +196,17 @@ export class GeminiTextAdapter<
         )
       }
 
+      const usageMetadata = result.usageMetadata
       return {
         data: parsed,
         rawText,
+        ...(usageMetadata && {
+          usage: {
+            promptTokens: usageMetadata.promptTokenCount ?? 0,
+            completionTokens: usageMetadata.candidatesTokenCount ?? 0,
+            totalTokens: usageMetadata.totalTokenCount ?? 0,
+          },
+        }),
       }
     } catch (error) {
       logger.errors('gemini.structuredOutput fatal', {

--- a/packages/typescript/ai-ollama/src/adapters/text.ts
+++ b/packages/typescript/ai-ollama/src/adapters/text.ts
@@ -201,9 +201,16 @@ export class OllamaTextAdapter<TModel extends string> extends BaseTextAdapter<
         )
       }
 
+      const promptTokens = response.prompt_eval_count ?? 0
+      const completionTokens = response.eval_count ?? 0
       return {
         data: parsed,
         rawText,
+        usage: {
+          promptTokens,
+          completionTokens,
+          totalTokens: promptTokens + completionTokens,
+        },
       }
     } catch (error: unknown) {
       const err = error as Error

--- a/packages/typescript/ai-openrouter/src/adapters/text.ts
+++ b/packages/typescript/ai-openrouter/src/adapters/text.ts
@@ -260,9 +260,17 @@ export class OpenRouterTextAdapter<
       // this).
       const transformed = this.transformStructuredOutput(parsed)
 
+      const usage = response.usage
       return {
         data: transformed,
         rawText,
+        ...(usage && {
+          usage: {
+            promptTokens: usage.promptTokens,
+            completionTokens: usage.completionTokens,
+            totalTokens: usage.totalTokens,
+          },
+        }),
       }
     } catch (error: unknown) {
       // Narrow before logging: raw SDK errors can carry request metadata

--- a/packages/typescript/ai/src/activities/chat/adapter.ts
+++ b/packages/typescript/ai/src/activities/chat/adapter.ts
@@ -40,6 +40,17 @@ export interface StructuredOutputResult<T = unknown> {
   data: T
   /** The raw text response from the model before parsing */
   rawText: string
+  /**
+   * Token usage reported by the provider for this call, when available.
+   * Forwarded by `fallbackStructuredOutputStream` onto the synthesized
+   * RUN_FINISHED so middleware `onUsage` hooks can account for the
+   * finalization round-trip.
+   */
+  usage?: {
+    promptTokens: number
+    completionTokens: number
+    totalTokens: number
+  }
 }
 
 /**

--- a/packages/typescript/ai/src/activities/chat/index.ts
+++ b/packages/typescript/ai/src/activities/chat/index.ts
@@ -2630,7 +2630,15 @@ async function* fallbackStructuredOutputStream(
     timestamp,
   }
 
-  let result: { data: unknown; rawText: string }
+  let result: {
+    data: unknown
+    rawText: string
+    usage?: {
+      promptTokens: number
+      completionTokens: number
+      totalTokens: number
+    }
+  }
   try {
     result = await adapter.structuredOutput(options)
   } catch (error) {
@@ -2686,6 +2694,7 @@ async function* fallbackStructuredOutputStream(
     model,
     timestamp,
     finishReason: 'stop',
+    ...(result.usage ? { usage: result.usage } : {}),
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #609. Adapters without a native `structuredOutputStream` (Anthropic, Gemini, Ollama, OpenRouter) run agentic structured output through the legacy finalization round-trip, but that extra call's token usage never reached the chat middleware `onUsage` hook — any cost-tracking middleware silently under-counted by exactly one call per structured-output request.

- Each affected adapter now returns `usage` from `structuredOutput()`, sourced from the provider's response (Anthropic `usage.input_tokens`/`output_tokens`, Gemini `usageMetadata`, Ollama `prompt_eval_count`/`eval_count`, OpenRouter normalized `usage`).
- `fallbackStructuredOutputStream` forwards `usage` onto the synthesized `RUN_FINISHED` event so the chat middleware accounts for the finalization call.
- `StructuredOutputResult` gains an optional `usage: { promptTokens, completionTokens, totalTokens }` field. When the provider doesn't return tokens (or the call fails before usage is known) the field stays `undefined`, which the engine already treats as "no usage to report" — no consumer-visible change beyond accurate `onUsage` totals.

## Test plan

- [ ] `pnpm --filter @tanstack/ai --filter @tanstack/ai-anthropic --filter @tanstack/ai-gemini --filter @tanstack/ai-ollama --filter @tanstack/ai-openrouter test:types` (verified locally)
- [ ] `pnpm test:lib` for the affected packages
- [ ] Manual: run a structured-output request through Anthropic/Gemini/Ollama/OpenRouter with an `onUsage` middleware and confirm the finalization call's tokens are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token usage metrics are now properly reported in structured output operations across all supported AI providers (Anthropic, Gemini, Ollama, and OpenRouter).
  * Chat middleware `onUsage` hooks now receive accurate token count totals, eliminating previous under-reporting in certain adapter paths.
  * Usage data is now consistently surfaced in structured output results, enabling proper cost tracking and usage analytics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->