### PR TITLE
docs: refresh AI SDK comparison against ai@6.0.200

### DIFF
--- a/.claude/skills/gap-analysis/SKILL.md
+++ b/.claude/skills/gap-analysis/SKILL.md
@@ -15,16 +15,16 @@ markdown report under `.agent/gap-analysis/`. **Do not edit source files.**
 
 ## Invocation
 
-| Args                             | Scope                                                  |
-| -------------------------------- | ------------------------------------------------------ |
-| `<provider>` (e.g. `openai`)     | One provider — all audit dimensions.                   |
-| `feature <feature>` (e.g. `tts`) | One feature row of the matrix across all providers.    |
-| `models`                         | New-model diff for every provider.                     |
-| `activities`                     | Activity-coverage diff: which of the 7 core activity   |
-|                                  | kinds each provider ships an adapter for, vs. what     |
-|                                  | upstream supports. (Dimension 6 only, all providers.)  |
-| `--all`                          | Full sweep (fan out subagents, one per provider).      |
-| _(none)_                         | Ask the user which scope via AskUserQuestion.          |
+| Args                             | Scope                                                 |
+| -------------------------------- | ----------------------------------------------------- |
+| `<provider>` (e.g. `openai`)     | One provider — all audit dimensions.                  |
+| `feature <feature>` (e.g. `tts`) | One feature row of the matrix across all providers.   |
+| `models`                         | New-model diff for every provider.                    |
+| `activities`                     | Activity-coverage diff: which of the 7 core activity  |
+|                                  | kinds each provider ships an adapter for, vs. what    |
+|                                  | upstream supports. (Dimension 6 only, all providers.) |
+| `--all`                          | Full sweep (fan out subagents, one per provider).     |
+| _(none)_                         | Ask the user which scope via AskUserQuestion.         |
 
 ## Workflow
 
@@ -110,15 +110,15 @@ union in `packages/ai/src/activities/index.ts` — always re-read it:
 A provider's activity surface is derived mechanically from its adapter files:
 `packages/ai-<provider>/src/adapters/`. Filename → activity-kind map:
 
-| Adapter file                          | Activity kind   |
-| ------------------------------------- | --------------- |
-| `text.ts` / `text-chat-completions.ts` / `responses-text.ts` | `text` |
-| `summarize.ts`                        | `summarize`     |
-| `image.ts`                            | `image`         |
-| `audio.ts`                            | `audio`         |
-| `video.ts`                            | `video`         |
-| `speech.ts` / `tts.ts`                | `tts`           |
-| `transcription.ts`                    | `transcription` |
+| Adapter file                                                 | Activity kind   |
+| ------------------------------------------------------------ | --------------- |
+| `text.ts` / `text-chat-completions.ts` / `responses-text.ts` | `text`          |
+| `summarize.ts`                                               | `summarize`     |
+| `image.ts`                                                   | `image`         |
+| `audio.ts`                                                   | `audio`         |
+| `video.ts`                                                   | `video`         |
+| `speech.ts` / `tts.ts`                                       | `tts`           |
+| `transcription.ts`                                           | `transcription` |
 
 (`cost.ts` is a helper, not an activity adapter.)
 

--- a/.claude/skills/gap-analysis/SKILL.md
+++ b/.claude/skills/gap-analysis/SKILL.md
@@ -15,13 +15,16 @@ markdown report under `.agent/gap-analysis/`. **Do not edit source files.**
 
 ## Invocation
 
-| Args                             | Scope                                               |
-| -------------------------------- | --------------------------------------------------- |
-| `<provider>` (e.g. `openai`)     | One provider — all four audit dimensions.           |
-| `feature <feature>` (e.g. `tts`) | One feature row of the matrix across all providers. |
-| `models`                         | New-model diff for every provider.                  |
-| `--all`                          | Full sweep (fan out subagents, one per provider).   |
-| _(none)_                         | Ask the user which scope via AskUserQuestion.       |
+| Args                             | Scope                                                  |
+| -------------------------------- | ------------------------------------------------------ |
+| `<provider>` (e.g. `openai`)     | One provider — all audit dimensions.                   |
+| `feature <feature>` (e.g. `tts`) | One feature row of the matrix across all providers.    |
+| `models`                         | New-model diff for every provider.                     |
+| `activities`                     | Activity-coverage diff: which of the 7 core activity   |
+|                                  | kinds each provider ships an adapter for, vs. what     |
+|                                  | upstream supports. (Dimension 6 only, all providers.)  |
+| `--all`                          | Full sweep (fan out subagents, one per provider).      |
+| _(none)_                         | Ask the user which scope via AskUserQuestion.          |
 
 ## Workflow
 
@@ -44,12 +47,18 @@ markdown report under `.agent/gap-analysis/`. **Do not edit source files.**
    4. Capability-flag drift
    5. Telemetry / observability parity (usage tokens, cache/reasoning
       counts, request ids, logging asymmetry)
+   6. Activity coverage (which of the 7 core activity kinds each provider
+      ships an adapter for vs. what upstream supports) — this is the **only**
+      dimension for the `activities` scope; it's also rolled into `--all`.
 5. **Fan out** for `--all`: launch one `Explore` subagent per provider, max 3
-   in parallel. Each subagent returns the five-dimension findings for its
-   provider; you synthesise into the combined report.
+   in parallel. Each subagent returns the multi-dimension findings for its
+   provider; you synthesise into the combined report. The `activities` scope
+   does **not** fan out — derive the provider×activity matrix centrally from
+   the adapter files (see dimension 6), since it's a fast mechanical diff.
 6. **Write the report** to `.agent/gap-analysis/YYYY-MM-DD-<scope>.md` using
    [references/report-template.md](references/report-template.md). Date is
-   today's ISO date. `<scope>` is `openai` / `feature-tts` / `models` / `all`.
+   today's ISO date. `<scope>` is `openai` / `feature-tts` / `models` /
+   `activities` / `all`.
 7. **Print the report path and a 5-line summary** to the user.
 
 ## Critical rules
@@ -87,6 +96,31 @@ re-read it; this list is a snapshot:
 `structured-output-stream`, `agentic-structured`, `multimodal-image`,
 `multimodal-structured`, `summarize`, `summarize-stream`, `image-gen`, `tts`,
 `transcription`, `video-gen`.
+
+## Known activities (7)
+
+**Features** (above) are matrix rows about behaviours within an activity.
+**Activities** are the coarser-grained core capability kinds in `@tanstack/ai`
+— each has a `Base<Kind>Adapter` and a provider "supports" one only if its
+package ships an adapter of that kind. Canonical list is the `AdapterKind`
+union in `packages/ai/src/activities/index.ts` — always re-read it:
+
+`text`, `summarize`, `image`, `audio`, `video`, `tts`, `transcription`.
+
+A provider's activity surface is derived mechanically from its adapter files:
+`packages/ai-<provider>/src/adapters/`. Filename → activity-kind map:
+
+| Adapter file                          | Activity kind   |
+| ------------------------------------- | --------------- |
+| `text.ts` / `text-chat-completions.ts` / `responses-text.ts` | `text` |
+| `summarize.ts`                        | `summarize`     |
+| `image.ts`                            | `image`         |
+| `audio.ts`                            | `audio`         |
+| `video.ts`                            | `video`         |
+| `speech.ts` / `tts.ts`                | `tts`           |
+| `transcription.ts`                    | `transcription` |
+
+(`cost.ts` is a helper, not an activity adapter.)
 
 ## Verification before finishing
 

--- a/.claude/skills/gap-analysis/references/audit-checklist.md
+++ b/.claude/skills/gap-analysis/references/audit-checklist.md
@@ -217,6 +217,65 @@ Steps:
 
 ---
 
+## 6. Activity coverage
+
+**Input:** each provider's `packages/ai-<provider>/src/adapters/` directory.
+**Reference:** the `AdapterKind` union in `packages/ai/src/activities/index.ts`
+(7 kinds: `text`, `summarize`, `image`, `audio`, `video`, `tts`,
+`transcription`).
+**Upstream:** each provider's API reference / models page.
+
+This dimension answers a coarser question than dimension 2: not "which
+behaviour within chat is exercised" but **"which whole activity kinds does the
+provider's API offer that we ship no adapter for at all."**
+
+Steps:
+
+1. For every provider, list its adapter files and map each to an activity kind
+   using the filename→kind table in `SKILL.md` (§ Known activities). That
+   yields the local provider×activity matrix. `text.ts`,
+   `text-chat-completions.ts`, and `responses-text.ts` all count as `text`;
+   `speech.ts` and `tts.ts` both count as `tts`; ignore `cost.ts` and other
+   helpers.
+2. Build the full grid (rows = 9 providers, cols = 7 activity kinds). A cell is
+   ✅ if an adapter file of that kind exists, ❌ otherwise.
+3. For each ❌ cell, WebFetch the provider's API reference and check whether
+   upstream offers that activity:
+   - **Real gap** — upstream offers it, we ship no adapter, and there is no
+     documented reason. High if it's a flagship activity for that provider
+     (e.g. a TTS provider missing `transcription`), medium otherwise.
+   - **Not a gap** — upstream genuinely doesn't offer that activity (e.g.
+     Anthropic has no image/audio/video/tts/transcription endpoints; Groq has
+     no image/video generation). Mark the cell ❌-by-design and omit from the
+     gap list, but keep it in the grid so the report is self-contained.
+4. Note the inverse too: any **local adapter for an activity the provider no
+   longer offers upstream** (rare; surface as a stale-adapter finding).
+
+Map activity kind → upstream capability to look for:
+
+| Activity kind   | Upstream capability                                  |
+| --------------- | ---------------------------------------------------- |
+| `text`          | Chat / messages / completions endpoint               |
+| `summarize`     | Any text completion (summarize is built on chat)     |
+| `image`         | Image generation endpoint                            |
+| `audio`         | Music / sound / general audio generation endpoint    |
+| `video`         | Video generation endpoint                            |
+| `tts`           | Text-to-speech endpoint                              |
+| `transcription` | Speech-to-text endpoint                              |
+
+**Priority rubric:**
+
+- Missing a core activity the provider's API clearly offers (e.g. OpenAI-class
+  provider with no `image`/`tts`/`transcription`) → **high**.
+- Missing a secondary/media activity → **medium**.
+- ❌-by-design (upstream doesn't offer it) → **out-of-scope**, keep in grid only.
+- Local adapter for a now-removed upstream activity → **medium** (deprecate).
+
+Render the grid in the report under its own "Activity coverage" section, with
+one bullet per real gap citing the upstream URL.
+
+---
+
 ## Subagent dispatch (for `--all` scope)
 
 When fan-out is needed, launch one `Explore` subagent per provider with a
@@ -225,12 +284,17 @@ prompt of this shape:
 > Audit the `<provider>` adapter at `packages/ai-<provider>/`
 > against upstream docs at the URLs in
 > `.claude/skills/gap-analysis/references/provider-doc-urls.md`. Walk
-> dimensions 1, 3, 4, and 5 from `audit-checklist.md`. Skip dimension 2
-> (the orchestrator handles cross-provider parity centrally) — but do
-> emit dimension-5 telemetry rows in the per-provider format; the
-> orchestrator stitches them into the cross-adapter table. Return
-> findings as markdown sections matching the report template — High /
-> Medium / Low / Out-of-scope — with upstream URLs cited for every claim.
+> dimensions 1, 3, 4, and 5 from `audit-checklist.md`. Skip dimensions 2
+> and 6 (the orchestrator handles cross-provider parity and the
+> activity-coverage grid centrally) — but do emit dimension-5 telemetry
+> rows in the per-provider format; the orchestrator stitches them into the
+> cross-adapter table. Return findings as markdown sections matching the
+> report template — High / Medium / Low / Out-of-scope — with upstream
+> URLs cited for every claim.
+
+The orchestrator builds the dimension-6 activity-coverage grid itself from
+the adapter-file listing (a one-shot `ls packages/ai-*/src/adapters/`), then
+WebFetches each provider's API reference only for the ❌ cells.
 
 Run at most 3 in parallel. Aggregate their returned markdown into the
 combined report.

--- a/.claude/skills/gap-analysis/references/audit-checklist.md
+++ b/.claude/skills/gap-analysis/references/audit-checklist.md
@@ -253,15 +253,15 @@ Steps:
 
 Map activity kind → upstream capability to look for:
 
-| Activity kind   | Upstream capability                                  |
-| --------------- | ---------------------------------------------------- |
-| `text`          | Chat / messages / completions endpoint               |
-| `summarize`     | Any text completion (summarize is built on chat)     |
-| `image`         | Image generation endpoint                            |
-| `audio`         | Music / sound / general audio generation endpoint    |
-| `video`         | Video generation endpoint                            |
-| `tts`           | Text-to-speech endpoint                              |
-| `transcription` | Speech-to-text endpoint                              |
+| Activity kind   | Upstream capability                               |
+| --------------- | ------------------------------------------------- |
+| `text`          | Chat / messages / completions endpoint            |
+| `summarize`     | Any text completion (summarize is built on chat)  |
+| `image`         | Image generation endpoint                         |
+| `audio`         | Music / sound / general audio generation endpoint |
+| `video`         | Video generation endpoint                         |
+| `tts`           | Text-to-speech endpoint                           |
+| `transcription` | Speech-to-text endpoint                           |
 
 **Priority rubric:**
 

--- a/.claude/skills/gap-analysis/references/report-template.md
+++ b/.claude/skills/gap-analysis/references/report-template.md
@@ -95,6 +95,29 @@ Replace every `{{placeholder}}`. Drop sections that have zero entries
 
 ---
 
+## Activity coverage
+
+> Per dimension 6 in audit-checklist.md. Which of the 7 core activity kinds
+> (`text`, `summarize`, `image`, `audio`, `video`, `tts`, `transcription`)
+> each provider ships an adapter for, vs. what upstream offers. Derived from
+> `packages/ai-<provider>/src/adapters/`.
+
+| Provider | text | summarize | image | audio | video | tts | transcription |
+| -------- | :--: | :-------: | :---: | :---: | :---: | :-: | :-----------: |
+| {{provider}} | {{✅/❌/—}} | … | … | … | … | … | … |
+
+Legend: ✅ adapter shipped · ❌ upstream offers it, no adapter (gap) · — upstream doesn't offer it (by design).
+
+- **[{{provider}}] missing `{{activity}}` activity**
+  - Upstream: [{{doc-title}}]({{doc-url}})
+  - Current state: no `{{file}}.ts` under `packages/ai-{{provider}}/src/adapters/`
+  - Suggested change: add a `{{provider}}{{Activity}}` adapter (mirror {{sibling provider that has it}}).
+  - Effort: {{S / M / L}}
+
+{{repeat per real activity gap}}
+
+---
+
 ## Out-of-scope — documented exclusions
 
 > Listed for completeness; no action required. Each links to the comment

--- a/.claude/skills/gap-analysis/references/report-template.md
+++ b/.claude/skills/gap-analysis/references/report-template.md
@@ -102,9 +102,9 @@ Replace every `{{placeholder}}`. Drop sections that have zero entries
 > each provider ships an adapter for, vs. what upstream offers. Derived from
 > `packages/ai-<provider>/src/adapters/`.
 
-| Provider | text | summarize | image | audio | video | tts | transcription |
-| -------- | :--: | :-------: | :---: | :---: | :---: | :-: | :-----------: |
-| {{provider}} | {{✅/❌/—}} | … | … | … | … | … | … |
+| Provider     |    text     | summarize | image | audio | video | tts | transcription |
+| ------------ | :---------: | :-------: | :---: | :---: | :---: | :-: | :-----------: |
+| {{provider}} | {{✅/❌/—}} |     …     |   …   |   …   |   …   |  …  |       …       |
 
 Legend: ✅ adapter shipped · ❌ upstream offers it, no adapter (gap) · — upstream doesn't offer it (by design).
 

--- a/docs/comparison/vercel-ai-sdk.md
+++ b/docs/comparison/vercel-ai-sdk.md
@@ -24,34 +24,38 @@ This article compares the two SDKs from TanStack AI's perspective, with honest a
 
 ## Feature Comparison
 
-Versions referenced below: TanStack AI as of this writing; Vercel AI SDK `ai@6.x` (v6.0.0 shipped December 2025, ESM-only).
+Versions referenced below: TanStack AI as of this writing; Vercel AI SDK `ai@6.x` (v6.0.0 shipped December 2025; v7 is in pre-release at the time of writing).
 
 | Feature | TanStack AI | Vercel AI SDK |
 |---------|------------|---------------|
 | License | MIT | Apache 2.0 |
 | Hosting | Works anywhere | Works anywhere |
-| Providers | 9 official + community; OpenRouter routes to 100s of models and the `openaiCompatible` adapter connects to any OpenAI-compatible endpoint | 50+ direct provider packages; 100+ models via AI Gateway |
-| Framework Hooks | React, Solid, Svelte, Vue, Preact (+ React Native) | React, Vue, Svelte, Solid, Angular |
+| Providers | 9 official + community; OpenRouter routes to 100s of models and the `openaiCompatible` adapter connects to any OpenAI-compatible endpoint | ~38 first-party provider packages (plus community providers); 100+ models via AI Gateway |
+| Framework Hooks | React, Solid, Svelte, Vue, Preact (+ React Native) | React, Vue, Svelte, Angular (Solid is community-maintained) |
+| Generation UI Hooks | One hook per activity: chat, structured output, image, audio, speech, transcription, summarize, video, realtime | `useChat`, `useCompletion`, `useObject` |
+| Wire Protocol | Native AG-UI events end to end | Proprietary UI Message Stream; AG-UI via external translation layer |
 | Streaming | Built-in with configurable chunk strategies | Built-in with progressive delivery |
 | Tool Calling | Isomorphic `.server()` / `.client()` system | `tool()` objects; client execution via `onToolCall` |
 | Agent Loop Control | Composable strategy functions `(state) => boolean` | `stopWhen` conditions + `Agent` (`ToolLoopAgent`) class |
 | Tool Approval | Per-tool `needsApproval` with batched approval flow | Per-tool `needsApproval` (human-in-the-loop) |
 | Type Safety | Per-model type narrowing | Per-provider types |
 | Tree-Shaking | Separate adapter per activity (text, image, speech, etc.) | Monolithic provider packages |
-| Lazy Tool Discovery | Built-in - token-optimized dynamic loading | - |
+| Lazy Tool Discovery | Built-in - works across every provider | Anthropic-only tool search with `deferLoading` (provider-hosted) |
 | Connection Adapters | SSE, HTTP stream, XHR (SSE/stream), RPC, direct async iterables, `fetcher`, custom | SSE-based data stream protocol (`ChatTransport`) |
 | Middleware | App-level lifecycle hooks (config, iterations, chunks, tool calls, usage, errors) | Model-level wrapping via `wrapLanguageModel()` |
-| Extend Adapter | Add custom/fine-tuned models with full type safety | - |
-| Structured Outputs | Typed `StructuredOutputPart`, streamed alongside tools in one chat call | `generateObject()` / `streamObject()` / `Output` API |
+| Extend Adapter | Add custom/fine-tuned models with per-model type narrowing | `customProvider()` / `createProviderRegistry()` (string model ids) |
+| Structured Outputs | Typed `StructuredOutputPart`, streamed alongside tools and preserved per turn in message history | `generateObject()` / `streamObject()` / `Output` API (per-call; no structured-output message part) |
 | Image Generation | Stable API with per-model type safety (OpenAI, Gemini, Grok, OpenRouter, fal.ai) | `generateImage()` (stable) |
 | Video Generation | Stable API with async job lifecycle (OpenAI, fal.ai) | `experimental_generateVideo()` |
 | Text-to-Speech | Stable API, 6 output formats, speed control (OpenAI, Gemini, Grok, ElevenLabs, fal.ai) | `generateSpeech()` (experimental) |
 | Transcription | Stable API with word timestamps and diarization (OpenAI, Grok, ElevenLabs, fal.ai) | `transcribe()` (experimental) |
 | Audio / Music Generation | `generateAudio()` for music & sound effects (Gemini, ElevenLabs, fal.ai) | - |
 | Summarization | Dedicated `summarize()` with streaming and style options | - |
-| Code Execution | Node.js, Cloudflare Workers, QuickJS sandboxes | - |
+| Code Execution | Node.js, Cloudflare Workers, QuickJS sandboxes you run yourself | Provider-hosted code-execution tools (Anthropic, xAI, OpenAI) |
+| Code Mode Skills | LLM-writable persistent skill library | - |
 | Realtime Voice | OpenAI, Grok, and ElevenLabs with VAD modes and tool support | - |
-| DevTools | TanStack DevTools integration | `devToolsMiddleware` + local inspector |
+| DevTools | Isomorphic in-app panel via TanStack DevTools (all frameworks, media previews) | `devToolsMiddleware` + local inspector (server-side, dev-only) |
+| Debug Logging | One flag, per-category toggles, pluggable logger | Warning logs + experimental telemetry hooks |
 | MCP Client | Standalone host-side client (`@tanstack/ai-mcp`) + provider-routed `mcpTool()` | Built-in (`@ai-sdk/mcp`, stable) |
 | Platform Association | None - pure library | Optional Vercel integration |
 
@@ -138,7 +142,7 @@ const addToCartClient = addToCartDef.client(async ({ itemId, quantity }) => {
 
 The same schema validates inputs and outputs on both sides. The type system tracks whether a tool is a `ServerTool` or `ClientTool` at compile time.
 
-Vercel AI SDK defines tools with a `tool()` helper and does support client-side execution - a tool with no `execute` function is handled in the browser via the UI hook's `onToolCall` callback, with the result returned through `addToolResult`. What it doesn't have is a single shared contract that produces separate `.server()` and `.client()` implementations: server and client tool code are declared independently rather than derived from one definition.
+Vercel AI SDK defines tools with a `tool()` helper and does support client-side execution - a tool with no `execute` function is handled in the browser via the UI hook's `onToolCall` callback, with the result returned through `addToolOutput` (renamed from `addToolResult` in v6). What it doesn't have is a single shared contract that produces separate `.server()` and `.client()` implementations: server and client tool code are declared independently rather than derived from one definition.
 
 ### Composable Agent Loop Strategies
 
@@ -193,7 +197,7 @@ const searchProducts = toolDefinition({
 
 The LLM sees a lightweight `__lazy__tool__discovery__` tool listing available tool names. When it needs one, it calls the discovery tool to get the full schema, then uses the real tool. For applications with large tool inventories, this significantly reduces per-request token costs.
 
-Vercel AI SDK has no equivalent - all tools must be sent upfront.
+Vercel AI SDK 6 added a provider-specific analogue for Anthropic: the tool search provider tool (`toolSearchBm25` / `toolSearchRegex`) with per-tool `deferLoading`, where deferred tools are excluded from the initial prompt and discovered on demand. It's Anthropic-only and runs provider-side; TanStack AI's lazy discovery works across every provider and runs in your own agent loop.
 
 ### Model Context Protocol (MCP)
 
@@ -297,7 +301,7 @@ const myOpenai = extendAdapter(openaiText, customModels)
 const adapter = myOpenai('my-fine-tuned-gpt4')
 ```
 
-Your custom models appear in autocomplete alongside official ones. Vercel AI SDK has no equivalent pattern.
+Your custom models appear in autocomplete alongside official ones. Vercel AI SDK covers the registration half of this with the now-stable `customProvider()` (custom and aliased model ids, settings overrides) and `createProviderRegistry()`; the difference is type-safety depth - registry model ids are plain strings, while `extendAdapter()` gives custom models the same literal-type narrowing and per-model option gating as official ones.
 
 ### Middleware
 
@@ -366,7 +370,7 @@ import { toolCacheMiddleware, contentGuardMiddleware } from '@tanstack/ai/middle
 import { otelMiddleware } from '@tanstack/ai/middlewares/otel'
 ```
 
-Vercel AI SDK takes a different approach: `wrapLanguageModel()` wraps a model instance with middleware that can intercept and transform calls (and v6 adds `wrapEmbeddingModel()`). It ships several built-in middleware (`extractReasoningMiddleware`, `simulateStreamingMiddleware`, `defaultSettingsMiddleware`, and the new `devToolsMiddleware`), but these all operate at the model level rather than the application level. There's no equivalent to TanStack AI's tool call interception, chunk-level stream processing, or lifecycle hooks like `onBeforeToolCall` and `onAfterToolCall`.
+Vercel AI SDK takes a different approach: `wrapLanguageModel()` wraps a model instance with middleware that can intercept and transform calls (and v6 adds `wrapEmbeddingModel()`). It ships several built-in middleware (`extractReasoningMiddleware`, `simulateStreamingMiddleware`, `defaultSettingsMiddleware`, and the new `devToolsMiddleware`), but these all operate at the model level rather than the application level. v6 also exposes per-call options that cover slices of this surface: `experimental_transform` for stream transforms, `experimental_onToolCallStart` / `experimental_onToolCallFinish` callbacks, `prepareStep` for per-step config changes, and `experimental_repairToolCall`. What it doesn't have is a unified middleware system at the application level - named, reusable middleware objects whose hooks span the whole lifecycle, compose in order, and can short-circuit tool calls with first-win semantics.
 
 ### No Platform Association
 
@@ -382,7 +386,7 @@ TanStack AI provides three isolate drivers for safe code execution in AI workflo
 - **`@tanstack/ai-isolate-cloudflare`** - Cloudflare Workers sandbox
 - **`@tanstack/ai-isolate-quickjs`** - QuickJS lightweight sandbox
 
-All three implement the same `IsolateDriver` interface, so you can swap execution environments without changing application code. This powers TanStack AI's code mode - where the LLM writes and executes code as part of the agent loop. A companion `@tanstack/ai-code-mode-skills` package lets you give code mode a persistent, reusable library of runtime skills.
+All three implement the same `IsolateDriver` interface, so you can swap execution environments without changing application code. This powers TanStack AI's code mode - where the LLM writes and executes code as part of the agent loop. A companion `@tanstack/ai-code-mode-skills` package lets you give code mode a persistent, reusable library of runtime skills. Skills are LLM-writable: the model can save working TypeScript snippets, list and reuse them across sessions, with trust strategies controlling what gets promoted to a first-class tool. The closest AI SDK analogues - Anthropic's provider-hosted code execution and developer-uploaded skills, or pre-authored file skills loaded into a sandbox - are provider-specific and static; none give the model a persistent, provider-agnostic skill library it builds itself.
 
 Vercel AI SDK does not provide built-in code execution sandboxes (though some providers expose their own server-side code execution as provider-executed tools).
 
@@ -466,15 +470,37 @@ const result = await generateTranscription({
 
 All media activities follow the same adapter pattern as chat - tree-shakeable imports, per-model type safety, and streaming support. If your app only uses chat, none of this media code enters your bundle.
 
+### Native AG-UI Protocol
+
+The events TanStack AI streams between server and client are [AG-UI](https://docs.ag-ui.com/) events (`RUN_STARTED`, `TEXT_MESSAGE_*`, `TOOL_CALL_*`, `RUN_FINISHED`), imported directly from `@ag-ui/core` - not a bespoke format with an AG-UI export bolted on. Anything that speaks AG-UI can sit on either side of the wire: AG-UI-compliant agent frameworks behind a TanStack AI frontend, or a TanStack AI client in front of an agent server written in another language entirely.
+
+Vercel AI SDK streams its own proprietary UI Message Stream protocol. AG-UI interop requires an external translation layer (`@ag-ui/vercel-ai-sdk`, built and maintained by the AG-UI project), and native support remains an open feature request on the AI SDK repo.
+
+### Hooks for Every Activity
+
+Chat isn't the only activity with a hook. Every activity ships one - `useGeneration` (streaming structured output), `useGenerateImage`, `useGenerateAudio`, `useGenerateSpeech`, `useTranscription`, `useSummarize`, `useGenerateVideo`, and `useRealtimeChat` - with the same connection-adapter wiring and devtools integration as `useChat`, across React, Solid, Vue, Svelte, and Preact.
+
+Vercel AI SDK's UI layer has three hooks: `useChat`, `useCompletion`, and `useObject`. Its media functions (`generateImage()`, `experimental_generateVideo()`, speech, transcription) are server-side only - surfacing them in a UI means hand-rolling your own routes and client state.
+
+### Multi-Turn Structured Output
+
+Structured output in TanStack AI is part of the conversation, not a separate call. Pass `outputSchema` to `useChat` and every assistant turn carries its own typed `StructuredOutputPart` - streamed as a `partial`, validated as a `final`, preserved in message history, with the schema generic threading all the way down to `messages[i].parts[j].data`.
+
+Vercel AI SDK's structured output (`generateObject` / `streamObject` / `Output`) is per-call: the typed object lives on the call result, the message-part union has no structured-output type, and combining `useChat` with typed structured output means manually parsing model text into custom data parts.
+
+### Debug Logging
+
+Set `debug: true` on any activity and the pipeline prints itself: raw provider chunks, post-middleware output, middleware hook inputs and outputs, tool execution, agent-loop iterations, config transforms, and request metadata - each category individually toggleable, with a pluggable `logger` for structured output. Vercel AI SDK's built-in logging covers provider warnings; richer observability goes through experimental telemetry hooks or the dev-only DevTools recorder rather than a debug log you can flip on anywhere.
+
 ### Community Adapter Ecosystem
 
 TanStack AI publishes an open adapter specification. The community has already built adapters for Decart, Cencori, Cloudflare, Soniox, and Mynth - with a [guide for building your own](../community-adapters/guide). The adapter interface is simple enough that adding a new provider is a focused, self-contained task.
 
 ## Where Vercel AI SDK Excels
 
-**Provider breadth.** Vercel AI SDK ships 50+ first-party, individually typed provider packages. If you want a specific provider as a dedicated, maintained package without writing an adapter, their coverage is broader today. Raw model *count* is not the differentiator, though - TanStack AI's OpenRouter adapter reaches OpenRouter's full catalog (several hundred models), and the `openaiCompatible` adapter connects to any OpenAI-compatible endpoint.
+**Provider breadth.** Vercel AI SDK ships ~38 first-party, individually typed provider packages, plus a large community list. If you want a specific provider as a dedicated, maintained package without writing an adapter, their coverage is broader today. Raw model *count* is not the differentiator, though - TanStack AI's OpenRouter adapter reaches OpenRouter's full catalog (several hundred models), and the `openaiCompatible` adapter connects to any OpenAI-compatible endpoint.
 
-**Angular support.** Vercel AI SDK has an official Angular integration. TanStack AI supports React, Solid, Svelte, Vue, and Preact, but not Angular. (Both ship Solid integrations, so Solid is not a differentiator.)
+**Angular support.** Vercel AI SDK has an official Angular integration. TanStack AI supports React, Solid, Svelte, Vue, and Preact, but not Angular. (Solid now cuts the other way: AI SDK's Solid package is community-maintained and pinned to an older SDK major, while TanStack AI ships an official, current Solid integration.)
 
 **Agent abstraction.** Vercel AI SDK v6 ships a dedicated `Agent` abstraction (the `ToolLoopAgent` class) that packages a model, tools, instructions, and loop settings into a reusable object with `.generate()` and `.stream()` methods, plus `InferAgentUIMessage` for end-to-end type safety. TanStack AI composes these pieces per call rather than offering a single agent class.
 
@@ -591,7 +617,9 @@ In TanStack AI, each activity (chat, image, speech, video, transcription, summar
 ## When to Choose TanStack AI
 
 - **Bundle size matters** - Tree-shakeable adapters per activity mean smaller bundles
-- **Preact or React Native** - One headless core covers React, Solid, Vue, Svelte, Preact, and React Native (via XHR adapters)
+- **AG-UI native** - The wire protocol is AG-UI end to end; interoperate with the agent-UI ecosystem and non-TypeScript agent servers without a translation layer
+- **Solid, Preact, or React Native** - One headless core covers React, Solid, Vue, Svelte, Preact, and React Native (via XHR adapters), all officially maintained
+- **Hooks beyond chat** - `useGeneration`, `useGenerateImage`, `useSummarize`, and the rest of the generation hook family across every supported framework
 - **Isomorphic tools** - Define a tool once and derive `.server()` / `.client()` implementations from one contract
 - **App-level middleware** - Lifecycle hooks for chunks, tool calls, usage, and errors - not just model wrapping
 - **Realtime voice** - Bidirectional audio across OpenAI, Grok, and ElevenLabs
@@ -603,7 +631,7 @@ In TanStack AI, each activity (chat, image, speech, video, transcription, summar
 
 ## When to Choose Vercel AI SDK
 
-- **Need 50+ first-party provider packages** - Broader coverage of dedicated, individually typed provider packages today (TanStack reaches comparable model breadth via OpenRouter + `openaiCompatible`)
+- **Need a first-party package for a specific provider** - ~38 dedicated, individually typed provider packages today (TanStack reaches comparable model breadth via OpenRouter + `openaiCompatible`)
 - **Angular support** - Official Angular integration
 - **Agent abstraction** - A reusable `Agent` (`ToolLoopAgent`) class with end-to-end UI message types
 - **Vercel platform** - AI Gateway, observability, and deployment optimization


### PR DESCRIPTION
## Summary

Fact-checked every claim in `docs/comparison/vercel-ai-sdk.md` with a multi-agent verification pass: TanStack-side claims checked against this repo, Vercel-side claims checked against current official sources (ai-sdk.dev, npm, vercel/ai releases), and each new "where we're ahead" item adversarially verified to confirm the AI SDK lacks an equivalent.

### Corrections (Vercel side had drifted)

- **ai@6 is dual CJS+ESM**, not ESM-only; noted that v7 is in pre-release
- **~38 first-party provider packages**, not 50+ (per the official providers index)
- **Solid**: AI SDK's package is community-maintained and frozen at an SDK-4-era version — updated from "not a differentiator" to a TanStack advantage
- **Lazy tool discovery**: AI SDK 6 shipped an Anthropic-only analogue (tool search + `deferLoading`) — claim narrowed from "no equivalent" to cross-provider vs provider-specific
- **Middleware**: acknowledged `experimental_transform`, `experimental_onToolCallStart/Finish`, `prepareStep`, `repairToolCall`; gap restated as the unified app-level middleware system
- **extendAdapter**: acknowledged stable `customProvider()` / `createProviderRegistry()`; edge restated as literal-type narrowing vs string model ids
- **Code execution**: acknowledged provider-hosted code tools (Anthropic, xAI, OpenAI); edge restated as SDK-managed sandboxes
- `addToolResult` → `addToolOutput` (v6 rename)

### New advantages added (each verified to have no AI SDK equivalent)

- **Native AG-UI protocol** — new section + wire-protocol table row; AI SDK streams its proprietary UI Message Stream, AG-UI interop only via the external `@ag-ui/vercel-ai-sdk` translation layer, native support an open feature request
- **Hooks for every activity** — new section + table row; AI SDK UI has only `useChat`/`useCompletion`/`useObject`
- **Multi-turn structured output** — new section; AI SDK structured output is per-call with no structured-output message part
- **Debug logging** — new section + table row
- **Code Mode skills** — table row + prose on the LLM-writable persistent skill library

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an activity-coverage audit dimension to gap-analysis docs to assess provider adapter support across seven activity kinds.
  * Updated audit checklist with rules for building provider×activity grids, identifying real gaps, and handling stale/missing adapters.
  * Expanded report template to include provider-by-activity matrices and gap entries with citations, suggested adapters, and effort estimates.
  * Revised Vercel AI SDK comparison with an updated feature matrix, tool-calling and middleware distinctions, and new AG-UI protocol coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->