### PR TITLE
fix(ai): detect callable ArkType schemas in convertSchemaToJsonSchema (#276)

### DIFF
--- a/.changeset/arktype-callable-schema.md
+++ b/.changeset/arktype-callable-schema.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai': patch
+---
+
+Fix `convertSchemaToJsonSchema` (and tool input/output validation) for ArkType schemas. ArkType's `type()` returns a callable function with `~standard` attached, but the Standard Schema detection guards required `typeof schema === 'object'`, so ArkType schemas were never recognized and the raw validator function was passed through instead of a JSON Schema object. The guards now also accept callable schemas. (#276)

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -93,6 +93,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@vitest/coverage-v8": "4.0.14",
+    "arktype": "^2.1.28",
     "zod": "^4.2.0"
   }
 }

--- a/packages/ai/src/activities/chat/tools/schema-converter.ts
+++ b/packages/ai/src/activities/chat/tools/schema-converter.ts
@@ -25,6 +25,20 @@ function toJsonSchema(obj: object): JSONSchema {
 }
 
 /**
+ * Whether a value can carry a `~standard` property. Most schema libraries
+ * (Zod, Valibot) return plain objects, but ArkType's `type()` returns a
+ * *callable function* with `~standard` attached — so `typeof` must accept
+ * both `'object'` and `'function'` or ArkType schemas are missed entirely
+ * (issue #276).
+ */
+function isPropertyCarrier(schema: unknown): schema is Record<string, unknown> {
+  return (
+    (typeof schema === 'object' || typeof schema === 'function') &&
+    schema !== null
+  )
+}
+
+/**
  * Check if a value is a Standard JSON Schema compliant schema.
  * Standard JSON Schema compliant libraries (Zod v4+, ArkType, Valibot with toStandardJsonSchema, etc.)
  * implement the '~standard' property with jsonSchema converter methods.
@@ -32,18 +46,23 @@ function toJsonSchema(obj: object): JSONSchema {
 export function isStandardJSONSchema(
   schema: unknown,
 ): schema is StandardJSONSchemaV1 {
-  return (
-    typeof schema === 'object' &&
-    schema !== null &&
-    '~standard' in schema &&
-    typeof (schema as StandardJSONSchemaV1)['~standard'] === 'object' &&
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard for caller-provided unknown; type assertion narrows but doesn't validate the wire payload
-    (schema as StandardJSONSchemaV1)['~standard'].version === 1 &&
-    typeof (schema as StandardJSONSchemaV1)['~standard'].jsonSchema ===
-      'object' &&
-    typeof (schema as StandardJSONSchemaV1)['~standard'].jsonSchema.input ===
-      'function'
-  )
+  if (!isPropertyCarrier(schema) || !('~standard' in schema)) return false
+
+  const standard = schema['~standard']
+  if (
+    typeof standard !== 'object' ||
+    standard === null ||
+    !('version' in standard) ||
+    standard.version !== 1 ||
+    !('jsonSchema' in standard) ||
+    typeof standard.jsonSchema !== 'object' ||
+    standard.jsonSchema === null ||
+    !('input' in standard.jsonSchema)
+  ) {
+    return false
+  }
+
+  return typeof standard.jsonSchema.input === 'function'
 }
 
 /**
@@ -52,8 +71,7 @@ export function isStandardJSONSchema(
  */
 export function isStandardSchema(schema: unknown): schema is StandardSchemaV1 {
   return (
-    typeof schema === 'object' &&
-    schema !== null &&
+    isPropertyCarrier(schema) &&
     '~standard' in schema &&
     typeof schema['~standard'] === 'object' &&
     schema['~standard'] !== null &&

--- a/packages/ai/tests/standard-converter.test.ts
+++ b/packages/ai/tests/standard-converter.test.ts
@@ -1,4 +1,5 @@
-﻿import { describe, expect, it } from 'vitest'
+﻿import { type } from 'arktype'
+import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import {
   convertSchemaToJsonSchema,
@@ -570,6 +571,58 @@ describe('convertSchemaToJsonSchema', () => {
     })
   })
 
+  // Regression guard for #276: ArkType `type()` returns a *callable function*
+  // (with `~standard` attached as a property), not a plain object. The
+  // detection guards previously required `typeof schema === 'object'`, so
+  // ArkType schemas matched neither branch and fell through the JSONSchema
+  // pass-through, returning the raw validator function instead of a converted
+  // JSON Schema object.
+  describe('ArkType (callable Standard JSON Schema)', () => {
+    it('returns a JSON Schema object, not the validator function', () => {
+      const schema = type({ foo: 'boolean' })
+      const result = convertSchemaToJsonSchema(schema)
+
+      expect(typeof result).toBe('object')
+      expect(result?.type).toBe('object')
+      expect(result?.properties?.['foo']?.type).toBe('boolean')
+      expect(result?.required).toContain('foo')
+    })
+
+    it('drops the $schema key', () => {
+      const schema = type({ foo: 'boolean' })
+      const result = convertSchemaToJsonSchema(schema)
+
+      expect('$schema' in (result || {})).toBe(false)
+    })
+
+    it('handles optional fields', () => {
+      const schema = type({
+        name: 'string',
+        'age?': 'number',
+      })
+      const result = convertSchemaToJsonSchema(schema)
+
+      expect(result?.type).toBe('object')
+      expect(result?.required).toContain('name')
+      expect(result?.required).not.toContain('age')
+    })
+
+    it('applies structured-output transformation', () => {
+      const schema = type({
+        name: 'string',
+        'age?': 'number',
+      })
+      const result = convertSchemaToJsonSchema(schema, {
+        forStructuredOutput: true,
+      })
+
+      expect(result?.additionalProperties).toBe(false)
+      // All properties required for structured output
+      expect(result?.required).toContain('name')
+      expect(result?.required).toContain('age')
+    })
+  })
+
   describe('Standard Schema validator without jsonSchema converter', () => {
     // Regression guard for #562: widening `SchemaInput` to also accept
     // `StandardSchemaV1<any, any>` means a validator-only schema (no
@@ -599,9 +652,18 @@ describe('isStandardJSONSchema', () => {
     expect(isStandardJSONSchema(schema)).toBe(true)
   })
 
+  it('should return true for ArkType schemas (callable Standard JSON Schema)', () => {
+    const schema = type({ foo: 'boolean' })
+    expect(isStandardJSONSchema(schema)).toBe(true)
+  })
+
   it('should return false for plain objects', () => {
     const plainObject = { type: 'object', properties: {} }
     expect(isStandardJSONSchema(plainObject)).toBe(false)
+  })
+
+  it('should return false for plain (non-schema) functions', () => {
+    expect(isStandardJSONSchema(() => {})).toBe(false)
   })
 
   it('should return false for null', () => {
@@ -625,9 +687,18 @@ describe('isStandardSchema', () => {
     expect(isStandardSchema(schema)).toBe(true)
   })
 
+  it('should return true for ArkType schemas (callable validators)', () => {
+    const schema = type({ foo: 'boolean' })
+    expect(isStandardSchema(schema)).toBe(true)
+  })
+
   it('should return false for plain objects', () => {
     const plainObject = { type: 'object', properties: {} }
     expect(isStandardSchema(plainObject)).toBe(false)
+  })
+
+  it('should return false for plain (non-schema) functions', () => {
+    expect(isStandardSchema(() => {})).toBe(false)
   })
 
   it('should return false for null', () => {
@@ -659,6 +730,24 @@ describe('parseWithStandardSchema', () => {
       name: z.string(),
       age: z.number(),
     })
+
+    expect(() =>
+      parseWithStandardSchema(schema, { name: 'John', age: 'not a number' }),
+    ).toThrow()
+  })
+
+  // #276: ArkType validators are callable functions; the `isStandardSchema`
+  // guard used by tool input/output validation must recognize them so data is
+  // actually validated instead of silently passed through.
+  it('should parse and throw with ArkType schema', () => {
+    const schema = type({ name: 'string', age: 'number' })
+
+    expect(
+      parseWithStandardSchema<{ name: string; age: number }>(schema, {
+        name: 'John',
+        age: 30,
+      }),
+    ).toEqual({ name: 'John', age: 30 })
 
     expect(() =>
       parseWithStandardSchema(schema, { name: 'John', age: 'not a number' }),
@@ -707,6 +796,27 @@ describe('validateWithStandardSchema', () => {
     if (!result.success) {
       expect(result.issues).toBeDefined()
       expect(result.issues.length).toBeGreaterThan(0)
+    }
+  })
+
+  // #276: ArkType validators are callable functions — verify they are
+  // recognized and produce issues on failure rather than passing through.
+  it('should validate ArkType schema (success and failure)', async () => {
+    const schema = type({ name: 'string', age: 'number' })
+
+    const ok = await validateWithStandardSchema(schema, {
+      name: 'John',
+      age: 30,
+    })
+    expect(ok.success).toBe(true)
+
+    const bad = await validateWithStandardSchema(schema, {
+      name: 'John',
+      age: 'not a number',
+    })
+    expect(bad.success).toBe(false)
+    if (!bad.success) {
+      expect(bad.issues.length).toBeGreaterThan(0)
     }
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1003,6 +1003,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.0.14
         version: 4.0.14(vitest@4.0.14(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(happy-dom@20.0.11)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.15))(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      arktype:
+        specifier: ^2.1.28
+        version: 2.2.0
       zod:
         specifier: ^4.2.0
         version: 4.2.1
@@ -1861,6 +1864,9 @@ importers:
       '@tanstack/react-start':
         specifier: ^1.159.0
         version: 1.159.5(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.3(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      arktype:
+        specifier: ^2.1.28
+        version: 2.2.0
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -2079,6 +2085,12 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@ark/schema@0.56.0':
+    resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
+
+  '@ark/util@0.56.0':
+    resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
 
   '@asamuzakjp/css-color@4.1.0':
     resolution: {integrity: sha512-9xiBAtLn4aNsa4mDnpovJvBn72tNEIACyvlqaNJ+ADemR+yeMJWnBudOi2qGDviJa7SwcDOU/TRh5dnET7qk0w==}
@@ -7782,6 +7794,12 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
+
+  arkregex@0.0.5:
+    resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
+
+  arktype@2.2.0:
+    resolution: {integrity: sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -13780,6 +13798,12 @@ snapshots:
       standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.2.1
+
+  '@ark/schema@0.56.0':
+    dependencies:
+      '@ark/util': 0.56.0
+
+  '@ark/util@0.56.0': {}
 
   '@asamuzakjp/css-color@4.1.0':
     dependencies:
@@ -20157,6 +20181,16 @@ snapshots:
       dequal: 2.0.3
 
   aria-query@5.3.2: {}
+
+  arkregex@0.0.5:
+    dependencies:
+      '@ark/util': 0.56.0
+
+  arktype@2.2.0:
+    dependencies:
+      '@ark/schema': 0.56.0
+      '@ark/util': 0.56.0
+      arkregex: 0.0.5
 
   array-buffer-byte-length@1.0.2:
     dependencies:

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -32,6 +32,7 @@
     "@tanstack/react-ai-devtools": "workspace:*",
     "@tanstack/react-router": "^1.158.4",
     "@tanstack/react-start": "^1.159.0",
+    "arktype": "^2.1.28",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0",

--- a/testing/e2e/src/routeTree.gen.ts
+++ b/testing/e2e/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as ApiMiddlewareTestRouteImport } from './routes/api.middleware-t
 import { Route as ApiImageRouteImport } from './routes/api.image'
 import { Route as ApiChatRouteImport } from './routes/api.chat'
 import { Route as ApiAudioRouteImport } from './routes/api.audio'
+import { Route as ApiArktypeToolWireRouteImport } from './routes/api.arktype-tool-wire'
 import { Route as ApiAnthropicBugTestRouteImport } from './routes/api.anthropic-bug-test'
 import { Route as ProviderFeatureRouteImport } from './routes/$provider/$feature'
 import { Route as ApiVideoStreamRouteImport } from './routes/api.video.stream'
@@ -150,6 +151,11 @@ const ApiAudioRoute = ApiAudioRouteImport.update({
   path: '/api/audio',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiArktypeToolWireRoute = ApiArktypeToolWireRouteImport.update({
+  id: '/api/arktype-tool-wire',
+  path: '/api/arktype-tool-wire',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAnthropicBugTestRoute = ApiAnthropicBugTestRouteImport.update({
   id: '/api/anthropic-bug-test',
   path: '/api/anthropic-bug-test',
@@ -199,6 +205,7 @@ export interface FileRoutesByFullPath {
   '/tools-test': typeof ToolsTestRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
   '/api/anthropic-bug-test': typeof ApiAnthropicBugTestRoute
+  '/api/arktype-tool-wire': typeof ApiArktypeToolWireRoute
   '/api/audio': typeof ApiAudioRouteWithChildren
   '/api/chat': typeof ApiChatRoute
   '/api/image': typeof ApiImageRouteWithChildren
@@ -230,6 +237,7 @@ export interface FileRoutesByTo {
   '/tools-test': typeof ToolsTestRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
   '/api/anthropic-bug-test': typeof ApiAnthropicBugTestRoute
+  '/api/arktype-tool-wire': typeof ApiArktypeToolWireRoute
   '/api/audio': typeof ApiAudioRouteWithChildren
   '/api/chat': typeof ApiChatRoute
   '/api/image': typeof ApiImageRouteWithChildren
@@ -262,6 +270,7 @@ export interface FileRoutesById {
   '/tools-test': typeof ToolsTestRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
   '/api/anthropic-bug-test': typeof ApiAnthropicBugTestRoute
+  '/api/arktype-tool-wire': typeof ApiArktypeToolWireRoute
   '/api/audio': typeof ApiAudioRouteWithChildren
   '/api/chat': typeof ApiChatRoute
   '/api/image': typeof ApiImageRouteWithChildren
@@ -295,6 +304,7 @@ export interface FileRouteTypes {
     | '/tools-test'
     | '/$provider/$feature'
     | '/api/anthropic-bug-test'
+    | '/api/arktype-tool-wire'
     | '/api/audio'
     | '/api/chat'
     | '/api/image'
@@ -326,6 +336,7 @@ export interface FileRouteTypes {
     | '/tools-test'
     | '/$provider/$feature'
     | '/api/anthropic-bug-test'
+    | '/api/arktype-tool-wire'
     | '/api/audio'
     | '/api/chat'
     | '/api/image'
@@ -357,6 +368,7 @@ export interface FileRouteTypes {
     | '/tools-test'
     | '/$provider/$feature'
     | '/api/anthropic-bug-test'
+    | '/api/arktype-tool-wire'
     | '/api/audio'
     | '/api/chat'
     | '/api/image'
@@ -389,6 +401,7 @@ export interface RootRouteChildren {
   ToolsTestRoute: typeof ToolsTestRoute
   ProviderFeatureRoute: typeof ProviderFeatureRoute
   ApiAnthropicBugTestRoute: typeof ApiAnthropicBugTestRoute
+  ApiArktypeToolWireRoute: typeof ApiArktypeToolWireRoute
   ApiAudioRoute: typeof ApiAudioRouteWithChildren
   ApiChatRoute: typeof ApiChatRoute
   ApiImageRoute: typeof ApiImageRouteWithChildren
@@ -559,6 +572,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAudioRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/arktype-tool-wire': {
+      id: '/api/arktype-tool-wire'
+      path: '/api/arktype-tool-wire'
+      fullPath: '/api/arktype-tool-wire'
+      preLoaderRoute: typeof ApiArktypeToolWireRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/anthropic-bug-test': {
       id: '/api/anthropic-bug-test'
       path: '/api/anthropic-bug-test'
@@ -682,6 +702,7 @@ const rootRouteChildren: RootRouteChildren = {
   ToolsTestRoute: ToolsTestRoute,
   ProviderFeatureRoute: ProviderFeatureRoute,
   ApiAnthropicBugTestRoute: ApiAnthropicBugTestRoute,
+  ApiArktypeToolWireRoute: ApiArktypeToolWireRoute,
   ApiAudioRoute: ApiAudioRouteWithChildren,
   ApiChatRoute: ApiChatRoute,
   ApiImageRoute: ApiImageRouteWithChildren,

--- a/testing/e2e/src/routes/api.arktype-tool-wire.ts
+++ b/testing/e2e/src/routes/api.arktype-tool-wire.ts
@@ -1,0 +1,89 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { chat, createChatOptions, toolDefinition } from '@tanstack/ai'
+import { createOpenRouterText } from '@tanstack/ai-openrouter'
+import { HTTPClient } from '@openrouter/sdk'
+import { type } from 'arktype'
+
+const LLMOCK_DEFAULT_BASE = process.env.LLMOCK_URL || 'http://127.0.0.1:4010'
+const DUMMY_KEY = 'sk-e2e-test-dummy-key'
+
+/**
+ * Regression route for #276. ArkType's `type()` returns a *callable function*
+ * with `~standard` attached, not a plain object. The schema-detection guards
+ * in `@tanstack/ai` previously required `typeof schema === 'object'`, so an
+ * ArkType `inputSchema` was never converted to JSON Schema — the raw validator
+ * function fell through and, once serialized to the wire, the tool's
+ * `parameters` collapsed to `{}` (functions don't survive `JSON.stringify`).
+ *
+ * This route drives the OpenRouter chat adapter with an ArkType-schema
+ * function tool against aimock so the companion spec can inspect aimock's
+ * journal (`GET /v1/_requests`) and assert the converted JSON Schema actually
+ * crossed the wire. The model response is irrelevant to the assertion.
+ */
+const arktypeWeatherTool = toolDefinition({
+  name: 'get_arktype_weather',
+  description: 'Get weather for a city (ArkType-schema tool, #276 wire test)',
+  inputSchema: type({
+    city: 'string',
+    'units?': "'celsius' | 'fahrenheit'",
+  }),
+}).server(async () => JSON.stringify({ ok: true }))
+
+export const Route = createFileRoute('/api/arktype-tool-wire')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const url = new URL(request.url)
+        const testId = url.searchParams.get('testId') ?? undefined
+
+        // Same X-Test-Id injection pattern as the other wire specs so this
+        // route gets its own aimock test bucket.
+        const httpClient = new HTTPClient()
+        if (testId) {
+          httpClient.addHook('beforeRequest', (req) => {
+            const next = new Request(req)
+            next.headers.set('X-Test-Id', testId)
+            return next
+          })
+        }
+
+        const adapter = createOpenRouterText(
+          'openai/gpt-4o' as never,
+          DUMMY_KEY,
+          {
+            serverURL: `${LLMOCK_DEFAULT_BASE}/v1`,
+            httpClient,
+          },
+        )
+
+        try {
+          for await (const _ of chat({
+            ...createChatOptions({ adapter }),
+            messages: [
+              {
+                role: 'user',
+                content: '[wire-test] arktype tool schema serialization',
+              },
+            ],
+            tools: [arktypeWeatherTool],
+          })) {
+            // Drain the stream.
+          }
+        } catch (error) {
+          return new Response(
+            JSON.stringify({
+              ok: false,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      },
+    },
+  },
+})

--- a/testing/e2e/tests/arktype-tool-wire.spec.ts
+++ b/testing/e2e/tests/arktype-tool-wire.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from './fixtures'
+
+/**
+ * Wire-format regression for #276 — ArkType schemas.
+ *
+ * ArkType's `type()` returns a callable function (with `~standard` attached),
+ * not a plain object. `@tanstack/ai`'s schema-detection guards previously
+ * required `typeof schema === 'object'`, so an ArkType `inputSchema` was never
+ * recognized as a Standard JSON Schema. The raw validator function fell through
+ * `convertSchemaToJsonSchema` unchanged and, when serialized to the wire, the
+ * tool's `parameters` collapsed to `{}` (functions don't survive
+ * `JSON.stringify`).
+ *
+ * This spec drives `/api/arktype-tool-wire` (OpenRouter chat adapter, ArkType
+ * function tool) and inspects aimock's journal (`GET /v1/_requests`) to assert
+ * the converted JSON Schema actually reached the provider.
+ */
+test.describe('arktype — tool schema wire format', () => {
+  test.beforeEach(async ({ request, aimockPort }) => {
+    // Clear the aimock journal so we only assert against this test's request —
+    // adjacent specs share the same aimock instance.
+    await request.delete(`http://127.0.0.1:${aimockPort}/v1/_requests`)
+  })
+
+  test('ArkType inputSchema is converted to JSON Schema on the wire', async ({
+    request,
+    aimockPort,
+    testId,
+  }) => {
+    const res = await request.post(
+      `/api/arktype-tool-wire?testId=${encodeURIComponent(testId)}`,
+    )
+    expect(res.ok()).toBe(true)
+    const { ok } = (await res.json()) as { ok: boolean; error?: string }
+    expect(ok).toBe(true)
+
+    const journalRes = await request.get(
+      `http://127.0.0.1:${aimockPort}/v1/_requests`,
+    )
+    const entries = (await journalRes.json()) as Array<{
+      body: {
+        tools?: Array<{
+          type?: string
+          function?: { name?: string; parameters?: Record<string, unknown> }
+        }>
+      } | null
+    }>
+
+    const captured = entries[0]?.body?.tools?.find(
+      (t) => t.function?.name === 'get_arktype_weather',
+    )
+
+    // Before the fix `parameters` was `{}` (the ArkType validator function was
+    // passed through unconverted and dropped by JSON serialization). After the
+    // fix it is the real JSON Schema produced from the ArkType type.
+    expect(captured?.function?.parameters).toMatchObject({
+      type: 'object',
+      properties: {
+        city: { type: 'string' },
+      },
+    })
+    expect(
+      (captured?.function?.parameters?.['required'] as Array<string>) ?? [],
+    ).toContain('city')
+  })
+})


### PR DESCRIPTION
## Fixes #276

`convertSchemaToJsonSchema` returned the raw ArkType validator (a function) instead of a JSON Schema object, so providers that validate the tool/output schema (e.g. OpenRouter) rejected it.

### Root cause

ArkType's `type()` returns a **callable function** with `~standard` attached as a property — not a plain object. Both Standard Schema detection guards (`isStandardJSONSchema`, `isStandardSchema`) required `typeof schema === 'object'`, which is `false` for a function. ArkType schemas therefore matched neither branch and fell through to the JSONSchema pass-through, which returned the function untouched. The same guard also gated tool input/output validation, so validation was silently skipped for ArkType tools.

Verified empirically against the reporter's version (arktype `2.1.28`): `typeof type({...}) === 'function'`, and `~standard.jsonSchema.input()` is present and works — so the only needed change is widening the guards.

### Fix

- Add an `isPropertyCarrier` helper that accepts both `'object'` and `'function'` (non-null).
- Route `isStandardJSONSchema` and `isStandardSchema` through it. Rewrote `isStandardJSONSchema` cast-free, which also drops the `eslint-disable` and turns a latent `null.jsonSchema` crash into a clean `false`.

Because tool input/output conversion/validation and structured output all route through these two functions, ArkType now works end-to-end for tools and structured output too — previously validation was silently skipped.

### Tests

- **Unit** (`packages/ai/tests/standard-converter.test.ts`): the reporter's exact repro plus guard detection, optional fields, structured-output transformation, and direct `parseWithStandardSchema` / `validateWithStandardSchema` coverage with ArkType.
- **E2E** (`testing/e2e/tests/arktype-tool-wire.spec.ts` + route): drives the OpenRouter chat adapter with an ArkType-schema function tool against aimock and inspects the journal to assert the converted JSON Schema reaches the wire (pre-fix the function-valued schema serialized to `{}`). Deterministic — no recorded LLM fixture needed.

### Verification

- `@tanstack/ai` unit suite green (63 tests in the converter spec); `test:types` clean; `test:eslint` 0 errors for the touched file.
- E2E `arktype — tool schema wire format` passes.
- `test:sherif` and Prettier clean.

A patch changeset is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed detection and validation of ArkType callable schemas in tool definitions. Previously, callable ArkType schemas were incorrectly handled due to overly strict schema type validation guards, causing improper conversion to JSON Schema format. The detection logic has been updated to properly recognize and convert all ArkType schema types, including callable variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/ai/pull/662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->