### PR TITLE
fix(ai-mcp): add shims to bin bundle for CJS dynamic-require compat

### DIFF
--- a/.changeset/mcp-cli-dynamic-require-shims.md
+++ b/.changeset/mcp-cli-dynamic-require-shims.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/ai-mcp": patch
+---
+
+Fix `@tanstack/ai-mcp` CLI crashing on startup with `Error: Dynamic require of "fs" is not supported`. The CLI ships as an ESM bundle with `json-schema-to-typescript` inlined, which uses CJS `require()` internally. Enabling tsup's `shims` option injects a `createRequire(import.meta.url)` shim so those `require()` calls resolve correctly.

--- a/.changeset/mcp-cli-dynamic-require-shims.md
+++ b/.changeset/mcp-cli-dynamic-require-shims.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/ai-mcp": patch
+'@tanstack/ai-mcp': patch
 ---
 
 Fix `@tanstack/ai-mcp` CLI crashing on startup with `Error: Dynamic require of "fs" is not supported`. The CLI ships as an ESM bundle with `json-schema-to-typescript` inlined, which uses CJS `require()` internally. Enabling tsup's `shims` option injects a `createRequire(import.meta.url)` shim so those `require()` calls resolve correctly.

--- a/packages/ai-mcp/tsup.bin.config.ts
+++ b/packages/ai-mcp/tsup.bin.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   noExternal: ['json-schema-to-typescript', 'jiti'],
   // Keep the heavy SDK + workspace pkg external (installed alongside).
   external: ['@modelcontextprotocol/sdk', '@tanstack/ai'],
+  // json-schema-to-typescript uses CJS dynamic require(); shims injects
+  // createRequire so those calls work inside this ESM bundle.
+  shims: true,
   banner: { js: '#!/usr/bin/env node' },
 })


### PR DESCRIPTION
## Summary

`@tanstack/ai-mcp` 0.1.0 ships its CLI as an ESM bundle with `json-schema-to-typescript` inlined via `noExternal`. That library uses `require()` internally, which is not available in ESM-output bundles — so the CLI crashes on startup with:

```
Error: Dynamic require of "fs" is not supported
    at .../node_modules/@tanstack/ai-mcp/dist/bin/chunk-LMMQX4CK.js
    at .../json-schema-to-typescript/dist/src/index.js
```

before it can print help or run codegen.

## Changes

- `packages/ai-mcp/tsup.bin.config.ts`: add `shims: true`

`tsup`'s `shims` option injects a `createRequire(import.meta.url)` shim at the top of the ESM bundle, making CJS dependencies' `require()` calls work correctly. This is the standard fix for CJS-in-ESM bundling with tsup.

Fixes #753

## Changes

- `packages/ai-mcp/tsup.bin.config.ts`: add `shims: true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a startup crash in the CLI’s ESM bundle caused by dynamic `require()` (e.g., resolving Node core modules such as `fs`).
* **Chores**
  * Updated the bundling configuration to inject compatibility shims for mixed ESM/CJS behavior, improving runtime reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->