### PR TITLE
fix(ai-grok): remove Record<string,unknown> index sig from GrokTextProviderOptions

### DIFF
--- a/.changeset/fix-grok-provider-options-index-sig.md
+++ b/.changeset/fix-grok-provider-options-index-sig.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/ai-grok": patch
+---
+
+Remove `Record<string, unknown>` index signature from `GrokTextProviderOptions` so that `grokSummarize` adapters are assignable to `SummarizeAdapter<string, object>`. Under `strictFunctionTypes`, the index signature caused `object` to be un-assignable to `GrokTextProviderOptions` (contravariant parameter check), making `grokSummarize('grok-4.3')` a type error at every `summarize()` call site. All fields on `GrokTextProviderOptions` are explicitly typed optional members, so the index signature was unnecessary.

--- a/packages/ai-grok/src/text/text-provider-options.ts
+++ b/packages/ai-grok/src/text/text-provider-options.ts
@@ -32,8 +32,7 @@ export interface GrokBaseOptions {
  * Grok-specific provider options for text/chat
  * Based on xAI Responses API options
  */
-export interface GrokTextProviderOptions
-  extends GrokBaseOptions, Record<string, unknown> {
+export interface GrokTextProviderOptions extends GrokBaseOptions {
   /**
    * Temperature for response generation (0-2)
    * Higher values make output more random, lower values more focused


### PR DESCRIPTION
## Summary

`grokSummarize('grok-4.3')` and `grokSummarize('grok-build-0.1')` are not assignable to `summarize()`'s `adapter` parameter, producing a type error at every call site.

Fixes #821

## Root cause

`GrokTextProviderOptions` extends both `GrokBaseOptions` **and** `Record<string, unknown>`. Under `strictFunctionTypes`, function parameters are checked contravariantly. The constraint on `summarize<TAdapter extends SummarizeAdapter<string, object>>` means the adapter's `summarize` method must accept `SummarizationOptions<object>`. Contravariance requires `object` to be assignable to `GrokTextProviderOptions`. But `object` is **not** assignable to `Record<string, unknown>` (index-signature types require a compatible index signature from the source), so the check fails.

OpenAI's provider options have no index signature and all-optional named fields, so they pass: `object` satisfies any all-optional interface.

## Fix

Remove `Record<string, unknown>` from the `extends` clause of `GrokTextProviderOptions`. All fields are explicitly typed optional members — the index signature was not needed. After this change, `object` is assignable to `GrokTextProviderOptions` (all-optional, no index signature), fixing the contravariant check.

`GrokBuildProviderOptions` (`Omit<GrokTextProviderOptions, 'reasoning'>`) is not affected: the named fields are preserved correctly by `Omit` since there is no longer an index signature to collapse.

The `TProviderOptions extends Record<string, unknown>` constraint on `GrokTextAdapter` remains satisfied: a named-property interface with `unknown`-compatible values is structurally assignable to `Record<string, unknown>`.

## Changes

- `packages/ai-grok/src/text/text-provider-options.ts`: Remove `Record<string, unknown>` from `GrokTextProviderOptions` extends clause
- `.changeset/fix-grok-provider-options-index-sig.md`: Patch changeset for `@tanstack/ai-grok`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript type compatibility for Grok summarization adapters, eliminating strict type errors at `summarize()` call sites.
  * Updated Grok text provider options to rely only on explicitly defined fields, removing the overly broad option shape that caused mismatches under strict function typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->