### PR TITLE
fix(gemini): surface token usage from image generateContent path (#330)

### DIFF
--- a/.changeset/gemini-image-usage.md
+++ b/.changeset/gemini-image-usage.md
@@ -1,0 +1,8 @@
+---
+'@tanstack/ai-gemini': patch
+---
+
+Surface token usage from the Gemini image adapter's `generateContent` path
+(e.g. Nano Banana) by parsing `usageMetadata` from the response instead of
+omitting `usage`. The Imagen (`generateImages`) path is unchanged — that SDK
+response type does not expose `usageMetadata`. Fixes #330.

--- a/packages/ai-gemini/src/adapters/image.ts
+++ b/packages/ai-gemini/src/adapters/image.ts
@@ -214,6 +214,16 @@ export class GeminiImageAdapter<
       id: generateId(this.name),
       model,
       images,
+      // Surface token usage when the model reports it (e.g. Nano Banana via
+      // generateContent). Conditionally spread to satisfy
+      // exactOptionalPropertyTypes — only include usage when present. See #330.
+      ...(response.usageMetadata && {
+        usage: {
+          inputTokens: response.usageMetadata.promptTokenCount ?? 0,
+          outputTokens: response.usageMetadata.candidatesTokenCount ?? 0,
+          totalTokens: response.usageMetadata.totalTokenCount ?? 0,
+        },
+      }),
     }
   }
 

--- a/packages/ai-gemini/tests/image-adapter.test.ts
+++ b/packages/ai-gemini/tests/image-adapter.test.ts
@@ -302,6 +302,52 @@ describe('Gemini Image Adapter', () => {
       expect(result.images[0]!.b64Json).toBe('gemini-base64-image')
     })
 
+    it('surfaces token usage from usageMetadata (#330)', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  inlineData: { mimeType: 'image/png', data: 'img' },
+                },
+              ],
+            },
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 12,
+          candidatesTokenCount: 34,
+          totalTokenCount: 46,
+        },
+      }
+
+      const adapter = createGeminiImage(
+        'gemini-3.1-flash-image-preview',
+        'test-api-key',
+      )
+      ;(
+        adapter as unknown as {
+          client: { models: { generateContent: unknown } }
+        }
+      ).client = {
+        models: {
+          generateContent: vi.fn().mockResolvedValueOnce(mockResponse),
+        },
+      }
+
+      const result = await generateImage({
+        adapter,
+        prompt: 'A futuristic city',
+      })
+
+      expect(result.usage).toEqual({
+        inputTokens: 12,
+        outputTokens: 34,
+        totalTokens: 46,
+      })
+    })
+
     it('calls generateContent without imageConfig when no size provided', async () => {
       const mockResponse = {
         candidates: [


### PR DESCRIPTION
## 🎯 Changes

Fixes #330. The Gemini image adapter hardcoded `usage: undefined`, so `ImageGenerationResult.usage` was never populated and the `image:usage` devtools event never fired for Gemini image generation — even though the `generateContent` response carries `usageMetadata`.

This parses `usageMetadata` (`promptTokenCount` / `candidatesTokenCount` / `totalTokenCount`) into `usage` on the native `generateContent` path (e.g. Nano Banana), matching the convention already used by the Gemini text adapter.

The Imagen (`generateImages`) path is intentionally left unchanged: the `GenerateImagesResponse` SDK type does not expose `usageMetadata`, so parsing it there would require a speculative `as any` cast for a field that may never exist.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token usage data tracking for Gemini image generation. The image adapter now properly exposes token usage information, including input tokens, output tokens, and total token counts, enabling better monitoring of API consumption and associated costs for image generation requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->