### PR TITLE
chore(ai-openrouter): update OpenRouter SDK

### DIFF
--- a/.changeset/fresh-openrouter-sdk.md
+++ b/.changeset/fresh-openrouter-sdk.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/ai-openrouter": patch
+'@tanstack/ai-openrouter': patch
 ---
 
 Update `@openrouter/sdk` to `0.13.20`. This removes the duplicate `rootDir` key from the published SDK package metadata (fixes #712) and picks up the fix to the `getVideoContent` download helper, which previously requested `Accept: application/octet-stream` and matched the streamed 200 response without a content type, so the upstream `video/mp4` body failed to match. The SDK now requests `Accept: video/mp4` and matches the stream with `ctype: "video/mp4"`.

--- a/.changeset/fresh-openrouter-sdk.md
+++ b/.changeset/fresh-openrouter-sdk.md
@@ -2,4 +2,4 @@
 "@tanstack/ai-openrouter": patch
 ---
 
-Update `@openrouter/sdk` to remove the duplicate `rootDir` key from the published SDK package metadata.
+Update `@openrouter/sdk` to `0.13.20`. This removes the duplicate `rootDir` key from the published SDK package metadata (fixes #712) and picks up the fix to the `getVideoContent` download helper, which previously requested `Accept: application/octet-stream` and matched the streamed 200 response without a content type, so the upstream `video/mp4` body failed to match. The SDK now requests `Accept: video/mp4` and matches the stream with `ctype: "video/mp4"`.

--- a/.changeset/fresh-openrouter-sdk.md
+++ b/.changeset/fresh-openrouter-sdk.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/ai-openrouter": patch
+---
+
+Update `@openrouter/sdk` to remove the duplicate `rootDir` key from the published SDK package metadata.

--- a/packages/ai-openrouter/package.json
+++ b/packages/ai-openrouter/package.json
@@ -60,7 +60,7 @@
     "model-router"
   ],
   "dependencies": {
-    "@openrouter/sdk": "0.12.35",
+    "@openrouter/sdk": "0.12.79",
     "@tanstack/ai-utils": "workspace:*"
   },
   "devDependencies": {

--- a/packages/ai-openrouter/package.json
+++ b/packages/ai-openrouter/package.json
@@ -60,7 +60,7 @@
     "model-router"
   ],
   "dependencies": {
-    "@openrouter/sdk": "0.12.79",
+    "@openrouter/sdk": "0.13.20",
     "@tanstack/ai-utils": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1567,8 +1567,8 @@ importers:
   packages/ai-openrouter:
     dependencies:
       '@openrouter/sdk':
-        specifier: 0.12.79
-        version: 0.12.79
+        specifier: 0.13.20
+        version: 0.13.20
       '@tanstack/ai-utils':
         specifier: workspace:*
         version: link:../ai-utils
@@ -1976,8 +1976,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
       '@openrouter/sdk':
-        specifier: 0.12.79
-        version: 0.12.79
+        specifier: 0.13.20
+        version: 0.13.20
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -4914,8 +4914,8 @@ packages:
     resolution: {integrity: sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==}
     engines: {node: '>=8.0'}
 
-  '@openrouter/sdk@0.12.79':
-    resolution: {integrity: sha512-0ZpwtnuHh3/B1piW9kHCUIQy6PAsaK/vjFdZuHxmCdAenCyUNsLA2mFpmfHNWRNb+bOO3yBc4IALa264UyzmBA==}
+  '@openrouter/sdk@0.13.20':
+    resolution: {integrity: sha512-fx4o19FHgadEldfrSOgSbXAi32hCE3O708q1nxcoxYrW6fP6/WggX3o5PmnlnObzmxrqLMkZpqg188K+Twguhg==}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -17812,7 +17812,7 @@ snapshots:
 
   '@oozcitak/util@8.3.8': {}
 
-  '@openrouter/sdk@0.12.79':
+  '@openrouter/sdk@0.13.20':
     dependencies:
       zod: 4.3.6
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1567,8 +1567,8 @@ importers:
   packages/ai-openrouter:
     dependencies:
       '@openrouter/sdk':
-        specifier: 0.12.35
-        version: 0.12.35
+        specifier: 0.12.79
+        version: 0.12.79
       '@tanstack/ai-utils':
         specifier: workspace:*
         version: link:../ai-utils
@@ -1976,8 +1976,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
       '@openrouter/sdk':
-        specifier: 0.12.35
-        version: 0.12.35
+        specifier: 0.12.79
+        version: 0.12.79
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -4914,8 +4914,8 @@ packages:
     resolution: {integrity: sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==}
     engines: {node: '>=8.0'}
 
-  '@openrouter/sdk@0.12.35':
-    resolution: {integrity: sha512-s4QVLLnG1AmfW3TjnnHUqGfsCkzwVK+kboGcZmKbde09m1DPqgzl4RUFt/HJ5v97MX8aEaN0UG3mKv2S+qj2Gw==}
+  '@openrouter/sdk@0.12.79':
+    resolution: {integrity: sha512-0ZpwtnuHh3/B1piW9kHCUIQy6PAsaK/vjFdZuHxmCdAenCyUNsLA2mFpmfHNWRNb+bOO3yBc4IALa264UyzmBA==}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -17812,7 +17812,7 @@ snapshots:
 
   '@oozcitak/util@8.3.8': {}
 
-  '@openrouter/sdk@0.12.35':
+  '@openrouter/sdk@0.12.79':
     dependencies:
       zod: 4.3.6
 

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@copilotkit/aimock": "^1.34.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openrouter/sdk": "0.12.35",
+    "@openrouter/sdk": "0.12.79",
     "@opentelemetry/api": "^1.9.0",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/ai": "workspace:*",

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@copilotkit/aimock": "^1.34.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openrouter/sdk": "0.12.79",
+    "@openrouter/sdk": "0.13.20",
     "@opentelemetry/api": "^1.9.0",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/ai": "workspace:*",


### PR DESCRIPTION
## Summary

Closes #712.

Updates `@openrouter/sdk` from `0.12.35` to `0.12.79`.

The currently pinned SDK version includes a duplicate `rootDir` key in its published `tsconfig.json`. The newer `0.12.79` tarball no longer has the duplicate key while staying on the same `0.12.x` release line.

`testing/e2e` is updated to the same SDK version to satisfy the workspace's single-version dependency check.

A patch changeset is included because this updates a published package dependency.

## Validation

```sh
pnpm install --frozen-lockfile
pnpm test:sherif
pnpm test:knip
pnpm --filter @tanstack/ai-openrouter test:types
pnpm --filter @tanstack/ai-openrouter test:build
```

I also checked `pnpm --filter @tanstack/ai-openrouter test:lib`; it currently fails on clean upstream `main` with the existing `OpenRouter structured output > flows through core chat() entrypoint with strict transformation` assertion, so this PR does not address that unrelated pre-existing failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the AI OpenRouter integration to a newer patch release for improved compatibility.
  * Fixed MP4 streaming/download behavior by correcting the content request so streamed responses match the expected `video/mp4` type.
  * Corrected published SDK package metadata to remove a duplicate `rootDir` entry that could affect consumers.
* **Chores**
  * Bumped the OpenRouter SDK dependency used by both the main package and the E2E test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->