### PR TITLE
docs: fix OpenAI explicit API key example

### DIFF
--- a/docs/adapters/openai.md
+++ b/docs/adapters/openai.md
@@ -68,8 +68,7 @@ With an explicit API key:
 import { chat } from "@tanstack/ai";
 import { createOpenaiChatCompletions } from "@tanstack/ai-openai";
 
-const adapter = createOpenaiChatCompletions("gpt-5.2", {
-  apiKey: process.env.OPENAI_API_KEY!,
+const adapter = createOpenaiChatCompletions("gpt-5.2", process.env.OPENAI_API_KEY!, {
   // organization, baseURL, headers — all optional
 });
 


### PR DESCRIPTION
## Summary

Fixes the OpenAI docs example for using an explicit API key with `createOpenaiChatCompletions`.

The example previously passed `{ apiKey }` as the second argument, but the exported function signature is:

```ts
createOpenaiChatCompletions(model, apiKey, config?)
```

This updates the example to match the implementation.

## Related issue

Related to #392.

The original `createOpenaiChat` example mentioned in the issue appears to already be fixed, but the same OpenAI docs page had the same kind of explicit API key mismatch for `createOpenaiChatCompletions`.

## Validation

```sh
pnpm test:docs
```

Passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenAI adapter documentation with revised examples demonstrating the recommended method for API authentication configuration. The documentation now provides clearer guidance on credential setup, helping users integrate OpenAI chat completion functionality with improved clarity on authentication best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->