### PR TITLE
chore: update pnpm to 11.9.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for contributing! This guide covers everything you need to get from a fre
 
 ## Prerequisites
 
-- **pnpm**: 10.17.0 or newer. Use the version pinned in `packageManager` (`pnpm@11.1.1`).
+- **pnpm**: 11.9.0 or newer. Use the version pinned in `packageManager` (`pnpm@11.9.0`).
   - Recommended: install via [Corepack](https://nodejs.org/api/corepack.html). Run `corepack enable` once and pnpm is managed automatically.
 - **Git**.
 

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "type": "git",
     "url": "git+https://github.com/TanStack/ai.git"
   },
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.9.0",
   "type": "module",
   "engines": {
-    "pnpm": ">=11.0.0"
+    "pnpm": ">=11.9.0"
   },
   "scripts": {
     "clean": "pnpm --filter \"./packages/**\" run clean",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,13 @@ linkWorkspacePackages: true
 preferWorkspacePackages: true
 blockExoticSubdeps: true
 trustPolicy: 'no-downgrade'
+minimumReleaseAge: 1
+
+trustPolicyExclude:
+  - 'chokidar@4.0.3' # existing transitive from sass/nitro; latest v4 with v5 available
+  - 'semver@5.7.2' # existing Babel/jscodeshift transitive; latest v5, released years ago
+  - 'semver@6.3.1' # existing Babel transitive; latest v6, released years ago
+  - 'undici-types@6.21.0' # existing @types/node transitive via happy-dom/vitest, types-only
 
 # pnpm v11 dropped support for these fields in package.json — they must live
 # here. See https://github.com/pnpm/pnpm/releases/tag/v11.0.0.


### PR DESCRIPTION
## Summary
- pin pnpm to 11.9.0 and raise the pnpm engine floor
- add minimumReleaseAge: 1
- add exact trust-policy exclusions for existing transitive lockfile entries

## Verification
- pnpm install --lockfile-only --ignore-scripts
- pnpm install --frozen-lockfile --ignore-scripts --trust-lockfile=false
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum required pnpm version to 11.9.0 across project configuration and contributor guidelines.
  * Enhanced workspace configuration with package release age and version control policy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->