### PR TITLE
fix(ai-react): sync tools to ChatClient when tools prop changes

### DIFF
--- a/packages/ai-react/src/use-chat.ts
+++ b/packages/ai-react/src/use-chat.ts
@@ -168,20 +168,29 @@ export function useChat<
     }
   }, [client])
 
+  // Sync each wire-payload slot in its own effect so an unrelated option
+  // changing doesn't re-run the others. `updateOptions` declares strict-optional
+  // fields and rejects explicit `undefined` under EOPT, so guard the optional
+  // slots before passing them.
   useEffect(() => {
-    // Conditional spread: `updateOptions` declares strict-optional
-    // fields and rejects explicit `undefined` under EOPT.
-    client.updateOptions({
-      body: options.body,
-      ...(options.forwardedProps !== undefined && {
-        forwardedProps: options.forwardedProps,
-      }),
-      ...(options.tools !== undefined && {
-        tools: options.tools,
-      }),
-      context: options.context,
-    })
-  }, [client, options.body, options.forwardedProps, options.tools, options.context])
+    client.updateOptions({ body: options.body })
+  }, [client, options.body])
+
+  useEffect(() => {
+    if (options.forwardedProps !== undefined) {
+      client.updateOptions({ forwardedProps: options.forwardedProps })
+    }
+  }, [client, options.forwardedProps])
+
+  useEffect(() => {
+    if (options.tools !== undefined) {
+      client.updateOptions({ tools: options.tools })
+    }
+  }, [client, options.tools])
+
+  useEffect(() => {
+    client.updateOptions({ context: options.context })
+  }, [client, options.context])
 
   useEffect(() => {
     if (options.live) {

--- a/packages/ai-react/src/use-chat.ts
+++ b/packages/ai-react/src/use-chat.ts
@@ -176,9 +176,12 @@ export function useChat<
       ...(options.forwardedProps !== undefined && {
         forwardedProps: options.forwardedProps,
       }),
+      ...(options.tools !== undefined && {
+        tools: options.tools,
+      }),
       context: options.context,
     })
-  }, [client, options.body, options.forwardedProps, options.context])
+  }, [client, options.body, options.forwardedProps, options.tools, options.context])
 
   useEffect(() => {
     if (options.live) {


### PR DESCRIPTION
## Summary

`useChat` initialises the `ChatClient` with the `tools` option passed at construction time, but never calls `client.updateOptions({ tools })` when the `tools` prop changes during the component lifecycle. This means the client-side tool registry becomes stale when callers swap tools — e.g. a project-management app where `updateTaskTool` closes over `projectId` and the user switches projects.

`ChatClient.updateOptions()` already accepts `tools` and rebuilds `clientToolsRef` when it receives them. The fix is to add `tools` to the existing `updateOptions` effect that already syncs `body`, `forwardedProps`, and `context`.

## Changes

- `packages/ai-react/src/use-chat.ts`: conditionally spread `options.tools` into the `updateOptions` call and add it to the dependency array, matching the existing pattern for `forwardedProps`.

Fixes #775

## Test plan

- Mount `useChat` with a `tools` array that closes over a value (e.g. `projectId`).
- Change `projectId` while the component stays mounted.
- Confirm the new tool implementation is used on the next LLM response (not the stale closure from mount time).
- Callers should `useMemo` their tools array (as shown in the issue) to avoid unnecessary re-registrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat option handling so updates to tool availability apply reliably and take effect immediately.
  * Refined option update behavior to reduce unintended re-runs when unrelated chat settings change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->