### PR TITLE
docs: fix grok video snippets failing kiira; publish @tanstack/ai-angular

### DIFF
--- a/.changeset/publish-ai-angular.md
+++ b/.changeset/publish-ai-angular.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-angular': patch
+---
+
+Publish a working `@tanstack/ai-angular` build. The only version previously on npm (`0.0.1`) was seeded with a manual `npm publish` and shipped unresolved `workspace:` specifiers in its `dependencies`/`peerDependencies`, making it uninstallable (`EUNSUPPORTEDPROTOCOL`). Releasing through the changesets pipeline rewrites those specifiers to concrete versions.

--- a/docs/adapters/grok.md
+++ b/docs/adapters/grok.md
@@ -270,6 +270,9 @@ console.log(status.url); // hosted .mp4 URL
 For image-to-video (required for `grok-imagine-video-1.5`, optional for `grok-imagine-video`), include an `image` prompt part as the starting frame and describe the desired motion in the text part. URL sources are fetched by xAI's servers (so they must be publicly reachable); use a `data` source for a base64 starting frame:
 
 ```typescript
+import { generateVideo } from "@tanstack/ai";
+import { grokVideo } from "@tanstack/ai-grok";
+
 const { jobId } = await generateVideo({
   adapter: grokVideo("grok-imagine-video-1.5"),
   prompt: [

--- a/docs/media/video-generation.md
+++ b/docs/media/video-generation.md
@@ -598,6 +598,9 @@ const { jobId } = await generateVideo({
 Image-to-video (required for `grok-imagine-video-1.5`) — include an `image` prompt part as the starting frame. URL sources are fetched by xAI's servers (so they must be publicly reachable); use a `data` source for a base64 starting frame:
 
 ```typescript
+import { generateVideo } from '@tanstack/ai'
+import { grokVideo } from '@tanstack/ai-grok'
+
 const { jobId } = await generateVideo({
   adapter: grokVideo('grok-imagine-video-1.5'),
   prompt: [
@@ -615,6 +618,8 @@ const { jobId } = await generateVideo({
 Both models accept any whole second in the **1–15** range. A raw `duration` is coerced into that range rather than rejected — values are clamped to `[1, 15]` and rounded to the nearest second. Inspect or pre-snap the range the same way as Veo:
 
 ```typescript
+import { grokVideo } from '@tanstack/ai-grok'
+
 const adapter = grokVideo('grok-imagine-video')
 
 adapter.availableDurations() // { kind: 'range', min: 1, max: 15, step: 1, unit: 'seconds' }


### PR DESCRIPTION
## Why

The `test:kiira` gate (doc code-sample type-checker, added in #805) has been **red on `main`** since the grok video-generation adapter docs landed (#742). The Release workflow runs `pnpm run test:ci` (which includes `test:kiira`) *before* `changeset publish`, so a red gate aborts the job before anything publishes — which is why no package has been published since 2026-06-23 and why `@tanstack/ai-angular` is stuck (see #811).

### The kiira failure

Two grok video snippets used `generateVideo` / `grokVideo` in **standalone** code fences without importing them:

- `docs/adapters/grok.md` — image-to-video example
- `docs/media/video-generation.md` — image-to-video + duration-inspection examples

```
✖ Kiira found 5 errors  (TS2304 Cannot find name 'generateVideo' / 'grokVideo')
```

Each fence is now self-contained with its own imports (no `group=`/rename hacks). Local run:

```
✓ Kiira found no errors in 83 files.
Checked 665 snippets. Passed 665. Failed 0.
```

### Publishing ai-angular

Adds a `patch` changeset for `@tanstack/ai-angular`. The only version on npm (`0.0.1`) was seeded by a manual `npm publish` and shipped unresolved `workspace:` specifiers (`EUNSUPPORTEDPROTOCOL`, #811). Now that trusted publishing is configured for the package and the kiira gate is green again, releasing through the changesets pipeline rewrites those specifiers to concrete versions and ships a clean build.

Closes #811.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Published a patch update to ensure the Angular package installs correctly from npm without broken dependency references.

* **Documentation**
  * Updated video-generation examples to include the required imports in code snippets.
  * Fixed the Grok adapter documentation so the TypeScript examples are ready to copy and run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->