### PR TITLE
chore(ai-event-client): drop unused @tanstack/ai peerDependency

### DIFF
--- a/.changeset/ai-event-client-drop-peer-dep.md
+++ b/.changeset/ai-event-client-drop-peer-dep.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-event-client': patch
+---
+
+Drop the unused `@tanstack/ai` peerDependency. `@tanstack/ai-event-client` mirrors the middleware types it needs locally and imports nothing from `@tanstack/ai`, so the peer dep only manufactured a package-manifest cycle (`@tanstack/ai` already depends on `@tanstack/ai-event-client`). Removing it — and the matching `!@tanstack/ai` Nx `implicitDependencies` workaround — keeps the build graph a clean DAG and unblocks devtools-only consumers.

--- a/packages/ai-event-client/package.json
+++ b/packages/ai-event-client/package.json
@@ -36,9 +36,6 @@
   "dependencies": {
     "@tanstack/devtools-event-client": "^0.4.1"
   },
-  "peerDependencies": {
-    "@tanstack/ai": "workspace:*"
-  },
   "devDependencies": {
     "@vitest/coverage-v8": "4.0.14"
   },

--- a/packages/ai-event-client/project.json
+++ b/packages/ai-event-client/project.json
@@ -1,4 +1,3 @@
 {
-  "name": "@tanstack/ai-event-client",
-  "implicitDependencies": ["!@tanstack/ai"]
+  "name": "@tanstack/ai-event-client"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1211,9 +1211,6 @@ importers:
 
   packages/ai-event-client:
     dependencies:
-      '@tanstack/ai':
-        specifier: workspace:*
-        version: link:../ai
       '@tanstack/devtools-event-client':
         specifier: ^0.4.1
         version: 0.4.1


### PR DESCRIPTION
Closes #552.

`@tanstack/ai-event-client` declared `@tanstack/ai` as a `peerDependency` but imports nothing from it — the middleware/usage types are mirrored locally. The only real edge runs the other way (`@tanstack/ai` depends on `ai-event-client`), so the peer dep just manufactured a manifest cycle that had to be neutralised with a `!@tanstack/ai` Nx `implicitDependencies` hack. This drops both.

**Why not `linked`/`fixed` changesets instead:** the changeset config keeps both empty — independent versioning is the convention — and `updateInternalDependencies: patch` already bumps `ai` when `ai-event-client` changes. So straight removal; happy to revisit if you'd prefer lockstep.

**Verified:** `pnpm install` no longer warns about the cyclic workspace dependency, and `build` / `test:types` / `test:lib` (14 passing) / `publint --strict` / `nx affected build` all pass.
