### PR TITLE
fix(ai-client): add missing methods to the no-op chat devtools bridge

### DIFF
--- a/.changeset/noop-chat-devtools-bridge-parity.md
+++ b/.changeset/noop-chat-devtools-bridge-parity.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-client': patch
+---
+
+Fix `ChatClient` throwing `TypeError: this.devtoolsBridge.mountWithTools is not a function` on the first `sendMessage()` (and on `updateOptions({ tools })`) when no devtools bridge factory is supplied. The default `NoOpChatDevtoolsBridge` was missing the `mountWithTools`, `notifyToolsChanged`, and `recordStreamId` methods of the real bridge; the throw happened before the user message was appended, so the first message was silently lost. The compile-time parity check between the real and no-op bridges now fails the build when the surfaces drift.

--- a/packages/ai-client/src/devtools-noop.ts
+++ b/packages/ai-client/src/devtools-noop.ts
@@ -72,7 +72,10 @@ export class NoOpChatDevtoolsBridge {
   dispose(): void {}
 
   // chat-specific surface
+  mountWithTools(_initialMessageCount: number): void {}
+  notifyToolsChanged(): void {}
   setCurrentStreamId(_streamId: string | null): void {}
+  recordStreamId(_streamId: string): void {}
   getCurrentStreamId(): string | null {
     return null
   }
@@ -150,9 +153,10 @@ export class NoOpVideoDevtoolsBridge<
 
 // Compile-time parity checks. If a public method is added to the real
 // bridge class without a matching stub on the no-op, the corresponding
-// `Exclude<...>` will resolve to a non-`never` union and the `as never`
-// assignment below will fail to typecheck — surfacing the drift at build
-// time instead of as a runtime TypeError later.
+// `Exclude<...>` resolves to a non-`never` union, which violates the
+// `extends never` constraint below and fails the build — surfacing the
+// drift at build time instead of as a runtime TypeError later.
+type AssertBridgeParity<TMissing extends never> = TMissing
 type _ChatBridgeMissing = Exclude<
   keyof ChatDevtoolsBridge,
   keyof NoOpChatDevtoolsBridge
@@ -165,12 +169,14 @@ type _VideoBridgeMissing = Exclude<
   keyof VideoDevtoolsBridge<unknown>,
   keyof NoOpVideoDevtoolsBridge<unknown>
 >
-const _chatBridgeParity: _ChatBridgeMissing = undefined as never
-const _generationBridgeParity: _GenerationBridgeMissing = undefined as never
-const _videoBridgeParity: _VideoBridgeMissing = undefined as never
-void _chatBridgeParity
-void _generationBridgeParity
-void _videoBridgeParity
+const _bridgeParity:
+  | [
+      AssertBridgeParity<_ChatBridgeMissing>,
+      AssertBridgeParity<_GenerationBridgeMissing>,
+      AssertBridgeParity<_VideoBridgeMissing>,
+    ]
+  | undefined = undefined
+void _bridgeParity
 
 // ===========================================================================
 // Factories — these are what the clients call when no real factory was

--- a/packages/ai-client/tests/chat-client-noop-devtools.test.ts
+++ b/packages/ai-client/tests/chat-client-noop-devtools.test.ts
@@ -1,0 +1,34 @@
+// Regression coverage for the shipping default. The suite-wide setup file
+// (`use-real-devtools-bridges.ts`) re-routes the no-op devtools factories to
+// the real bridges, so no other test exercises the bridge production
+// consumers actually get when they don't opt into devtools. Unmock here so
+// `ChatClient` runs against the actual no-op bridge that ships as the
+// default, instead of the real-bridge substitute the setup file installs.
+import { describe, expect, it, vi } from 'vitest'
+import { ChatClient } from '../src/chat-client'
+import { createMockConnectionAdapter, createTextChunks } from './test-utils'
+
+vi.unmock('../src/devtools-noop')
+
+describe('ChatClient with default no-op devtools bridge', () => {
+  it('sends the first message and appends it', async () => {
+    const adapter = createMockConnectionAdapter({
+      chunks: createTextChunks('Hi there'),
+    })
+    const client = new ChatClient({ connection: adapter })
+
+    await client.sendMessage('hello')
+
+    const messages = client.getMessages()
+    expect(messages.at(0)?.role).toBe('user')
+    expect(messages.at(0)?.parts).toEqual([{ type: 'text', content: 'hello' }])
+    expect(messages.at(1)?.role).toBe('assistant')
+  })
+
+  it('updates tools without throwing', () => {
+    const adapter = createMockConnectionAdapter()
+    const client = new ChatClient({ connection: adapter })
+
+    expect(() => client.updateOptions({ tools: [] })).not.toThrow()
+  })
+})

--- a/testing/e2e/src/routeTree.gen.ts
+++ b/testing/e2e/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as DevtoolsRouteBRouteImport } from './routes/devtools-route-b'
 import { Route as DevtoolsRouteARouteImport } from './routes/devtools-route-a'
 import { Route as DevtoolsGenerationHooksRouteImport } from './routes/devtools-generation-hooks'
 import { Route as DevtoolsChatRouteImport } from './routes/devtools-chat'
+import { Route as ChatClientDefaultBridgeRouteImport } from './routes/chat-client-default-bridge'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProviderIndexRouteImport } from './routes/$provider/index'
 import { Route as ApiVideoRouteImport } from './routes/api.video'
@@ -93,6 +94,11 @@ const DevtoolsGenerationHooksRoute = DevtoolsGenerationHooksRouteImport.update({
 const DevtoolsChatRoute = DevtoolsChatRouteImport.update({
   id: '/devtools-chat',
   path: '/devtools-chat',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ChatClientDefaultBridgeRoute = ChatClientDefaultBridgeRouteImport.update({
+  id: '/chat-client-default-bridge',
+  path: '/chat-client-default-bridge',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -257,6 +263,7 @@ const ApiAudioStreamRoute = ApiAudioStreamRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/chat-client-default-bridge': typeof ChatClientDefaultBridgeRoute
   '/devtools-chat': typeof DevtoolsChatRoute
   '/devtools-generation-hooks': typeof DevtoolsGenerationHooksRoute
   '/devtools-route-a': typeof DevtoolsRouteARoute
@@ -299,6 +306,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/chat-client-default-bridge': typeof ChatClientDefaultBridgeRoute
   '/devtools-chat': typeof DevtoolsChatRoute
   '/devtools-generation-hooks': typeof DevtoolsGenerationHooksRoute
   '/devtools-route-a': typeof DevtoolsRouteARoute
@@ -342,6 +350,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/chat-client-default-bridge': typeof ChatClientDefaultBridgeRoute
   '/devtools-chat': typeof DevtoolsChatRoute
   '/devtools-generation-hooks': typeof DevtoolsGenerationHooksRoute
   '/devtools-route-a': typeof DevtoolsRouteARoute
@@ -386,6 +395,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/chat-client-default-bridge'
     | '/devtools-chat'
     | '/devtools-generation-hooks'
     | '/devtools-route-a'
@@ -428,6 +438,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/chat-client-default-bridge'
     | '/devtools-chat'
     | '/devtools-generation-hooks'
     | '/devtools-route-a'
@@ -470,6 +481,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/chat-client-default-bridge'
     | '/devtools-chat'
     | '/devtools-generation-hooks'
     | '/devtools-route-a'
@@ -513,6 +525,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ChatClientDefaultBridgeRoute: typeof ChatClientDefaultBridgeRoute
   DevtoolsChatRoute: typeof DevtoolsChatRoute
   DevtoolsGenerationHooksRoute: typeof DevtoolsGenerationHooksRoute
   DevtoolsRouteARoute: typeof DevtoolsRouteARoute
@@ -612,6 +625,13 @@ declare module '@tanstack/react-router' {
       path: '/devtools-chat'
       fullPath: '/devtools-chat'
       preLoaderRoute: typeof DevtoolsChatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/chat-client-default-bridge': {
+      id: '/chat-client-default-bridge'
+      path: '/chat-client-default-bridge'
+      fullPath: '/chat-client-default-bridge'
+      preLoaderRoute: typeof ChatClientDefaultBridgeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -894,6 +914,7 @@ const ApiVideoRouteWithChildren = ApiVideoRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ChatClientDefaultBridgeRoute: ChatClientDefaultBridgeRoute,
   DevtoolsChatRoute: DevtoolsChatRoute,
   DevtoolsGenerationHooksRoute: DevtoolsGenerationHooksRoute,
   DevtoolsRouteARoute: DevtoolsRouteARoute,

--- a/testing/e2e/src/routes/chat-client-default-bridge.tsx
+++ b/testing/e2e/src/routes/chat-client-default-bridge.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { ChatClient } from '@tanstack/ai-client'
+import type { UIMessage } from '@tanstack/ai-client'
+
+export const Route = createFileRoute('/chat-client-default-bridge')({
+  component: ChatClientDefaultBridgePage,
+})
+
+// Covers the vanilla `ChatClient` shipping default: no `devtoolsBridgeFactory`,
+// so the client falls back to the no-op devtools bridge. The framework hooks
+// (`useChat` etc.) always inject the real bridge, so every other route in this
+// suite bypasses the no-op path entirely. A static SSE body keeps the scenario
+// deterministic; the transport is not what is under test here.
+const SSE_BODY = [
+  'data: {"type":"RUN_STARTED","threadId":"thread-default-bridge","runId":"run-default-bridge"}\n\n',
+  'data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"msg-default-bridge","model":"test","timestamp":0,"delta":"Hi from the assistant","content":"Hi from the assistant"}\n\n',
+  'data: {"type":"RUN_FINISHED","threadId":"thread-default-bridge","runId":"run-default-bridge","model":"test","timestamp":0,"finishReason":"stop"}\n\n',
+].join('')
+
+function ChatClientDefaultBridgePage() {
+  const [messages, setMessages] = useState<Array<UIMessage>>([])
+  const [error, setError] = useState<string | null>(null)
+  const [client] = useState(
+    () =>
+      new ChatClient({
+        fetcher: () =>
+          new Response(SSE_BODY, {
+            headers: { 'Content-Type': 'text/event-stream' },
+          }),
+        onMessagesChange: setMessages,
+      }),
+  )
+
+  // The button starts disabled in the server-rendered HTML and enables on
+  // hydration, so Playwright's actionability check cannot click before the
+  // onClick handler is attached.
+  const [hydrated, setHydrated] = useState(false)
+  useEffect(() => {
+    setHydrated(true)
+  }, [])
+
+  const handleSend = () => {
+    client
+      .sendMessage('hello from the vanilla client')
+      .catch((sendError: unknown) => setError(String(sendError)))
+  }
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto space-y-4">
+      <h1 className="text-xl font-semibold">
+        Vanilla ChatClient (default no-op devtools bridge)
+      </h1>
+      <button
+        data-testid="send-button"
+        type="button"
+        disabled={!hydrated}
+        onClick={handleSend}
+      >
+        Send
+      </button>
+      {error !== null && <div data-testid="send-error">{error}</div>}
+      <div data-testid="messages">
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            data-testid={
+              message.role === 'user' ? 'user-message' : 'assistant-message'
+            }
+          >
+            {message.parts
+              .map((part) => (part.type === 'text' ? part.content : ''))
+              .join('')}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/testing/e2e/tests/chat-client-default-bridge.spec.ts
+++ b/testing/e2e/tests/chat-client-default-bridge.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test'
+
+// The framework hooks always pass the real devtools bridge factory, so this
+// is the only scenario in the suite that exercises the no-op bridge that
+// vanilla `ChatClient` consumers get by default.
+test.describe('vanilla ChatClient with default no-op devtools bridge', () => {
+  test('first sendMessage appends the user message and streams a reply', async ({
+    page,
+  }) => {
+    await page.goto('/chat-client-default-bridge')
+
+    await page.getByTestId('send-button').click()
+
+    await expect(page.getByTestId('user-message')).toHaveText(
+      'hello from the vanilla client',
+    )
+    await expect(page.getByTestId('assistant-message')).toContainText(
+      'Hi from the assistant',
+    )
+    await expect(page.getByTestId('send-error')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Repro of the issue: https://stackblitz.com/github/jan-kubica/tanstack-ai-noop-bridge-repro?file=index.mjs

If you create a `ChatClient` without a `devtoolsBridgeFactory` you get the bundled no-op bridge, and that class is missing three methods the client expects: `mountWithTools`, `notifyToolsChanged` and `recordStreamId`. 

So the first `sendMessage()` errors with:

```
TypeError: this.devtoolsBridge.mountWithTools is not a function
```

It throws before `addUserMessage`, so the message is just gone. The second send works fine, because `mountDevtools()` flips `devtoolsMounted` before calling the method that doesn't exist, so it may look like a transient issue.

The parity check at the bottom of `devtools-noop.ts` was supposed to catch this, but it assigns `undefined as never` *to* the missing-keys type, and since `never` is assignable to anything, that line can't fail no matter how out of sync the no-op gets. I suggest to change the direction: the missing-keys union now has to satisfy an `extends never` constraint, so a stale no-op fails tsc with `Type '"mountWithTools"' does not satisfy the constraint 'never'`.

## Test plan

- `packages/ai-client`: `pnpm test:lib` (the new `chat-client-noop-devtools.test.ts` fails on main with the TypeError above, passes here)
- `pnpm test:pr` is green locally
- e2e: `pnpm --filter @tanstack/ai-e2e exec playwright test chat-client-default-bridge`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `ChatClient` throwing an error when using the default configuration without a custom devtools bridge.
  * Fixed issue where the first message was lost when calling `sendMessage()` or `updateOptions()` on first use with the default configuration.

* **Tests**
  * Added regression tests and end-to-end tests to verify default configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->