### PR TITLE
feat(ai-grok): use xAI Responses API

### DIFF
--- a/.changeset/grok-responses-api.md
+++ b/.changeset/grok-responses-api.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/ai-grok": minor
+'@tanstack/ai-grok': minor
 ---
 
 Migrate Grok text and summarize adapters to xAI's Responses API with support for grok-4.3, grok-build-0.1, reasoning options, structured output, function tools, and xAI server-side tools.

--- a/.changeset/grok-responses-api.md
+++ b/.changeset/grok-responses-api.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/ai-grok": minor
+---
+
+Migrate Grok text and summarize adapters to xAI's Responses API with support for grok-4.3, grok-build-0.1, reasoning options, structured output, function tools, and xAI server-side tools.

--- a/docs/adapters/grok.md
+++ b/docs/adapters/grok.md
@@ -2,18 +2,17 @@
 title: Grok (xAI)
 id: grok-adapter
 order: 5
-description: "Use xAI Grok models with TanStack AI — Grok 4.1, Grok 4, Grok 3, and Grok 2 Image generation via @tanstack/ai-grok."
+description: "Use xAI Grok Responses models with TanStack AI — Grok 4.3 and Grok Build 0.1 via @tanstack/ai-grok."
 keywords:
   - tanstack ai
   - grok
   - xai
-  - grok 4
-  - grok 4.1
-  - image generation
+  - grok 4.3
+  - grok build
   - adapter
 ---
 
-The Grok adapter provides access to xAI's Grok models, including Grok 4.1, Grok 4, Grok 3, and image generation with Grok 2 Image.
+The Grok text and summarization adapters provide access to xAI's Responses API for `grok-4.3` and `grok-build-0.1`.
 
 ## Installation
 
@@ -28,7 +27,7 @@ import { chat } from "@tanstack/ai";
 import { grokText } from "@tanstack/ai-grok";
 
 const stream = chat({
-  adapter: grokText("grok-4"),
+  adapter: grokText("grok-build-0.1"),
   messages: [{ role: "user", content: "Hello!" }],
 });
 ```
@@ -39,7 +38,7 @@ const stream = chat({
 import { chat } from "@tanstack/ai";
 import { createGrokText } from "@tanstack/ai-grok";
 
-const adapter = createGrokText("grok-4", process.env.XAI_API_KEY!);
+const adapter = createGrokText("grok-build-0.1", process.env.XAI_API_KEY!);
 
 const stream = chat({
   adapter,
@@ -56,7 +55,7 @@ const config: Omit<GrokTextConfig, "apiKey"> = {
   baseURL: "https://api.x.ai/v1", // Optional, this is the default
 };
 
-const adapter = createGrokText("grok-4", process.env.XAI_API_KEY!, config);
+const adapter = createGrokText("grok-build-0.1", process.env.XAI_API_KEY!, config);
 ```
 
 ## Example: Chat Completion
@@ -69,7 +68,7 @@ export async function POST(request: Request) {
   const { messages } = await request.json();
 
   const stream = chat({
-    adapter: grokText("grok-4"),
+    adapter: grokText("grok-build-0.1"),
     messages,
   });
 
@@ -98,7 +97,7 @@ const getWeather = getWeatherDef.server(async ({ location }) => {
 });
 
 const stream = chat({
-  adapter: grokText("grok-4-1-fast-reasoning"),
+  adapter: grokText("grok-build-0.1"),
   messages,
   tools: [getWeather],
 });
@@ -106,19 +105,18 @@ const stream = chat({
 
 ## Model Options
 
-Grok supports various provider-specific options. Sampling parameters live here too — `temperature`, `top_p`, and `max_tokens` — rather than as root-level props on `chat()`:
+Grok supports xAI Responses API options. Sampling parameters live here too — `temperature`, `top_p`, and `max_output_tokens` — rather than as root-level props on `chat()`:
 
 ```typescript
 const stream = chat({
-  adapter: grokText("grok-4"),
+  adapter: grokText("grok-build-0.1"),
   messages,
   modelOptions: {
     temperature: 0.7,
     top_p: 0.9,
-    max_tokens: 1024,
-    frequency_penalty: 0.5,
-    presence_penalty: 0.5,
-    stop: ["END"],
+    max_output_tokens: 1024,
+    store: false,
+    include: ["reasoning.encrypted_content"],
   },
 });
 ```
@@ -134,7 +132,7 @@ import { summarize } from "@tanstack/ai";
 import { grokSummarize } from "@tanstack/ai-grok";
 
 const result = await summarize({
-  adapter: grokSummarize("grok-4"),
+  adapter: grokSummarize("grok-build-0.1"),
   text: "Your long text to summarize...",
   maxLength: 100,
   style: "concise", // "concise" | "bullet-points" | "paragraph"
@@ -253,19 +251,11 @@ XAI_API_KEY=xai-...
 
 ## Implementation Notes
 
-### Why Chat Completions API (Not Responses API)
+### Responses API
 
-The Grok adapter uses xAI's **Chat Completions API** (`/v1/chat/completions`) rather than the Responses API (`/v1/responses`). This is an intentional architectural decision:
+The Grok text and summarize adapters use xAI's **Responses API** (`/v1/responses`). Requests default to `store: false` and include encrypted reasoning content with `include: ["reasoning.encrypted_content"]`; both can be overridden through `modelOptions`.
 
-1. **User-Defined Tools**: The Chat Completions API supports user-defined function tools, which is essential for TanStack AI's tool calling functionality. The Responses API only supports xAI's server-side tools (web search, X search, code execution).
-
-2. **Full Tool Calling Support**: With Chat Completions, you can define custom tools with Zod schemas that run in your application. The Responses API restricts you to xAI's built-in tools only.
-
-3. **Streaming Compatibility**: The streaming event format differs significantly between the two APIs. Chat Completions uses `delta.tool_calls` with argument accumulation, while Responses API uses `response.output_item.added` and `response.function_call_arguments.done`.
-
-4. **OpenAI SDK Compatibility**: xAI's Chat Completions API is fully compatible with the OpenAI SDK, making integration straightforward while maintaining full feature parity for tool calling.
-
-If you need xAI's server-side tools (web search, X/Twitter search, code execution), you would need to use the Responses API directly. However, for most use cases requiring custom tool definitions, the Chat Completions API is the correct choice.
+The shared Responses implementation supports streaming text, reasoning events, structured output via `text.format`, and user-defined function tools.
 
 ## API Reference
 
@@ -275,7 +265,7 @@ Creates a Grok text adapter using environment variables.
 
 **Parameters:**
 
-- `model` - The model name (e.g., `'grok-4'`, `'grok-4-1-fast-reasoning'`)
+- `model` - The model name (`'grok-4.3'` or `'grok-build-0.1'`)
 - `config.baseURL?` - Custom base URL (optional)
 
 **Returns:** A Grok text adapter instance.
@@ -319,10 +309,6 @@ Creates a Grok speech-to-text adapter.
 ### `grokRealtime(...)` / `grokRealtimeToken(...)`
 
 Realtime voice adapter and token issuer. See [Realtime Voice Chat](../media/realtime-chat) for usage.
-
-## Limitations
-
-- **Responses API Tools**: Server-side tools (web search, X search, code execution) are not supported through this adapter. Use the Chat Completions API with custom tools instead.
 
 ## Next Steps
 

--- a/examples/ts-react-chat/src/lib/model-selection.ts
+++ b/examples/ts-react-chat/src/lib/model-selection.ts
@@ -191,43 +191,13 @@ export const MODEL_OPTIONS: Array<ModelOption> = [
   // Grok
   {
     provider: 'grok',
+    model: 'grok-build-0.1',
+    label: 'Grok - Grok Build 0.1',
+  },
+  {
+    provider: 'grok',
     model: 'grok-4.3',
     label: 'Grok - Grok 4.3',
-  },
-  {
-    provider: 'grok',
-    model: 'grok-4.20',
-    label: 'Grok - Grok 4.20',
-  },
-  {
-    provider: 'grok',
-    model: 'grok-4-1-fast-reasoning',
-    label: 'Grok - Grok 4.1 Fast (Reasoning)',
-  },
-  {
-    provider: 'grok',
-    model: 'grok-4-1-fast-non-reasoning',
-    label: 'Grok - Grok 4.1 Fast',
-  },
-  {
-    provider: 'grok',
-    model: 'grok-4-fast-reasoning',
-    label: 'Grok - Grok 4 Fast (reasoning)',
-  },
-  {
-    provider: 'grok',
-    model: 'grok-code-fast-1',
-    label: 'Grok - Grok Code Fast 1',
-  },
-  {
-    provider: 'grok',
-    model: 'grok-4',
-    label: 'Grok - Grok 4',
-  },
-  {
-    provider: 'grok',
-    model: 'grok-3',
-    label: 'Grok - Grok 3',
   },
 ]
 

--- a/examples/ts-react-chat/src/routes/api.structured-output.ts
+++ b/examples/ts-react-chat/src/routes/api.structured-output.ts
@@ -165,9 +165,7 @@ function adapterFor(provider: Provider, model?: string): AnyTextAdapter {
       // (`gemini-3-pro-preview`) was retired by Google and now 404s.
       return geminiText((baseModel || 'gemini-3.5-flash') as 'gemini-3.5-flash')
     case 'grok':
-      return grokText(
-        (model || 'grok-4-1-fast-reasoning') as 'grok-4-1-fast-reasoning',
-      )
+      return grokText((model || 'grok-build-0.1') as 'grok-build-0.1')
     case 'groq':
       return groqText(
         (model ||
@@ -291,9 +289,7 @@ function reasoningOptionsFor(
       // both the chat-completions and Responses-beta endpoints.
       return { reasoning: { effort: 'medium' } }
     case 'grok':
-      // xAI surfaces `delta.reasoning_content` automatically on reasoning
-      // models (grok-3-mini, grok-4-fast-reasoning, grok-4-1-fast-reasoning).
-      // No request param needed.
+      // The Grok Responses adapter includes encrypted reasoning by default.
       return undefined
   }
 }

--- a/examples/ts-react-chat/src/routes/api.tanchat.ts
+++ b/examples/ts-react-chat/src/routes/api.tanchat.ts
@@ -293,7 +293,9 @@ export const Route = createFileRoute('/api/tanchat')({
             }),
           grok: () =>
             createChatOptions({
-              adapter: grokText((model || 'grok-4.20') as 'grok-4.20'),
+              adapter: grokText(
+                (model || 'grok-build-0.1') as 'grok-build-0.1',
+              ),
               modelOptions: {},
             }),
           groq: () =>

--- a/examples/ts-react-chat/src/routes/generations.structured-output.tsx
+++ b/examples/ts-react-chat/src/routes/generations.structured-output.tsx
@@ -92,27 +92,11 @@ const PROVIDER_MODELS: Record<
       label: 'Gemini 3.1 Flash Lite (Preview)',
     },
   ],
-  // Grok 4 family supports the #605 combined-mode path (`tools` +
-  // `response_format: json_schema` in one streaming Chat Completions
-  // request). Grok 2 / 3 reject the combination per xAI docs, so they're
-  // omitted — they'd hit the engine's legacy finalization path instead
-  // and silently lose streaming. Values must match `GROK_COMBINED_TOOLS_AND_SCHEMA_MODELS`
-  // in `ai-grok/model-meta` exactly.
+  // The Grok adapter uses xAI's Responses API and intentionally exposes only
+  // these chat models.
   grok: [
+    { value: 'grok-build-0.1', label: 'Grok Build 0.1' },
     { value: 'grok-4.3', label: 'Grok 4.3' },
-    { value: 'grok-4.20', label: 'Grok 4.20' },
-    { value: 'grok-4-1-fast-reasoning', label: 'Grok 4.1 Fast (reasoning)' },
-    {
-      value: 'grok-4-1-fast-non-reasoning',
-      label: 'Grok 4.1 Fast (non-reasoning)',
-    },
-    { value: 'grok-4-fast-reasoning', label: 'Grok 4 Fast (reasoning)' },
-    {
-      value: 'grok-4-fast-non-reasoning',
-      label: 'Grok 4 Fast (non-reasoning)',
-    },
-    { value: 'grok-code-fast-1', label: 'Grok Code Fast 1' },
-    { value: 'grok-4', label: 'Grok 4' },
   ],
   groq: [
     {

--- a/packages/ai-code-mode/models-eval/eval-config.ts
+++ b/packages/ai-code-mode/models-eval/eval-config.ts
@@ -68,7 +68,7 @@ export const EVAL_MODELS: Array<EvalModel> = [
   { name: 'Gemini 2.5 Flash', model: 'gemini:gemini-2.5-flash' },
 
   // --- Grok (xAI) ---
-  { name: 'Grok 4.1 Fast', model: 'grok:grok-4-1-fast-non-reasoning' },
+  { name: 'Grok Build 0.1', model: 'grok:grok-build-0.1' },
 
   // --- Groq ---
   { name: 'Llama 3.3 70B (Groq)', model: 'groq:llama-3.3-70b-versatile' },

--- a/packages/ai-code-mode/models-eval/run-eval.ts
+++ b/packages/ai-code-mode/models-eval/run-eval.ts
@@ -204,7 +204,7 @@ function getTextAdapter(
     case 'gemini':
       return geminiText(modelId as 'gemini-2.5-flash')
     case 'grok':
-      return grokText(modelId as 'grok-3-mini')
+      return grokText(modelId as 'grok-build-0.1')
     case 'groq':
       return groqText(modelId as 'llama-3.3-70b-versatile')
   }
@@ -227,9 +227,9 @@ function maxTokensModelOptions(
       // dropped at the wire.
       return { options: { num_predict: maxTokens, num_ctx: 32768 } }
     case 'openai':
+    case 'grok':
       return { max_output_tokens: maxTokens }
     case 'anthropic':
-    case 'grok':
       return { max_tokens: maxTokens }
     case 'gemini':
       return { maxOutputTokens: maxTokens }

--- a/packages/ai-grok/README.md
+++ b/packages/ai-grok/README.md
@@ -28,11 +28,10 @@ export XAI_API_KEY="xai-..."
 import { grokText } from '@tanstack/ai-grok'
 import { generate } from '@tanstack/ai'
 
-const adapter = grokText()
+const adapter = grokText('grok-build-0.1')
 
 const result = await generate({
   adapter,
-  model: 'grok-3',
   messages: [
     { role: 'user', content: 'Explain quantum computing in simple terms' },
   ],
@@ -47,11 +46,10 @@ console.log(result.text)
 import { grokSummarize } from '@tanstack/ai-grok'
 import { summarize } from '@tanstack/ai'
 
-const adapter = grokSummarize()
+const adapter = grokSummarize('grok-build-0.1')
 
 const result = await summarize({
   adapter,
-  model: 'grok-3',
   text: 'Long article text...',
   style: 'bullet-points',
 })
@@ -83,27 +81,17 @@ console.log(result.images[0].url)
 ```typescript
 import { createGrokText } from '@tanstack/ai-grok'
 
-const adapter = createGrokText('xai-your-api-key-here')
+const adapter = createGrokText('grok-build-0.1', 'xai-your-api-key-here')
 ```
 
-## Supported Models
+## Supported Chat Models
 
-### Chat Models
-
-- `grok-4` - Latest flagship model
-- `grok-3` - Previous generation model
-- `grok-3-mini` - Smaller, faster model
-- `grok-4-fast` - Fast inference model
-- `grok-4.1-fast` - Production-focused fast model
-- `grok-2-vision-1212` - Vision-capable model (text + image input)
-
-### Image Models
-
-- `grok-2-image-1212` - Image generation model
+- `grok-build-0.1` - Build-focused reasoning model with text + image input
+- `grok-4.3` - Reasoning, structured outputs, tool calling, text + image input
 
 ## Features
 
-- ✅ Streaming chat completions
+- ✅ Streaming chat via xAI Responses API
 - ✅ Structured output (JSON Schema)
 - ✅ Function/tool calling
 - ✅ Multimodal input (text + images for vision models)

--- a/packages/ai-grok/src/adapters/summarize.ts
+++ b/packages/ai-grok/src/adapters/summarize.ts
@@ -17,14 +17,14 @@ export type GrokSummarizeModel = (typeof GROK_CHAT_MODELS)[number]
  * Creates a Grok summarize adapter with explicit API key.
  * Type resolution happens here at the call site.
  *
- * @param model - The model name (e.g., 'grok-3', 'grok-4')
+ * @param model - The model name (e.g., 'grok-build-0.1')
  * @param apiKey - Your xAI API key
  * @param config - Optional additional configuration
  * @returns Configured Grok summarize adapter instance with resolved types
  *
  * @example
  * ```typescript
- * const adapter = createGrokSummarize('grok-3', "xai-...");
+ * const adapter = createGrokSummarize('grok-build-0.1', "xai-...");
  * ```
  */
 export function createGrokSummarize<TModel extends GrokSummarizeModel>(
@@ -50,7 +50,7 @@ export function createGrokSummarize<TModel extends GrokSummarizeModel>(
  * - `process.env` (Node.js)
  * - `window.env` (Browser with injected env)
  *
- * @param model - The model name (e.g., 'grok-3', 'grok-4')
+ * @param model - The model name (e.g., 'grok-build-0.1')
  * @param config - Optional configuration (excluding apiKey which is auto-detected)
  * @returns Configured Grok summarize adapter instance with resolved types
  * @throws Error if XAI_API_KEY is not found in environment
@@ -58,7 +58,7 @@ export function createGrokSummarize<TModel extends GrokSummarizeModel>(
  * @example
  * ```typescript
  * // Automatically uses XAI_API_KEY from environment
- * const adapter = grokSummarize('grok-3');
+ * const adapter = grokSummarize('grok-build-0.1');
  *
  * await summarize({
  *   adapter,

--- a/packages/ai-grok/src/adapters/text.ts
+++ b/packages/ai-grok/src/adapters/text.ts
@@ -1,16 +1,17 @@
 import OpenAI from 'openai'
-import { OpenAIBaseChatCompletionsTextAdapter } from '@tanstack/openai-base'
+import { OpenAIBaseResponsesTextAdapter } from '@tanstack/openai-base'
 import { getGrokApiKeyFromEnv, withGrokDefaults } from '../utils/client'
-import { GROK_COMBINED_TOOLS_AND_SCHEMA_MODELS } from '../model-meta'
+import { convertToolsToProviderFormat } from '../tools'
 import type {
   GROK_CHAT_MODELS,
   GrokChatModelToolCapabilitiesByName,
   ResolveInputModalities,
   ResolveProviderOptions,
 } from '../model-meta'
-import type { Modality } from '@tanstack/ai'
+import type { Modality, TextOptions } from '@tanstack/ai'
 import type { GrokMessageMetadataByModality } from '../message-types'
 import type { GrokClientConfig } from '../utils'
+import type { ResponseCreateParams } from 'openai/resources/responses/responses'
 
 /**
  * Resolve tool capabilities for a specific Grok model.
@@ -34,20 +35,21 @@ export type { ExternalTextProviderOptions as GrokTextProviderOptions } from '../
  * Grok Text (Chat) Adapter
  *
  * Tree-shakeable adapter for Grok chat/text completion functionality.
- * Uses OpenAI-compatible Chat Completions API (not Responses API).
+ * Uses xAI's OpenAI-compatible Responses API.
  *
- * Delegates implementation to {@link OpenAIBaseChatCompletionsTextAdapter}
+ * Delegates implementation to {@link OpenAIBaseResponsesTextAdapter}
  * from `@tanstack/openai-base` and threads Grok-specific tool-capability
  * typing through the 5th generic of the base class.
  */
 export class GrokTextAdapter<
   TModel extends (typeof GROK_CHAT_MODELS)[number],
-  TProviderOptions extends Record<string, any> = ResolveProviderOptions<TModel>,
+  TProviderOptions extends Record<string, unknown> =
+    ResolveProviderOptions<TModel>,
   TInputModalities extends ReadonlyArray<Modality> =
     ResolveInputModalities<TModel>,
   TToolCapabilities extends ReadonlyArray<string> =
     ResolveToolCapabilities<TModel>,
-> extends OpenAIBaseChatCompletionsTextAdapter<
+> extends OpenAIBaseResponsesTextAdapter<
   TModel,
   TProviderOptions,
   TInputModalities,
@@ -61,36 +63,34 @@ export class GrokTextAdapter<
     super(model, 'grok', new OpenAI(withGrokDefaults(config)))
   }
 
-  /**
-   * Surfaces xAI reasoning deltas on Grok reasoning models. The DeepSeek-style
-   * convention puts the chain-of-thought on `delta.reasoning_content`; some
-   * Grok variants also populate `delta.reasoning`. Reading both keeps
-   * reasoning flowing through the base's REASONING_* lifecycle for both
-   * `chatStream` and `structuredOutputStream`.
-   */
-  protected override extractReasoning(
-    chunk: OpenAI.Chat.Completions.ChatCompletionChunk,
-  ): { text: string } | undefined {
-    const delta = chunk.choices[0]?.delta as
-      | { reasoning?: unknown; reasoning_content?: unknown }
-      | undefined
-    const raw = delta?.reasoning_content ?? delta?.reasoning
-    if (typeof raw === 'string' && raw.length > 0) {
-      return { text: raw }
-    }
-    return undefined
-  }
+  protected override mapOptionsToRequest(
+    options: TextOptions<TProviderOptions>,
+  ): Omit<ResponseCreateParams, 'stream'> {
+    const { tools: _baseTools, ...request } = super.mapOptionsToRequest({
+      ...options,
+      tools: undefined,
+    })
+    void _baseTools
 
-  /**
-   * Grok's combined tools + schema support is gated to the Grok 4 family
-   * per xAI's structured-output docs; Grok 2 / 3 reject the combination.
-   * The wiring on the wire is already correct (inherits the OpenAI Chat
-   * Completions `response_format: json_schema` attach from the base
-   * adapter); this override just narrows the capability claim to the
-   * supported model family.
-   */
-  override supportsCombinedToolsAndSchema(): boolean {
-    return GROK_COMBINED_TOOLS_AND_SCHEMA_MODELS.has(this.model)
+    if (this.model === 'grok-build-0.1' && request.reasoning !== undefined) {
+      throw new Error(
+        'grok-build-0.1 does not support reasoning modelOptions; omit reasoning for this model.',
+      )
+    }
+
+    const tools = options.tools
+      ? convertToolsToProviderFormat(options.tools)
+      : undefined
+
+    return {
+      ...request,
+      // xAI recommends encrypted reasoning for reasoning-capable Responses
+      // requests; callers can still override either field in modelOptions.
+      store: request.store ?? false,
+      include: request.include ?? ['reasoning.encrypted_content'],
+      ...(tools &&
+        tools.length > 0 && { tools: tools as ResponseCreateParams['tools'] }),
+    }
   }
 }
 
@@ -98,15 +98,15 @@ export class GrokTextAdapter<
  * Creates a Grok text adapter with explicit API key.
  * Type resolution happens here at the call site.
  *
- * @param model - The model name (e.g., 'grok-3', 'grok-4')
+ * @param model - The model name (e.g., 'grok-build-0.1')
  * @param apiKey - Your xAI API key
  * @param config - Optional additional configuration
  * @returns Configured Grok text adapter instance with resolved types
  *
  * @example
  * ```typescript
- * const adapter = createGrokText('grok-3', "xai-...");
- * // adapter has type-safe providerOptions for grok-3
+ * const adapter = createGrokText('grok-build-0.1', "xai-...");
+ * // adapter has type-safe providerOptions for grok-build-0.1
  * ```
  */
 export function createGrokText<
@@ -127,7 +127,7 @@ export function createGrokText<
  * - `process.env` (Node.js)
  * - `window.env` (Browser with injected env)
  *
- * @param model - The model name (e.g., 'grok-3', 'grok-4')
+ * @param model - The model name (e.g., 'grok-build-0.1')
  * @param config - Optional configuration (excluding apiKey which is auto-detected)
  * @returns Configured Grok text adapter instance with resolved types
  * @throws Error if XAI_API_KEY is not found in environment
@@ -135,7 +135,7 @@ export function createGrokText<
  * @example
  * ```typescript
  * // Automatically uses XAI_API_KEY from environment
- * const adapter = grokText('grok-3');
+ * const adapter = grokText('grok-build-0.1');
  *
  * const stream = chat({
  *   adapter,

--- a/packages/ai-grok/src/model-meta.ts
+++ b/packages/ai-grok/src/model-meta.ts
@@ -1,13 +1,18 @@
 /**
  * Model metadata interface for documentation and type inference
  */
+import type {
+  GrokBuildProviderOptions,
+  GrokTextProviderOptions,
+} from './text/text-provider-options'
+
 interface ModelMeta {
   name: string
   supports: {
     input: Array<'text' | 'image' | 'audio' | 'video' | 'document'>
     output: Array<'text' | 'image' | 'audio' | 'video'>
     capabilities?: Array<'reasoning' | 'tool_calling' | 'structured_outputs'>
-    tools?: ReadonlyArray<never>
+    tools?: ReadonlyArray<GrokProviderToolKind>
   }
   max_input_tokens?: number
   max_output_tokens?: number
@@ -24,184 +29,18 @@ interface ModelMeta {
   }
 }
 
-const GROK_4_1_FAST_REASONING = {
-  name: 'grok-4-1-fast-reasoning',
-  context_window: 2_000_000,
-  supports: {
-    input: ['text', 'image'],
-    output: ['text'],
-    capabilities: ['reasoning', 'structured_outputs', 'tool_calling'],
-    tools: [] as const,
-  },
-  pricing: {
-    input: {
-      normal: 0.2,
-      cached: 0.05,
-    },
-    output: {
-      normal: 0.5,
-    },
-  },
-} as const satisfies ModelMeta
+export type GrokProviderToolKind =
+  | 'web_search'
+  | 'x_search'
+  | 'file_search'
+  | 'mcp'
 
-const GROK_4_1_FAST_NON_REASONING = {
-  name: 'grok-4-1-fast-non-reasoning',
-  context_window: 2_000_000,
-  supports: {
-    input: ['text', 'image'],
-    output: ['text'],
-    capabilities: ['structured_outputs', 'tool_calling'],
-    tools: [] as const,
-  },
-  pricing: {
-    input: {
-      normal: 0.2,
-      cached: 0.05,
-    },
-    output: {
-      normal: 0.5,
-    },
-  },
-} as const satisfies ModelMeta
-
-const GROK_CODE_FAST_1 = {
-  name: 'grok-code-fast-1',
-  context_window: 256_000,
-  supports: {
-    input: ['text'],
-    output: ['text'],
-    capabilities: ['reasoning', 'structured_outputs', 'tool_calling'],
-    tools: [] as const,
-  },
-  pricing: {
-    input: {
-      normal: 0.2,
-      cached: 0.02,
-    },
-    output: {
-      normal: 1.5,
-    },
-  },
-} as const satisfies ModelMeta
-
-const GROK_4_FAST_REASONING = {
-  name: 'grok-4-fast-reasoning',
-  context_window: 2_000_000,
-  supports: {
-    input: ['text', 'image'],
-    output: ['text'],
-    capabilities: ['reasoning', 'structured_outputs', 'tool_calling'],
-    tools: [] as const,
-  },
-  pricing: {
-    input: {
-      normal: 0.2,
-      cached: 0.05,
-    },
-    output: {
-      normal: 0.5,
-    },
-  },
-} as const satisfies ModelMeta
-
-const GROK_4_FAST_NON_REASONING = {
-  name: 'grok-4-fast-non-reasoning',
-  context_window: 2_000_000,
-  supports: {
-    input: ['text', 'image'],
-    output: ['text'],
-    capabilities: ['structured_outputs', 'tool_calling'],
-    tools: [] as const,
-  },
-  pricing: {
-    input: {
-      normal: 0.2,
-      cached: 0.05,
-    },
-    output: {
-      normal: 0.5,
-    },
-  },
-} as const satisfies ModelMeta
-
-const GROK_4 = {
-  name: 'grok-4',
-  context_window: 256_000,
-  supports: {
-    input: ['text', 'image'],
-    output: ['text'],
-    capabilities: ['reasoning', 'structured_outputs', 'tool_calling'],
-    tools: [] as const,
-  },
-  pricing: {
-    input: {
-      normal: 3,
-      cached: 0.75,
-    },
-    output: {
-      normal: 15,
-    },
-  },
-} as const satisfies ModelMeta
-
-const GROK_3_MINI = {
-  name: 'grok-3-mini',
-  context_window: 131_072,
-  supports: {
-    input: ['text'],
-    output: ['text'],
-    capabilities: ['reasoning', 'structured_outputs', 'tool_calling'],
-    tools: [] as const,
-  },
-  pricing: {
-    input: {
-      normal: 0.3,
-      cached: 0.075,
-    },
-    output: {
-      normal: 0.5,
-    },
-  },
-} as const satisfies ModelMeta
-
-const GROK_3 = {
-  name: 'grok-3',
-  context_window: 131_072,
-  supports: {
-    input: ['text'],
-    output: ['text'],
-    capabilities: ['structured_outputs', 'tool_calling'],
-    tools: [] as const,
-  },
-  pricing: {
-    input: {
-      normal: 3,
-      cached: 0.75,
-    },
-    output: {
-      normal: 15,
-    },
-  },
-} as const satisfies ModelMeta
-
-const GROK_2_VISION = {
-  name: 'grok-2-vision-1212',
-  context_window: 32_768,
-  supports: {
-    input: ['text', 'image'],
-    output: ['text'],
-    capabilities: ['structured_outputs', 'tool_calling'],
-    tools: [] as const,
-  },
-  pricing: {
-    input: {
-      normal: 2,
-    },
-    output: {
-      normal: 10,
-    },
-  },
-} as const satisfies ModelMeta
+const GROK_RESPONSES_TOOLS = [
+  'web_search',
+  'x_search',
+  'file_search',
+  'mcp',
+] as const satisfies ReadonlyArray<GrokProviderToolKind>
 
 const GROK_2_IMAGE = {
   name: 'grok-2-image-1212',
@@ -252,50 +91,6 @@ const GROK_IMAGINE_IMAGE_QUALITY = {
   },
 } as const satisfies ModelMeta
 
-/**
- * Grok Chat Models
- * Based on xAI's available models as of 2025
- */
-const GROK_4_20 = {
-  name: 'grok-4.20',
-  context_window: 2_000_000,
-  supports: {
-    input: ['text', 'image', 'document'],
-    output: ['text'],
-    capabilities: ['reasoning', 'structured_outputs', 'tool_calling'],
-    tools: [] as const,
-  },
-  pricing: {
-    input: {
-      normal: 2,
-      cached: 0.2,
-    },
-    output: {
-      normal: 6,
-    },
-  },
-} as const satisfies ModelMeta
-
-const GROK_4_20_MULTI_AGENT = {
-  name: 'grok-4.20-multi-agent',
-  context_window: 2_000_000,
-  supports: {
-    input: ['text', 'image', 'document'],
-    output: ['text'],
-    capabilities: ['reasoning', 'structured_outputs', 'tool_calling'],
-    tools: [] as const,
-  },
-  pricing: {
-    input: {
-      normal: 2,
-      cached: 0.2,
-    },
-    output: {
-      normal: 6,
-    },
-  },
-} as const satisfies ModelMeta
-
 const GROK_4_3 = {
   name: 'grok-4.3',
   context_window: 1_000_000,
@@ -303,7 +98,7 @@ const GROK_4_3 = {
     input: ['text', 'image'],
     output: ['text'],
     capabilities: ['reasoning', 'structured_outputs', 'tool_calling'],
-    tools: [],
+    tools: GROK_RESPONSES_TOOLS,
   },
   pricing: {
     input: {
@@ -323,7 +118,7 @@ const GROK_BUILD_0_1 = {
     input: ['text', 'image'],
     output: ['text'],
     capabilities: ['reasoning', 'structured_outputs', 'tool_calling'],
-    tools: [],
+    tools: GROK_RESPONSES_TOOLS,
   },
   pricing: {
     input: {
@@ -336,48 +131,10 @@ const GROK_BUILD_0_1 = {
   },
 } as const satisfies ModelMeta
 
-export const GROK_CHAT_MODELS = [
-  GROK_4_1_FAST_REASONING.name,
-  GROK_4_1_FAST_NON_REASONING.name,
-  GROK_CODE_FAST_1.name,
-  GROK_4_FAST_REASONING.name,
-  GROK_4_FAST_NON_REASONING.name,
-  GROK_4.name,
-  GROK_3.name,
-  GROK_3_MINI.name,
-  GROK_2_VISION.name,
-
-  GROK_4_20.name,
-  GROK_4_20_MULTI_AGENT.name,
-
-  GROK_4_3.name,
-
-  GROK_BUILD_0_1.name,
-] as const
-
 /**
- * Grok models that support combining `tools` + `response_format: json_schema`
- * in a single streaming Chat Completions request (per issue #605). xAI
- * docs gate this to the Grok 4 family — Grok 2 / 3 reject the
- * combination. Grok 2 image generation is not a chat model, omitted.
- *
- * Note: Grok streams tool-call arguments atomically (not token-streamed)
- * per the issue's source matrix; partial-JSON tool-arg parsing should be
- * skipped for Grok specifically. That's a separate adapter concern from
- * this set — the set only gates whether the engine takes the native
- * combined path vs the legacy finalization path.
+ * Grok chat models supported by the Responses adapter.
  */
-export const GROK_COMBINED_TOOLS_AND_SCHEMA_MODELS = new Set<string>([
-  GROK_4_1_FAST_REASONING.name,
-  GROK_4_1_FAST_NON_REASONING.name,
-  GROK_CODE_FAST_1.name,
-  GROK_4_FAST_REASONING.name,
-  GROK_4_FAST_NON_REASONING.name,
-  GROK_4.name,
-  GROK_4_20.name,
-  GROK_4_20_MULTI_AGENT.name,
-  GROK_4_3.name,
-])
+export const GROK_CHAT_MODELS = [GROK_BUILD_0_1.name, GROK_4_3.name] as const
 
 /**
  * Grok Image Generation Models
@@ -450,68 +207,28 @@ export type GrokRealtimeModel = (typeof GROK_REALTIME_MODELS)[number]
  * Used for type inference when constructing multimodal messages.
  */
 export type GrokModelInputModalitiesByName = {
-  [GROK_4_1_FAST_REASONING.name]: typeof GROK_4_1_FAST_REASONING.supports.input
-  [GROK_4_1_FAST_NON_REASONING.name]: typeof GROK_4_1_FAST_NON_REASONING.supports.input
-  [GROK_CODE_FAST_1.name]: typeof GROK_CODE_FAST_1.supports.input
-  [GROK_4_FAST_REASONING.name]: typeof GROK_4_FAST_REASONING.supports.input
-  [GROK_4_FAST_NON_REASONING.name]: typeof GROK_4_FAST_NON_REASONING.supports.input
-  [GROK_4.name]: typeof GROK_4.supports.input
-  [GROK_3.name]: typeof GROK_3.supports.input
-  [GROK_3_MINI.name]: typeof GROK_3_MINI.supports.input
-  [GROK_2_VISION.name]: typeof GROK_2_VISION.supports.input
-  [GROK_4_20.name]: typeof GROK_4_20.supports.input
-  [GROK_4_20_MULTI_AGENT.name]: typeof GROK_4_20_MULTI_AGENT.supports.input
   [GROK_4_3.name]: typeof GROK_4_3.supports.input
   [GROK_BUILD_0_1.name]: typeof GROK_BUILD_0_1.supports.input
 }
 
 /**
- * Type-only map from Grok chat model name to its provider options type.
- * Since Grok uses OpenAI-compatible API, we reuse OpenAI provider options.
- */
-export type GrokChatModelProviderOptionsByName = {
-  [K in (typeof GROK_CHAT_MODELS)[number]]: GrokProviderOptions
-}
-
-/**
  * Type-only map from Grok chat model name to its supported provider tools.
- * Grok exposes no provider-specific tool factories, so every model gets an
- * empty tuple. This ensures that passing an Anthropic/OpenAI ProviderTool to
- * a Grok adapter produces a compile-time type error.
+ * Keeps Grok provider-tool factories type-checked against the models that
+ * advertise xAI Responses server-side tools.
  */
 export type GrokChatModelToolCapabilitiesByName = {
-  [GROK_4_1_FAST_REASONING.name]: typeof GROK_4_1_FAST_REASONING.supports.tools
-  [GROK_4_1_FAST_NON_REASONING.name]: typeof GROK_4_1_FAST_NON_REASONING.supports.tools
-  [GROK_CODE_FAST_1.name]: typeof GROK_CODE_FAST_1.supports.tools
-  [GROK_4_FAST_REASONING.name]: typeof GROK_4_FAST_REASONING.supports.tools
-  [GROK_4_FAST_NON_REASONING.name]: typeof GROK_4_FAST_NON_REASONING.supports.tools
-  [GROK_4.name]: typeof GROK_4.supports.tools
-  [GROK_3.name]: typeof GROK_3.supports.tools
-  [GROK_3_MINI.name]: typeof GROK_3_MINI.supports.tools
-  [GROK_2_VISION.name]: typeof GROK_2_VISION.supports.tools
-  [GROK_4_20.name]: typeof GROK_4_20.supports.tools
-  [GROK_4_20_MULTI_AGENT.name]: typeof GROK_4_20_MULTI_AGENT.supports.tools
+  [GROK_4_3.name]: typeof GROK_4_3.supports.tools
+  [GROK_BUILD_0_1.name]: typeof GROK_BUILD_0_1.supports.tools
 }
 
+export type GrokProviderOptions = GrokTextProviderOptions
+
 /**
- * Grok-specific provider options
- * Based on OpenAI-compatible API options
+ * Type-only map from Grok chat model name to its provider options type.
  */
-export interface GrokProviderOptions {
-  /** Temperature for response generation (0-2) */
-  temperature?: number
-  /** Maximum tokens in the response */
-  max_tokens?: number
-  /** Top-p sampling parameter */
-  top_p?: number
-  /** Frequency penalty (-2.0 to 2.0) */
-  frequency_penalty?: number
-  /** Presence penalty (-2.0 to 2.0) */
-  presence_penalty?: number
-  /** Stop sequences */
-  stop?: string | Array<string>
-  /** A unique identifier representing your end-user */
-  user?: string
+export type GrokChatModelProviderOptionsByName = {
+  [GROK_4_3.name]: GrokProviderOptions
+  [GROK_BUILD_0_1.name]: GrokBuildProviderOptions
 }
 
 // ===========================

--- a/packages/ai-grok/src/text/text-provider-options.ts
+++ b/packages/ai-grok/src/text/text-provider-options.ts
@@ -1,9 +1,21 @@
 /**
  * Grok Text Provider Options
  *
- * Grok uses an OpenAI-compatible Chat Completions API.
- * However, not all OpenAI features may be supported by Grok.
+ * Grok uses xAI's OpenAI-compatible Responses API. Engine-managed fields
+ * such as `model`, `input`, `tools`, and `text.format` are owned by the
+ * adapter; user-supplied values live under `modelOptions`.
  */
+
+import type { ResponseCreateParams } from 'openai/resources/responses/responses'
+
+export type GrokReasoningEffort = 'none' | 'low' | 'medium' | 'high'
+
+export type GrokReasoning = Omit<
+  NonNullable<ResponseCreateParams['reasoning']>,
+  'effort'
+> & {
+  effort?: GrokReasoningEffort
+}
 
 /**
  * Base provider options for Grok text/chat models
@@ -18,9 +30,10 @@ export interface GrokBaseOptions {
 
 /**
  * Grok-specific provider options for text/chat
- * Based on OpenAI-compatible API options
+ * Based on xAI Responses API options
  */
-export interface GrokTextProviderOptions extends GrokBaseOptions {
+export interface GrokTextProviderOptions
+  extends GrokBaseOptions, Record<string, unknown> {
   /**
    * Temperature for response generation (0-2)
    * Higher values make output more random, lower values more focused
@@ -34,19 +47,26 @@ export interface GrokTextProviderOptions extends GrokBaseOptions {
   /**
    * Maximum tokens in the response
    */
-  max_tokens?: number
+  max_output_tokens?: number
   /**
-   * Frequency penalty (-2.0 to 2.0)
+   * Whether xAI should store the response. Defaults to `false` in the adapter.
    */
-  frequency_penalty?: number
+  store?: boolean
   /**
-   * Presence penalty (-2.0 to 2.0)
+   * Additional response fields to include. Defaults to encrypted reasoning.
    */
-  presence_penalty?: number
+  include?: ResponseCreateParams['include']
   /**
-   * Stop sequences
+   * xAI/OpenAI-compatible reasoning controls for reasoning-capable models.
    */
-  stop?: string | Array<string>
+  reasoning?: GrokReasoning
+}
+
+export type GrokBuildProviderOptions = Omit<
+  GrokTextProviderOptions,
+  'reasoning'
+> & {
+  reasoning?: never
 }
 
 /**

--- a/packages/ai-grok/src/tools/index.ts
+++ b/packages/ai-grok/src/tools/index.ts
@@ -1,5 +1,212 @@
-export {
-  type ChatCompletionFunctionTool as FunctionTool,
-  convertFunctionToolToChatCompletionsFormat as convertFunctionToolToAdapterFormat,
-  convertToolsToChatCompletionsFormat as convertToolsToProviderFormat,
-} from '@tanstack/openai-base'
+import { brandProviderTool } from '@tanstack/ai'
+import { convertFunctionToolToResponsesFormat } from '@tanstack/openai-base'
+import type { ProviderTool, Tool } from '@tanstack/ai'
+import type { ResponsesFunctionTool } from '@tanstack/openai-base'
+import type { GrokProviderToolKind } from '../model-meta'
+
+export type FunctionTool = ResponsesFunctionTool
+
+export { convertFunctionToolToResponsesFormat as convertFunctionToolToAdapterFormat }
+
+export type GrokProviderTool<TKind extends GrokProviderToolKind> = ProviderTool<
+  'grok',
+  TKind
+>
+
+type GrokToolKindMarker<TKind extends GrokProviderToolKind> = `grok.${TKind}`
+
+export interface GrokWebSearchToolConfig {
+  type: 'web_search'
+  filters?: {
+    allowed_domains?: Array<string>
+    excluded_domains?: Array<string>
+  }
+  enable_image_understanding?: boolean
+  enable_image_search?: boolean
+}
+
+export interface GrokXSearchToolConfig {
+  type: 'x_search'
+  allowed_x_handles?: Array<string>
+  excluded_x_handles?: Array<string>
+  from_date?: string
+  to_date?: string
+  enable_image_understanding?: boolean
+  enable_video_understanding?: boolean
+}
+
+export interface GrokFileSearchToolConfig {
+  type: 'file_search'
+  vector_store_ids: Array<string>
+  max_num_results?: number
+}
+
+export interface GrokMCPToolConfig {
+  type: 'mcp'
+  server_label: string
+  server_url: string
+  allowed_tools?: Array<string>
+  server_description?: string
+  authorization?: string
+  headers?: Record<string, string>
+}
+
+export type GrokServerTool =
+  | GrokWebSearchToolConfig
+  | GrokXSearchToolConfig
+  | GrokFileSearchToolConfig
+  | GrokMCPToolConfig
+
+type GrokProviderToolMetadata<TKind extends GrokProviderToolKind> = Extract<
+  GrokServerTool,
+  { type: TKind }
+> & {
+  __kind: GrokToolKindMarker<TKind>
+}
+
+export type GrokResponsesTool = GrokServerTool | ResponsesFunctionTool
+
+function providerTool<TKind extends GrokProviderToolKind>(
+  kind: TKind,
+  description: string,
+  metadata: Extract<GrokServerTool, { type: TKind }>,
+): GrokProviderTool<TKind> {
+  return brandProviderTool<GrokProviderTool<TKind>>({
+    name: kind,
+    description,
+    metadata: {
+      __kind: `grok.${kind}`,
+      ...metadata,
+    },
+  })
+}
+
+export function grokWebSearchTool(
+  config: Omit<GrokWebSearchToolConfig, 'type'> = {},
+): GrokProviderTool<'web_search'> {
+  if (
+    config.filters?.allowed_domains !== undefined &&
+    config.filters.excluded_domains !== undefined
+  ) {
+    throw new Error(
+      'allowed_domains and excluded_domains cannot both be provided.',
+    )
+  }
+  if (
+    config.filters?.allowed_domains !== undefined &&
+    config.filters.allowed_domains.length > 5
+  ) {
+    throw new Error('allowed_domains supports at most 5 domains.')
+  }
+  if (
+    config.filters?.excluded_domains !== undefined &&
+    config.filters.excluded_domains.length > 5
+  ) {
+    throw new Error('excluded_domains supports at most 5 domains.')
+  }
+  return providerTool('web_search', 'Search the web', {
+    type: 'web_search',
+    ...config,
+  })
+}
+
+export function grokXSearchTool(
+  config: Omit<GrokXSearchToolConfig, 'type'> = {},
+): GrokProviderTool<'x_search'> {
+  if (
+    config.allowed_x_handles !== undefined &&
+    config.excluded_x_handles !== undefined
+  ) {
+    throw new Error(
+      'allowed_x_handles and excluded_x_handles cannot both be provided.',
+    )
+  }
+  if (
+    config.allowed_x_handles !== undefined &&
+    config.allowed_x_handles.length > 20
+  ) {
+    throw new Error('allowed_x_handles supports at most 20 handles.')
+  }
+  if (
+    config.excluded_x_handles !== undefined &&
+    config.excluded_x_handles.length > 20
+  ) {
+    throw new Error('excluded_x_handles supports at most 20 handles.')
+  }
+  return providerTool('x_search', 'Search X posts', {
+    type: 'x_search',
+    ...config,
+  })
+}
+
+export function grokFileSearchTool(
+  config: Omit<GrokFileSearchToolConfig, 'type'>,
+): GrokProviderTool<'file_search'> {
+  if (config.vector_store_ids.length === 0) {
+    throw new Error('vector_store_ids must contain at least one collection id.')
+  }
+  if (config.max_num_results !== undefined) {
+    if (config.max_num_results < 1 || config.max_num_results > 50) {
+      throw new Error('max_num_results must be between 1 and 50.')
+    }
+  }
+  return providerTool('file_search', 'Search xAI file collections', {
+    type: 'file_search',
+    ...config,
+  })
+}
+
+export function grokMCPTool(
+  config: Omit<GrokMCPToolConfig, 'type'>,
+): GrokProviderTool<'mcp'> {
+  if (!config.server_url) {
+    throw new Error('server_url must be provided.')
+  }
+  return providerTool('mcp', config.server_description || 'Remote MCP server', {
+    type: 'mcp',
+    ...config,
+  })
+}
+
+function getGrokProviderToolKind(tool: Tool): GrokProviderToolKind | undefined {
+  const kind = (tool.metadata as { __kind?: unknown } | undefined)?.__kind
+  switch (kind) {
+    case 'grok.web_search':
+      return 'web_search'
+    case 'grok.x_search':
+      return 'x_search'
+    case 'grok.file_search':
+      return 'file_search'
+    case 'grok.mcp':
+      return 'mcp'
+    default:
+      return undefined
+  }
+}
+
+function convertGrokProviderToolToAdapterFormat(
+  tool: Tool,
+  kind: GrokProviderToolKind,
+): GrokServerTool {
+  const metadata = tool.metadata as GrokProviderToolMetadata<typeof kind>
+  if (metadata.type !== kind) {
+    throw new Error(
+      `convertGrokProviderToolToAdapterFormat: tool "${tool.name}" has mismatched Grok tool metadata.`,
+    )
+  }
+  const { __kind: _kind, ...toolConfig } = metadata
+  void _kind
+  return toolConfig
+}
+
+export function convertToolsToProviderFormat(
+  tools: Array<Tool>,
+): Array<GrokResponsesTool> {
+  return tools.map((tool) => {
+    const grokProviderToolKind = getGrokProviderToolKind(tool)
+    if (grokProviderToolKind) {
+      return convertGrokProviderToolToAdapterFormat(tool, grokProviderToolKind)
+    }
+    return convertFunctionToolToResponsesFormat(tool)
+  })
+}

--- a/packages/ai-grok/tests/grok-adapter.test.ts
+++ b/packages/ai-grok/tests/grok-adapter.test.ts
@@ -1,31 +1,33 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import { EventType } from '@tanstack/ai'
 import { createGrokText, grokText } from '../src/adapters/text'
 import { createGrokImage, grokImage } from '../src/adapters/image'
 import { createGrokSummarize, grokSummarize } from '../src/adapters/summarize'
-import { EventType } from '@tanstack/ai'
+import { GROK_CHAT_MODELS } from '../src/model-meta'
+import {
+  grokFileSearchTool,
+  grokMCPTool,
+  grokWebSearchTool,
+  grokXSearchTool,
+} from '../src/tools'
 import type { StreamChunk, Tool } from '@tanstack/ai'
-import type { GrokTextProviderOptions } from '../src/index'
 
-// Test helper: a silent logger for test chatStream calls.
 const testLogger = resolveDebugOption(false)
 
-// Mock the OpenAI SDK to avoid constructing a real client during adapter
-// instantiation. Tests that need to inspect calls inject their own mock client
-// via `injectMockClient`.
 vi.mock('openai', () => {
   return {
     default: class {
-      chat = {
-        completions: {
-          create: vi.fn(),
-        },
+      responses = {
+        create: vi.fn(),
+      }
+      images = {
+        generate: vi.fn(),
       }
     },
   }
 })
 
-// Helper to create async iterable from chunks
 function createAsyncIterable<T>(chunks: Array<T>): AsyncIterable<T> {
   return {
     [Symbol.asyncIterator]() {
@@ -42,8 +44,7 @@ function createAsyncIterable<T>(chunks: Array<T>): AsyncIterable<T> {
   }
 }
 
-// Helper to create a mock OpenAI client and inject it into an adapter
-function injectMockClient(
+function injectMockResponsesClient(
   adapter: object,
   streamChunks: Array<Record<string, unknown>>,
   nonStreamResponse?: Record<string, unknown>,
@@ -55,13 +56,42 @@ function injectMockClient(
     return Promise.resolve(nonStreamResponse)
   })
   ;(adapter as any).client = {
-    chat: {
-      completions: {
-        create: mockCreate,
-      },
+    responses: {
+      create: mockCreate,
     },
   }
   return mockCreate
+}
+
+async function consume(stream: AsyncIterable<unknown>): Promise<void> {
+  for await (const _chunk of stream) {
+    // Exhaust the stream so the adapter sends the request and processes events.
+  }
+}
+
+const responseCreated = {
+  type: 'response.created',
+  response: { id: 'resp_123', model: 'grok-4.3' },
+}
+
+const responseCompleted = {
+  type: 'response.completed',
+  response: {
+    id: 'resp_123',
+    model: 'grok-4.3',
+    output: [
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Hello world' }],
+      },
+    ],
+    usage: {
+      input_tokens: 1,
+      output_tokens: 2,
+      total_tokens: 3,
+    },
+  },
 }
 
 const weatherTool: Tool = {
@@ -74,92 +104,319 @@ describe('Grok adapters', () => {
     vi.unstubAllEnvs()
   })
 
+  it('exposes only the supported xAI Responses chat models', () => {
+    expect(GROK_CHAT_MODELS).toEqual(['grok-build-0.1', 'grok-4.3'])
+  })
+
   describe('Text adapter', () => {
     it('creates a text adapter with explicit API key', () => {
-      const adapter = createGrokText('grok-3', 'test-api-key')
+      const adapter = createGrokText('grok-build-0.1', 'test-api-key')
 
       expect(adapter).toBeDefined()
       expect(adapter.kind).toBe('text')
       expect(adapter.name).toBe('grok')
-      expect(adapter.model).toBe('grok-3')
+      expect(adapter.model).toBe('grok-build-0.1')
     })
 
     it('creates a text adapter from environment variable', () => {
       vi.stubEnv('XAI_API_KEY', 'env-api-key')
 
-      const adapter = grokText('grok-4')
+      const adapter = grokText('grok-build-0.1')
 
       expect(adapter).toBeDefined()
       expect(adapter.kind).toBe('text')
-      expect(adapter.model).toBe('grok-4')
+      expect(adapter.model).toBe('grok-build-0.1')
     })
 
     it('throws if XAI_API_KEY is not set when using grokText', () => {
       vi.stubEnv('XAI_API_KEY', '')
 
-      expect(() => grokText('grok-3')).toThrow('XAI_API_KEY is required')
-    })
-
-    it('allows custom baseURL override', () => {
-      const adapter = createGrokText('grok-3', 'test-api-key', {
-        baseURL: 'https://custom.api.example.com/v1',
-      })
-
-      expect(adapter).toBeDefined()
-    })
-
-    it('native combined tools+schema mode is gated per Grok model family (#605)', () => {
-      // Grok 4 family supports `response_format: json_schema` + `tools`
-      // + `stream` together; Grok 2 / 3 reject the combination per xAI's
-      // structured-output docs.
-      const grok4 = createGrokText('grok-4', 'test-api-key')
-      const grok4FastReasoning = createGrokText(
-        'grok-4-1-fast-reasoning',
-        'test-api-key',
+      expect(() => grokText('grok-build-0.1')).toThrow(
+        'XAI_API_KEY is required',
       )
-      const grok3 = createGrokText('grok-3', 'test-api-key')
-      const grok3Mini = createGrokText('grok-3-mini', 'test-api-key')
-
-      expect(grok4.supportsCombinedToolsAndSchema()).toBe(true)
-      expect(grok4FastReasoning.supportsCombinedToolsAndSchema()).toBe(true)
-      expect(grok3.supportsCombinedToolsAndSchema()).toBe(false)
-      expect(grok3Mini.supportsCombinedToolsAndSchema()).toBe(false)
     })
 
-    it('forwards sampling options from modelOptions with Grok wire names', async () => {
-      const streamChunks = [
-        {
-          id: 'chatcmpl-sampling',
-          model: 'grok-3',
-          choices: [{ delta: {}, finish_reason: 'stop' }],
-          usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
-        },
-      ]
+    it('uses Responses API defaults and model option wire names', async () => {
+      const adapter = createGrokText('grok-build-0.1', 'test-api-key')
+      const mockCreate = injectMockResponsesClient(adapter, [
+        responseCreated,
+        { type: 'response.output_text.delta', delta: 'Hello world' },
+        responseCompleted,
+      ])
 
-      const adapter = createGrokText('grok-3', 'test-api-key')
-      const mockCreate = injectMockClient(adapter, streamChunks)
-
-      const modelOptions: GrokTextProviderOptions = {
+      const modelOptions = {
         temperature: 0.5,
         top_p: 0.8,
-        max_tokens: 128,
+        max_output_tokens: 128,
       }
 
-      for await (const _ of adapter.chatStream({
-        model: 'grok-3',
+      const chunks: Array<StreamChunk> = []
+      for await (const chunk of adapter.chatStream({
+        model: 'grok-build-0.1',
         messages: [{ role: 'user', content: 'Hello' }],
         modelOptions,
         logger: testLogger,
       })) {
-        // consume stream
+        chunks.push(chunk)
       }
 
       expect(mockCreate).toHaveBeenCalledTimes(1)
       expect(mockCreate.mock.calls[0]?.[0]).toMatchObject({
+        model: 'grok-build-0.1',
+        stream: true,
+        store: false,
+        include: ['reasoning.encrypted_content'],
         temperature: 0.5,
         top_p: 0.8,
-        max_tokens: 128,
+        max_output_tokens: 128,
       })
+      expect(mockCreate.mock.calls[0]?.[0]).toHaveProperty('input')
+      expect(
+        chunks.some((chunk) => chunk.type === EventType.RUN_FINISHED),
+      ).toBe(true)
+    })
+
+    it('lets callers override xAI Responses reasoning persistence defaults', async () => {
+      const adapter = createGrokText('grok-build-0.1', 'test-api-key')
+      const mockCreate = injectMockResponsesClient(adapter, [
+        responseCreated,
+        { type: 'response.output_text.delta', delta: 'Hello world' },
+        responseCompleted,
+      ])
+
+      await consume(
+        adapter.chatStream({
+          model: 'grok-build-0.1',
+          messages: [{ role: 'user', content: 'Hello' }],
+          modelOptions: {
+            store: true,
+            include: [],
+          },
+          logger: testLogger,
+        }),
+      )
+
+      expect(mockCreate.mock.calls[0]?.[0]).toMatchObject({
+        store: true,
+        include: [],
+      })
+    })
+
+    it('rejects reasoning options locally for grok-build-0.1', async () => {
+      const adapter = createGrokText('grok-build-0.1', 'test-api-key')
+      const mockCreate = injectMockResponsesClient(adapter, [])
+
+      const chunks: Array<StreamChunk> = []
+      for await (const chunk of adapter.chatStream({
+        model: 'grok-build-0.1',
+        messages: [{ role: 'user', content: 'Hello' }],
+        modelOptions: {
+          reasoning: { effort: 'high' },
+        } as any,
+        logger: testLogger,
+      })) {
+        chunks.push(chunk)
+      }
+
+      expect(mockCreate).not.toHaveBeenCalled()
+      expect(chunks.some((chunk) => chunk.type === EventType.RUN_ERROR)).toBe(
+        true,
+      )
+      expect(
+        chunks.find((chunk) => chunk.type === EventType.RUN_ERROR),
+      ).toMatchObject({
+        message:
+          'grok-build-0.1 does not support reasoning modelOptions; omit reasoning for this model.',
+      })
+    })
+
+    it('converts function tools to Responses API tools', async () => {
+      const adapter = createGrokText('grok-build-0.1', 'test-api-key')
+      const mockCreate = injectMockResponsesClient(adapter, [
+        responseCreated,
+        responseCompleted,
+      ])
+
+      await consume(
+        adapter.chatStream({
+          model: 'grok-build-0.1',
+          messages: [{ role: 'user', content: 'What is the weather?' }],
+          tools: [weatherTool],
+          logger: testLogger,
+        }),
+      )
+
+      expect(mockCreate.mock.calls[0]?.[0]).toMatchObject({
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup_weather',
+            description: 'Return the forecast for a location',
+          },
+        ],
+      })
+    })
+
+    it('passes xAI server-side Responses tools through unchanged', async () => {
+      const adapter = createGrokText('grok-build-0.1', 'test-api-key')
+      const mockCreate = injectMockResponsesClient(adapter, [
+        responseCreated,
+        responseCompleted,
+      ])
+
+      await consume(
+        adapter.chatStream({
+          model: 'grok-build-0.1',
+          messages: [{ role: 'user', content: 'Use server tools' }],
+          tools: [
+            grokWebSearchTool({
+              filters: { allowed_domains: ['x.ai'] },
+            }),
+            grokXSearchTool({
+              allowed_x_handles: ['xai'],
+              from_date: '2026-01-01',
+            }),
+            grokFileSearchTool({
+              vector_store_ids: ['collection_123'],
+              max_num_results: 3,
+            }),
+            grokMCPTool({
+              server_label: 'deepwiki',
+              server_url: 'https://mcp.deepwiki.com/mcp',
+              allowed_tools: ['ask_question'],
+              authorization: 'Bearer mcp-test-token',
+              headers: { 'X-Test-MCP': 'true' },
+            }),
+          ],
+          logger: testLogger,
+        }),
+      )
+
+      expect(mockCreate.mock.calls[0]?.[0]).toMatchObject({
+        tools: [
+          {
+            type: 'web_search',
+            filters: { allowed_domains: ['x.ai'] },
+          },
+          {
+            type: 'x_search',
+            allowed_x_handles: ['xai'],
+            from_date: '2026-01-01',
+          },
+          {
+            type: 'file_search',
+            vector_store_ids: ['collection_123'],
+            max_num_results: 3,
+          },
+          {
+            type: 'mcp',
+            server_label: 'deepwiki',
+            server_url: 'https://mcp.deepwiki.com/mcp',
+            allowed_tools: ['ask_question'],
+            authorization: 'Bearer mcp-test-token',
+            headers: { 'X-Test-MCP': 'true' },
+          },
+        ],
+      })
+    })
+
+    it('keeps same-named user tools as function tools', async () => {
+      const adapter = createGrokText('grok-build-0.1', 'test-api-key')
+      const mockCreate = injectMockResponsesClient(adapter, [
+        responseCreated,
+        responseCompleted,
+      ])
+
+      await consume(
+        adapter.chatStream({
+          model: 'grok-build-0.1',
+          messages: [
+            { role: 'user', content: 'Call my local web_search tool' },
+          ],
+          tools: [
+            {
+              name: 'web_search',
+              description: 'Local app search function, not xAI web search.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  query: { type: 'string' },
+                },
+                required: ['query'],
+                additionalProperties: false,
+              },
+            },
+          ],
+          logger: testLogger,
+        }),
+      )
+
+      expect(mockCreate.mock.calls[0]?.[0]).toMatchObject({
+        tools: [
+          {
+            type: 'function',
+            name: 'web_search',
+            description: 'Local app search function, not xAI web search.',
+          },
+        ],
+      })
+    })
+
+    it('validates xAI server-side tool factories', () => {
+      expect(() =>
+        grokWebSearchTool({
+          filters: {
+            allowed_domains: ['x.ai'],
+            excluded_domains: ['example.com'],
+          },
+        }),
+      ).toThrow('allowed_domains and excluded_domains cannot both be provided.')
+      expect(() =>
+        grokWebSearchTool({
+          filters: {
+            allowed_domains: [
+              'a.example',
+              'b.example',
+              'c.example',
+              'd.example',
+              'e.example',
+              'f.example',
+            ],
+          },
+        }),
+      ).toThrow('allowed_domains supports at most 5 domains.')
+      expect(() =>
+        grokXSearchTool({
+          allowed_x_handles: ['xai'],
+          excluded_x_handles: ['elonmusk'],
+        }),
+      ).toThrow(
+        'allowed_x_handles and excluded_x_handles cannot both be provided.',
+      )
+      expect(() =>
+        grokXSearchTool({
+          allowed_x_handles: Array.from(
+            { length: 21 },
+            (_, index) => `handle${index}`,
+          ),
+        }),
+      ).toThrow('allowed_x_handles supports at most 20 handles.')
+      expect(() =>
+        grokFileSearchTool({
+          vector_store_ids: [],
+        }),
+      ).toThrow('vector_store_ids must contain at least one collection id.')
+      expect(() =>
+        grokFileSearchTool({
+          vector_store_ids: ['collection_123'],
+          max_num_results: 0,
+        }),
+      ).toThrow('max_num_results must be between 1 and 50.')
+      expect(() =>
+        grokMCPTool({
+          server_label: 'bad',
+        } as any),
+      ).toThrow('server_url must be provided.')
     })
   })
 
@@ -215,213 +472,20 @@ describe('Grok adapters', () => {
     })
   })
 
-  describe('Image adapter — image prompt parts (Imagine edits endpoint)', () => {
-    const editResponse = (body: Record<string, unknown>, ok = true) =>
-      vi.fn().mockResolvedValue({
-        ok,
-        status: ok ? 200 : 422,
-        statusText: ok ? 'OK' : 'Unprocessable Entity',
-        json: () => Promise.resolve(body),
-        text: () => Promise.resolve(JSON.stringify(body)),
-      })
-
-    beforeEach(() => {
-      vi.unstubAllGlobals()
-    })
-
-    it('routes a single image part to POST /v1/images/edits with the prompt sent verbatim', async () => {
-      const mockFetch = editResponse({
-        data: [{ url: 'https://example.com/edited.png' }],
-      })
-      vi.stubGlobal('fetch', mockFetch)
-
-      const adapter = createGrokImage('grok-imagine-image', 'test-api-key')
-      const result = await adapter.generateImages({
-        model: 'grok-imagine-image',
-        prompt: [
-          { type: 'text', content: 'Make it a pencil sketch' },
-          {
-            type: 'image',
-            source: { type: 'url', value: 'https://example.com/source.png' },
-          },
-        ],
-        logger: testLogger,
-      })
-
-      expect(mockFetch).toHaveBeenCalledTimes(1)
-      const [url, init] = mockFetch.mock.calls[0]!
-      expect(url).toBe('https://api.x.ai/v1/images/edits')
-      expect(init.headers.Authorization).toBe('Bearer test-api-key')
-      expect(JSON.parse(init.body)).toMatchObject({
-        model: 'grok-imagine-image',
-        prompt: 'Make it a pencil sketch',
-        image: { url: 'https://example.com/source.png' },
-      })
-      expect(result.images).toEqual([{ url: 'https://example.com/edited.png' }])
-    })
-
-    it('flattens interleaved text verbatim — no markers are injected', async () => {
-      const mockFetch = editResponse({ data: [{ b64_json: 'aGVsbG8=' }] })
-      vi.stubGlobal('fetch', mockFetch)
-
-      const adapter = createGrokImage('grok-imagine-image', 'test-api-key')
-      await adapter.generateImages({
-        model: 'grok-imagine-image',
-        prompt: [
-          { type: 'text', content: 'Not like' },
-          {
-            type: 'image',
-            source: { type: 'url', value: 'https://example.com/bad.png' },
-          },
-          { type: 'text', content: 'more like' },
-          {
-            type: 'image',
-            source: { type: 'url', value: 'https://example.com/good.png' },
-          },
-        ],
-        logger: testLogger,
-      })
-
-      const body = JSON.parse(mockFetch.mock.calls[0]![1].body)
-      expect(body.prompt).toBe('Not like\n\nmore like')
-      expect(body.images).toEqual([
-        { url: 'https://example.com/bad.png' },
-        { url: 'https://example.com/good.png' },
-      ])
-    })
-
-    it('passes user-written referencing text through verbatim, sends images[] and maps size', async () => {
-      const mockFetch = editResponse({ data: [{ b64_json: 'aGVsbG8=' }] })
-      vi.stubGlobal('fetch', mockFetch)
-
-      const adapter = createGrokImage(
-        'grok-imagine-image-quality',
-        'test-api-key',
-      )
-      const result = await adapter.generateImages({
-        model: 'grok-imagine-image-quality',
-        prompt: [
-          { type: 'text', content: 'Put <IMAGE_0> in the style of <IMAGE_1>' },
-          {
-            type: 'image',
-            source: { type: 'url', value: 'https://example.com/product.png' },
-          },
-          {
-            type: 'image',
-            source: { type: 'data', value: 'c3R5bGU=', mimeType: 'image/png' },
-          },
-        ],
-        size: '1:1',
-        logger: testLogger,
-      })
-
-      const body = JSON.parse(mockFetch.mock.calls[0]![1].body)
-      expect(body.prompt).toBe('Put <IMAGE_0> in the style of <IMAGE_1>')
-      expect(body.images).toEqual([
-        { url: 'https://example.com/product.png' },
-        { url: 'data:image/png;base64,c3R5bGU=' },
-      ])
-      expect(body.image).toBeUndefined()
-      expect(body.aspect_ratio).toBe('1:1')
-      expect(result.images).toEqual([{ b64Json: 'aGVsbG8=' }])
-    })
-
-    it('throws for image prompt parts on the legacy grok-2 image model', async () => {
-      const adapter = createGrokImage('grok-2-image-1212', 'test-api-key')
-
-      await expect(
-        adapter.generateImages({
-          model: 'grok-2-image-1212',
-          prompt: [
-            { type: 'text', content: 'Edit this' },
-            {
-              type: 'image',
-              source: { type: 'url', value: 'https://example.com/a.png' },
-            },
-          ],
-          logger: testLogger,
-        }),
-      ).rejects.toThrow(/does not support image prompt parts/)
-    })
-
-    it('throws for more than 3 source images', async () => {
-      const adapter = createGrokImage('grok-imagine-image', 'test-api-key')
-      const part = {
-        type: 'image' as const,
-        source: { type: 'url' as const, value: 'https://example.com/a.png' },
-      }
-
-      await expect(
-        adapter.generateImages({
-          model: 'grok-imagine-image',
-          prompt: [
-            { type: 'text', content: 'Combine these' },
-            part,
-            part,
-            part,
-            part,
-          ],
-          logger: testLogger,
-        }),
-      ).rejects.toThrow(/at most 3 source images/)
-    })
-
-    it('throws for mask/control roles (no Imagine API equivalent)', async () => {
-      const adapter = createGrokImage('grok-imagine-image', 'test-api-key')
-
-      await expect(
-        adapter.generateImages({
-          model: 'grok-imagine-image',
-          prompt: [
-            { type: 'text', content: 'Inpaint' },
-            {
-              type: 'image',
-              source: { type: 'url', value: 'https://example.com/m.png' },
-              metadata: { role: 'mask' },
-            },
-          ],
-          logger: testLogger,
-        }),
-      ).rejects.toThrow(/no mask input/)
-    })
-
-    it('throws with response detail on a failed edit request', async () => {
-      vi.stubGlobal(
-        'fetch',
-        editResponse({ error: 'bad image' }, /* ok */ false),
-      )
-
-      const adapter = createGrokImage('grok-imagine-image', 'test-api-key')
-      await expect(
-        adapter.generateImages({
-          model: 'grok-imagine-image',
-          prompt: [
-            { type: 'text', content: 'Edit' },
-            {
-              type: 'image',
-              source: { type: 'url', value: 'https://example.com/a.png' },
-            },
-          ],
-          logger: testLogger,
-        }),
-      ).rejects.toThrow(/image edit request failed \(422/)
-    })
-  })
-
   describe('Summarize adapter', () => {
     it('creates a summarize adapter with explicit API key', () => {
-      const adapter = createGrokSummarize('grok-3', 'test-api-key')
+      const adapter = createGrokSummarize('grok-build-0.1', 'test-api-key')
 
       expect(adapter).toBeDefined()
       expect(adapter.kind).toBe('summarize')
       expect(adapter.name).toBe('grok')
-      expect(adapter.model).toBe('grok-3')
+      expect(adapter.model).toBe('grok-build-0.1')
     })
 
     it('creates a summarize adapter from environment variable', () => {
       vi.stubEnv('XAI_API_KEY', 'env-api-key')
 
-      const adapter = grokSummarize('grok-4')
+      const adapter = grokSummarize('grok-build-0.1')
 
       expect(adapter).toBeDefined()
       expect(adapter.kind).toBe('summarize')
@@ -430,477 +494,9 @@ describe('Grok adapters', () => {
     it('throws if XAI_API_KEY is not set when using grokSummarize', () => {
       vi.stubEnv('XAI_API_KEY', '')
 
-      expect(() => grokSummarize('grok-3')).toThrow('XAI_API_KEY is required')
+      expect(() => grokSummarize('grok-build-0.1')).toThrow(
+        'XAI_API_KEY is required',
+      )
     })
-  })
-})
-
-describe('Grok AG-UI event emission', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    vi.unstubAllEnvs()
-  })
-
-  it('emits RUN_STARTED as the first event', async () => {
-    const streamChunks = [
-      {
-        id: 'chatcmpl-123',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: { content: 'Hello' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-123',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 5,
-          completion_tokens: 1,
-          total_tokens: 6,
-        },
-      },
-    ]
-
-    const adapter = createGrokText('grok-3', 'test-api-key')
-    injectMockClient(adapter, streamChunks)
-    const chunks: Array<StreamChunk> = []
-
-    for await (const chunk of adapter.chatStream({
-      model: 'grok-3',
-      messages: [{ role: 'user', content: 'Hello' }],
-      logger: testLogger,
-    })) {
-      chunks.push(chunk)
-    }
-
-    expect(chunks[0]?.type).toBe('RUN_STARTED')
-    if (chunks[0]?.type === 'RUN_STARTED') {
-      expect(chunks[0].runId).toBeDefined()
-      expect(chunks[0].model).toBe('grok-3')
-    }
-  })
-
-  it('emits TEXT_MESSAGE_START before TEXT_MESSAGE_CONTENT', async () => {
-    const streamChunks = [
-      {
-        id: 'chatcmpl-123',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: { content: 'Hello' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-123',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 5,
-          completion_tokens: 1,
-          total_tokens: 6,
-        },
-      },
-    ]
-
-    const adapter = createGrokText('grok-3', 'test-api-key')
-    injectMockClient(adapter, streamChunks)
-    const chunks: Array<StreamChunk> = []
-
-    for await (const chunk of adapter.chatStream({
-      model: 'grok-3',
-      messages: [{ role: 'user', content: 'Hello' }],
-      logger: testLogger,
-    })) {
-      chunks.push(chunk)
-    }
-
-    const textStartIndex = chunks.findIndex(
-      (c) => c.type === 'TEXT_MESSAGE_START',
-    )
-    const textContentIndex = chunks.findIndex(
-      (c) => c.type === 'TEXT_MESSAGE_CONTENT',
-    )
-
-    expect(textStartIndex).toBeGreaterThan(-1)
-    expect(textContentIndex).toBeGreaterThan(-1)
-    expect(textStartIndex).toBeLessThan(textContentIndex)
-
-    const textStart = chunks[textStartIndex]
-    if (textStart?.type === 'TEXT_MESSAGE_START') {
-      expect(textStart.messageId).toBeDefined()
-      expect(textStart.role).toBe('assistant')
-    }
-  })
-
-  it('emits TEXT_MESSAGE_END and RUN_FINISHED at the end', async () => {
-    const streamChunks = [
-      {
-        id: 'chatcmpl-123',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: { content: 'Hello' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-123',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 5,
-          completion_tokens: 1,
-          total_tokens: 6,
-        },
-      },
-    ]
-
-    const adapter = createGrokText('grok-3', 'test-api-key')
-    injectMockClient(adapter, streamChunks)
-    const chunks: Array<StreamChunk> = []
-
-    for await (const chunk of adapter.chatStream({
-      model: 'grok-3',
-      messages: [{ role: 'user', content: 'Hello' }],
-      logger: testLogger,
-    })) {
-      chunks.push(chunk)
-    }
-
-    const textEndChunk = chunks.find((c) => c.type === 'TEXT_MESSAGE_END')
-    expect(textEndChunk).toBeDefined()
-    if (textEndChunk?.type === 'TEXT_MESSAGE_END') {
-      expect(textEndChunk.messageId).toBeDefined()
-    }
-
-    const runFinishedChunk = chunks.find((c) => c.type === 'RUN_FINISHED')
-    expect(runFinishedChunk).toBeDefined()
-    if (runFinishedChunk?.type === 'RUN_FINISHED') {
-      expect(runFinishedChunk.runId).toBeDefined()
-      expect(runFinishedChunk.finishReason).toBe('stop')
-      expect(runFinishedChunk.usage).toMatchObject({
-        promptTokens: 5,
-        completionTokens: 1,
-        totalTokens: 6,
-      })
-    }
-  })
-
-  it('emits AG-UI tool call events', async () => {
-    const streamChunks = [
-      {
-        id: 'chatcmpl-456',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: {
-              tool_calls: [
-                {
-                  index: 0,
-                  id: 'call_abc123',
-                  type: 'function',
-                  function: {
-                    name: 'lookup_weather',
-                    arguments: '{"location":',
-                  },
-                },
-              ],
-            },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-456',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: {
-              tool_calls: [
-                {
-                  index: 0,
-                  function: {
-                    arguments: '"Berlin"}',
-                  },
-                },
-              ],
-            },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-456',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'tool_calls',
-          },
-        ],
-        usage: {
-          prompt_tokens: 10,
-          completion_tokens: 5,
-          total_tokens: 15,
-        },
-      },
-    ]
-
-    const adapter = createGrokText('grok-3', 'test-api-key')
-    injectMockClient(adapter, streamChunks)
-    const chunks: Array<StreamChunk> = []
-
-    for await (const chunk of adapter.chatStream({
-      model: 'grok-3',
-      messages: [{ role: 'user', content: 'Weather in Berlin?' }],
-      tools: [weatherTool],
-      logger: testLogger,
-    })) {
-      chunks.push(chunk)
-    }
-
-    // Check AG-UI tool events
-    const toolStartChunk = chunks.find((c) => c.type === 'TOOL_CALL_START')
-    expect(toolStartChunk).toBeDefined()
-    if (toolStartChunk?.type === 'TOOL_CALL_START') {
-      expect(toolStartChunk.toolCallId).toBe('call_abc123')
-      expect(toolStartChunk.toolName).toBe('lookup_weather')
-    }
-
-    const toolArgsChunks = chunks.filter((c) => c.type === 'TOOL_CALL_ARGS')
-    expect(toolArgsChunks.length).toBeGreaterThan(0)
-
-    const toolEndChunk = chunks.find((c) => c.type === 'TOOL_CALL_END')
-    expect(toolEndChunk).toBeDefined()
-    if (toolEndChunk?.type === 'TOOL_CALL_END') {
-      expect(toolEndChunk.toolCallId).toBe('call_abc123')
-      expect(toolEndChunk.toolName).toBe('lookup_weather')
-      expect(toolEndChunk.input).toEqual({ location: 'Berlin' })
-    }
-
-    // Check finish reason
-    const runFinishedChunk = chunks.find((c) => c.type === 'RUN_FINISHED')
-    if (runFinishedChunk?.type === 'RUN_FINISHED') {
-      expect(runFinishedChunk.finishReason).toBe('tool_calls')
-    }
-  })
-
-  it('emits RUN_ERROR on stream error', async () => {
-    const streamChunks = [
-      {
-        id: 'chatcmpl-123',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: { content: 'Hello' },
-            finish_reason: null,
-          },
-        ],
-      },
-    ]
-
-    // Create an async iterable that throws mid-stream
-    const errorIterable = {
-      [Symbol.asyncIterator]() {
-        let index = 0
-        return {
-          async next() {
-            if (index < streamChunks.length) {
-              return { value: streamChunks[index++]!, done: false }
-            }
-            throw new Error('Stream interrupted')
-          },
-        }
-      },
-    }
-
-    const adapter = createGrokText('grok-3', 'test-api-key')
-    const mockCreate = vi.fn().mockResolvedValue(errorIterable)
-    ;(adapter as any).client = {
-      chat: {
-        completions: {
-          create: mockCreate,
-        },
-      },
-    }
-
-    const chunks: Array<StreamChunk> = []
-
-    for await (const chunk of adapter.chatStream({
-      model: 'grok-3',
-      messages: [{ role: 'user', content: 'Hello' }],
-      logger: testLogger,
-    })) {
-      chunks.push(chunk)
-    }
-
-    // Should emit RUN_ERROR
-    const runErrorChunk = chunks.find((c) => c.type === 'RUN_ERROR')
-    expect(runErrorChunk).toBeDefined()
-    if (runErrorChunk?.type === 'RUN_ERROR') {
-      expect(runErrorChunk.error!.message).toBe('Stream interrupted')
-    }
-  })
-
-  it('emits proper AG-UI event sequence', async () => {
-    const streamChunks = [
-      {
-        id: 'chatcmpl-123',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: { content: 'Hello world' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-123',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 5,
-          completion_tokens: 2,
-          total_tokens: 7,
-        },
-      },
-    ]
-
-    const adapter = createGrokText('grok-3', 'test-api-key')
-    injectMockClient(adapter, streamChunks)
-    const chunks: Array<StreamChunk> = []
-
-    for await (const chunk of adapter.chatStream({
-      model: 'grok-3',
-      messages: [{ role: 'user', content: 'Hello' }],
-      logger: testLogger,
-    })) {
-      chunks.push(chunk)
-    }
-
-    // Verify proper AG-UI event sequence
-    const eventTypes = chunks.map((c) => c.type)
-
-    // Should start with RUN_STARTED
-    expect(eventTypes[0]).toBe('RUN_STARTED')
-
-    // Should have TEXT_MESSAGE_START before TEXT_MESSAGE_CONTENT
-    const textStartIndex = eventTypes.indexOf(EventType.TEXT_MESSAGE_START)
-    const textContentIndex = eventTypes.indexOf(EventType.TEXT_MESSAGE_CONTENT)
-    expect(textStartIndex).toBeGreaterThan(-1)
-    expect(textContentIndex).toBeGreaterThan(textStartIndex)
-
-    // Should have TEXT_MESSAGE_END before RUN_FINISHED
-    const textEndIndex = eventTypes.indexOf(EventType.TEXT_MESSAGE_END)
-    const runFinishedIndex = eventTypes.indexOf(EventType.RUN_FINISHED)
-    expect(textEndIndex).toBeGreaterThan(-1)
-    expect(runFinishedIndex).toBeGreaterThan(textEndIndex)
-
-    // Verify RUN_FINISHED has proper data
-    const runFinishedChunk = chunks.find((c) => c.type === 'RUN_FINISHED')
-    if (runFinishedChunk?.type === 'RUN_FINISHED') {
-      expect(runFinishedChunk.finishReason).toBe('stop')
-      expect(runFinishedChunk.usage).toBeDefined()
-    }
-  })
-
-  it('streams content with correct accumulated values', async () => {
-    const streamChunks = [
-      {
-        id: 'chatcmpl-stream',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: { content: 'Hello ' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-stream',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: { content: 'world' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-stream',
-        model: 'grok-3',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 5,
-          completion_tokens: 2,
-          total_tokens: 7,
-        },
-      },
-    ]
-
-    const adapter = createGrokText('grok-3', 'test-api-key')
-    injectMockClient(adapter, streamChunks)
-    const chunks: Array<StreamChunk> = []
-
-    for await (const chunk of adapter.chatStream({
-      model: 'grok-3',
-      messages: [{ role: 'user', content: 'Say hello' }],
-      logger: testLogger,
-    })) {
-      chunks.push(chunk)
-    }
-
-    // Check TEXT_MESSAGE_CONTENT events have correct accumulated content
-    const contentChunks = chunks.filter(
-      (c) => c.type === 'TEXT_MESSAGE_CONTENT',
-    )
-    expect(contentChunks.length).toBe(2)
-
-    const firstContent = contentChunks[0]
-    if (firstContent?.type === 'TEXT_MESSAGE_CONTENT') {
-      expect(firstContent.delta).toBe('Hello ')
-      expect(firstContent.content).toBe('Hello ')
-    }
-
-    const secondContent = contentChunks[1]
-    if (secondContent?.type === 'TEXT_MESSAGE_CONTENT') {
-      expect(secondContent.delta).toBe('world')
-      expect(secondContent.content).toBe('Hello world')
-    }
   })
 })

--- a/packages/ai-grok/tests/usage-extraction.test.ts
+++ b/packages/ai-grok/tests/usage-extraction.test.ts
@@ -4,25 +4,16 @@ import { GrokTextAdapter } from '../src/adapters/text'
 import type { StreamChunk } from '@tanstack/ai'
 
 const mocks = vi.hoisted(() => {
-  const chatCompletionsCreate = vi.fn()
-  return { chatCompletionsCreate }
+  const responsesCreate = vi.fn()
+  return { responsesCreate }
 })
 
-// Mock the SDK using a constructor function rather than a `class` with a `chat`
-// field: `useDefineForClassFields: true` emits real ES2022 class fields, and
-// vitest's mock-hoister mis-rewrites a field named `chat` because that
-// identifier is also a named import on line 2 (`import { chat } from
-// '@tanstack/ai'`). A plain constructor function with `this.*` sidesteps it.
 vi.mock('openai', () => {
-  const { chatCompletionsCreate } = mocks
+  const { responsesCreate } = mocks
 
-  function MockOpenAI(this: {
-    chat: { completions: { create: typeof chatCompletionsCreate } }
-  }) {
-    this.chat = {
-      completions: {
-        create: chatCompletionsCreate,
-      },
+  function MockOpenAI(this: { responses: { create: typeof responsesCreate } }) {
+    this.responses = {
+      create: responsesCreate,
     }
   }
 
@@ -30,13 +21,12 @@ vi.mock('openai', () => {
 })
 
 const createAdapter = () =>
-  new GrokTextAdapter({ apiKey: 'test-key' }, 'grok-3')
+  new GrokTextAdapter({ apiKey: 'test-key' }, 'grok-4.3')
 
 function createMockStream(
   chunks: Array<Record<string, unknown>>,
 ): AsyncIterable<Record<string, unknown>> {
   return {
-    // eslint-disable-next-line @typescript-eslint/require-await
     async *[Symbol.asyncIterator]() {
       for (const chunk of chunks) {
         yield chunk
@@ -45,39 +35,47 @@ function createMockStream(
   }
 }
 
+function responseStreamWithUsage(usage: Record<string, unknown>) {
+  return createMockStream([
+    {
+      type: 'response.created',
+      response: { id: 'resp_123', model: 'grok-4.3' },
+    },
+    {
+      type: 'response.output_text.delta',
+      delta: 'Hello world',
+    },
+    {
+      type: 'response.completed',
+      response: {
+        id: 'resp_123',
+        model: 'grok-4.3',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Hello world' }],
+          },
+        ],
+        usage,
+      },
+    },
+  ])
+}
+
 describe('Grok usage extraction', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('extracts basic token usage from chat completions', async () => {
-    const mockStream = createMockStream([
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: { content: 'Hello world' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 100,
-          completion_tokens: 50,
-          total_tokens: 150,
-        },
-      },
-    ])
-
-    mocks.chatCompletionsCreate.mockResolvedValueOnce(mockStream)
+  it('extracts basic token usage from Responses API streams', async () => {
+    mocks.responsesCreate.mockResolvedValueOnce(
+      responseStreamWithUsage({
+        input_tokens: 100,
+        output_tokens: 50,
+        total_tokens: 150,
+      }),
+    )
 
     const chunks: Array<StreamChunk> = []
     for await (const chunk of chat({
@@ -98,37 +96,20 @@ describe('Grok usage extraction', () => {
     }
   })
 
-  it('extracts prompt tokens details with cached tokens', async () => {
-    const mockStream = createMockStream([
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: { content: 'Hello world' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 100,
-          completion_tokens: 50,
-          total_tokens: 150,
-          prompt_tokens_details: {
-            cached_tokens: 25,
-          },
+  it('extracts cached prompt and reasoning output token details', async () => {
+    mocks.responsesCreate.mockResolvedValueOnce(
+      responseStreamWithUsage({
+        input_tokens: 100,
+        output_tokens: 80,
+        total_tokens: 180,
+        input_tokens_details: {
+          cached_tokens: 25,
         },
-      },
-    ])
-
-    mocks.chatCompletionsCreate.mockResolvedValueOnce(mockStream)
+        output_tokens_details: {
+          reasoning_tokens: 30,
+        },
+      }),
+    )
 
     const chunks: Array<StreamChunk> = []
     for await (const chunk of chat({
@@ -141,240 +122,17 @@ describe('Grok usage extraction', () => {
     const doneChunk = chunks.find((c) => c.type === 'RUN_FINISHED')
     expect(doneChunk).toBeDefined()
     if (doneChunk?.type === 'RUN_FINISHED') {
-      expect(doneChunk.usage?.promptTokensDetails).toEqual({
-        cachedTokens: 25,
+      expect(doneChunk.usage).toMatchObject({
+        promptTokens: 100,
+        completionTokens: 80,
+        totalTokens: 180,
+        promptTokensDetails: {
+          cachedTokens: 25,
+        },
+        completionTokensDetails: {
+          reasoningTokens: 30,
+        },
       })
-    }
-  })
-
-  it('extracts completion tokens details with reasoning tokens', async () => {
-    const mockStream = createMockStream([
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: { content: 'Hello world' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 100,
-          completion_tokens: 50,
-          total_tokens: 150,
-          completion_tokens_details: {
-            reasoning_tokens: 30,
-          },
-        },
-      },
-    ])
-
-    mocks.chatCompletionsCreate.mockResolvedValueOnce(mockStream)
-
-    const chunks: Array<StreamChunk> = []
-    for await (const chunk of chat({
-      adapter: createAdapter(),
-      messages: [{ role: 'user', content: 'Hello' }],
-    })) {
-      chunks.push(chunk)
-    }
-
-    const doneChunk = chunks.find((c) => c.type === 'RUN_FINISHED')
-    expect(doneChunk).toBeDefined()
-    if (doneChunk?.type === 'RUN_FINISHED') {
-      expect(doneChunk.usage?.completionTokensDetails).toEqual({
-        reasoningTokens: 30,
-      })
-    }
-  })
-
-  it('surfaces predicted-output tokens in providerUsageDetails', async () => {
-    const mockStream = createMockStream([
-      {
-        id: 'chatcmpl-123',
-        choices: [{ delta: { content: 'Hello world' }, finish_reason: null }],
-      },
-      {
-        id: 'chatcmpl-123',
-        choices: [{ delta: {}, finish_reason: 'stop' }],
-        usage: {
-          prompt_tokens: 100,
-          completion_tokens: 50,
-          total_tokens: 150,
-          completion_tokens_details: {
-            accepted_prediction_tokens: 20,
-            rejected_prediction_tokens: 5,
-          },
-        },
-      },
-    ])
-
-    mocks.chatCompletionsCreate.mockResolvedValueOnce(mockStream)
-
-    const chunks: Array<StreamChunk> = []
-    for await (const chunk of chat({
-      adapter: createAdapter(),
-      messages: [{ role: 'user', content: 'Hello' }],
-    })) {
-      chunks.push(chunk)
-    }
-
-    const doneChunk = chunks.find((c) => c.type === 'RUN_FINISHED')
-    expect(doneChunk).toBeDefined()
-    if (doneChunk?.type === 'RUN_FINISHED') {
-      expect(doneChunk.usage?.providerUsageDetails).toEqual({
-        acceptedPredictionTokens: 20,
-        rejectedPredictionTokens: 5,
-      })
-    }
-  })
-
-  it('extracts audio tokens in prompt details', async () => {
-    const mockStream = createMockStream([
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: { content: 'Hello world' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 100,
-          completion_tokens: 50,
-          total_tokens: 150,
-          prompt_tokens_details: {
-            audio_tokens: 15,
-          },
-        },
-      },
-    ])
-
-    mocks.chatCompletionsCreate.mockResolvedValueOnce(mockStream)
-
-    const chunks: Array<StreamChunk> = []
-    for await (const chunk of chat({
-      adapter: createAdapter(),
-      messages: [{ role: 'user', content: 'Hello' }],
-    })) {
-      chunks.push(chunk)
-    }
-
-    const doneChunk = chunks.find((c) => c.type === 'RUN_FINISHED')
-    expect(doneChunk).toBeDefined()
-    if (doneChunk?.type === 'RUN_FINISHED') {
-      expect(doneChunk.usage?.promptTokensDetails).toEqual({
-        audioTokens: 15,
-      })
-    }
-  })
-
-  it('handles response with no usage data', async () => {
-    const mockStream = createMockStream([
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: { content: 'Hello world' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'stop',
-          },
-        ],
-        // No usage field
-      },
-    ])
-
-    mocks.chatCompletionsCreate.mockResolvedValueOnce(mockStream)
-
-    const chunks: Array<StreamChunk> = []
-    for await (const chunk of chat({
-      adapter: createAdapter(),
-      messages: [{ role: 'user', content: 'Hello' }],
-    })) {
-      chunks.push(chunk)
-    }
-
-    const doneChunk = chunks.find((c) => c.type === 'RUN_FINISHED')
-    expect(doneChunk).toBeDefined()
-    if (doneChunk?.type === 'RUN_FINISHED') {
-      expect(doneChunk.usage).toBeUndefined()
-    }
-  })
-
-  it('omits empty details when all values are zero', async () => {
-    const mockStream = createMockStream([
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: { content: 'Hello world' },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-123',
-        choices: [
-          {
-            delta: {},
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 100,
-          completion_tokens: 50,
-          total_tokens: 150,
-          prompt_tokens_details: {
-            cached_tokens: 0,
-            audio_tokens: 0,
-          },
-          completion_tokens_details: {
-            reasoning_tokens: 0,
-          },
-        },
-      },
-    ])
-
-    mocks.chatCompletionsCreate.mockResolvedValueOnce(mockStream)
-
-    const chunks: Array<StreamChunk> = []
-    for await (const chunk of chat({
-      adapter: createAdapter(),
-      messages: [{ role: 'user', content: 'Hello' }],
-    })) {
-      chunks.push(chunk)
-    }
-
-    const doneChunk = chunks.find((c) => c.type === 'RUN_FINISHED')
-    expect(doneChunk).toBeDefined()
-    if (doneChunk?.type === 'RUN_FINISHED') {
-      expect(doneChunk.usage?.promptTokensDetails).toBeUndefined()
-      expect(doneChunk.usage?.completionTokensDetails).toBeUndefined()
     }
   })
 })

--- a/testing/e2e/src/lib/features.ts
+++ b/testing/e2e/src/lib/features.ts
@@ -80,7 +80,7 @@ export const featureConfigs: Record<Feature, FeatureConfig> = {
     modelOptions: {},
     modelOverrides: {
       gemini: 'gemini-3-flash-preview',
-      grok: 'grok-4-1-fast-non-reasoning',
+      grok: 'grok-build-0.1',
     },
   },
   'multimodal-image': {

--- a/testing/e2e/src/lib/providers.ts
+++ b/testing/e2e/src/lib/providers.ts
@@ -24,7 +24,7 @@ const defaultModels: Record<Provider, string> = {
   gemini: 'gemini-2.5-flash',
   ollama: 'mistral',
   groq: 'llama-3.3-70b-versatile',
-  grok: 'grok-3',
+  grok: 'grok-build-0.1',
   openrouter: 'openai/gpt-4o',
   'openrouter-responses': 'openai/gpt-4o',
   'openai-compatible': 'gpt-4o',
@@ -109,7 +109,7 @@ export function createTextAdapter(
       }),
     grok: () =>
       createChatOptions({
-        adapter: createGrokText(model as 'grok-3', DUMMY_KEY, {
+        adapter: createGrokText(model as 'grok-build-0.1', DUMMY_KEY, {
           baseURL: openaiUrl,
           defaultHeaders: testHeaders,
         }),

--- a/testing/e2e/src/routes/api.summarize.ts
+++ b/testing/e2e/src/routes/api.summarize.ts
@@ -47,7 +47,7 @@ function createSummarizeAdapter(
       }),
     ollama: () => createOllamaSummarize('mistral', llmockBase(aimockPort)),
     grok: () =>
-      createGrokSummarize('grok-3', DUMMY_KEY, {
+      createGrokSummarize('grok-build-0.1', DUMMY_KEY, {
         baseURL: openaiUrl(aimockPort),
         defaultHeaders: headers,
       }),

--- a/testing/panel/src/lib/model-selection.ts
+++ b/testing/panel/src/lib/model-selection.ts
@@ -77,23 +77,13 @@ export const MODEL_OPTIONS: Array<ModelOption> = [
   // Grok
   {
     provider: 'grok',
-    model: 'grok-4',
-    label: 'Grok - Grok 4 - slow thinking',
+    model: 'grok-build-0.1',
+    label: 'Grok - Grok Build 0.1',
   },
   {
     provider: 'grok',
-    model: 'grok-4-fast-non-reasoning',
-    label: 'Grok - Grok 4 Fast',
-  },
-  {
-    provider: 'grok',
-    model: 'grok-3',
-    label: 'Grok - Grok 3',
-  },
-  {
-    provider: 'grok',
-    model: 'grok-3-mini',
-    label: 'Grok - Grok 3 Mini',
+    model: 'grok-4.3',
+    label: 'Grok - Grok 4.3',
   },
 
   // OpenRouter

--- a/testing/panel/src/routes/api.chat.ts
+++ b/testing/panel/src/routes/api.chat.ts
@@ -182,7 +182,7 @@ export const Route = createFileRoute('/api/chat')({
               }),
             grok: () =>
               createChatOptions({
-                adapter: grokText((model || 'grok-3') as any),
+                adapter: grokText((model || 'grok-build-0.1') as any),
               }),
             ollama: () =>
               createChatOptions({

--- a/testing/panel/src/routes/api.structured.ts
+++ b/testing/panel/src/routes/api.structured.ts
@@ -66,7 +66,7 @@ export const Route = createFileRoute('/api/structured')({
           const defaultModels: Record<Provider, string> = {
             anthropic: 'claude-sonnet-4-5',
             gemini: 'gemini-2.5-flash',
-            grok: 'grok-3-mini',
+            grok: 'grok-build-0.1',
             ollama: 'mistral:7b',
             openai: 'gpt-4o',
             openrouter: 'openai/gpt-4o',

--- a/testing/panel/src/routes/api.summarize.ts
+++ b/testing/panel/src/routes/api.summarize.ts
@@ -36,7 +36,7 @@ export const Route = createFileRoute('/api/summarize')({
           const defaultModels: Record<Provider, string> = {
             anthropic: 'claude-sonnet-4-5',
             gemini: 'gemini-2.5-flash',
-            grok: 'grok-3-mini',
+            grok: 'grok-build-0.1',
             ollama: 'mistral:7b',
             openai: 'gpt-4o-mini',
             openrouter: 'openai/gpt-4o-mini',

--- a/testing/panel/tests/vendor-config.ts
+++ b/testing/panel/tests/vendor-config.ts
@@ -79,7 +79,7 @@ export const PROVIDERS: ProviderConfig[] = [
     id: 'grok',
     name: 'Grok',
     envKey: 'XAI_API_KEY',
-    defaultModel: 'grok-3-mini',
+    defaultModel: 'grok-build-0.1',
     supportsBasicInference: true,
     supportsTools: true,
     supportsSummarization: true,


### PR DESCRIPTION
## 🎯 Changes

- Move Grok text and summarization adapters to xAI's Responses API for `grok-build-0.1` and `grok-4.3`.
- Add xAI Responses server-side tools for web search, X search, file search, and MCP, while keeping local function tools working.
- Update docs, examples, test harness defaults, and model metadata so Grok chat support is limited to `grok-build-0.1` and `grok-4.3`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Test plan

- `pnpm --filter @tanstack/ai-grok test:types`
- `pnpm --filter @tanstack/ai-grok test:lib`
- `pnpm --filter @tanstack/ai-grok test:eslint`
- `pnpm --filter @tanstack/ai-grok build`
- `pnpm test:pr`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Grok model support to `grok-4.3` and `grok-build-0.1`
  * Added reasoning capabilities with configurable effort levels
  * Enabled structured output using JSON Schema
  * Added function tool calling support
  * Integrated xAI server-side tools (web search, file search, MCP)

* **Documentation**
  * Updated Grok adapter documentation with new supported models and features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->