### PR TITLE
docs: add homepage and bugs metadata for @tanstack/ai-openai

### DIFF
--- a/packages/ai-openai/package.json
+++ b/packages/ai-openai/package.json
@@ -9,6 +9,10 @@
     "url": "git+https://github.com/TanStack/ai.git",
     "directory": "packages/ai-openai"
   },
+  "homepage": "https://github.com/TanStack/ai/tree/main/packages/ai-openai#readme",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  },
   "type": "module",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",


### PR DESCRIPTION
This PR adds the missing `homepage` and `bugs` metadata to the `@tanstack/ai-openai` package, as requested in the microbounty issue #1461.

- Added `homepage` URL pointing to the package directory.
- Added `bugs` URL pointing to the repository issues.

Fixes #1461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include homepage information and bug reporting URL, enabling users to easily access project details and submit issues through the designated tracking page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->