### PR TITLE
fix: pass and use threadId

### DIFF
--- a/.changeset/sour-bugs-like.md
+++ b/.changeset/sour-bugs-like.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/ai-preact': patch
+'@tanstack/ai-svelte': patch
+'@tanstack/ai-react': patch
+'@tanstack/ai-solid': patch
+'@tanstack/ai-vue': patch
+---
+
+Forward `threadId` option to `ChatClient` in all framework wrappers

--- a/packages/ai-preact/src/use-chat.ts
+++ b/packages/ai-preact/src/use-chat.ts
@@ -76,7 +76,9 @@ export function useChat<
       id: clientId,
       initialMessages: messagesToUse,
       ...(initialOptions.body !== undefined && { body: initialOptions.body }),
-      ...(initialOptions.threadId !== undefined && { threadId: initialOptions.threadId }),
+      ...(initialOptions.threadId !== undefined && {
+        threadId: initialOptions.threadId,
+      }),
       ...(initialOptions.forwardedProps !== undefined && {
         forwardedProps: initialOptions.forwardedProps,
       }),

--- a/packages/ai-preact/src/use-chat.ts
+++ b/packages/ai-preact/src/use-chat.ts
@@ -76,6 +76,7 @@ export function useChat<
       id: clientId,
       initialMessages: messagesToUse,
       ...(initialOptions.body !== undefined && { body: initialOptions.body }),
+      ...(initialOptions.threadId !== undefined && { threadId: initialOptions.threadId }),
       ...(initialOptions.forwardedProps !== undefined && {
         forwardedProps: initialOptions.forwardedProps,
       }),

--- a/packages/ai-react/src/use-chat.ts
+++ b/packages/ai-react/src/use-chat.ts
@@ -84,6 +84,7 @@ export function useChat<
       id: clientId,
       initialMessages: messagesToUse,
       ...(initialOptions.body !== undefined && { body: initialOptions.body }),
+      ...(initialOptions.threadId !== undefined && { threadId: initialOptions.threadId }),
       ...(initialOptions.forwardedProps !== undefined && {
         forwardedProps: initialOptions.forwardedProps,
       }),

--- a/packages/ai-react/src/use-chat.ts
+++ b/packages/ai-react/src/use-chat.ts
@@ -84,7 +84,9 @@ export function useChat<
       id: clientId,
       initialMessages: messagesToUse,
       ...(initialOptions.body !== undefined && { body: initialOptions.body }),
-      ...(initialOptions.threadId !== undefined && { threadId: initialOptions.threadId }),
+      ...(initialOptions.threadId !== undefined && {
+        threadId: initialOptions.threadId,
+      }),
       ...(initialOptions.forwardedProps !== undefined && {
         forwardedProps: initialOptions.forwardedProps,
       }),

--- a/packages/ai-solid/src/use-chat.ts
+++ b/packages/ai-solid/src/use-chat.ts
@@ -87,6 +87,7 @@ export function useChat<
         persistence: options.persistence,
       }),
       body: options.body,
+      ...(options.threadId !== undefined && { threadId: options.threadId }),
       ...(options.forwardedProps !== undefined && {
         forwardedProps: options.forwardedProps,
       }),

--- a/packages/ai-svelte/src/create-chat.svelte.ts
+++ b/packages/ai-svelte/src/create-chat.svelte.ts
@@ -104,6 +104,7 @@ export function createChat<
       persistence: options.persistence,
     }),
     ...(options.body !== undefined && { body: options.body }),
+    ...(options.threadId !== undefined && { threadId: options.threadId }),
     ...(options.forwardedProps !== undefined && {
       forwardedProps: options.forwardedProps,
     }),

--- a/packages/ai-vue/src/use-chat.ts
+++ b/packages/ai-vue/src/use-chat.ts
@@ -90,6 +90,7 @@ export function useChat<
       persistence: options.persistence,
     }),
     ...(options.body !== undefined && { body: options.body }),
+    ...(options.threadId !== undefined && { threadId: options.threadId }),
     ...(options.forwardedProps !== undefined && {
       forwardedProps: options.forwardedProps,
     }),


### PR DESCRIPTION
## 🎯 Changes

bug: `threadId` is [documented](https://tanstack.com/ai/latest/docs/api/ai-svelte#options) as an option and exists in the type definitions but fails to be exposed or used in the current code. It is also mentioned in this [migration guide](https://tanstack.com/ai/latest/docs/migration/ag-ui-compliance#conversationid--threadid) but does not work as documented

<!-- What changes are made in this PR? Describe the change and its motivation. -->
`threadId` can be passed, but all framework wrappers (useChat/createChat) forget to forward it when constructing ChatClient. Because of this, a fallback auto-generated ID is used which cannot consistently identify the same thread. A one-liner addition to every wrapper ensures it is forwarded and can be used by consumers to correlate or resume threads.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

all checks passed

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

changeset included as `patch` for all 5 wrappers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `threadId` option is now correctly forwarded to the chat client across all framework wrappers, enabling proper thread-scoped chat behavior.
  * Updated support across Preact, React, Solid, Svelte, and Vue framework implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->