### PR TITLE
fix: remove dangerous non-null assertions in compareGuitars

### DIFF
--- a/examples/ts-react-chat/src/lib/guitar-tools.ts
+++ b/examples/ts-react-chat/src/lib/guitar-tools.ts
@@ -173,9 +173,16 @@ export const compareGuitars = compareGuitarsToolDef.server((args) => {
     .map((id) => guitars.find((g) => g.id === id))
     .filter(Boolean) as (typeof guitars)[number][]
 
+  if (selected.length === 0) {
+    throw new Error('No valid guitars found for the provided IDs')
+  }
+
   const prices = selected.map((g) => g.price)
   const minPrice = Math.min(...prices)
   const maxPrice = Math.max(...prices)
+
+  const cheapestGuitar = selected.find((g) => g.price === minPrice)
+  const mostExpensiveGuitar = selected.find((g) => g.price === maxPrice)
 
   return {
     comparison: selected.map((g) => ({
@@ -185,11 +192,11 @@ export const compareGuitars = compareGuitarsToolDef.server((args) => {
       description: g.shortDescription,
       priceDifference:
         g.price === minPrice
-          ? 'Cheapest'
-          : `+$${g.price - minPrice} more than cheapest`,
+          ? 'Cheapest in selection'
+          : `+$${g.price - minPrice} more than cheapest in selection`,
     })),
-    cheapest: selected.find((g) => g.price === minPrice)!.name,
-    mostExpensive: selected.find((g) => g.price === maxPrice)!.name,
+    cheapest: cheapestGuitar?.name ?? 'Unknown',
+    mostExpensive: mostExpensiveGuitar?.name ?? 'Unknown',
   }
 })
 


### PR DESCRIPTION
Removed dangerous non-null assertions () in  tool implementation in the  example. Added a check for empty selection and used optional chaining to prevent potential runtime crashes. Also improved the clarity of 'cheapest' labels.

This ensures that if the tool is called with invalid IDs, it throws a meaningful error instead of crashing the whole app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in guitar comparison to catch invalid guitar selections.
  * Enhanced price information display with "Unknown" fallback when pricing data is unavailable.

* **Improvements**
  * Updated price difference labeling for clearer comparison messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->