### PR TITLE
docs: add homepage and bugs metadata for @tanstack/ai

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -9,6 +9,10 @@
     "url": "git+https://github.com/TanStack/ai.git",
     "directory": "packages/ai"
   },
+  "homepage": "https://tanstack.com/ai",
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  },
   "type": "module",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",


### PR DESCRIPTION
This PR adds the missing `homepage` and `bugs` metadata to the `@tanstack/ai` package, as requested in the microbounty issue #398.

- Added `homepage` URL pointing to the official TanStack AI docs.
- Added `bugs` URL pointing to the repository issues.

Fixes #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include homepage URL and added a bugs section for issue reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->