### PR TITLE
chore: add homepage and bugs metadata to all published packages

### DIFF
--- a/packages/ai-anthropic/package.json
+++ b/packages/ai-anthropic/package.json
@@ -62,4 +62,9 @@
     "@vitest/coverage-v8": "4.0.14",
     "zod": "^4.2.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-client/package.json
+++ b/packages/ai-client/package.json
@@ -62,4 +62,9 @@
     "vite": "^7.3.3",
     "zod": "^4.2.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-code-mode-skills/package.json
+++ b/packages/ai-code-mode-skills/package.json
@@ -81,4 +81,9 @@
     "tsx": "^4.21.0",
     "zod": "^4.2.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-code-mode/package.json
+++ b/packages/ai-code-mode/package.json
@@ -63,4 +63,9 @@
     "@vitest/coverage-v8": "4.0.14",
     "zod": "^4.2.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-devtools/package.json
+++ b/packages/ai-devtools/package.json
@@ -97,4 +97,9 @@
     "vite": "^7.3.3",
     "vite-plugin-solid": "^2.11.10"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-elevenlabs/package.json
+++ b/packages/ai-elevenlabs/package.json
@@ -63,4 +63,9 @@
     "@tanstack/ai-client": "workspace:*",
     "@vitest/coverage-v8": "4.0.14"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-event-client/package.json
+++ b/packages/ai-event-client/package.json
@@ -53,4 +53,9 @@
     "streaming",
     "chat"
   ]
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-fal/package.json
+++ b/packages/ai-fal/package.json
@@ -61,4 +61,9 @@
   "peerDependencies": {
     "@tanstack/ai": "workspace:*"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-gemini/package.json
+++ b/packages/ai-gemini/package.json
@@ -68,4 +68,9 @@
     "vite": "^7.3.3",
     "zod": "^4.2.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-grok/package.json
+++ b/packages/ai-grok/package.json
@@ -65,4 +65,9 @@
     "@tanstack/ai": "workspace:^",
     "zod": "^4.0.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-groq/package.json
+++ b/packages/ai-groq/package.json
@@ -62,4 +62,9 @@
     "@tanstack/openai-base": "workspace:*",
     "openai": "^6.41.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-isolate-cloudflare/package.json
+++ b/packages/ai-isolate-cloudflare/package.json
@@ -65,4 +65,9 @@
     "@vitest/coverage-v8": "4.0.14",
     "wrangler": "^4.88.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-isolate-node/package.json
+++ b/packages/ai-isolate-node/package.json
@@ -57,4 +57,9 @@
   "devDependencies": {
     "@vitest/coverage-v8": "4.0.14"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-isolate-quickjs/package.json
+++ b/packages/ai-isolate-quickjs/package.json
@@ -54,4 +54,9 @@
   "devDependencies": {
     "@vitest/coverage-v8": "4.0.14"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-mcp/package.json
+++ b/packages/ai-mcp/package.json
@@ -59,4 +59,9 @@
     "vite": "^7.3.3",
     "zod": "^4.2.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-ollama/package.json
+++ b/packages/ai-ollama/package.json
@@ -58,4 +58,9 @@
     "@vitest/coverage-v8": "4.0.14",
     "vite": "^7.3.3"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-openai/package.json
+++ b/packages/ai-openai/package.json
@@ -74,4 +74,9 @@
     "vite": "^7.3.3",
     "zod": "^4.2.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-openrouter/package.json
+++ b/packages/ai-openrouter/package.json
@@ -64,4 +64,9 @@
   "peerDependencies": {
     "@tanstack/ai": "workspace:^"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-preact/package.json
+++ b/packages/ai-preact/package.json
@@ -57,4 +57,9 @@
     "@tanstack/ai": "workspace:^",
     "preact": ">=10.11.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-react-ui/package.json
+++ b/packages/ai-react-ui/package.json
@@ -64,4 +64,9 @@
     "react-dom": "^19.2.3",
     "vite": "^7.3.3"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-react/package.json
+++ b/packages/ai-react/package.json
@@ -64,4 +64,9 @@
     "react": "^19.2.3",
     "vite": "^7.3.3"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-solid-ui/package.json
+++ b/packages/ai-solid-ui/package.json
@@ -63,4 +63,9 @@
     "solid-js": "^1.9.10",
     "vite": "^7.3.3"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-solid/package.json
+++ b/packages/ai-solid/package.json
@@ -63,4 +63,9 @@
     "typescript": "5.9.3",
     "vitest": "^4.0.14"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-svelte/package.json
+++ b/packages/ai-svelte/package.json
@@ -67,4 +67,9 @@
     "typescript": "5.9.3",
     "vite": "^7.3.3"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-utils/package.json
+++ b/packages/ai-utils/package.json
@@ -46,4 +46,9 @@
     "@vitest/coverage-v8": "4.0.14",
     "vite": "^7.3.3"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-vue-ui/package.json
+++ b/packages/ai-vue-ui/package.json
@@ -59,4 +59,9 @@
     "vue": "^3.5.25",
     "vue-tsc": "^2.2.10"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai-vue/package.json
+++ b/packages/ai-vue/package.json
@@ -63,4 +63,9 @@
     "vitest": "^4.0.14",
     "vue": "^3.5.25"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -96,4 +96,9 @@
     "arktype": "^2.1.28",
     "zod": "^4.2.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/openai-base/package.json
+++ b/packages/openai-base/package.json
@@ -57,4 +57,9 @@
     "vite": "^7.3.3",
     "zod": "^4.2.0"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/preact-ai-devtools/package.json
+++ b/packages/preact-ai-devtools/package.json
@@ -70,4 +70,8 @@
     "chat",
     "tool-calling"
   ]
+,
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/react-ai-devtools/package.json
+++ b/packages/react-ai-devtools/package.json
@@ -73,4 +73,8 @@
     "chat",
     "tool-calling"
   ]
+,
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }

--- a/packages/solid-ai-devtools/package.json
+++ b/packages/solid-ai-devtools/package.json
@@ -64,4 +64,9 @@
     "vite": "^7.3.3",
     "vite-plugin-solid": "^2.11.10"
   }
+,
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  }
 }


### PR DESCRIPTION
All `@tanstack/ai-*` packages are missing `bugs` metadata (and most are also missing `homepage`). This adds both fields to all 32 published packages.

No runtime code, dependencies, tests, or build configuration are changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata across all packages with homepage URL and issue tracker links to improve package discoverability and streamline issue reporting processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->