### PR TITLE
docs: dedicated MCP sidebar section + shorter nav labels

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -103,7 +103,12 @@
           "label": "Lazy Tool Discovery",
           "to": "tools/lazy-tool-discovery",
           "addedAt": "2026-04-15"
-        },
+        }
+      ]
+    },
+    {
+      "label": "MCP",
+      "children": [
         {
           "label": "MCP Server Tools",
           "to": "tools/mcp",
@@ -115,7 +120,7 @@
           "addedAt": "2026-06-05"
         },
         {
-          "label": "Manual MCP: Tools, Resources & Prompts",
+          "label": "Manual MCP",
           "to": "tools/mcp-manual",
           "addedAt": "2026-06-05"
         },
@@ -340,7 +345,7 @@
           "addedAt": "2026-05-16"
         },
         {
-          "label": "Sampling Options to modelOptions",
+          "label": "Sampling → modelOptions",
           "to": "migration/sampling-options-to-model-options",
           "addedAt": "2026-06-03"
         }


### PR DESCRIPTION
## What

Sidebar (`docs/config.json`) cleanup, following up on #708:

- **Dedicated MCP section** — moved the four MCP pages (MCP Server Tools, Managed MCP with chat(), Manual MCP, MCP Type Generation) out of **Tools** into their own top-level **MCP** sidebar section.
- **Shorter nav labels:**
  - `Manual MCP: Tools, Resources & Prompts` → `Manual MCP`
  - `Sampling Options to modelOptions` → `Sampling → modelOptions`

`addedAt` values are preserved on every moved/renamed entry.

## Verification

- `docs/config.json` is valid JSON and Prettier-formatted.
- `pnpm test:docs` → ✅ no broken links.

Docs-only change — no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation navigation labels for improved clarity
  * Simplified "Manual MCP" section label
  * Enhanced "Sampling" entry with improved arrow notation for better navigation guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->