### PR TITLE
fix(ai-grok): make grok provider options assignable to summarize() adapter param

### DIFF
--- a/.changeset/grok-summarize-adapter-assignability.md
+++ b/.changeset/grok-summarize-adapter-assignability.md
@@ -1,0 +1,16 @@
+---
+'@tanstack/ai-grok': patch
+---
+
+Fix `grokSummarize`/`createGrokSummarize` not being assignable to `summarize()`'s
+`adapter` param for any current Grok model (`grok-4.3`, `grok-build-0.1`).
+
+`GrokTextProviderOptions` was declared as an `interface` extending
+`Record<string, unknown>`, giving it an explicit index signature. Under
+`strictFunctionTypes`, the `SummarizeAdapter` constraint is checked
+contravariantly, which requires `object` to be assignable to the provider
+options — but `object` is not assignable to an index-signature type, so the
+check failed (Grok-only; OpenAI's all-optional, no-index-signature options
+passed). The options are now a type-alias intersection matching the OpenAI
+shape, and the text adapter's provider-options constraint is widened to
+`Record<string, any>` to mirror `OpenAITextAdapter`.

--- a/packages/ai-grok/src/adapters/text.ts
+++ b/packages/ai-grok/src/adapters/text.ts
@@ -43,7 +43,11 @@ export type { ExternalTextProviderOptions as GrokTextProviderOptions } from '../
  */
 export class GrokTextAdapter<
   TModel extends (typeof GROK_CHAT_MODELS)[number],
-  TProviderOptions extends Record<string, unknown> =
+  // Use `Record<string, any>` (not `unknown`) to match the OpenAI text
+  // adapter: the resolved Grok provider options are a type-alias intersection
+  // with no explicit index signature, which is assignable to
+  // `Record<string, any>` but not `Record<string, unknown>`. See issue #821.
+  TProviderOptions extends Record<string, any> =
     ResolveProviderOptions<TModel>,
   TInputModalities extends ReadonlyArray<Modality> =
     ResolveInputModalities<TModel>,

--- a/packages/ai-grok/src/adapters/text.ts
+++ b/packages/ai-grok/src/adapters/text.ts
@@ -47,8 +47,7 @@ export class GrokTextAdapter<
   // adapter: the resolved Grok provider options are a type-alias intersection
   // with no explicit index signature, which is assignable to
   // `Record<string, any>` but not `Record<string, unknown>`. See issue #821.
-  TProviderOptions extends Record<string, any> =
-    ResolveProviderOptions<TModel>,
+  TProviderOptions extends Record<string, any> = ResolveProviderOptions<TModel>,
   TInputModalities extends ReadonlyArray<Modality> =
     ResolveInputModalities<TModel>,
   TToolCapabilities extends ReadonlyArray<string> =

--- a/packages/ai-grok/src/text/text-provider-options.ts
+++ b/packages/ai-grok/src/text/text-provider-options.ts
@@ -29,11 +29,9 @@ export interface GrokBaseOptions {
 }
 
 /**
- * Grok-specific provider options for text/chat
- * Based on xAI Responses API options
+ * Sampling and response controls for Grok text/chat models.
  */
-export interface GrokTextProviderOptions
-  extends GrokBaseOptions, Record<string, unknown> {
+export interface GrokSamplingOptions {
   /**
    * Temperature for response generation (0-2)
    * Higher values make output more random, lower values more focused
@@ -61,6 +59,21 @@ export interface GrokTextProviderOptions
    */
   reasoning?: GrokReasoning
 }
+
+/**
+ * Grok-specific provider options for text/chat
+ * Based on xAI Responses API options.
+ *
+ * Declared as a type-alias intersection of interfaces with all-optional props
+ * (matching the OpenAI text adapter), NOT an `interface ... extends
+ * Record<string, unknown>`. An explicit index signature makes `object`
+ * un-assignable to these options, which breaks the contravariantly-checked
+ * `summarize()` adapter constraint (`SummarizeAdapter<string, object>`); see
+ * issue #821. Without the index signature these options no longer satisfy a
+ * `Record<string, unknown>` constraint, so the text adapter's provider-options
+ * generic is widened to `Record<string, any>` to match OpenAI.
+ */
+export type GrokTextProviderOptions = GrokBaseOptions & GrokSamplingOptions
 
 export type GrokBuildProviderOptions = Omit<
   GrokTextProviderOptions,

--- a/packages/ai-grok/tests/grok-adapter.test.ts
+++ b/packages/ai-grok/tests/grok-adapter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
-import { EventType } from '@tanstack/ai'
+import { EventType, summarize } from '@tanstack/ai'
 import { createGrokText, grokText } from '../src/adapters/text'
 import { createGrokImage, grokImage } from '../src/adapters/image'
 import { createGrokSummarize, grokSummarize } from '../src/adapters/summarize'
@@ -497,6 +497,19 @@ describe('Grok adapters', () => {
       expect(() => grokSummarize('grok-build-0.1')).toThrow(
         'XAI_API_KEY is required',
       )
+    })
+
+    it('grokSummarize is assignable to summarize() adapter param for every model (#821)', () => {
+      // Type-level regression guard: the SummarizeAdapter constraint only
+      // instantiates at the summarize() call site, so constructing the adapter
+      // (covered above) is not enough. This closure is type-checked but never
+      // executed — passing CI's test:types is the assertion.
+      const _typeCheck = () => {
+        void summarize({ adapter: grokSummarize('grok-4.3'), text: '' })
+        void summarize({ adapter: grokSummarize('grok-build-0.1'), text: '' })
+      }
+
+      expect(_typeCheck).toBeInstanceOf(Function)
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

`grokSummarize(...)` / `createGrokSummarize(...)` was **not assignable to `summarize()`'s `adapter` param for any current Grok model** (`grok-4.3`, `grok-build-0.1`) — a type regression from `main`'s provider-options rewrite that slipped through because the only call sites lived in `testing/**`, which CI excludes from `test:types` (#820).

**Root cause:** `GrokTextProviderOptions` was declared as `interface ... extends GrokBaseOptions, Record<string, unknown>`, giving it an explicit index signature. `SummarizeAdapter.summarize` is a property-position function, so under `strictFunctionTypes` the constraint `SummarizeAdapter<string, object>` is checked **contravariantly** — reducing to "is `object` assignable to `TProviderOptions`?". `object` is **not** assignable to an index-signature type, so it failed. OpenAI passed because its options are an all-optional type-alias intersection with no index signature.

**Fix:**
- Split the named props into a `GrokSamplingOptions` interface and redefine `GrokTextProviderOptions` as a type-alias intersection (`GrokBaseOptions & GrokSamplingOptions`) — all-optional, no explicit index signature — matching the OpenAI text adapter. `object` is now assignable.
- Widen the text adapter's provider-options generic from `Record<string, unknown>` to `Record<string, any>`, mirroring `OpenAITextAdapter` (the intersection satisfies `Record<string, any>` but not `Record<string, unknown>`).
- Add a **call-site** type-level regression guard in `packages/ai-grok/tests/` (an *included* package) so this can't regress silently again — constructing the adapter alone doesn't instantiate the constraint.

Confirmed per-model narrowing still holds: `grok-build-0.1` rejects `reasoning` (`reasoning?: never`) while `grok-4.3` accepts it.

Closes #821

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript compatibility for Grok summarization with the shared summarization API, ensuring Grok models work correctly in stricter type-checking setups.
* **Tests**
  * Added a regression test that validates type-level assignability for Grok summarization adapters across supported Grok versions.
* **Documentation**
  * Updated exported text provider option types and clarified sampling-related option typing behavior for Grok.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->