### PR TITLE
fix(scripts): retain web_fetch in OpenRouter tool-capability codegen

### DIFF
--- a/scripts/convert-openrouter-models.ts
+++ b/scripts/convert-openrouter-models.ts
@@ -65,16 +65,16 @@ function generateChatModelsArray(): string {
 }
 
 /**
- * OpenRouter's web_search plugin works across all chat models via the gateway,
- * so the tool-capability map is structural and identical for every chat model.
- * Emitted as a mapped type to stay in sync with OPENROUTER_CHAT_MODELS without
- * touching each model constant.
+ * OpenRouter's web_search and web_fetch plugins work across all chat models via
+ * the gateway, so the tool-capability map is structural and identical for every
+ * chat model. Emitted as a mapped type to stay in sync with
+ * OPENROUTER_CHAT_MODELS without touching each model constant.
  */
 function generateChatToolCapabilitiesType(): string {
   if (chatModels.size === 0) {
     return ''
   }
-  return `export type OpenRouterChatModelToolCapabilitiesByName = {\n  [K in (typeof OPENROUTER_CHAT_MODELS)[number]]: readonly ['web_search']\n}`
+  return `export type OpenRouterChatModelToolCapabilitiesByName = {\n  [K in (typeof OPENROUTER_CHAT_MODELS)[number]]: readonly ['web_search', 'web_fetch']\n}`
 }
 
 function generateImageModelsArray(): string {


### PR DESCRIPTION
## Problem

`generateChatToolCapabilitiesType()` in `scripts/convert-openrouter-models.ts` emitted only `readonly ['web_search']` for the `OpenRouterChatModelToolCapabilitiesByName` mapped type. The committed `packages/ai-openrouter/src/model-meta.ts` correctly declares `readonly ['web_search', 'web_fetch']`, so the next regeneration of the model meta would have silently dropped `web_fetch` from every chat model's tool capabilities.

Both `web_search` and `web_fetch` are real OpenRouter gateway tools available across all chat models (see `packages/ai-openrouter/src/tools/web-search-tool.ts` and `web-fetch-tool.ts`).

## Fix

- Emit `readonly ['web_search', 'web_fetch']` from the codegen so regenerating `model-meta.ts` matches the committed source.
- Update the doc comment to mention both plugins.

## Notes

Script-only change — no published package output changes (the committed `model-meta.ts` already has the correct value), so no changeset is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat models now support expanded tool capabilities, including both web search and web fetch functionalities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->