### PR TITLE
fix(ai-openrouter): forward tool-definition cacheControl to enable prompt caching

### DIFF
--- a/.changeset/openrouter-forward-tool-cache-control.md
+++ b/.changeset/openrouter-forward-tool-cache-control.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-openrouter': patch
+---
+
+Forward tool-definition `cacheControl` through the OpenRouter function-tool converter so Anthropic prompt caching of tool definitions works over OpenRouter. Previously `metadata.cacheControl` was dropped before serialization, so the cache breakpoint never reached the wire. The OpenRouter SDK already accepts `cacheControl` on a function tool and remaps it to `cache_control`; this mirrors `convertCustomToolToAdapterFormat` in `@tanstack/ai-anthropic`.

--- a/packages/ai-openrouter/src/tools/function-tool.ts
+++ b/packages/ai-openrouter/src/tools/function-tool.ts
@@ -1,5 +1,15 @@
 import type { JSONSchema, Tool } from '@tanstack/ai'
 
+/**
+ * Anthropic-style ephemeral cache-control marker. The OpenRouter SDK accepts
+ * this (camelCase) on a function tool and remaps it to `cache_control` on the
+ * wire, enabling Anthropic prompt caching of tool definitions.
+ */
+export interface CacheControl {
+  type: 'ephemeral'
+  ttl?: '5m' | '1h'
+}
+
 export interface FunctionTool {
   type: 'function'
   function: {
@@ -7,6 +17,7 @@ export interface FunctionTool {
     description?: string
     parameters: Record<string, unknown>
   }
+  cacheControl?: CacheControl
 }
 
 /**
@@ -22,7 +33,7 @@ export function convertFunctionToolToAdapterFormat(tool: Tool): FunctionTool {
     required: [],
   }) as JSONSchema
 
-  return {
+  const result: FunctionTool = {
     type: 'function',
     function: {
       name: tool.name,
@@ -30,4 +41,18 @@ export function convertFunctionToolToAdapterFormat(tool: Tool): FunctionTool {
       parameters: inputSchema,
     },
   }
+
+  // Forward an optional cache-control marker so OpenRouter can cache the tool
+  // definition (Anthropic prompt caching). Mirrors
+  // `convertCustomToolToAdapterFormat` in `@tanstack/ai-anthropic`. The SDK
+  // remaps `cacheControl` -> `cache_control` on the wire; a snake_case key is
+  // silently stripped by its outbound schema.
+  const cacheControl = (
+    tool.metadata as { cacheControl?: CacheControl } | undefined
+  )?.cacheControl
+  if (cacheControl) {
+    result.cacheControl = cacheControl
+  }
+
+  return result
 }

--- a/packages/ai-openrouter/src/tools/function-tool.ts
+++ b/packages/ai-openrouter/src/tools/function-tool.ts
@@ -1,14 +1,5 @@
+import type { ChatContentCacheControl } from '@openrouter/sdk/models'
 import type { JSONSchema, Tool } from '@tanstack/ai'
-
-/**
- * Anthropic-style ephemeral cache-control marker. The OpenRouter SDK accepts
- * this (camelCase) on a function tool and remaps it to `cache_control` on the
- * wire, enabling Anthropic prompt caching of tool definitions.
- */
-export interface CacheControl {
-  type: 'ephemeral'
-  ttl?: '5m' | '1h'
-}
 
 export interface FunctionTool {
   type: 'function'
@@ -17,7 +8,17 @@ export interface FunctionTool {
     description?: string
     parameters: Record<string, unknown>
   }
-  cacheControl?: CacheControl
+  /**
+   * Anthropic-style prompt-cache breakpoint for the tool definition.
+   *
+   * The SDK accepts this camelCase field as a top-level sibling of `function`
+   * and remaps it to `cache_control` on the wire (its outbound Zod schema
+   * strips an unrecognized snake_case `cache_control`, so the field must be
+   * `cacheControl`). Forwarding it lets callers cache tool definitions through
+   * OpenRouter exactly as `@tanstack/ai-anthropic` does directly. Uses the
+   * SDK's `ChatContentCacheControl` type, matching `OpenRouterSystemPromptMetadata`.
+   */
+  cacheControl?: ChatContentCacheControl
 }
 
 /**
@@ -33,26 +34,25 @@ export function convertFunctionToolToAdapterFormat(tool: Tool): FunctionTool {
     required: [],
   }) as JSONSchema
 
-  const result: FunctionTool = {
+  // Forward an optional cache-control marker so OpenRouter can cache the tool
+  // definition (Anthropic prompt caching). Mirrors
+  // `convertCustomToolToAdapterFormat` in `@tanstack/ai-anthropic`. The SDK
+  // remaps `cacheControl` -> `cache_control` on the wire; a snake_case key is
+  // silently stripped by its outbound schema.
+  //
+  // `Tool.metadata` is `Record<string, any>`, so the field is already
+  // assignable here — the annotation narrows it without a cast.
+  const cacheControl: ChatContentCacheControl | null | undefined =
+    tool.metadata?.cacheControl
+
+  return {
     type: 'function',
     function: {
       name: tool.name,
       description: tool.description,
       parameters: inputSchema,
     },
+    // Only present when supplied — additive and non-breaking.
+    ...(cacheControl ? { cacheControl } : {}),
   }
-
-  // Forward an optional cache-control marker so OpenRouter can cache the tool
-  // definition (Anthropic prompt caching). Mirrors
-  // `convertCustomToolToAdapterFormat` in `@tanstack/ai-anthropic`. The SDK
-  // remaps `cacheControl` -> `cache_control` on the wire; a snake_case key is
-  // silently stripped by its outbound schema.
-  const cacheControl = (
-    tool.metadata as { cacheControl?: CacheControl } | undefined
-  )?.cacheControl
-  if (cacheControl) {
-    result.cacheControl = cacheControl
-  }
-
-  return result
 }

--- a/packages/ai-openrouter/tests/function-tool-cache-control.test.ts
+++ b/packages/ai-openrouter/tests/function-tool-cache-control.test.ts
@@ -107,6 +107,16 @@ describe('OpenRouter function-tool cacheControl (post-SDK serialization)', () =>
     })
   })
 
+  it('forwards the cache TTL when supplied', async () => {
+    const wireTool = await captureSerializedTool({
+      ...baseTool,
+      metadata: { cacheControl: { type: 'ephemeral', ttl: '1h' } },
+    })
+    expect(wireTool).toMatchObject({
+      cache_control: { type: 'ephemeral', ttl: '1h' },
+    })
+  })
+
   it('omits cache_control entirely when no cacheControl metadata is supplied', async () => {
     const wireTool = await captureSerializedTool(baseTool)
     expect(wireTool).toMatchObject({

--- a/packages/ai-openrouter/tests/function-tool-cache-control.test.ts
+++ b/packages/ai-openrouter/tests/function-tool-cache-control.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { chat } from '@tanstack/ai'
+import { ChatRequest$outboundSchema } from '@openrouter/sdk/models'
+import { createOpenRouterText } from '../src/adapters/text'
+import type { StreamChunk, Tool } from '@tanstack/ai'
+
+/**
+ * Wire-format verification for function-tool `cacheControl` forwarding.
+ *
+ * The adapter hands a `ChatRequest` to the SDK, which runs it through
+ * `ChatRequest$outboundSchema` (a Zod serializer) before sending bytes
+ * upstream. The SDK accepts `cacheControl` (camelCase) on a function tool and
+ * remaps it to `cache_control` on the wire — but a key it doesn't recognise is
+ * silently stripped. These tests replay the adapter's request through that same
+ * outbound schema to assert that a caller-supplied `metadata.cacheControl`
+ * actually reaches OpenRouter, enabling Anthropic prompt caching of tool
+ * definitions (matching `@tanstack/ai-anthropic`'s custom-tool behaviour).
+ */
+
+let mockSend: any
+
+// eslint-disable-next-line @typescript-eslint/require-await
+vi.mock('@openrouter/sdk', async () => {
+  function OpenRouter(this: {
+    chat: { send: (...args: Array<unknown>) => unknown }
+  }) {
+    this.chat = {
+      send: (...args: Array<unknown>) => mockSend(...args),
+    }
+  }
+  return { OpenRouter }
+})
+
+function createAsyncIterable<T>(chunks: Array<T>): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0
+      return {
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async next() {
+          if (index < chunks.length) {
+            return { value: chunks[index++]!, done: false }
+          }
+          return { value: undefined as T, done: true }
+        },
+      }
+    },
+  }
+}
+
+function setupMockSend(): void {
+  mockSend = vi.fn().mockImplementation((params) => {
+    if (params.chatRequest?.stream) {
+      return Promise.resolve(
+        createAsyncIterable([
+          {
+            id: 'x',
+            model: 'openai/gpt-4o-mini',
+            choices: [{ delta: { content: 'ok' }, finishReason: 'stop' }],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          },
+        ]),
+      )
+    }
+    return Promise.resolve({})
+  })
+}
+
+async function captureSerializedTool(tool: Tool): Promise<any> {
+  setupMockSend()
+  const adapter = createOpenRouterText('openai/gpt-4o-mini', 'test-key')
+  const chunks: Array<StreamChunk> = []
+  for await (const c of chat({
+    adapter,
+    messages: [{ role: 'user', content: 'hi' }],
+    tools: [tool as never],
+  })) {
+    chunks.push(c)
+  }
+  const [rawParams] = mockSend.mock.calls[0]!
+  const serialized = ChatRequest$outboundSchema.parse(
+    rawParams.chatRequest,
+  ) as { tools?: Array<any> }
+  return serialized.tools?.[0]
+}
+
+const baseTool: Tool = {
+  name: 'shared_context',
+  description: 'Standing constraints carried as a cacheable tool.',
+  inputSchema: { type: 'object', properties: {}, required: [] },
+}
+
+describe('OpenRouter function-tool cacheControl (post-SDK serialization)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forwards metadata.cacheControl as `cache_control` on the wire', async () => {
+    const wireTool = await captureSerializedTool({
+      ...baseTool,
+      metadata: { cacheControl: { type: 'ephemeral' } },
+    })
+    expect(wireTool).toMatchObject({
+      type: 'function',
+      function: { name: 'shared_context' },
+      cache_control: { type: 'ephemeral' },
+    })
+  })
+
+  it('omits cache_control entirely when no cacheControl metadata is supplied', async () => {
+    const wireTool = await captureSerializedTool(baseTool)
+    expect(wireTool).toMatchObject({
+      type: 'function',
+      function: { name: 'shared_context' },
+    })
+    expect(wireTool).not.toHaveProperty('cache_control')
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Closes #822

`@tanstack/ai-openrouter`'s `convertFunctionToolToAdapterFormat` dropped `tool.metadata.cacheControl`, so an Anthropic-style `cache_control` marker on a tool definition never reached the wire — making Anthropic **prompt caching of tool definitions impossible over OpenRouter**. `@tanstack/ai-anthropic` already forwards this in `convertCustomToolToAdapterFormat`, so the adapters were inconsistent.

This forwards `metadata.cacheControl` as a `cacheControl` field on the function tool. The OpenRouter SDK already accepts `cacheControl` and remaps it to `cache_control` on the wire (a snake_case key is stripped by its outbound Zod schema, which is why the camelCase form is required).

**Additive and non-breaking** — the field is only emitted when a caller supplies `metadata.cacheControl`.

### Evidence

Replaying the adapter's request through the SDK's `ChatRequest$outboundSchema` (the existing `web-tools-wire-format.test.ts` pattern), a tool with `metadata.cacheControl` now serializes with `cache_control: { type: 'ephemeral' }`. End-to-end through TanStack → OpenRouter → Anthropic (Sonnet 4.5): call 1 writes the cache (`cache_write: 3111`), call 2 with the identical leading tool reads it (`cache_read: 3111`). Without the fix, both are 0.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenRouter function tools now forward cache-control settings from tool definitions to the wire format, enabling Anthropic-style prompt caching for tool definitions.
* **Tests**
  * Added automated coverage to confirm cache-control (including optional TTL) is serialized correctly when provided, and omitted when not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->