### PR TITLE
fix(openrouter): forward tool metadata.cacheControl so tool-definition prompt caching reaches the wire

### DIFF
--- a/.changeset/openrouter-tool-cache-control.md
+++ b/.changeset/openrouter-tool-cache-control.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/ai-openrouter': patch
+---
+
+Forward a tool's `metadata.cacheControl` breakpoint to OpenRouter so Anthropic
+prompt caching of tool definitions works through the adapter. The function-tool
+converter now emits the SDK's camelCase `cacheControl` field (which serializes
+to `cache_control` on the wire); previously it was dropped, so caching a leading
+tool definition was impossible over OpenRouter. Additive and non-breaking — the
+field is only present when supplied, mirroring `@tanstack/ai-anthropic`.

--- a/packages/ai-openrouter/src/tools/function-tool.ts
+++ b/packages/ai-openrouter/src/tools/function-tool.ts
@@ -1,3 +1,4 @@
+import type { ChatContentCacheControl } from '@openrouter/sdk/models'
 import type { JSONSchema, Tool } from '@tanstack/ai'
 
 export interface FunctionTool {
@@ -7,6 +8,16 @@ export interface FunctionTool {
     description?: string
     parameters: Record<string, unknown>
   }
+  /**
+   * Anthropic-style prompt-cache breakpoint for the tool definition.
+   *
+   * The SDK accepts this camelCase field as a top-level sibling of `function`
+   * and remaps it to `cache_control` on the wire (its outbound Zod schema
+   * strips an unrecognized snake_case `cache_control`, so the field must be
+   * `cacheControl`). Forwarding it lets callers cache tool definitions through
+   * OpenRouter exactly as `@tanstack/ai-anthropic` does directly.
+   */
+  cacheControl?: ChatContentCacheControl
 }
 
 /**
@@ -22,6 +33,11 @@ export function convertFunctionToolToAdapterFormat(tool: Tool): FunctionTool {
     required: [],
   }) as JSONSchema
 
+  // `Tool.metadata` is `Record<string, any>`, so the field is already
+  // assignable here — the annotation narrows it without a cast.
+  const cacheControl: ChatContentCacheControl | null | undefined =
+    tool.metadata?.cacheControl
+
   return {
     type: 'function',
     function: {
@@ -29,5 +45,7 @@ export function convertFunctionToolToAdapterFormat(tool: Tool): FunctionTool {
       description: tool.description,
       parameters: inputSchema,
     },
+    // Only present when supplied — additive and non-breaking.
+    ...(cacheControl ? { cacheControl } : {}),
   }
 }

--- a/packages/ai-openrouter/tests/function-tool-wire-format.test.ts
+++ b/packages/ai-openrouter/tests/function-tool-wire-format.test.ts
@@ -81,7 +81,9 @@ async function captureSerializedTool(tool: Tool): Promise<unknown> {
     chunks.push(c)
   }
   const [rawParams] = mockSend.mock.calls[0]!
-  const serialized = ChatRequest$outboundSchema.parse(rawParams.chatRequest) as {
+  const serialized = ChatRequest$outboundSchema.parse(
+    rawParams.chatRequest,
+  ) as {
     tools?: Array<unknown>
   }
   return serialized.tools?.[0]

--- a/packages/ai-openrouter/tests/function-tool-wire-format.test.ts
+++ b/packages/ai-openrouter/tests/function-tool-wire-format.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { chat } from '@tanstack/ai'
+import { ChatRequest$outboundSchema } from '@openrouter/sdk/models'
+import { createOpenRouterText } from '../src/adapters/text'
+import type { StreamChunk, Tool } from '@tanstack/ai'
+
+/**
+ * Wire-format verification for OpenRouter function-tool prompt caching.
+ *
+ * A `cacheControl` breakpoint placed on a tool's `metadata` enables Anthropic
+ * prompt caching of tool definitions when those models are routed through
+ * OpenRouter — the equivalent of `@tanstack/ai-anthropic` forwarding
+ * `cache_control` on a custom tool directly.
+ *
+ * The catch (see #822): the SDK's `ChatFunctionToolFunction` accepts the field
+ * as a top-level camelCase `cacheControl` and remaps it to `cache_control` on
+ * the wire. Its outbound Zod schema strips an unrecognized snake_case
+ * `cache_control`, so the converter must emit `cacheControl`. These tests
+ * replay the adapter's request through the same `ChatRequest$outboundSchema`
+ * the SDK uses, asserting `cache_control` actually reaches the wire.
+ */
+
+let mockSend: any
+
+// eslint-disable-next-line @typescript-eslint/require-await
+vi.mock('@openrouter/sdk', async () => {
+  function OpenRouter(this: {
+    chat: { send: (...args: Array<unknown>) => unknown }
+  }) {
+    this.chat = {
+      send: (...args: Array<unknown>) => mockSend(...args),
+    }
+  }
+  return { OpenRouter }
+})
+
+function createAsyncIterable<T>(chunks: Array<T>): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0
+      return {
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async next() {
+          if (index < chunks.length) {
+            return { value: chunks[index++]!, done: false }
+          }
+          return { value: undefined as T, done: true }
+        },
+      }
+    },
+  }
+}
+
+function setupMockSend(): void {
+  mockSend = vi.fn().mockImplementation((params) => {
+    if (params.chatRequest?.stream) {
+      return Promise.resolve(
+        createAsyncIterable([
+          {
+            id: 'x',
+            model: 'openai/gpt-4o-mini',
+            choices: [{ delta: { content: 'ok' }, finishReason: 'stop' }],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          },
+        ]),
+      )
+    }
+    return Promise.resolve({})
+  })
+}
+
+async function captureSerializedTool(tool: Tool): Promise<unknown> {
+  setupMockSend()
+  const adapter = createOpenRouterText('openai/gpt-4o-mini', 'test-key')
+  const chunks: Array<StreamChunk> = []
+  for await (const c of chat({
+    adapter,
+    messages: [{ role: 'user', content: 'hi' }],
+    tools: [tool],
+  })) {
+    chunks.push(c)
+  }
+  const [rawParams] = mockSend.mock.calls[0]!
+  const serialized = ChatRequest$outboundSchema.parse(rawParams.chatRequest) as {
+    tools?: Array<unknown>
+  }
+  return serialized.tools?.[0]
+}
+
+const baseTool: Tool = {
+  name: 'lookup',
+  description: 'Look something up',
+  inputSchema: {
+    type: 'object',
+    properties: { query: { type: 'string' } },
+    required: ['query'],
+  },
+}
+
+describe('OpenRouter function-tool wire format (post-SDK serialization)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forwards metadata.cacheControl as cache_control on the wire', async () => {
+    const wireTool = await captureSerializedTool({
+      ...baseTool,
+      metadata: { cacheControl: { type: 'ephemeral' } },
+    })
+    expect(wireTool).toMatchObject({
+      type: 'function',
+      function: { name: 'lookup' },
+      cache_control: { type: 'ephemeral' },
+    })
+  })
+
+  it('forwards the cache TTL when supplied', async () => {
+    const wireTool = await captureSerializedTool({
+      ...baseTool,
+      metadata: { cacheControl: { type: 'ephemeral', ttl: '1h' } },
+    })
+    expect(wireTool).toMatchObject({
+      cache_control: { type: 'ephemeral', ttl: '1h' },
+    })
+  })
+
+  it('omits cache_control entirely when no cacheControl is supplied', async () => {
+    const wireTool = (await captureSerializedTool(baseTool)) as {
+      cache_control?: unknown
+    }
+    expect(wireTool).not.toHaveProperty('cache_control')
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes #822.

`convertFunctionToolToAdapterFormat` (`packages/ai-openrouter/src/tools/function-tool.ts`) was dropping a tool's `metadata.cacheControl`, so Anthropic **prompt caching of tool definitions** never reached the wire when routing through OpenRouter — inconsistent with `@tanstack/ai-anthropic`, which forwards `cache_control` on a custom tool directly.

The fix forwards the breakpoint as the SDK's **camelCase `cacheControl`** field — a top-level sibling of `function`, which the SDK remaps to `cache_control` on the wire. (A snake_case `cache_control` is stripped by the SDK's outbound Zod schema, which is the root cause noted in the issue.) The field is only present when supplied, so the change is additive and non-breaking.

- `FunctionTool` gains a `cacheControl?: ChatContentCacheControl` field, typed directly from `@openrouter/sdk/models`.
- The converter reads `tool.metadata?.cacheControl` (no cast needed — `Tool.metadata` is `Record<string, any>`) and spreads it only when present.

Added a wire-format test (`tests/function-tool-wire-format.test.ts`) mirroring the existing `web-tools-wire-format.test.ts` pattern: it replays the adapter's request through `ChatRequest$outboundSchema` (the same serializer the SDK uses) and asserts `cache_control` — including TTL — actually reaches the wire, and is omitted when no `cacheControl` is supplied.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally (`test:lib`, `test:types`, `test:eslint`, `test:build` for `@tanstack/ai-openrouter` all green).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset (patch for `@tanstack/ai-openrouter`).
- [ ] This change is docs/CI/dev-only (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool definitions can now carry cache-control settings through to OpenRouter, enabling prompt caching for leading tool definitions when configured.

* **Bug Fixes**
  * Fixed an issue where cache-control settings on tools were previously dropped during request conversion.
  * Preserves optional TTL values and only includes cache-control data when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->