### PR TITLE
chore(ai-event-client): drop unused peer dependency on @tanstack/ai

### DIFF
--- a/.changeset/quiet-pandas-travel.md
+++ b/.changeset/quiet-pandas-travel.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/ai-event-client": patch
+'@tanstack/ai-event-client': patch
 ---
 
 Remove the unused `@tanstack/ai` peer dependency and the matching Nx dependency-graph override.

--- a/.changeset/quiet-pandas-travel.md
+++ b/.changeset/quiet-pandas-travel.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/ai-event-client": patch
+---
+
+Remove the unused `@tanstack/ai` peer dependency and the matching Nx dependency-graph override.

--- a/packages/ai-event-client/package.json
+++ b/packages/ai-event-client/package.json
@@ -44,9 +44,6 @@
   "dependencies": {
     "@tanstack/devtools-event-client": "^0.4.1"
   },
-  "peerDependencies": {
-    "@tanstack/ai": "workspace:*"
-  },
   "devDependencies": {
     "@vitest/coverage-v8": "4.0.14"
   },

--- a/packages/ai-event-client/project.json
+++ b/packages/ai-event-client/project.json
@@ -1,4 +1,3 @@
 {
-  "name": "@tanstack/ai-event-client",
-  "implicitDependencies": ["!@tanstack/ai"]
+  "name": "@tanstack/ai-event-client"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1333,9 +1333,6 @@ importers:
 
   packages/ai-event-client:
     dependencies:
-      '@tanstack/ai':
-        specifier: workspace:*
-        version: link:../ai
       '@tanstack/devtools-event-client':
         specifier: ^0.4.1
         version: 0.4.1


### PR DESCRIPTION
## Summary

Closes #552.

Removes the unused `@tanstack/ai` peer dependency from `@tanstack/ai-event-client` and removes the matching Nx `implicitDependencies` override that existed only to neutralize the inferred package graph cycle.

Also updates `pnpm-lock.yaml` and adds a patch changeset because this changes published package metadata.

## Validation

```sh
pnpm install
pnpm --filter @tanstack/ai-event-client test:build
pnpm --filter @tanstack/ai-event-client test:types
pnpm --filter @tanstack/ai-event-client test:lib
pnpm test:sherif
pnpm test:knip
```

All passed locally. `test:lib` printed an unrelated existing warning while parsing `examples/ts-svelte-chat/tsconfig.json` because `.svelte-kit/tsconfig.json` is not present, but the `@tanstack/ai-event-client` Vitest suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused peer dependency from the ai-event-client package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->