### PR TITLE
fix(ai-event-client): defer devtools runtime-id generation to first use

### DIFF
--- a/.changeset/lazy-runtime-id.md
+++ b/.changeset/lazy-runtime-id.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/ai-event-client': patch
+---
+
+Defer devtools runtime-id generation to first use so importing `@tanstack/ai` is safe in edge/global scope.
+
+`@tanstack/ai-event-client` previously seeded its runtime id at module scope by calling `crypto.randomUUID()` (falling back to `Math.random()`) inside a top-level IIFE. Because `@tanstack/ai`'s `chat()` always pulls in the devtools middleware, this random-value generation ran at module-evaluation time. Edge runtimes such as Cloudflare Workers forbid generating random values in global scope, so simply importing `chat()` crashed the Worker with `Disallowed operation called within global scope`.
+
+The runtime id is now generated lazily on first use (inside `getAIDevtoolsRuntimeId()` / `createAIDevtoolsEventEnvelope()`) and memoized, so evaluating the module performs no random-value generation. The cross-bundle global (`globalThis.__TANSTACK_AI_DEVTOOLS_RUNTIME_ID__`) and the generated values are unchanged. Fixes #667.

--- a/packages/ai-event-client/src/envelope.ts
+++ b/packages/ai-event-client/src/envelope.ts
@@ -51,12 +51,22 @@ function createRuntimeId(): string {
   return Math.random().toString(36).slice(2)
 }
 
-const runtimeId = (() => {
+// Memoized after first resolution. Generation is deferred to first use rather
+// than computed at module scope so importing this module performs no random
+// value generation — edge runtimes (e.g. Cloudflare Workers) forbid that in
+// global scope and would crash on module evaluation. See issue #667.
+let memoizedRuntimeId: string | undefined
+
+function getRuntimeId(): string {
+  if (memoizedRuntimeId !== undefined) {
+    return memoizedRuntimeId
+  }
   if (!globalThis.__TANSTACK_AI_DEVTOOLS_RUNTIME_ID__) {
     globalThis.__TANSTACK_AI_DEVTOOLS_RUNTIME_ID__ = createRuntimeId()
   }
-  return globalThis.__TANSTACK_AI_DEVTOOLS_RUNTIME_ID__
-})()
+  memoizedRuntimeId = globalThis.__TANSTACK_AI_DEVTOOLS_RUNTIME_ID__
+  return memoizedRuntimeId
+}
 
 let eventCounter = 0
 
@@ -72,7 +82,7 @@ function timestampBucket(timestamp: number): number {
 export function createAIDevtoolsEventEnvelope(
   input: AIDevtoolsEventEnvelopeInput,
 ): AIDevtoolsEventEnvelope {
-  const resolvedRuntimeId = input.runtimeId ?? runtimeId
+  const resolvedRuntimeId = input.runtimeId ?? getRuntimeId()
   const eventId =
     input.eventId && input.eventId.length > 0
       ? input.eventId
@@ -90,7 +100,7 @@ export function createAIDevtoolsEventEnvelope(
           idPart(input.toolCallId),
           idPart(input.sequence),
           input.timestamp,
-          runtimeId,
+          getRuntimeId(),
           eventCounter++,
         ].join(':')
 
@@ -102,7 +112,7 @@ export function createAIDevtoolsEventEnvelope(
 }
 
 export function getAIDevtoolsRuntimeId(): string {
-  return runtimeId
+  return getRuntimeId()
 }
 
 export function getAIDevtoolsDedupeKey(

--- a/packages/ai-event-client/tests/runtime-id.test.ts
+++ b/packages/ai-event-client/tests/runtime-id.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Regression coverage for issue #667: importing this module must not generate a
+// random value in global scope. Edge runtimes (e.g. Cloudflare Workers) forbid
+// random-value generation at module-evaluation time, so eager seeding of the
+// runtime id crashed the Worker simply by importing `@tanstack/ai`'s `chat()`,
+// which pulls in the devtools middleware → this module.
+//
+// These tests live in a dedicated file (rather than envelope.test.ts) so the
+// module can be imported lazily via dynamic import after `vi.resetModules()`,
+// letting us observe behavior at the exact moment of module evaluation.
+describe('runtime id generation is deferred to first use (issue #667)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    Reflect.deleteProperty(globalThis, '__TANSTACK_AI_DEVTOOLS_RUNTIME_ID__')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    Reflect.deleteProperty(globalThis, '__TANSTACK_AI_DEVTOOLS_RUNTIME_ID__')
+  })
+
+  it('does not generate a random value at module import time', async () => {
+    const randomUUID = vi.spyOn(globalThis.crypto, 'randomUUID')
+    const mathRandom = vi.spyOn(Math, 'random')
+
+    const mod = await import('../src/envelope')
+
+    // The crux of the bug: simply evaluating the module must touch no RNG.
+    expect(randomUUID).not.toHaveBeenCalled()
+    expect(mathRandom).not.toHaveBeenCalled()
+    expect(globalThis.__TANSTACK_AI_DEVTOOLS_RUNTIME_ID__).toBeUndefined()
+
+    // The id is generated lazily, on first use, inside a handler/call.
+    const id = mod.getAIDevtoolsRuntimeId()
+    expect(randomUUID).toHaveBeenCalledTimes(1)
+    expect(typeof id).toBe('string')
+    expect(id.length).toBeGreaterThan(0)
+    expect(globalThis.__TANSTACK_AI_DEVTOOLS_RUNTIME_ID__).toBe(id)
+  })
+
+  it('also defers generation when reached via createAIDevtoolsEventEnvelope', async () => {
+    const randomUUID = vi.spyOn(globalThis.crypto, 'randomUUID')
+
+    const mod = await import('../src/envelope')
+    expect(randomUUID).not.toHaveBeenCalled()
+
+    const envelope = mod.createAIDevtoolsEventEnvelope({
+      eventType: 'run:started',
+      source: 'server',
+      visibility: 'server-internal',
+      timestamp: 1,
+    })
+
+    expect(randomUUID).toHaveBeenCalled()
+    expect(envelope.runtimeId).toBe(mod.getAIDevtoolsRuntimeId())
+  })
+
+  it('reuses a runtime id already present on the global without regenerating', async () => {
+    const randomUUID = vi.spyOn(globalThis.crypto, 'randomUUID')
+    const mathRandom = vi.spyOn(Math, 'random')
+    globalThis.__TANSTACK_AI_DEVTOOLS_RUNTIME_ID__ = 'preseeded-runtime-id'
+
+    const mod = await import('../src/envelope')
+
+    expect(mod.getAIDevtoolsRuntimeId()).toBe('preseeded-runtime-id')
+    expect(randomUUID).not.toHaveBeenCalled()
+    expect(mathRandom).not.toHaveBeenCalled()
+  })
+
+  it('memoizes after first resolution so the id is stable across calls', async () => {
+    const mod = await import('../src/envelope')
+
+    const first = mod.getAIDevtoolsRuntimeId()
+    const second = mod.getAIDevtoolsRuntimeId()
+    const envelope = mod.createAIDevtoolsEventEnvelope({
+      eventType: 'run:started',
+      source: 'server',
+      visibility: 'server-internal',
+      timestamp: 1,
+    })
+
+    expect(second).toBe(first)
+    expect(envelope.runtimeId).toBe(first)
+  })
+
+  it('falls back to Math.random when crypto.randomUUID is unavailable', async () => {
+    const cryptoDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'crypto',
+    )
+    // Simulate a runtime without Web Crypto (forces the Math.random fallback).
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: undefined,
+    })
+    const mathRandom = vi.spyOn(Math, 'random')
+
+    try {
+      const mod = await import('../src/envelope')
+      expect(mathRandom).not.toHaveBeenCalled()
+
+      const id = mod.getAIDevtoolsRuntimeId()
+      expect(mathRandom).toHaveBeenCalled()
+      expect(typeof id).toBe('string')
+      expect(id.length).toBeGreaterThan(0)
+    } finally {
+      if (cryptoDescriptor) {
+        Object.defineProperty(globalThis, 'crypto', cryptoDescriptor)
+      }
+    }
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

`@tanstack/ai-event-client` seeded its devtools runtime id at **module scope** (a top-level IIFE calling `crypto.randomUUID()` / `Math.random()`). Because `@tanstack/ai`'s `chat()` always pulls in the devtools middleware, this RNG ran at module-evaluation time — and Cloudflare Workers / edge runtimes forbid generating random values in global scope, so importing `chat()` crashed the Worker at startup/prerender (`Disallowed operation called within global scope`).

Fix: generate the runtime id **lazily on first use** (in `getAIDevtoolsRuntimeId()` / `createAIDevtoolsEventEnvelope()`) and memoize it, so module evaluation does no RNG. The cross-bundle global and generated id values are unchanged. Adds isolated regression tests asserting no RNG happens at import.

Fixes #667.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).