### PR TITLE
Add npm metadata for @tanstack/ai

### DIFF
--- a/.changeset/clean-vans-think.md
+++ b/.changeset/clean-vans-think.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/ai": patch
+'@tanstack/ai': patch
 ---
 
 Add npm package homepage and issue tracker metadata.

--- a/.changeset/clean-vans-think.md
+++ b/.changeset/clean-vans-think.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/ai": patch
+---
+
+Add npm package homepage and issue tracker metadata.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -9,6 +9,10 @@
     "url": "git+https://github.com/TanStack/ai.git",
     "directory": "packages/ai"
   },
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  },
   "type": "module",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",


### PR DESCRIPTION
## Summary

- add `homepage` metadata for `@tanstack/ai`
- add `bugs.url` metadata pointing to the GitHub issue tracker
- add a patch changeset for the published package metadata update

This lets npm users and tooling navigate from the package metadata to the TanStack AI docs and issue tracker. The change is metadata-only and does not affect runtime behavior.

## Validation

- `node -e "const p=require('./packages/ai/package.json'); if(p.homepage!=='https://tanstack.com/ai') throw new Error('homepage mismatch'); if(p.bugs?.url!=='https://github.com/TanStack/ai/issues') throw new Error('bugs mismatch'); console.log('metadata smoke ok')"`
- `npm pack --dry-run --ignore-scripts ./packages/ai`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to add a homepage URL and an issue tracker link, improving discoverability and access to support resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->