### PR TITLE
fix: add ai-openai package metadata

### DIFF
--- a/packages/ai-openai/package.json
+++ b/packages/ai-openai/package.json
@@ -9,6 +9,10 @@
     "url": "git+https://github.com/TanStack/ai.git",
     "directory": "packages/ai-openai"
   },
+  "homepage": "https://github.com/TanStack/ai/tree/main/packages/ai-openai#readme",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  },
   "type": "module",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",


### PR DESCRIPTION
## Summary
- Add npm `homepage` metadata for `@tanstack/ai-openai` pointing to the package README
- Add `bugs.url` metadata pointing to the TanStack AI issue tracker

## Validation
- `node` JSON parse/assertion for `packages/ai-openai/package.json`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata with repository homepage link and bug reporting URL for improved package discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->