### PR TITLE
docs: add Requesty to openai-compatible adapter provider list

### DIFF
--- a/docs/adapters/openai-compatible.md
+++ b/docs/adapters/openai-compatible.md
@@ -138,6 +138,7 @@ Any provider implementing the OpenAI Chat Completions API works. Common ones are
 | Cerebras | `https://api.cerebras.ai/v1` | `llama-3.3-70b` |
 | DeepInfra | `https://api.deepinfra.com/v1/openai` | `meta-llama/Llama-3.3-70B-Instruct` |
 | Perplexity | `https://api.perplexity.ai` | `sonar`, `sonar-pro` |
+| Requesty | `https://router.requesty.ai/v1` | `openai/gpt-4o-mini` |
 | Mistral | `https://api.mistral.ai/v1` | `mistral-large-latest` |
 | Nebius | `https://api.studio.nebius.ai/v1` | `meta-llama/Llama-3.3-70B-Instruct` |
 | Z.AI (GLM) | `https://api.z.ai/api/paas/v4` | `glm-4.6` |

--- a/docs/config.json
+++ b/docs/config.json
@@ -457,7 +457,8 @@
         {
           "label": "OpenAI-Compatible",
           "to": "adapters/openai-compatible",
-          "addedAt": "2026-06-01"
+          "addedAt": "2026-06-01",
+          "updatedAt": "2026-06-20"
         }
       ]
     },


### PR DESCRIPTION
## What

Adds **Requesty** to the Supported Providers table in the OpenAI-Compatible
adapter docs (`docs/adapters/openai-compatible.md`).

## Why this approach

The repo already ships a generic `openaiCompatible` adapter and the docs
explicitly say to use it for any provider that speaks the OpenAI Chat
Completions wire format but does not have its own `@tanstack/ai-*` package
("If a dedicated adapter exists … prefer it — those carry curated per-model
metadata").

Requesty (`https://router.requesty.ai/v1`) is exactly that case:

- It implements the OpenAI Chat Completions API (`/chat/completions`).
- It uses `provider/model` naming (e.g. `openai/gpt-4o-mini`), like OpenRouter.

So the cleanest, most idiomatic contribution is a one-line docs example in the
existing provider table — **not** a new dedicated package. The dedicated
`@tanstack/ai-openrouter` package is heavy (its own SDK dependency plus a
~16k-line curated `model-meta.ts`); mirroring that for Requesty would add a
large, hard-to-maintain package for a provider that the generic adapter
already covers. A docs row matches how the repo expects OpenAI-compatible
providers to be added.

## Files changed

- `docs/adapters/openai-compatible.md` — add a `Requesty` row to the
  "Supported Providers" table.
- `docs/config.json` — set `updatedAt` on the `openai-compatible` docs entry
  to today's date, per `AGENTS.md` (content change to an existing page).

No package code changes, so per `CONTRIBUTING.md` ("Examples, internal test
harnesses, codemods, and docs do not [require a changeset]") no changeset is
included.

## Verification

- The new table row contains only backtick code spans — no markdown links —
  so `test:docs` (internal-link verification) is unaffected.
- `docs/config.json` remains valid JSON.
- Branched from current `main` (`2cb0313`), up to date with `origin/main`.

## Live test against Requesty

```
GET  https://router.requesty.ai/v1/models            -> 200
POST https://router.requesty.ai/v1/chat/completions
     { "model": "openai/gpt-4o-mini", ... }           -> 200
     content: "REQUESTY_OK"   model: gpt-4o-mini-2024-07-18
```

Confirms the documented base URL + `provider/model` id work over the OpenAI
Chat Completions surface the `openaiCompatible` adapter targets.

---

I work at Requesty. This mirrors the existing OpenRouter integration /
openai-compatible adapter. Happy to adjust or close it if it is not a fit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the OpenAI-Compatible adapter documentation to include Requesty as a supported provider with its router endpoint and example model configuration.
  * Updated adapter registry with the latest modification timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->