### PR TITLE
docs: require maintaining addedAt/updatedAt in docs config when touching docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,14 @@ When editing docs under `docs/`:
   include snippets for both halves (server endpoint AND client consumption).
 - **Use the latest model per provider**, sourced from each adapter's
   `model-meta.ts` (newest `gpt-*`, `claude-*`, `gemini-*`, …), in example code.
+- **Maintain `addedAt` / `updatedAt` on docs entries in `docs/config.json`.**
+  Every page entry carries an `addedAt` (ISO `YYYY-MM-DD`) and, once edited, an
+  `updatedAt`. When you touch a docs page, update its entry: add a new entry
+  with `addedAt` set to today's date for a **new page**, or set/refresh
+  `updatedAt` to today's date when you make a **content change** to an existing
+  page (new section, capability, reworked guidance, new examples). **Bug fixes
+  don't bump anything** — typos, broken links, code-fence languages,
+  formatting, and factual fixes must not touch `addedAt` or `updatedAt`.
 - Run `pnpm test:docs` (link verification) before pushing.
 
 ## Everything Else

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,17 @@ OPENAI_API_KEY=sk-... pnpm --filter @tanstack/ai-e2e record
 - **Use the latest model per provider in examples**, sourced from each
   adapter's `model-meta.ts` (the newest `gpt-*`, `claude-*`, `gemini-*`,
   etc.). Don't introduce superseded model ids in new or edited samples.
+- **Maintain `addedAt` / `updatedAt` on docs entries in `docs/config.json`.**
+  Every page entry carries an `addedAt` (ISO `YYYY-MM-DD`) and, once edited,
+  an `updatedAt`. When you touch a docs page, update its entry:
+  - **New page** → add the entry with `addedAt` set to today's date.
+  - **Content change** to an existing page (new section, new capability,
+    reworked guidance, new examples) → set/refresh `updatedAt` to today's
+    date.
+  - **Bug fixes don't bump anything.** Pure corrections — typos, broken
+    links, code-fence languages, formatting, factual fixes — must **not**
+    touch `addedAt` or `updatedAt`. Only genuinely new or changed content
+    moves these dates.
 
 ## Key Dependencies
 


### PR DESCRIPTION
## What

Adds a convention to **`CLAUDE.md`** and **`AGENTS.md`**: when an agent touches a docs page, it must maintain that page's entry in `docs/config.json`.

- **New page** → add the entry with `addedAt` (ISO `YYYY-MM-DD`) set to today.
- **Content change** to an existing page (new section, capability, reworked guidance, new examples) → set/refresh `updatedAt` to today.
- **Bug fixes don't bump anything** — typos, broken links, code-fence languages, formatting, and factual fixes must not touch `addedAt` or `updatedAt`.

This codifies the `addedAt` field introduced in #708 and establishes a companion `updatedAt` for content edits, while keeping pure fixes from churning the dates.

## Notes

- Documentation-only change to the two agent-guidance files; no code or `docs/` content touched.
- `updatedAt` is not back-filled here — entries gain it the first time their page receives a content change under the new rule.

No changeset (repo guidance only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidelines for properly maintaining documentation metadata timestamps based on the type of change being made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->