### PR TITLE
fix(openai): apply strict fallback in the provider-path function-tool converter

### DIFF
--- a/.changeset/openai-strict-fallback-function-tool.md
+++ b/.changeset/openai-strict-fallback-function-tool.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/openai-base': patch
+---
+
+Apply the strict-mode fallback in the provider-path `function-tool` converter. A tool whose input JSON Schema can't satisfy OpenAI's strict function-calling constraints now falls back to a non-strict tool definition (matching the converter's other path) instead of emitting an invalid strict tool, so such tools work across the OpenAI-based adapters (`@tanstack/ai-openai`, `@tanstack/ai-grok`, `@tanstack/ai-groq`).

--- a/packages/openai-base/src/tools/function-tool.ts
+++ b/packages/openai-base/src/tools/function-tool.ts
@@ -1,4 +1,8 @@
-import { makeStructuredOutputCompatible } from '../utils/schema-converter'
+import {
+  isStrictModeCompatible,
+  makeStructuredOutputCompatible,
+  stripUnsupportedFormats,
+} from '../utils/schema-converter'
 import type { FunctionTool as FunctionToolConfig } from 'openai/resources/responses/responses'
 import type { JSONSchema, Tool } from '@tanstack/ai'
 
@@ -17,6 +21,12 @@ export type FunctionTool = FunctionToolConfig
  * - additionalProperties: false
  *
  * This enables strict mode for all tools automatically.
+ *
+ * Some tool schemas (e.g. MCP server tools that use `oneOf`, `$ref`, or
+ * `$defs`) cannot be expressed under OpenAI's strict Structured Outputs
+ * subset. For those we fall back to a non-strict tool definition — stripping
+ * only the formats OpenAI rejects — so the tool is still usable instead of
+ * failing the request with a 400 "Invalid schema" error.
  */
 export function convertFunctionToolToAdapterFormat(
   tool: Tool,
@@ -26,6 +36,16 @@ export function convertFunctionToolToAdapterFormat(
     properties: {},
     required: [],
   }) as JSONSchema
+
+  if (!isStrictModeCompatible(inputSchema)) {
+    return {
+      type: 'function',
+      name: tool.name,
+      description: tool.description,
+      parameters: stripUnsupportedFormats(inputSchema),
+      strict: false,
+    } satisfies FunctionToolConfig
+  }
 
   const jsonSchema = makeStructuredOutputCompatible(
     inputSchema,

--- a/packages/openai-base/tests/tool-converter-strict-fallback.test.ts
+++ b/packages/openai-base/tests/tool-converter-strict-fallback.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { convertFunctionToolToResponsesFormat } from '../src/adapters/responses-tool-converter'
 import { convertFunctionToolToChatCompletionsFormat } from '../src/adapters/chat-completions-tool-converter'
+import { convertFunctionToolToAdapterFormat } from '../src/tools/function-tool'
 import type { Tool } from '@tanstack/ai'
 
 /** A schema fully inside OpenAI's strict Structured Outputs subset. */
@@ -72,5 +73,29 @@ describe('chat-completions tool converter — strict fallback', () => {
     const params = out.function.parameters as any
     expect(params.$defs.parent.oneOf).toBeDefined()
     expect(params.properties.site.format).toBeUndefined()
+  })
+})
+
+// This is the converter the provider tool-dispatcher (`convertToolsToProviderFormat`)
+// actually uses for MCP / function tools on the Responses + Chat Completions
+// adapters, so the same strict fallback must apply here.
+describe('function-tool adapter converter — strict fallback', () => {
+  it('uses strict:true for strict-subset schemas', () => {
+    const out = convertFunctionToolToAdapterFormat(strictSafeTool)
+    expect(out.strict).toBe(true)
+    expect(
+      (out.parameters as Record<string, unknown>).additionalProperties,
+    ).toBe(false)
+  })
+
+  it('falls back to strict:false for schemas with unsupported keywords', () => {
+    const out = convertFunctionToolToAdapterFormat(gnarlyTool)
+    expect(out.strict).toBe(false)
+    // Schema is preserved (not corrupted) so the tool stays callable...
+    const params = out.parameters as any
+    expect(params.$defs.parent.oneOf).toBeDefined()
+    // ...but unsupported `format` keywords are still stripped.
+    expect(params.properties.site.format).toBeUndefined()
+    expect(params.properties.user_id.format).toBe('uuid')
   })
 })


### PR DESCRIPTION
Follow-up to #786.

#786 added the `strict:false` fallback to `responses-tool-converter.ts` and `chat-completions-tool-converter.ts`, but the adapter's provider tool dispatcher (`convertToolsToProviderFormat`) routes MCP and function tools through a **third** converter — `convertFunctionToolToAdapterFormat` in `tools/function-tool.ts` — which still forced `strict: true`. So tools whose schema is outside OpenAI's strict subset (e.g. Notion MCP tools using `$defs`/`oneOf`) still 400'd the whole request.

This applies the same `isStrictModeCompatible` check there: emit `strict: false` and strip unsupported formats when the schema can't be expressed under strict Structured Outputs, keeping the tool callable.

Verified end-to-end: a TanStack `chat()` with the Notion + Linear MCP servers now completes (previously 400'd on `API-get-user`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved OpenAI Structured Outputs handling by automatically falling back to non-strict function definitions when a tool’s input schema isn’t fully compatible, preventing “Invalid schema” validation errors.

* **Tests**
  * Added test coverage to verify strict vs. fallback behavior based on schema compatibility, including preservation of valid schema structure and removal of unsupported `format` entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->