### PR TITLE
feat: cost for OpenRouter image models

### DIFF
--- a/.changeset/openrouter-image-cost.md
+++ b/.changeset/openrouter-image-cost.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/ai-openrouter': patch
+---
+
+Surface OpenRouter provider-reported cost on image generation usage, matching
+the existing text adapter behavior.

--- a/packages/ai-openrouter/src/adapters/image.ts
+++ b/packages/ai-openrouter/src/adapters/image.ts
@@ -206,8 +206,10 @@ export class OpenRouterImageAdapter<
     // response carries the same `usage` shape as text. Surface it (with any
     // detail breakdowns and provider-reported cost) when present.
     const baseUsage = buildOpenRouterUsage(response.usage)
-    const usage =
-      baseUsage && { ...baseUsage, ...extractUsageCost(response.usage) }
+    const usage = baseUsage && {
+      ...baseUsage,
+      ...extractUsageCost(response.usage),
+    }
 
     return {
       id: response.id || this.generateId(),

--- a/packages/ai-openrouter/src/adapters/image.ts
+++ b/packages/ai-openrouter/src/adapters/image.ts
@@ -6,6 +6,7 @@ import {
   generateId as utilGenerateId,
 } from '../utils'
 import { buildOpenRouterUsage } from '../usage'
+import { extractUsageCost } from './cost'
 import type { OpenRouterClientConfig } from '../utils'
 import type {
   OpenRouterImageModelInputModalitiesByName,
@@ -203,10 +204,10 @@ export class OpenRouterImageAdapter<
 
     // OpenRouter routes image generation through the chat surface, so the
     // response carries the same `usage` shape as text. Surface it (with any
-    // detail breakdowns) when present.
-    const usage = response.usage
-      ? buildOpenRouterUsage(response.usage)
-      : undefined
+    // detail breakdowns and provider-reported cost) when present.
+    const baseUsage = buildOpenRouterUsage(response.usage)
+    const usage =
+      baseUsage && { ...baseUsage, ...extractUsageCost(response.usage) }
 
     return {
       id: response.id || this.generateId(),

--- a/packages/ai-openrouter/tests/image-adapter.test.ts
+++ b/packages/ai-openrouter/tests/image-adapter.test.ts
@@ -111,6 +111,45 @@ describe('OpenRouter Image Adapter', () => {
     })
   })
 
+  it('surfaces provider-reported cost from OpenRouter image usage', async () => {
+    const mockResponse = {
+      ...createMockImageResponse([{ url: 'https://example.com/image1.png' }]),
+      usage: {
+        completionTokens: 1291,
+        cost: 0.0387076,
+        cost_details: {
+          upstream_inference_completions_cost: 0.0387025,
+          upstream_inference_cost: 0.0387076,
+          upstream_inference_prompt_cost: 0.0000051,
+        },
+        promptTokens: 17,
+        totalTokens: 1308,
+      },
+    }
+
+    mockSend = vi.fn().mockResolvedValueOnce(mockResponse)
+
+    const adapter = createAdapter()
+
+    const result = await adapter.generateImages({
+      model: 'google/gemini-2.5-flash-image',
+      prompt: 'A futuristic city at sunset',
+      logger: testLogger,
+    })
+
+    expect(result.usage).toMatchObject({
+      promptTokens: 17,
+      completionTokens: 1291,
+      totalTokens: 1308,
+      cost: 0.0387076,
+      costDetails: {
+        upstreamOutputCost: 0.0387025,
+        upstreamCost: 0.0387076,
+        upstreamInputCost: 0.0000051,
+      },
+    })
+  })
+
   it('generates multiple images', async () => {
     const mockResponse = createMockImageResponse([
       { url: 'https://example.com/image1.png' },


### PR DESCRIPTION
## 🎯 Changes

Fix OpenRouter image generation usage reporting so provider-reported request **cost** is surfaced on `result.usage`, matching the existing OpenRouter text adapter behavior.

OpenRouter image generation already normalized token usage via `buildOpenRouterUsage(...)`, but did not merge in `extractUsageCost(...)`. This meant `cost` and `cost_details` were dropped for image generation responses even when OpenRouter returned them.

Adds a regression test covering image usage with provider-reported `cost` and snake_case `cost_details`.

I also tested in [my test project](https://github.com/edemaine/client-side-tanstack-ai-demo) via `pnpm link`. Costs are now surfaced.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenRouter image generation now surfaces provider-reported cost data in usage metrics, consistent with text generation behavior.

* **Tests**
  * Added test coverage to verify image generation usage includes provider-reported cost details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->