### PR TITLE
chore: set pnpm minimum release age to 1440

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,10 @@ linkWorkspacePackages: true
 preferWorkspacePackages: true
 blockExoticSubdeps: true
 trustPolicy: 'no-downgrade'
-minimumReleaseAge: 1
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - 'kiira@0.5.0' # root dev dependency already locked on main
+  - 'kiira-core@0.5.0' # transitive dependency of kiira@0.5.0
 
 trustPolicyExclude:
   - 'chokidar@4.0.3' # existing transitive from sass/nitro; latest v4 with v5 available


### PR DESCRIPTION
Follow-up to #815 after merge. The merged branch left pnpm-workspace.yaml with minimumReleaseAge: 1; this raises it to 1440 and adds version-pinned age exclusions for the already-locked kiira packages required by the frozen install check.