### PR TITLE
chore(ai-event-client): drop unused @tanstack/ai peerDependency

### DIFF
--- a/.changeset/drop-ai-event-client-ai-peer.md
+++ b/.changeset/drop-ai-event-client-ai-peer.md
@@ -1,0 +1,18 @@
+---
+'@tanstack/ai-event-client': patch
+---
+
+chore: drop unused `@tanstack/ai` peerDependency
+
+`@tanstack/ai-event-client` never imported from `@tanstack/ai` — the middleware
+and event types it needs are mirrored locally to avoid the `ai` →
+`ai-event-client` (dependency) / `ai-event-client` → `ai` (peer) manifest cycle.
+The peer entry was therefore dead weight, and the `!@tanstack/ai`
+implicit-dependency edge in `project.json` existed solely to neutralize that
+cycle in Nx's project graph.
+
+Both are removed (the `project.json` is dropped entirely, restoring the package
+to pure Nx inference like its siblings). No runtime or type surface changes, and
+no consumer is affected — `@tanstack/ai`, `@tanstack/ai-client`, and
+`@tanstack/ai-devtools` all depend on `@tanstack/ai-event-client` as a normal
+dependency, never as a peer.

--- a/packages/ai-event-client/package.json
+++ b/packages/ai-event-client/package.json
@@ -44,9 +44,6 @@
   "dependencies": {
     "@tanstack/devtools-event-client": "^0.4.1"
   },
-  "peerDependencies": {
-    "@tanstack/ai": "workspace:*"
-  },
   "devDependencies": {
     "@vitest/coverage-v8": "4.0.14"
   },

--- a/packages/ai-event-client/project.json
+++ b/packages/ai-event-client/project.json
@@ -1,4 +1,0 @@
-{
-  "name": "@tanstack/ai-event-client",
-  "implicitDependencies": ["!@tanstack/ai"]
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1330,9 +1330,6 @@ importers:
 
   packages/ai-event-client:
     dependencies:
-      '@tanstack/ai':
-        specifier: workspace:*
-        version: link:../ai
       '@tanstack/devtools-event-client':
         specifier: ^0.4.1
         version: 0.4.1


### PR DESCRIPTION
Closes #552.

`@tanstack/ai-event-client` declared `@tanstack/ai` as a `peerDependency` but never imports from it. The middleware/event types it needs are mirrored locally (see the comments in `src/index.ts` and `src/devtools-middleware.ts`) specifically to avoid the `ai` → `ai-event-client` (dependency) / `ai-event-client` → `ai` (peer) manifest cycle. The peer entry was therefore dead weight, and the `"!@tanstack/ai"` `implicitDependencies` edge in `project.json` existed only to neutralize that cycle in Nx's project graph.

## Changes

- Remove the `peerDependencies` block from `packages/ai-event-client/package.json`.
- Delete `packages/ai-event-client/project.json`. With the peer gone there is no cycle to break, so the `!@tanstack/ai` edge is dead weight; the package now relies on pure Nx inference like every other package (it was the only `project.json` in the repo).
- Update `pnpm-lock.yaml` to drop the now-removed importer entry.
- Add a `patch` changeset for `@tanstack/ai-event-client`.

## Notes

- No runtime or type-surface changes. `@tanstack/ai`, `@tanstack/ai-client`, and `@tanstack/ai-devtools` all depend on `@tanstack/ai-event-client` as a normal `dependency`, never as a peer, so no consumer is affected.
- The published `@tanstack/ai-event-client@0.6.3` shipped this peer pinned to a concrete `@tanstack/ai` version (pnpm rewrites `workspace:*` at publish time), which put an unnecessary install constraint on devtools-only consumers. This removes it.

## Test plan

- `sherif` (workspace consistency) — pass
- `knip` (unused dependencies) — pass
- `nx affected --target=build` + `publint --strict` — pass
- `test:types`, `test:lib` — pass

Manifest-only change with no behavior change; the e2e suite runs in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary peer dependency constraint. Package structure has been simplified to avoid circular dependencies, with required types mirrored locally. No runtime or type surface changes—all existing functionality remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->