### PR TITLE
fix(chat-message): update part type to UIMessage['parts'][number] and…

### DIFF
--- a/.changeset/red-pillows-cheer.md
+++ b/.changeset/red-pillows-cheer.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-react-ui': patch
+---
+
+Fix `ChatMessage` rendering of multimodal tool results. Tool-result content is `string | Array<ContentPart>`, but the renderer previously typed the message part as `any` and passed the raw content straight to React — an array of content-part objects would throw React's "Objects are not valid as a React child". The part is now typed as `UIMessage['parts'][number]`, and array content is flattened to the concatenation of its text parts (non-text parts are skipped) before rendering, both for the built-in renderer and the `toolResultRenderer` prop.

--- a/packages/ai-react-ui/src/chat-message.tsx
+++ b/packages/ai-react-ui/src/chat-message.tsx
@@ -1,4 +1,5 @@
 import { ThinkingPart } from './thinking-part'
+import { toolResultContentToString } from './tool-result-content'
 import type { ReactNode } from 'react'
 import type { UIMessage } from '@tanstack/ai-react'
 
@@ -239,8 +240,7 @@ function MessagePart({
 
   // Tool result part
   if (part.type === 'tool-result') {
-    const toolResultContent =
-      typeof part.content === 'string' ? part.content : ''
+    const toolResultContent = toolResultContentToString(part.content)
 
     if (toolResultRenderer) {
       return (

--- a/packages/ai-react-ui/src/chat-message.tsx
+++ b/packages/ai-react-ui/src/chat-message.tsx
@@ -144,8 +144,7 @@ function MessagePart({
   defaultToolRenderer,
   toolResultRenderer,
 }: {
-  // TODO Fix me
-  part: any
+  part: UIMessage['parts'][number]
   isThinkingComplete?: boolean
   textPartRenderer?: ChatMessageProps['textPartRenderer']
   thinkingPartRenderer?: ChatMessageProps['thinkingPartRenderer']
@@ -240,12 +239,15 @@ function MessagePart({
 
   // Tool result part
   if (part.type === 'tool-result') {
+    const toolResultContent =
+      typeof part.content === 'string' ? part.content : ''
+
     if (toolResultRenderer) {
       return (
         <>
           {toolResultRenderer({
             toolCallId: part.toolCallId,
-            content: part.content,
+            content: toolResultContent,
             state: part.state,
           })}
         </>
@@ -258,7 +260,7 @@ function MessagePart({
         data-tool-call-id={part.toolCallId}
         data-tool-result-state={part.state}
       >
-        <div data-tool-result-content>{part.content}</div>
+        <div data-tool-result-content>{toolResultContent}</div>
       </div>
     )
   }

--- a/packages/ai-react-ui/src/tool-result-content.ts
+++ b/packages/ai-react-ui/src/tool-result-content.ts
@@ -1,0 +1,32 @@
+import type { UIMessage } from '@tanstack/ai-react'
+
+type ToolResultPart = Extract<
+  UIMessage['parts'][number],
+  { type: 'tool-result' }
+>
+
+/** `string | Array<ContentPart>` — a tool result's raw content. */
+type ToolResultContent = ToolResultPart['content']
+
+type ContentPartItem = Exclude<ToolResultContent, string>[number]
+
+/**
+ * Reduce a tool-result part's `content` to a plain string for rendering.
+ *
+ * Tool results carry `string | Array<ContentPart>` (multimodal results are
+ * normalized to an array of content parts upstream). The `ChatMessage`
+ * renderers operate on plain strings, so array content is flattened to the
+ * concatenation of its text parts. Non-text parts (image, audio, video,
+ * document) have no string form here and are skipped — matching the
+ * text-extraction behavior used elsewhere for `string | Array<ContentPart>`.
+ */
+export function toolResultContentToString(content: ToolResultContent): string {
+  if (typeof content === 'string') return content
+  return content
+    .filter(
+      (part): part is Extract<ContentPartItem, { type: 'text' }> =>
+        part.type === 'text',
+    )
+    .map((part) => part.content)
+    .join('')
+}

--- a/packages/ai-react-ui/tests/tool-result-content.test.ts
+++ b/packages/ai-react-ui/tests/tool-result-content.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { toolResultContentToString } from '../src/tool-result-content'
+
+describe('toolResultContentToString', () => {
+  it('returns string content unchanged', () => {
+    expect(toolResultContentToString('hello world')).toBe('hello world')
+  })
+
+  it('returns an empty string unchanged', () => {
+    expect(toolResultContentToString('')).toBe('')
+  })
+
+  it('concatenates the text parts of array content', () => {
+    const content = [
+      { type: 'text' as const, content: 'first' },
+      { type: 'text' as const, content: 'second' },
+    ]
+    expect(toolResultContentToString(content)).toBe('firstsecond')
+  })
+
+  it('skips non-text parts and keeps surrounding text', () => {
+    const content = [
+      { type: 'text' as const, content: 'before' },
+      {
+        type: 'image' as const,
+        source: { type: 'url' as const, value: 'https://example.com/x.png' },
+      },
+      { type: 'text' as const, content: 'after' },
+    ]
+    expect(toolResultContentToString(content)).toBe('beforeafter')
+  })
+
+  it('returns an empty string when array content has no text parts', () => {
+    const content = [
+      {
+        type: 'image' as const,
+        source: { type: 'url' as const, value: 'https://example.com/x.png' },
+      },
+    ]
+    expect(toolResultContentToString(content)).toBe('')
+  })
+
+  it('returns an empty string for an empty array', () => {
+    expect(toolResultContentToString([])).toBe('')
+  })
+})


### PR DESCRIPTION
 🎯 Changes

Restore typing for ChatMessage parts by replacing the migration-era any with the existing UIMessage part type and removing the associated TODO.

This change also adds local narrowing for tool-result content to satisfy the ToolResultPart.content union while preserving the existing renderer contract and runtime behavior.

No public APIs, package functionality, or runtime behavior are changed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat rendering for multimodal tool results by safely normalizing tool-result content into a consistent plain-text string before display, preventing incorrect rendering when content is provided as structured parts.
* **New Features**
  * Added a helper utility to convert tool-result content into a renderable string (used by both the built-in and custom tool-result renderers).
* **Tests**
  * Added unit tests covering tool-result content normalization for strings, mixed parts, and non-text-only content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->