### PR TITLE
fix: infer onResult transform type on generation hooks (#848)

### DIFF
--- a/.changeset/fix-generation-hooks-onresult-inference.md
+++ b/.changeset/fix-generation-hooks-onresult-inference.md
@@ -1,0 +1,23 @@
+---
+'@tanstack/ai-react': patch
+'@tanstack/ai-solid': patch
+'@tanstack/ai-svelte': patch
+'@tanstack/ai-vue': patch
+'@tanstack/ai-angular': patch
+---
+
+Fix `onResult` transform type inference on the generation hooks across every
+framework package — the base generation hook plus `generateImage`,
+`generateAudio`, `generateSpeech`, `generateVideo`, `transcription`, and
+`summarize` (React `use*`, Vue `use*`, Solid `use*`, Svelte `create*`, and
+Angular `inject*`).
+
+The hooks declared the `onResult` transform via a single defaulted type
+parameter inferred from an optional nested property, which TypeScript collapses
+to its default — leaving the callback parameter typed `any` (a hard error under
+`strict`) and never narrowing `result` to the transform's return type. The
+hooks now infer the transform type from the `onResult` return position (a
+covariant inference site that works for an optional nested property), so the
+callback parameter is typed as the raw result and `result` narrows to the
+transform's return type; omitting the transform keeps the raw result type. See
+issue #848.

--- a/packages/ai-angular/src/inject-generate-audio.ts
+++ b/packages/ai-angular/src/inject-generate-audio.ts
@@ -6,7 +6,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 import type { Signal } from '@angular/core'
 import type { ReactiveOption } from './internal/to-reactive'
@@ -96,15 +96,12 @@ export interface InjectGenerateAudioResult<TOutput = AudioGenerationResult> {
  * }
  * ```
  */
-export function injectGenerateAudio<
-  TOnResult extends ((result: AudioGenerationResult) => any) | undefined =
-    undefined,
->(
+export function injectGenerateAudio<TTransformed = void>(
   options: Omit<InjectGenerateAudioOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: AudioGenerationResult) => TTransformed
   },
 ): InjectGenerateAudioResult<
-  InferGenerationOutput<AudioGenerationResult, TOnResult>
+  InferGenerationOutputFromReturn<AudioGenerationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -113,7 +110,7 @@ export function injectGenerateAudio<
     outputKind: 'audio' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    injectGeneration<AudioGenerateInput, AudioGenerationResult, TOnResult>({
+    injectGeneration<AudioGenerateInput, AudioGenerationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-angular/src/inject-generate-image.ts
+++ b/packages/ai-angular/src/inject-generate-image.ts
@@ -4,7 +4,7 @@ import type { ImageGenerationResult } from '@tanstack/ai'
 import type {
   GenerationClientState,
   ImageGenerateInput,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 import type { InjectGenerationOptions } from './inject-generation'
 
@@ -25,15 +25,12 @@ export interface InjectGenerateImageResult<TOutput = ImageGenerationResult> {
   reset: () => void
 }
 
-export function injectGenerateImage<
-  TOnResult extends ((result: ImageGenerationResult) => any) | undefined =
-    undefined,
->(
+export function injectGenerateImage<TTransformed = void>(
   options: Omit<InjectGenerateImageOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: ImageGenerationResult) => TTransformed
   },
 ): InjectGenerateImageResult<
-  InferGenerationOutput<ImageGenerationResult, TOnResult>
+  InferGenerationOutputFromReturn<ImageGenerationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -42,7 +39,7 @@ export function injectGenerateImage<
     outputKind: 'image' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    injectGeneration<ImageGenerateInput, ImageGenerationResult, TOnResult>({
+    injectGeneration<ImageGenerateInput, ImageGenerationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-angular/src/inject-generate-speech.ts
+++ b/packages/ai-angular/src/inject-generate-speech.ts
@@ -3,7 +3,7 @@ import type { Signal } from '@angular/core'
 import type { TTSResult } from '@tanstack/ai'
 import type {
   GenerationClientState,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   SpeechGenerateInput,
 } from '@tanstack/ai-client'
 import type { InjectGenerationOptions } from './inject-generation'
@@ -25,13 +25,13 @@ export interface InjectGenerateSpeechResult<TOutput = TTSResult> {
   reset: () => void
 }
 
-export function injectGenerateSpeech<
-  TOnResult extends ((result: TTSResult) => any) | undefined = undefined,
->(
+export function injectGenerateSpeech<TTransformed = void>(
   options: Omit<InjectGenerateSpeechOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TTSResult) => TTransformed
   },
-): InjectGenerateSpeechResult<InferGenerationOutput<TTSResult, TOnResult>> {
+): InjectGenerateSpeechResult<
+  InferGenerationOutputFromReturn<TTSResult, TTransformed>
+> {
   const devtools = {
     ...options.devtools,
     framework: 'angular' as const,
@@ -39,7 +39,7 @@ export function injectGenerateSpeech<
     outputKind: 'audio' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    injectGeneration<SpeechGenerateInput, TTSResult, TOnResult>({
+    injectGeneration<SpeechGenerateInput, TTSResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-angular/src/inject-generate-video.ts
+++ b/packages/ai-angular/src/inject-generate-video.ts
@@ -17,7 +17,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   VideoGenerateInput,
   VideoGenerateResult,
   VideoStatusInfo,
@@ -52,19 +52,19 @@ export interface InjectGenerateVideoResult<TOutput = VideoGenerateResult> {
   reset: () => void
 }
 
-export function injectGenerateVideo<
-  TOnResult extends ((result: VideoGenerateResult) => any) | undefined =
-    undefined,
->(
+// `TTransformed` infers from the `onResult` return position so the callback
+// parameter is typed as `VideoGenerateResult` and `result` narrows to the
+// transform's return. See issue #848.
+export function injectGenerateVideo<TTransformed = void>(
   options: Omit<InjectGenerateVideoOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: VideoGenerateResult) => TTransformed
   },
 ): InjectGenerateVideoResult<
-  InferGenerationOutput<VideoGenerateResult, TOnResult>
+  InferGenerationOutputFromReturn<VideoGenerateResult, TTransformed>
 > {
   assertInInjectionContext(injectGenerateVideo)
 
-  type TOutput = InferGenerationOutput<VideoGenerateResult, TOnResult>
+  type TOutput = InferGenerationOutputFromReturn<VideoGenerateResult, TTransformed>
 
   const destroyRef = inject(DestroyRef)
   const injector = inject(Injector)
@@ -90,7 +90,12 @@ export function injectGenerateVideo<
       hookName: 'injectGenerateVideo',
       outputKind: 'video' as const,
     },
-    onResult: (r: VideoGenerateResult) => options.onResult?.(r),
+    // The transform's raw return type (`TTransformed`) and the stored output
+    // (`TOutput`, with null/void/undefined stripped) are identical at runtime;
+    // the cast bridges the relationship that the conditional type hides.
+    onResult: ((r: VideoGenerateResult) => options.onResult?.(r)) as (
+      result: VideoGenerateResult,
+    ) => TOutput | null | void,
     onError: (e: Error) => options.onError?.(e),
     onProgress: (p: number, m?: string) => options.onProgress?.(p, m),
     onChunk: (c: StreamChunk) => options.onChunk?.(c),

--- a/packages/ai-angular/src/inject-generate-video.ts
+++ b/packages/ai-angular/src/inject-generate-video.ts
@@ -64,7 +64,10 @@ export function injectGenerateVideo<TTransformed = void>(
 > {
   assertInInjectionContext(injectGenerateVideo)
 
-  type TOutput = InferGenerationOutputFromReturn<VideoGenerateResult, TTransformed>
+  type TOutput = InferGenerationOutputFromReturn<
+    VideoGenerateResult,
+    TTransformed
+  >
 
   const destroyRef = inject(DestroyRef)
   const injector = inject(Injector)

--- a/packages/ai-angular/src/inject-generation.ts
+++ b/packages/ai-angular/src/inject-generation.ts
@@ -18,7 +18,7 @@ import type {
   GenerationClientOptions,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 import type { ReactiveOption } from './internal/to-reactive'
 
@@ -68,18 +68,26 @@ export interface InjectGenerationResult<TOutput> {
   reset: () => void
 }
 
+// `TTransformed` infers from the `onResult` return position (a covariant
+// inference site that works even for an optional nested property), which types
+// the callback parameter as `TResult` and narrows `result`. Inferring the
+// whole callback as a defaulted type parameter instead collapses to the
+// default, leaving the parameter `any` — a hard error under `strict`. See
+// issue #848.
 export function injectGeneration<
   TInput extends Record<string, any>,
   TResult,
-  TOnResult extends ((result: TResult) => any) | undefined = undefined,
+  TTransformed = void,
 >(
   options: Omit<InjectGenerationOptions<TInput, TResult>, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TResult) => TTransformed
   },
-): InjectGenerationResult<InferGenerationOutput<TResult, TOnResult>> {
+): InjectGenerationResult<
+  InferGenerationOutputFromReturn<TResult, TTransformed>
+> {
   assertInInjectionContext(injectGeneration)
 
-  type TOutput = InferGenerationOutput<TResult, TOnResult>
+  type TOutput = InferGenerationOutputFromReturn<TResult, TTransformed>
 
   const destroyRef = inject(DestroyRef)
   const injector = inject(Injector)
@@ -102,7 +110,12 @@ export function injectGeneration<
       framework: 'angular',
       hookName: 'injectGeneration',
     },
-    onResult: (r: TResult) => options.onResult?.(r),
+    // The transform's raw return type (`TTransformed`) and the stored output
+    // (`TOutput`, with null/void/undefined stripped) are identical at runtime;
+    // the cast bridges the relationship that the conditional type hides.
+    onResult: ((r: TResult) => options.onResult?.(r)) as (
+      result: TResult,
+    ) => TOutput | null | void,
     onError: (e: Error) => options.onError?.(e),
     onProgress: (p: number, m?: string) => options.onProgress?.(p, m),
     onChunk: (c: StreamChunk) => options.onChunk?.(c),

--- a/packages/ai-angular/src/inject-summarize.ts
+++ b/packages/ai-angular/src/inject-summarize.ts
@@ -39,10 +39,12 @@ export function injectSummarize<TTransformed = void>(
     outputKind: 'text' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    injectGeneration<SummarizeGenerateInput, SummarizationResult, TTransformed>({
-      ...options,
-      devtools,
-    })
+    injectGeneration<SummarizeGenerateInput, SummarizationResult, TTransformed>(
+      {
+        ...options,
+        devtools,
+      },
+    )
   return {
     generate: generate as (input: SummarizeGenerateInput) => Promise<void>,
     result,

--- a/packages/ai-angular/src/inject-summarize.ts
+++ b/packages/ai-angular/src/inject-summarize.ts
@@ -3,7 +3,7 @@ import type { Signal } from '@angular/core'
 import type { SummarizationResult } from '@tanstack/ai'
 import type {
   GenerationClientState,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   SummarizeGenerateInput,
 } from '@tanstack/ai-client'
 import type { InjectGenerationOptions } from './inject-generation'
@@ -25,15 +25,12 @@ export interface InjectSummarizeResult<TOutput = SummarizationResult> {
   reset: () => void
 }
 
-export function injectSummarize<
-  TOnResult extends ((result: SummarizationResult) => any) | undefined =
-    undefined,
->(
+export function injectSummarize<TTransformed = void>(
   options: Omit<InjectSummarizeOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: SummarizationResult) => TTransformed
   },
 ): InjectSummarizeResult<
-  InferGenerationOutput<SummarizationResult, TOnResult>
+  InferGenerationOutputFromReturn<SummarizationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -42,7 +39,7 @@ export function injectSummarize<
     outputKind: 'text' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    injectGeneration<SummarizeGenerateInput, SummarizationResult, TOnResult>({
+    injectGeneration<SummarizeGenerateInput, SummarizationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-angular/src/inject-transcription.ts
+++ b/packages/ai-angular/src/inject-transcription.ts
@@ -3,7 +3,7 @@ import type { Signal } from '@angular/core'
 import type { TranscriptionResult } from '@tanstack/ai'
 import type {
   GenerationClientState,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   TranscriptionGenerateInput,
 } from '@tanstack/ai-client'
 import type { InjectGenerationOptions } from './inject-generation'
@@ -29,15 +29,12 @@ export interface InjectTranscriptionResult<TOutput = TranscriptionResult> {
   reset: () => void
 }
 
-export function injectTranscription<
-  TOnResult extends ((result: TranscriptionResult) => any) | undefined =
-    undefined,
->(
+export function injectTranscription<TTransformed = void>(
   options: Omit<InjectTranscriptionOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TranscriptionResult) => TTransformed
   },
 ): InjectTranscriptionResult<
-  InferGenerationOutput<TranscriptionResult, TOnResult>
+  InferGenerationOutputFromReturn<TranscriptionResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -49,7 +46,7 @@ export function injectTranscription<
     injectGeneration<
       TranscriptionGenerateInput,
       TranscriptionResult,
-      TOnResult
+      TTransformed
     >({
       ...options,
       devtools,

--- a/packages/ai-angular/tests/inject-generation-types.test.ts
+++ b/packages/ai-angular/tests/inject-generation-types.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Type-level tests for the generation injectables' `onResult` transform
+ * inference (issue #848). `TTransformed` infers from the `onResult` return
+ * position — a covariant inference site that works even for an optional nested
+ * property — which contextually types the callback parameter as the raw result
+ * and narrows `result` to the transform's return. (Inferring the whole callback
+ * as a defaulted type parameter instead collapses to its default, leaving the
+ * parameter `any`.) These are pure compile-time assertions — the scenario
+ * functions are never executed (the inject* helpers require an injection
+ * context at runtime), so `expectTypeOf` runs as a no-op and `tsc`
+ * (`test:types`) is what validates them.
+ */
+
+import { describe, expectTypeOf, it } from 'vitest'
+import { injectGeneration } from '../src/inject-generation'
+import { injectTranscription } from '../src/inject-transcription'
+import { injectGenerateSpeech } from '../src/inject-generate-speech'
+import type { TTSResult, TranscriptionResult } from '@tanstack/ai'
+
+describe('generation onResult inference (#848)', () => {
+  describe('base injectGeneration', () => {
+    it('infers TResult from the fetcher and narrows result to the transform return', () => {
+      function _scenario() {
+        const api = injectGeneration({
+          fetcher: async () => ({ id: '1', audio: 'base64data' }),
+          onResult: (raw) => ({ playable: raw.audio.length > 0 }),
+        })
+        // `raw` is contextually typed from the fetcher; `result` narrows to the
+        // transform's return type — no explicit type arguments needed.
+        expectTypeOf(api.result()).toEqualTypeOf<{ playable: boolean } | null>()
+      }
+      void _scenario
+    })
+
+    it('keeps the raw result type when no onResult is provided', () => {
+      function _scenario() {
+        const api = injectGeneration({
+          fetcher: async () => ({ id: '1', text: 'hi' }),
+        })
+        expectTypeOf(api.result()).toEqualTypeOf<{
+          id: string
+          text: string
+        } | null>()
+      }
+      void _scenario
+    })
+
+    it('infers TResult from an annotated onResult parameter in connection-only mode', () => {
+      function _scenario() {
+        type StreamResult = { id: string; images: Array<string> }
+        // The connection adapter is untyped, but annotating the `onResult`
+        // parameter gives the base hook a site to infer `TResult` from (it
+        // appears directly in the callback parameter position) — no explicit
+        // type arguments needed.
+        const api = injectGeneration({
+          connection: undefined as any,
+          onResult: (raw: StreamResult) => ({ count: raw.images.length }),
+        })
+        expectTypeOf(api.result()).toEqualTypeOf<{ count: number } | null>()
+      }
+      void _scenario
+    })
+  })
+
+  describe('wrapper hooks', () => {
+    it('narrows the wrapper result type to the transform return', () => {
+      function _scenario() {
+        const api = injectTranscription({
+          fetcher: async () => ({ id: '1', text: 'hi', model: 'whisper-1' }),
+          onResult: (res) => res.text,
+        })
+        expectTypeOf(api.result()).toEqualTypeOf<string | null>()
+      }
+      void _scenario
+    })
+
+    it('infers the raw result type when no onResult is provided', () => {
+      function _scenario() {
+        const api = injectTranscription({
+          fetcher: async () => ({ id: '1', text: 'hi', model: 'whisper-1' }),
+        })
+        expectTypeOf(api.result()).toEqualTypeOf<TranscriptionResult | null>()
+      }
+      void _scenario
+    })
+
+    it('narrows injectGenerateSpeech result to the transform return', () => {
+      function _scenario() {
+        const mockTTSResult: TTSResult = {
+          id: '1',
+          model: 'tts-1',
+          audio: 'base64audio',
+          format: 'mp3',
+          contentType: 'audio/mpeg',
+        }
+        const api = injectGenerateSpeech({
+          fetcher: async () => mockTTSResult,
+          onResult: (raw) => ({
+            audioUrl: `data:${raw.contentType};base64,${raw.audio}`,
+          }),
+        })
+        expectTypeOf(api.result()).toEqualTypeOf<{ audioUrl: string } | null>()
+      }
+      void _scenario
+    })
+
+    it('keeps the raw result type for injectGenerateSpeech without onResult', () => {
+      function _scenario() {
+        const api = injectGenerateSpeech({
+          fetcher: async () => undefined as unknown as TTSResult,
+        })
+        expectTypeOf(api.result()).toEqualTypeOf<TTSResult | null>()
+      }
+      void _scenario
+    })
+  })
+})

--- a/packages/ai-angular/tests/inject-generation.test.ts
+++ b/packages/ai-angular/tests/inject-generation.test.ts
@@ -54,4 +54,18 @@ describe('injectGeneration', () => {
   it('throws without connection or fetcher', () => {
     expect(() => renderInjectGeneration({})).toThrow()
   })
+
+  it('transforms the result when onResult returns a value', async () => {
+    const { result, flush } = renderInjectGeneration({
+      fetcher: async () => ({ id: '1', audio: 'base64data' }),
+      onResult: (raw: { id: string; audio: string }) => ({
+        playable: raw.audio.length > 0,
+      }),
+    })
+
+    await result.generate({ prompt: 'x' })
+    flush()
+    expect(result.result()).toEqual({ playable: true })
+    expect(result.status()).toBe('success')
+  })
 })

--- a/packages/ai-client/src/generation-types.ts
+++ b/packages/ai-client/src/generation-types.ts
@@ -11,7 +11,29 @@ import type {
 // ===========================
 
 /**
- * Infers the output type from an `onResult` callback's return type.
+ * Maps an `onResult` transform's raw return type to the stored output type.
+ *
+ * - A concrete return (excluding null/void/undefined) becomes the output type.
+ * - A return of only null/void/undefined falls back to TResult (the transform
+ *   reacted to the result or chose to keep it, rather than replacing it).
+ *
+ * Hooks infer `TReturn` directly from the `onResult` return position — a
+ * covariant inference site that works even for an optional nested property —
+ * which both contextually types the callback parameter as `TResult` and
+ * narrows `result`. See issue #848.
+ *
+ * @template TResult - The raw result type from the generation
+ * @template TReturn - The transform's return type (defaults to `void` when no
+ *   transform is provided)
+ */
+export type InferGenerationOutputFromReturn<TResult, TReturn> = [
+  Exclude<TReturn, null | void | undefined>,
+] extends [never]
+  ? TResult
+  : Exclude<TReturn, null | void | undefined>
+
+/**
+ * Infers the output type from an `onResult` callback's type.
  *
  * - If the callback returns a concrete type (excluding null/void/undefined), uses that type.
  * - If the callback only returns null/void/undefined, or is not provided, falls back to TResult.
@@ -22,9 +44,7 @@ import type {
 export type InferGenerationOutput<TResult, TFn> = TFn extends (
   result: any,
 ) => infer R
-  ? [Exclude<R, null | void | undefined>] extends [never]
-    ? TResult
-    : Exclude<R, null | void | undefined>
+  ? InferGenerationOutputFromReturn<TResult, R>
   : TResult
 
 // ===========================

--- a/packages/ai-client/src/index.ts
+++ b/packages/ai-client/src/index.ts
@@ -37,6 +37,7 @@ export type {
 // Generation client types
 export type {
   InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   GenerationClientState,
   GenerationClientOptions,
   GenerationFetcher,

--- a/packages/ai-react/src/use-generate-audio.ts
+++ b/packages/ai-react/src/use-generate-audio.ts
@@ -6,7 +6,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 
 /**
@@ -93,15 +93,12 @@ export interface UseGenerateAudioReturn<TOutput = AudioGenerationResult> {
  * }
  * ```
  */
-export function useGenerateAudio<
-  TOnResult extends ((result: AudioGenerationResult) => any) | undefined =
-    undefined,
->(
+export function useGenerateAudio<TTransformed = void>(
   options: Omit<UseGenerateAudioOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: AudioGenerationResult) => TTransformed
   },
 ): UseGenerateAudioReturn<
-  InferGenerationOutput<AudioGenerationResult, TOnResult>
+  InferGenerationOutputFromReturn<AudioGenerationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -110,7 +107,7 @@ export function useGenerateAudio<
     outputKind: 'audio' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<AudioGenerateInput, AudioGenerationResult, TOnResult>({
+    useGeneration<AudioGenerateInput, AudioGenerationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-react/src/use-generate-image.ts
+++ b/packages/ai-react/src/use-generate-image.ts
@@ -6,7 +6,7 @@ import type {
   GenerationClientState,
   GenerationFetcher,
   ImageGenerateInput,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 
 /**
@@ -95,15 +95,12 @@ export interface UseGenerateImageReturn<TOutput = ImageGenerationResult> {
  * }
  * ```
  */
-export function useGenerateImage<
-  TOnResult extends ((result: ImageGenerationResult) => any) | undefined =
-    undefined,
->(
+export function useGenerateImage<TTransformed = void>(
   options: Omit<UseGenerateImageOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: ImageGenerationResult) => TTransformed
   },
 ): UseGenerateImageReturn<
-  InferGenerationOutput<ImageGenerationResult, TOnResult>
+  InferGenerationOutputFromReturn<ImageGenerationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -112,7 +109,7 @@ export function useGenerateImage<
     outputKind: 'image' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<ImageGenerateInput, ImageGenerationResult, TOnResult>({
+    useGeneration<ImageGenerateInput, ImageGenerationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-react/src/use-generate-speech.ts
+++ b/packages/ai-react/src/use-generate-speech.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   SpeechGenerateInput,
 } from '@tanstack/ai-client'
 
@@ -89,13 +89,13 @@ export interface UseGenerateSpeechReturn<TOutput = TTSResult> {
  * }
  * ```
  */
-export function useGenerateSpeech<
-  TOnResult extends ((result: TTSResult) => any) | undefined = undefined,
->(
+export function useGenerateSpeech<TTransformed = void>(
   options: Omit<UseGenerateSpeechOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TTSResult) => TTransformed
   },
-): UseGenerateSpeechReturn<InferGenerationOutput<TTSResult, TOnResult>> {
+): UseGenerateSpeechReturn<
+  InferGenerationOutputFromReturn<TTSResult, TTransformed>
+> {
   const devtools = {
     ...options.devtools,
     framework: 'react',
@@ -103,7 +103,7 @@ export function useGenerateSpeech<
     outputKind: 'audio' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<SpeechGenerateInput, TTSResult, TOnResult>({
+    useGeneration<SpeechGenerateInput, TTSResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-react/src/use-generate-video.ts
+++ b/packages/ai-react/src/use-generate-video.ts
@@ -7,7 +7,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   VideoGenerateInput,
   VideoGenerateResult,
   VideoStatusInfo,
@@ -104,17 +104,20 @@ export interface UseGenerateVideoReturn<TOutput = VideoGenerateResult> {
  * }
  * ```
  */
-export function useGenerateVideo<
-  TOnResult extends ((result: VideoGenerateResult) => any) | undefined =
-    undefined,
->(
+// `TTransformed` infers from the `onResult` return position so the callback
+// parameter is typed as `VideoGenerateResult` and `result` narrows to the
+// transform's return. See issue #848.
+export function useGenerateVideo<TTransformed = void>(
   options: Omit<UseGenerateVideoOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: VideoGenerateResult) => TTransformed
   },
 ): UseGenerateVideoReturn<
-  InferGenerationOutput<VideoGenerateResult, TOnResult>
+  InferGenerationOutputFromReturn<VideoGenerateResult, TTransformed>
 > {
-  type TOutput = InferGenerationOutput<VideoGenerateResult, TOnResult>
+  type TOutput = InferGenerationOutputFromReturn<
+    VideoGenerateResult,
+    TTransformed
+  >
   const hookId = useId()
   const clientId = options.id || hookId
 
@@ -146,7 +149,13 @@ export function useGenerateVideo<
         hookName: 'useGenerateVideo',
         outputKind: 'video' as const,
       },
-      onResult: (r: VideoGenerateResult) => optionsRef.current.onResult?.(r),
+      // The transform's raw return type (`TTransformed`) and the stored output
+      // (`TOutput`, with null/void/undefined stripped) are identical at runtime;
+      // the cast bridges the relationship that the conditional type hides.
+      onResult: ((r: VideoGenerateResult) =>
+        optionsRef.current.onResult?.(r)) as (
+        result: VideoGenerateResult,
+      ) => TOutput | null | void,
       onError: (e: Error) => {
         optionsRef.current.onError?.(e)
       },

--- a/packages/ai-react/src/use-generation.ts
+++ b/packages/ai-react/src/use-generation.ts
@@ -8,7 +8,7 @@ import type {
   GenerationClientOptions,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 
 /**
@@ -88,16 +88,22 @@ export interface UseGenerationReturn<TOutput> {
  * await generate({ prompt: 'Hello' })
  * ```
  */
+// `TTransformed` infers from the `onResult` return position (a covariant
+// inference site that works even for an optional nested property), which types
+// the callback parameter as `TResult` and narrows `result`. Inferring the
+// whole callback as a defaulted type parameter instead collapses to the
+// default, leaving the parameter `any` — a hard error under `strict`. See
+// issue #848.
 export function useGeneration<
   TInput extends Record<string, any>,
   TResult,
-  TOnResult extends ((result: TResult) => any) | undefined = undefined,
+  TTransformed = void,
 >(
   options: Omit<UseGenerationOptions<TInput, TResult>, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TResult) => TTransformed
   },
-): UseGenerationReturn<InferGenerationOutput<TResult, TOnResult>> {
-  type TOutput = InferGenerationOutput<TResult, TOnResult>
+): UseGenerationReturn<InferGenerationOutputFromReturn<TResult, TTransformed>> {
+  type TOutput = InferGenerationOutputFromReturn<TResult, TTransformed>
   const hookId = useId()
   const clientId = options.id || hookId
 
@@ -125,7 +131,12 @@ export function useGeneration<
         framework: 'react',
         ...opts.devtools,
       },
-      onResult: (r: TResult) => optionsRef.current.onResult?.(r),
+      // The transform's raw return type (`TTransformed`) and the stored output
+      // (`TOutput`, with null/void/undefined stripped) are identical at runtime;
+      // the cast bridges the relationship that the conditional type hides.
+      onResult: ((r: TResult) => optionsRef.current.onResult?.(r)) as (
+        result: TResult,
+      ) => TOutput | null | void,
       onError: (e: Error) => {
         optionsRef.current.onError?.(e)
       },

--- a/packages/ai-react/src/use-summarize.ts
+++ b/packages/ai-react/src/use-summarize.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   SummarizeGenerateInput,
 } from '@tanstack/ai-client'
 
@@ -92,14 +92,13 @@ export interface UseSummarizeReturn<TOutput = SummarizationResult> {
  * }
  * ```
  */
-export function useSummarize<
-  TOnResult extends ((result: SummarizationResult) => any) | undefined =
-    undefined,
->(
+export function useSummarize<TTransformed = void>(
   options: Omit<UseSummarizeOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: SummarizationResult) => TTransformed
   },
-): UseSummarizeReturn<InferGenerationOutput<SummarizationResult, TOnResult>> {
+): UseSummarizeReturn<
+  InferGenerationOutputFromReturn<SummarizationResult, TTransformed>
+> {
   const devtools = {
     ...options.devtools,
     framework: 'react',
@@ -107,7 +106,7 @@ export function useSummarize<
     outputKind: 'text' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<SummarizeGenerateInput, SummarizationResult, TOnResult>({
+    useGeneration<SummarizeGenerateInput, SummarizationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-react/src/use-transcription.ts
+++ b/packages/ai-react/src/use-transcription.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   TranscriptionGenerateInput,
 } from '@tanstack/ai-client'
 
@@ -97,15 +97,12 @@ export interface UseTranscriptionReturn<TOutput = TranscriptionResult> {
  * }
  * ```
  */
-export function useTranscription<
-  TOnResult extends ((result: TranscriptionResult) => any) | undefined =
-    undefined,
->(
+export function useTranscription<TTransformed = void>(
   options: Omit<UseTranscriptionOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TranscriptionResult) => TTransformed
   },
 ): UseTranscriptionReturn<
-  InferGenerationOutput<TranscriptionResult, TOnResult>
+  InferGenerationOutputFromReturn<TranscriptionResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -114,10 +111,9 @@ export function useTranscription<
     outputKind: 'text' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<TranscriptionGenerateInput, TranscriptionResult, TOnResult>({
-      ...options,
-      devtools,
-    })
+    useGeneration<TranscriptionGenerateInput, TranscriptionResult, TTransformed>(
+      { ...options, devtools },
+    )
 
   return {
     generate: generate as (input: TranscriptionGenerateInput) => Promise<void>,

--- a/packages/ai-react/src/use-transcription.ts
+++ b/packages/ai-react/src/use-transcription.ts
@@ -111,9 +111,11 @@ export function useTranscription<TTransformed = void>(
     outputKind: 'text' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<TranscriptionGenerateInput, TranscriptionResult, TTransformed>(
-      { ...options, devtools },
-    )
+    useGeneration<
+      TranscriptionGenerateInput,
+      TranscriptionResult,
+      TTransformed
+    >({ ...options, devtools })
 
   return {
     generate: generate as (input: TranscriptionGenerateInput) => Promise<void>,

--- a/packages/ai-react/tests/use-generation.test.ts
+++ b/packages/ai-react/tests/use-generation.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { useGeneration } from '../src/use-generation'
 import { useGenerateImage } from '../src/use-generate-image'
 import { useGenerateAudio } from '../src/use-generate-audio'
@@ -8,7 +8,11 @@ import { useTranscription } from '../src/use-transcription'
 import { useSummarize } from '../src/use-summarize'
 import { useGenerateVideo } from '../src/use-generate-video'
 import { createMockConnectionAdapter } from './test-utils'
-import type { StreamChunk, TTSResult } from '@tanstack/ai'
+import type {
+  StreamChunk,
+  TTSResult,
+  TranscriptionResult,
+} from '@tanstack/ai'
 import { EventType } from '@tanstack/ai'
 
 // Helper to create generation stream chunks
@@ -685,20 +689,18 @@ describe('useGenerateVideo', () => {
 
 describe('onResult transform', () => {
   it('should transform result when onResult returns a value (fetcher)', async () => {
-    // useGeneration's TOnResult generic defaults to `undefined` if not pinned
-    // (the standard Omit-plus-callback inference pattern doesn't recover it),
-    // so the callback parameter type can't infer from the fetcher's return.
-    // Pin TResult and TOnResult explicitly — no cast needed.
-    type FetcherResult = { id: string; audio: string }
-    const onResult = (raw: FetcherResult) => ({
-      playable: raw.audio.length > 0,
-    })
+    // Inference (issue #848): `onResult`'s parameter is contextually typed from
+    // the fetcher's return, and `result` narrows to the transform's return —
+    // no explicit type arguments needed.
     const { result } = renderHook(() =>
-      useGeneration<Record<string, any>, FetcherResult, typeof onResult>({
+      useGeneration({
         fetcher: async () => ({ id: '1', audio: 'base64data' }),
-        onResult,
+        onResult: (raw) => ({ playable: raw.audio.length > 0 }),
       }),
     )
+    expectTypeOf(result.current.result).toEqualTypeOf<{
+      playable: boolean
+    } | null>()
 
     await act(async () => {
       await result.current.generate({ prompt: 'test' })
@@ -749,16 +751,18 @@ describe('onResult transform', () => {
     const chunks = createGenerationChunks(mockResult)
     const adapter = createMockConnectionAdapter({ chunks })
 
-    // The stream chunk's `value` payload is `unknown` at the type level
-    // (CUSTOM events are opaque), so TResult cannot infer from `adapter`. Pin
-    // TResult and TOnResult explicitly via the generics — no cast needed.
-    const onResult = (raw: StreamResult) => ({ count: raw.images.length })
+    // `connection` is untyped, but annotating the `onResult` parameter gives the
+    // base hook a site to infer `TResult` from (it appears directly in the
+    // callback parameter position) — no explicit type arguments needed.
     const { result } = renderHook(() =>
-      useGeneration<Record<string, any>, StreamResult, typeof onResult>({
+      useGeneration({
         connection: adapter,
-        onResult,
+        onResult: (raw: StreamResult) => ({ count: raw.images.length }),
       }),
     )
+    expectTypeOf(result.current.result).toEqualTypeOf<{
+      count: number
+    } | null>()
 
     await act(async () => {
       await result.current.generate({ prompt: 'test' })
@@ -776,17 +780,20 @@ describe('onResult transform', () => {
       contentType: 'audio/mpeg',
     }
 
-    // The hook's TOnResult generic defaults to undefined, so let's pin the
-    // callback type explicitly. TResult here is the concrete TTSResult.
-    const onResult = (raw: TTSResult) => ({
-      audioUrl: `data:${raw.contentType};base64,${raw.audio}`,
-    })
+    // Inference (issue #848): the wrapper hooks infer the output type from
+    // `onResult` with no explicit type argument. `raw` is contextually typed
+    // as `TTSResult`.
     const { result } = renderHook(() =>
-      useGenerateSpeech<typeof onResult>({
+      useGenerateSpeech({
         fetcher: async () => mockTTSResult,
-        onResult,
+        onResult: (raw) => ({
+          audioUrl: `data:${raw.contentType};base64,${raw.audio}`,
+        }),
       }),
     )
+    expectTypeOf(result.current.result).toEqualTypeOf<{
+      audioUrl: string
+    } | null>()
 
     await act(async () => {
       await result.current.generate({ text: 'Hello' })
@@ -795,5 +802,25 @@ describe('onResult transform', () => {
     expect(result.current.result).toEqual({
       audioUrl: 'data:audio/mpeg;base64,base64audio',
     })
+  })
+
+  it('infers the raw result type when no onResult is provided', () => {
+    const { result } = renderHook(() =>
+      useTranscription({
+        fetcher: async () => ({ id: '1', text: 'hi', model: 'whisper-1' }),
+      }),
+    )
+    // Without a transform, `result` stays the raw TranscriptionResult.
+    expectTypeOf(result.current.result).toEqualTypeOf<TranscriptionResult | null>()
+  })
+
+  it('narrows the wrapper result type to the transform return', () => {
+    const { result } = renderHook(() =>
+      useTranscription({
+        fetcher: async () => ({ id: '1', text: 'hi', model: 'whisper-1' }),
+        onResult: (res) => res.text,
+      }),
+    )
+    expectTypeOf(result.current.result).toEqualTypeOf<string | null>()
   })
 })

--- a/packages/ai-react/tests/use-generation.test.ts
+++ b/packages/ai-react/tests/use-generation.test.ts
@@ -8,11 +8,7 @@ import { useTranscription } from '../src/use-transcription'
 import { useSummarize } from '../src/use-summarize'
 import { useGenerateVideo } from '../src/use-generate-video'
 import { createMockConnectionAdapter } from './test-utils'
-import type {
-  StreamChunk,
-  TTSResult,
-  TranscriptionResult,
-} from '@tanstack/ai'
+import type { StreamChunk, TTSResult, TranscriptionResult } from '@tanstack/ai'
 import { EventType } from '@tanstack/ai'
 
 // Helper to create generation stream chunks
@@ -811,7 +807,9 @@ describe('onResult transform', () => {
       }),
     )
     // Without a transform, `result` stays the raw TranscriptionResult.
-    expectTypeOf(result.current.result).toEqualTypeOf<TranscriptionResult | null>()
+    expectTypeOf(
+      result.current.result,
+    ).toEqualTypeOf<TranscriptionResult | null>()
   })
 
   it('narrows the wrapper result type to the transform return', () => {

--- a/packages/ai-solid/src/use-generate-audio.ts
+++ b/packages/ai-solid/src/use-generate-audio.ts
@@ -6,7 +6,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 import type { Accessor } from 'solid-js'
 
@@ -88,15 +88,12 @@ export interface UseGenerateAudioReturn<TOutput = AudioGenerationResult> {
  * }
  * ```
  */
-export function useGenerateAudio<
-  TOnResult extends ((result: AudioGenerationResult) => any) | undefined =
-    undefined,
->(
+export function useGenerateAudio<TTransformed = void>(
   options: Omit<UseGenerateAudioOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: AudioGenerationResult) => TTransformed
   },
 ): UseGenerateAudioReturn<
-  InferGenerationOutput<AudioGenerationResult, TOnResult>
+  InferGenerationOutputFromReturn<AudioGenerationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -105,7 +102,7 @@ export function useGenerateAudio<
     outputKind: 'audio' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<AudioGenerateInput, AudioGenerationResult, TOnResult>({
+    useGeneration<AudioGenerateInput, AudioGenerationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-solid/src/use-generate-image.ts
+++ b/packages/ai-solid/src/use-generate-image.ts
@@ -6,7 +6,7 @@ import type {
   GenerationClientState,
   GenerationFetcher,
   ImageGenerateInput,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 import type { Accessor } from 'solid-js'
 
@@ -96,15 +96,12 @@ export interface UseGenerateImageReturn<TOutput = ImageGenerationResult> {
  * }
  * ```
  */
-export function useGenerateImage<
-  TOnResult extends ((result: ImageGenerationResult) => any) | undefined =
-    undefined,
->(
+export function useGenerateImage<TTransformed = void>(
   options: Omit<UseGenerateImageOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: ImageGenerationResult) => TTransformed
   },
 ): UseGenerateImageReturn<
-  InferGenerationOutput<ImageGenerationResult, TOnResult>
+  InferGenerationOutputFromReturn<ImageGenerationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -113,7 +110,7 @@ export function useGenerateImage<
     outputKind: 'image' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<ImageGenerateInput, ImageGenerationResult, TOnResult>({
+    useGeneration<ImageGenerateInput, ImageGenerationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-solid/src/use-generate-speech.ts
+++ b/packages/ai-solid/src/use-generate-speech.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   SpeechGenerateInput,
 } from '@tanstack/ai-client'
 import type { Accessor } from 'solid-js'
@@ -90,13 +90,13 @@ export interface UseGenerateSpeechReturn<TOutput = TTSResult> {
  * }
  * ```
  */
-export function useGenerateSpeech<
-  TOnResult extends ((result: TTSResult) => any) | undefined = undefined,
->(
+export function useGenerateSpeech<TTransformed = void>(
   options: Omit<UseGenerateSpeechOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TTSResult) => TTransformed
   },
-): UseGenerateSpeechReturn<InferGenerationOutput<TTSResult, TOnResult>> {
+): UseGenerateSpeechReturn<
+  InferGenerationOutputFromReturn<TTSResult, TTransformed>
+> {
   const devtools = {
     ...options.devtools,
     framework: 'solid',
@@ -104,7 +104,7 @@ export function useGenerateSpeech<
     outputKind: 'audio' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<SpeechGenerateInput, TTSResult, TOnResult>({
+    useGeneration<SpeechGenerateInput, TTSResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-solid/src/use-generate-video.ts
+++ b/packages/ai-solid/src/use-generate-video.ts
@@ -14,7 +14,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   VideoGenerateInput,
   VideoGenerateResult,
   VideoStatusInfo,
@@ -114,17 +114,20 @@ export interface UseGenerateVideoReturn<TOutput = VideoGenerateResult> {
  * }
  * ```
  */
-export function useGenerateVideo<
-  TOnResult extends ((result: VideoGenerateResult) => any) | undefined =
-    undefined,
->(
+// `TTransformed` infers from the `onResult` return position so the callback
+// parameter is typed as `VideoGenerateResult` and `result` narrows to the
+// transform's return. See issue #848.
+export function useGenerateVideo<TTransformed = void>(
   options: Omit<UseGenerateVideoOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: VideoGenerateResult) => TTransformed
   },
 ): UseGenerateVideoReturn<
-  InferGenerationOutput<VideoGenerateResult, TOnResult>
+  InferGenerationOutputFromReturn<VideoGenerateResult, TTransformed>
 > {
-  type TOutput = InferGenerationOutput<VideoGenerateResult, TOnResult>
+  type TOutput = InferGenerationOutputFromReturn<
+    VideoGenerateResult,
+    TTransformed
+  >
   const hookId = createUniqueId()
   const clientId = options.id || hookId
 
@@ -150,7 +153,12 @@ export function useGenerateVideo<
         hookName: 'useGenerateVideo',
         outputKind: 'video' as const,
       },
-      onResult: (r: VideoGenerateResult) => options.onResult?.(r),
+      // The transform's raw return type (`TTransformed`) and the stored output
+      // (`TOutput`, with null/void/undefined stripped) are identical at runtime;
+      // the cast bridges the relationship that the conditional type hides.
+      onResult: ((r: VideoGenerateResult) => options.onResult?.(r)) as (
+        result: VideoGenerateResult,
+      ) => TOutput | null | void,
       onError: (e: Error) => options.onError?.(e),
       onProgress: (p: number, m?: string) => options.onProgress?.(p, m),
       onChunk: (c: StreamChunk) => options.onChunk?.(c),

--- a/packages/ai-solid/src/use-generation.ts
+++ b/packages/ai-solid/src/use-generation.ts
@@ -15,7 +15,7 @@ import type {
   GenerationClientOptions,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 import type { Accessor } from 'solid-js'
 
@@ -97,16 +97,22 @@ export interface UseGenerationReturn<TOutput> {
  * await generate({ prompt: 'Hello' })
  * ```
  */
+// `TTransformed` infers from the `onResult` return position (a covariant
+// inference site that works even for an optional nested property), which types
+// the callback parameter as `TResult` and narrows `result`. Inferring the
+// whole callback as a defaulted type parameter instead collapses to the
+// default, leaving the parameter `any` — a hard error under `strict`. See
+// issue #848.
 export function useGeneration<
   TInput extends Record<string, any>,
   TResult,
-  TOnResult extends ((result: TResult) => any) | undefined = undefined,
+  TTransformed = void,
 >(
   options: Omit<UseGenerationOptions<TInput, TResult>, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TResult) => TTransformed
   },
-): UseGenerationReturn<InferGenerationOutput<TResult, TOnResult>> {
-  type TOutput = InferGenerationOutput<TResult, TOnResult>
+): UseGenerationReturn<InferGenerationOutputFromReturn<TResult, TTransformed>> {
+  type TOutput = InferGenerationOutputFromReturn<TResult, TTransformed>
   const hookId = createUniqueId()
   const clientId = options.id || hookId
 
@@ -128,7 +134,12 @@ export function useGeneration<
         framework: 'solid',
         hookName: 'useGeneration',
       },
-      onResult: (r: TResult) => options.onResult?.(r),
+      // The transform's raw return type (`TTransformed`) and the stored output
+      // (`TOutput`, with null/void/undefined stripped) are identical at runtime;
+      // the cast bridges the relationship that the conditional type hides.
+      onResult: ((r: TResult) => options.onResult?.(r)) as (
+        result: TResult,
+      ) => TOutput | null | void,
       onError: (e: Error) => options.onError?.(e),
       onProgress: (p: number, m?: string) => options.onProgress?.(p, m),
       onChunk: (c: StreamChunk) => options.onChunk?.(c),

--- a/packages/ai-solid/src/use-summarize.ts
+++ b/packages/ai-solid/src/use-summarize.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   SummarizeGenerateInput,
 } from '@tanstack/ai-client'
 import type { Accessor } from 'solid-js'
@@ -93,14 +93,13 @@ export interface UseSummarizeReturn<TOutput = SummarizationResult> {
  * }
  * ```
  */
-export function useSummarize<
-  TOnResult extends ((result: SummarizationResult) => any) | undefined =
-    undefined,
->(
+export function useSummarize<TTransformed = void>(
   options: Omit<UseSummarizeOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: SummarizationResult) => TTransformed
   },
-): UseSummarizeReturn<InferGenerationOutput<SummarizationResult, TOnResult>> {
+): UseSummarizeReturn<
+  InferGenerationOutputFromReturn<SummarizationResult, TTransformed>
+> {
   const devtools = {
     ...options.devtools,
     framework: 'solid',
@@ -108,7 +107,7 @@ export function useSummarize<
     outputKind: 'text' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<SummarizeGenerateInput, SummarizationResult, TOnResult>({
+    useGeneration<SummarizeGenerateInput, SummarizationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-solid/src/use-transcription.ts
+++ b/packages/ai-solid/src/use-transcription.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   TranscriptionGenerateInput,
 } from '@tanstack/ai-client'
 import type { Accessor } from 'solid-js'
@@ -99,15 +99,12 @@ export interface UseTranscriptionReturn<TOutput = TranscriptionResult> {
  * }
  * ```
  */
-export function useTranscription<
-  TOnResult extends ((result: TranscriptionResult) => any) | undefined =
-    undefined,
->(
+export function useTranscription<TTransformed = void>(
   options: Omit<UseTranscriptionOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TranscriptionResult) => TTransformed
   },
 ): UseTranscriptionReturn<
-  InferGenerationOutput<TranscriptionResult, TOnResult>
+  InferGenerationOutputFromReturn<TranscriptionResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -116,10 +113,9 @@ export function useTranscription<
     outputKind: 'text' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<TranscriptionGenerateInput, TranscriptionResult, TOnResult>({
-      ...options,
-      devtools,
-    })
+    useGeneration<TranscriptionGenerateInput, TranscriptionResult, TTransformed>(
+      { ...options, devtools },
+    )
 
   return {
     generate: generate as (input: TranscriptionGenerateInput) => Promise<void>,

--- a/packages/ai-solid/src/use-transcription.ts
+++ b/packages/ai-solid/src/use-transcription.ts
@@ -113,9 +113,11 @@ export function useTranscription<TTransformed = void>(
     outputKind: 'text' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<TranscriptionGenerateInput, TranscriptionResult, TTransformed>(
-      { ...options, devtools },
-    )
+    useGeneration<
+      TranscriptionGenerateInput,
+      TranscriptionResult,
+      TTransformed
+    >({ ...options, devtools })
 
   return {
     generate: generate as (input: TranscriptionGenerateInput) => Promise<void>,

--- a/packages/ai-solid/tests/use-generation.test.ts
+++ b/packages/ai-solid/tests/use-generation.test.ts
@@ -8,11 +8,7 @@ import { useTranscription } from '../src/use-transcription'
 import { useSummarize } from '../src/use-summarize'
 import { useGenerateVideo } from '../src/use-generate-video'
 import { createMockConnectionAdapter } from './test-utils'
-import type {
-  StreamChunk,
-  TTSResult,
-  TranscriptionResult,
-} from '@tanstack/ai'
+import type { StreamChunk, TTSResult, TranscriptionResult } from '@tanstack/ai'
 import { EventType } from '@tanstack/ai'
 
 // Helper to create generation stream chunks

--- a/packages/ai-solid/tests/use-generation.test.ts
+++ b/packages/ai-solid/tests/use-generation.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@solidjs/testing-library'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { useGeneration } from '../src/use-generation'
 import { useGenerateImage } from '../src/use-generate-image'
 import { useGenerateAudio } from '../src/use-generate-audio'
@@ -8,7 +8,11 @@ import { useTranscription } from '../src/use-transcription'
 import { useSummarize } from '../src/use-summarize'
 import { useGenerateVideo } from '../src/use-generate-video'
 import { createMockConnectionAdapter } from './test-utils'
-import type { StreamChunk } from '@tanstack/ai'
+import type {
+  StreamChunk,
+  TTSResult,
+  TranscriptionResult,
+} from '@tanstack/ai'
 import { EventType } from '@tanstack/ai'
 
 // Helper to create generation stream chunks
@@ -1087,5 +1091,133 @@ describe('useGenerateVideo', () => {
         'useGenerateVideo requires either a connection or fetcher option',
       )
     })
+  })
+})
+
+describe('onResult transform', () => {
+  it('should transform result when onResult returns a value (fetcher)', async () => {
+    // Inference (issue #848): `onResult`'s parameter is contextually typed from
+    // the fetcher's return, and `result` narrows to the transform's return —
+    // no explicit type arguments needed.
+    const { result } = renderHook(() =>
+      useGeneration({
+        fetcher: async () => ({ id: '1', audio: 'base64data' }),
+        onResult: (raw) => ({ playable: raw.audio.length > 0 }),
+      }),
+    )
+    expectTypeOf(result.result()).toEqualTypeOf<{
+      playable: boolean
+    } | null>()
+
+    await result.generate({ prompt: 'test' })
+
+    expect(result.result()).toEqual({ playable: true })
+    expect(result.status()).toBe('success')
+  })
+
+  it('should use raw result when onResult returns void', async () => {
+    const onResult = vi.fn()
+
+    const { result } = renderHook(() =>
+      useGeneration({
+        fetcher: async () => ({ id: '1', data: 'test' }),
+        onResult,
+      }),
+    )
+
+    await result.generate({ prompt: 'test' })
+
+    expect(onResult).toHaveBeenCalledWith({ id: '1', data: 'test' })
+    expect(result.result()).toEqual({ id: '1', data: 'test' })
+  })
+
+  it('should keep previous result when onResult returns null', async () => {
+    const { result } = renderHook(() =>
+      useGeneration({
+        fetcher: async () => ({ id: '1' }),
+        onResult: () => null,
+      }),
+    )
+
+    await result.generate({ prompt: 'test' })
+
+    // null return → keep previous (which was null initially)
+    expect(result.result()).toBeNull()
+    expect(result.status()).toBe('success')
+  })
+
+  it('should transform result from connection stream', async () => {
+    type StreamResult = { id: string; images: Array<string> }
+    const mockResult: StreamResult = { id: '1', images: ['img1', 'img2'] }
+    const chunks = createGenerationChunks(mockResult)
+    const adapter = createMockConnectionAdapter({ chunks })
+
+    // `connection` is untyped, but annotating the `onResult` parameter gives the
+    // base hook a site to infer `TResult` from (it appears directly in the
+    // callback parameter position) — no explicit type arguments needed.
+    const { result } = renderHook(() =>
+      useGeneration({
+        connection: adapter,
+        onResult: (raw: StreamResult) => ({ count: raw.images.length }),
+      }),
+    )
+    expectTypeOf(result.result()).toEqualTypeOf<{
+      count: number
+    } | null>()
+
+    await result.generate({ prompt: 'test' })
+
+    expect(result.result()).toEqual({ count: 2 })
+  })
+
+  it('should work with useGenerateSpeech transform', async () => {
+    const mockTTSResult: TTSResult = {
+      id: '1',
+      model: 'tts-1',
+      audio: 'base64audio',
+      format: 'mp3',
+      contentType: 'audio/mpeg',
+    }
+
+    // Inference (issue #848): the wrapper hooks infer the output type from
+    // `onResult` with no explicit type argument. `raw` is contextually typed
+    // as `TTSResult`.
+    const { result } = renderHook(() =>
+      useGenerateSpeech({
+        fetcher: async () => mockTTSResult,
+        onResult: (raw) => ({
+          audioUrl: `data:${raw.contentType};base64,${raw.audio}`,
+        }),
+      }),
+    )
+    expectTypeOf(result.result()).toEqualTypeOf<{
+      audioUrl: string
+    } | null>()
+
+    await result.generate({ text: 'Hello' })
+
+    expect(result.result()).toEqual({
+      audioUrl: 'data:audio/mpeg;base64,base64audio',
+    })
+  })
+
+  it('infers the raw result type when no onResult is provided', () => {
+    const { result } = renderHook(() =>
+      useTranscription({
+        fetcher: async () => ({ id: '1', text: 'hi', model: 'whisper-1' }),
+      }),
+    )
+    // Without a transform, `result` stays the raw TranscriptionResult.
+    expectTypeOf(result.result()).toEqualTypeOf<TranscriptionResult | null>()
+  })
+
+  it('narrows the wrapper result type to the transform return', () => {
+    const { result } = renderHook(() =>
+      useTranscription({
+        fetcher: async () => ({ id: '1', text: 'hi', model: 'whisper-1' }),
+        onResult: (res) => res.text,
+      }),
+    )
+    expectTypeOf(result.result()).toEqualTypeOf<string | null>()
   })
 })

--- a/packages/ai-svelte/src/create-generate-audio.svelte.ts
+++ b/packages/ai-svelte/src/create-generate-audio.svelte.ts
@@ -6,7 +6,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 
 /**
@@ -91,15 +91,12 @@ export interface CreateGenerateAudioReturn<TOutput = AudioGenerationResult> {
  * </div>
  * ```
  */
-export function createGenerateAudio<
-  TOnResult extends ((result: AudioGenerationResult) => any) | undefined =
-    undefined,
->(
+export function createGenerateAudio<TTransformed = void>(
   options: Omit<CreateGenerateAudioOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: AudioGenerationResult) => TTransformed
   },
 ): CreateGenerateAudioReturn<
-  InferGenerationOutput<AudioGenerationResult, TOnResult>
+  InferGenerationOutputFromReturn<AudioGenerationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -110,7 +107,7 @@ export function createGenerateAudio<
   const gen = createGeneration<
     AudioGenerateInput,
     AudioGenerationResult,
-    TOnResult
+    TTransformed
   >({
     ...options,
     devtools,

--- a/packages/ai-svelte/src/create-generate-image.svelte.ts
+++ b/packages/ai-svelte/src/create-generate-image.svelte.ts
@@ -6,7 +6,7 @@ import type {
   GenerationClientState,
   GenerationFetcher,
   ImageGenerateInput,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 
 /**
@@ -100,15 +100,12 @@ export interface CreateGenerateImageReturn<TOutput = ImageGenerationResult> {
  * </div>
  * ```
  */
-export function createGenerateImage<
-  TOnResult extends ((result: ImageGenerationResult) => any) | undefined =
-    undefined,
->(
+export function createGenerateImage<TTransformed = void>(
   options: Omit<CreateGenerateImageOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: ImageGenerationResult) => TTransformed
   },
 ): CreateGenerateImageReturn<
-  InferGenerationOutput<ImageGenerationResult, TOnResult>
+  InferGenerationOutputFromReturn<ImageGenerationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -119,7 +116,7 @@ export function createGenerateImage<
   const gen = createGeneration<
     ImageGenerateInput,
     ImageGenerationResult,
-    TOnResult
+    TTransformed
   >({
     ...options,
     devtools,

--- a/packages/ai-svelte/src/create-generate-speech.svelte.ts
+++ b/packages/ai-svelte/src/create-generate-speech.svelte.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   SpeechGenerateInput,
 } from '@tanstack/ai-client'
 
@@ -91,20 +91,20 @@ export interface CreateGenerateSpeechReturn<TOutput = TTSResult> {
  * </div>
  * ```
  */
-export function createGenerateSpeech<
-  TOnResult extends ((result: TTSResult) => any) | undefined = undefined,
->(
+export function createGenerateSpeech<TTransformed = void>(
   options: Omit<CreateGenerateSpeechOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TTSResult) => TTransformed
   },
-): CreateGenerateSpeechReturn<InferGenerationOutput<TTSResult, TOnResult>> {
+): CreateGenerateSpeechReturn<
+  InferGenerationOutputFromReturn<TTSResult, TTransformed>
+> {
   const devtools = {
     ...options.devtools,
     framework: 'svelte',
     hookName: 'createGenerateSpeech',
     outputKind: 'audio' as const,
   }
-  const gen = createGeneration<SpeechGenerateInput, TTSResult, TOnResult>({
+  const gen = createGeneration<SpeechGenerateInput, TTSResult, TTransformed>({
     ...options,
     devtools,
   })

--- a/packages/ai-svelte/src/create-generate-video.svelte.ts
+++ b/packages/ai-svelte/src/create-generate-video.svelte.ts
@@ -6,7 +6,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   VideoGenerateInput,
   VideoGenerateResult,
   VideoStatusInfo,
@@ -108,17 +108,20 @@ export interface CreateGenerateVideoReturn<TOutput = VideoGenerateResult> {
  * </div>
  * ```
  */
-export function createGenerateVideo<
-  TOnResult extends ((result: VideoGenerateResult) => any) | undefined =
-    undefined,
->(
+// `TTransformed` infers from the `onResult` return position so the callback
+// parameter is typed as `VideoGenerateResult` and `result` narrows to the
+// transform's return. See issue #848.
+export function createGenerateVideo<TTransformed = void>(
   options: Omit<CreateGenerateVideoOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: VideoGenerateResult) => TTransformed
   },
 ): CreateGenerateVideoReturn<
-  InferGenerationOutput<VideoGenerateResult, TOnResult>
+  InferGenerationOutputFromReturn<VideoGenerateResult, TTransformed>
 > {
-  type TOutput = InferGenerationOutput<VideoGenerateResult, TOnResult>
+  type TOutput = InferGenerationOutputFromReturn<
+    VideoGenerateResult,
+    TTransformed
+  >
   const clientId =
     options.id ||
     `video-${Date.now()}-${Math.random().toString(36).substring(7)}`
@@ -145,7 +148,12 @@ export function createGenerateVideo<
       hookName: 'createGenerateVideo',
       outputKind: 'video' as const,
     },
-    onResult: (r: VideoGenerateResult) => options.onResult?.(r),
+    // The transform's raw return type (`TTransformed`) and the stored output
+    // (`TOutput`, with null/void/undefined stripped) are identical at runtime;
+    // the cast bridges the relationship that the conditional type hides.
+    onResult: ((r: VideoGenerateResult) => options.onResult?.(r)) as (
+      result: VideoGenerateResult,
+    ) => TOutput | null | void,
     onError: (e: Error) => options.onError?.(e),
     onProgress: (p: number, m?: string) => options.onProgress?.(p, m),
     onChunk: (c: StreamChunk) => options.onChunk?.(c),

--- a/packages/ai-svelte/src/create-generation.svelte.ts
+++ b/packages/ai-svelte/src/create-generation.svelte.ts
@@ -7,7 +7,7 @@ import type {
   GenerationClientOptions,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 
 /**
@@ -103,16 +103,24 @@ export interface CreateGenerationReturn<TOutput> {
  * </div>
  * ```
  */
+// `TTransformed` infers from the `onResult` return position (a covariant
+// inference site that works even for an optional nested property), which types
+// the callback parameter as `TResult` and narrows `result`. Inferring the
+// whole callback as a defaulted type parameter instead collapses to the
+// default, leaving the parameter `any` — a hard error under `strict`. See
+// issue #848.
 export function createGeneration<
   TInput extends Record<string, any>,
   TResult,
-  TOnResult extends ((result: TResult) => any) | undefined = undefined,
+  TTransformed = void,
 >(
   options: Omit<CreateGenerationOptions<TInput, TResult>, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TResult) => TTransformed
   },
-): CreateGenerationReturn<InferGenerationOutput<TResult, TOnResult>> {
-  type TOutput = InferGenerationOutput<TResult, TOnResult>
+): CreateGenerationReturn<
+  InferGenerationOutputFromReturn<TResult, TTransformed>
+> {
+  type TOutput = InferGenerationOutputFromReturn<TResult, TTransformed>
   const clientId =
     options.id || `gen-${Date.now()}-${Math.random().toString(36).substring(7)}`
 
@@ -136,7 +144,12 @@ export function createGeneration<
       framework: 'svelte',
       hookName: 'createGeneration',
     },
-    onResult: (r: TResult) => options.onResult?.(r),
+    // The transform's raw return type (`TTransformed`) and the stored output
+    // (`TOutput`, with null/void/undefined stripped) are identical at runtime;
+    // the cast bridges the relationship that the conditional type hides.
+    onResult: ((r: TResult) => options.onResult?.(r)) as (
+      result: TResult,
+    ) => TOutput | null | void,
     onError: (e: Error) => options.onError?.(e),
     onProgress: (p: number, m?: string) => options.onProgress?.(p, m),
     onChunk: (c: StreamChunk) => options.onChunk?.(c),

--- a/packages/ai-svelte/src/create-summarize.svelte.ts
+++ b/packages/ai-svelte/src/create-summarize.svelte.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   SummarizeGenerateInput,
 } from '@tanstack/ai-client'
 
@@ -95,15 +95,12 @@ export interface CreateSummarizeReturn<TOutput = SummarizationResult> {
  * </div>
  * ```
  */
-export function createSummarize<
-  TOnResult extends ((result: SummarizationResult) => any) | undefined =
-    undefined,
->(
+export function createSummarize<TTransformed = void>(
   options: Omit<CreateSummarizeOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: SummarizationResult) => TTransformed
   },
 ): CreateSummarizeReturn<
-  InferGenerationOutput<SummarizationResult, TOnResult>
+  InferGenerationOutputFromReturn<SummarizationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -114,7 +111,7 @@ export function createSummarize<
   const gen = createGeneration<
     SummarizeGenerateInput,
     SummarizationResult,
-    TOnResult
+    TTransformed
   >({
     ...options,
     devtools,

--- a/packages/ai-svelte/src/create-transcription.svelte.ts
+++ b/packages/ai-svelte/src/create-transcription.svelte.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   TranscriptionGenerateInput,
 } from '@tanstack/ai-client'
 
@@ -100,15 +100,12 @@ export interface CreateTranscriptionReturn<TOutput = TranscriptionResult> {
  * </div>
  * ```
  */
-export function createTranscription<
-  TOnResult extends ((result: TranscriptionResult) => any) | undefined =
-    undefined,
->(
+export function createTranscription<TTransformed = void>(
   options: Omit<CreateTranscriptionOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TranscriptionResult) => TTransformed
   },
 ): CreateTranscriptionReturn<
-  InferGenerationOutput<TranscriptionResult, TOnResult>
+  InferGenerationOutputFromReturn<TranscriptionResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -119,7 +116,7 @@ export function createTranscription<
   const gen = createGeneration<
     TranscriptionGenerateInput,
     TranscriptionResult,
-    TOnResult
+    TTransformed
   >({
     ...options,
     devtools,

--- a/packages/ai-svelte/tests/create-generation.test.ts
+++ b/packages/ai-svelte/tests/create-generation.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { createGeneration } from '../src/create-generation.svelte'
 import { createGenerateImage } from '../src/create-generate-image.svelte'
 import { createGenerateSpeech } from '../src/create-generate-speech.svelte'
@@ -7,6 +7,7 @@ import { createSummarize } from '../src/create-summarize.svelte'
 import { createGenerateVideo } from '../src/create-generate-video.svelte'
 import { createMockConnectionAdapter } from './test-utils'
 import { EventType, type StreamChunk } from '@tanstack/ai'
+import type { TTSResult, TranscriptionResult } from '@tanstack/ai'
 
 // Helper to create generation stream chunks
 function createGenerationChunks(result: unknown): Array<StreamChunk> {
@@ -665,5 +666,117 @@ describe('createGenerateVideo', () => {
     expect(typeof gen.stop).toBe('function')
     expect(typeof gen.reset).toBe('function')
     expect(typeof gen.updateBody).toBe('function')
+  })
+})
+
+describe('onResult transform', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should transform result when onResult returns a value (fetcher)', async () => {
+    // Inference (issue #848): `onResult`'s parameter is contextually typed from
+    // the fetcher's return, and `result` narrows to the transform's return —
+    // no explicit type arguments needed.
+    const gen = createGeneration({
+      fetcher: async () => ({ id: '1', audio: 'base64data' }),
+      onResult: (raw) => ({ playable: raw.audio.length > 0 }),
+    })
+    expectTypeOf(gen.result).toEqualTypeOf<{ playable: boolean } | null>()
+
+    await gen.generate({ prompt: 'test' })
+
+    expect(gen.result).toEqual({ playable: true })
+    expect(gen.status).toBe('success')
+  })
+
+  it('should use raw result when onResult returns void', async () => {
+    const onResult = vi.fn()
+
+    const gen = createGeneration({
+      fetcher: async () => ({ id: '1', data: 'test' }),
+      onResult,
+    })
+
+    await gen.generate({ prompt: 'test' })
+
+    expect(onResult).toHaveBeenCalledWith({ id: '1', data: 'test' })
+    expect(gen.result).toEqual({ id: '1', data: 'test' })
+  })
+
+  it('should keep previous result when onResult returns null', async () => {
+    const gen = createGeneration({
+      fetcher: async () => ({ id: '1' }),
+      onResult: () => null,
+    })
+
+    await gen.generate({ prompt: 'test' })
+
+    // null return → keep previous (which was null initially)
+    expect(gen.result).toBeNull()
+    expect(gen.status).toBe('success')
+  })
+
+  it('should transform result from connection stream', async () => {
+    type StreamResult = { id: string; images: Array<string> }
+    const mockResult: StreamResult = { id: '1', images: ['img1', 'img2'] }
+    const chunks = createGenerationChunks(mockResult)
+    const adapter = createMockConnectionAdapter({ chunks })
+
+    // In connection mode there's no fetcher to infer `TResult` from, so annotate
+    // the `onResult` parameter — `TResult` infers from the annotation and
+    // `result` narrows to the transform's return. No explicit type args needed.
+    const gen = createGeneration({
+      connection: adapter,
+      onResult: (raw: StreamResult) => ({ count: raw.images.length }),
+    })
+    expectTypeOf(gen.result).toEqualTypeOf<{ count: number } | null>()
+
+    await gen.generate({ prompt: 'test' })
+
+    expect(gen.result).toEqual({ count: 2 })
+  })
+
+  it('should work with createGenerateSpeech transform', async () => {
+    const mockTTSResult: TTSResult = {
+      id: '1',
+      model: 'tts-1',
+      audio: 'base64audio',
+      format: 'mp3',
+      contentType: 'audio/mpeg',
+    }
+
+    // Inference (issue #848): the wrapper hooks infer the output type from
+    // `onResult` with no explicit type argument. `raw` is contextually typed
+    // as `TTSResult`.
+    const gen = createGenerateSpeech({
+      fetcher: async () => mockTTSResult,
+      onResult: (raw) => ({
+        audioUrl: `data:${raw.contentType};base64,${raw.audio}`,
+      }),
+    })
+    expectTypeOf(gen.result).toEqualTypeOf<{ audioUrl: string } | null>()
+
+    await gen.generate({ text: 'Hello' })
+
+    expect(gen.result).toEqual({
+      audioUrl: 'data:audio/mpeg;base64,base64audio',
+    })
+  })
+
+  it('infers the raw result type when no onResult is provided', () => {
+    const gen = createTranscription({
+      fetcher: async () => ({ id: '1', text: 'hi', model: 'whisper-1' }),
+    })
+    // Without a transform, `result` stays the raw TranscriptionResult.
+    expectTypeOf(gen.result).toEqualTypeOf<TranscriptionResult | null>()
+  })
+
+  it('narrows the wrapper result type to the transform return', () => {
+    const gen = createTranscription({
+      fetcher: async () => ({ id: '1', text: 'hi', model: 'whisper-1' }),
+      onResult: (res) => res.text,
+    })
+    expectTypeOf(gen.result).toEqualTypeOf<string | null>()
   })
 })

--- a/packages/ai-vue/src/use-generate-audio.ts
+++ b/packages/ai-vue/src/use-generate-audio.ts
@@ -6,7 +6,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 import type { DeepReadonly, ShallowRef } from 'vue'
 
@@ -88,15 +88,12 @@ export interface UseGenerateAudioReturn<TOutput = AudioGenerationResult> {
  * </template>
  * ```
  */
-export function useGenerateAudio<
-  TOnResult extends ((result: AudioGenerationResult) => any) | undefined =
-    undefined,
->(
+export function useGenerateAudio<TTransformed = void>(
   options: Omit<UseGenerateAudioOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: AudioGenerationResult) => TTransformed
   },
 ): UseGenerateAudioReturn<
-  InferGenerationOutput<AudioGenerationResult, TOnResult>
+  InferGenerationOutputFromReturn<AudioGenerationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -105,7 +102,7 @@ export function useGenerateAudio<
     outputKind: 'audio' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<AudioGenerateInput, AudioGenerationResult, TOnResult>({
+    useGeneration<AudioGenerateInput, AudioGenerationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-vue/src/use-generate-image.ts
+++ b/packages/ai-vue/src/use-generate-image.ts
@@ -6,7 +6,7 @@ import type {
   GenerationClientState,
   GenerationFetcher,
   ImageGenerateInput,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 import type { DeepReadonly, ShallowRef } from 'vue'
 
@@ -98,15 +98,12 @@ export interface UseGenerateImageReturn<TOutput = ImageGenerationResult> {
  * </template>
  * ```
  */
-export function useGenerateImage<
-  TOnResult extends ((result: ImageGenerationResult) => any) | undefined =
-    undefined,
->(
+export function useGenerateImage<TTransformed = void>(
   options: Omit<UseGenerateImageOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: ImageGenerationResult) => TTransformed
   },
 ): UseGenerateImageReturn<
-  InferGenerationOutput<ImageGenerationResult, TOnResult>
+  InferGenerationOutputFromReturn<ImageGenerationResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -115,7 +112,7 @@ export function useGenerateImage<
     outputKind: 'image' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<ImageGenerateInput, ImageGenerationResult, TOnResult>({
+    useGeneration<ImageGenerateInput, ImageGenerationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-vue/src/use-generate-speech.ts
+++ b/packages/ai-vue/src/use-generate-speech.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   SpeechGenerateInput,
 } from '@tanstack/ai-client'
 import type { DeepReadonly, ShallowRef } from 'vue'
@@ -92,13 +92,13 @@ export interface UseGenerateSpeechReturn<TOutput = TTSResult> {
  * </template>
  * ```
  */
-export function useGenerateSpeech<
-  TOnResult extends ((result: TTSResult) => any) | undefined = undefined,
->(
+export function useGenerateSpeech<TTransformed = void>(
   options: Omit<UseGenerateSpeechOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TTSResult) => TTransformed
   },
-): UseGenerateSpeechReturn<InferGenerationOutput<TTSResult, TOnResult>> {
+): UseGenerateSpeechReturn<
+  InferGenerationOutputFromReturn<TTSResult, TTransformed>
+> {
   const devtools = {
     ...options.devtools,
     framework: 'vue',
@@ -106,7 +106,7 @@ export function useGenerateSpeech<
     outputKind: 'audio' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<SpeechGenerateInput, TTSResult, TOnResult>({
+    useGeneration<SpeechGenerateInput, TTSResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-vue/src/use-generate-video.ts
+++ b/packages/ai-vue/src/use-generate-video.ts
@@ -14,7 +14,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   VideoGenerateInput,
   VideoGenerateResult,
   VideoStatusInfo,
@@ -114,17 +114,20 @@ export interface UseGenerateVideoReturn<TOutput = VideoGenerateResult> {
  * </template>
  * ```
  */
-export function useGenerateVideo<
-  TOnResult extends ((result: VideoGenerateResult) => any) | undefined =
-    undefined,
->(
+// `TTransformed` infers from the `onResult` return position so the callback
+// parameter is typed as `VideoGenerateResult` and `result` narrows to the
+// transform's return. See issue #848.
+export function useGenerateVideo<TTransformed = void>(
   options: Omit<UseGenerateVideoOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: VideoGenerateResult) => TTransformed
   },
 ): UseGenerateVideoReturn<
-  InferGenerationOutput<VideoGenerateResult, TOnResult>
+  InferGenerationOutputFromReturn<VideoGenerateResult, TTransformed>
 > {
-  type TOutput = InferGenerationOutput<VideoGenerateResult, TOnResult>
+  type TOutput = InferGenerationOutputFromReturn<
+    VideoGenerateResult,
+    TTransformed
+  >
   const hookId = useId()
   const clientId = options.id || hookId
 
@@ -148,7 +151,12 @@ export function useGenerateVideo<
       hookName: 'useGenerateVideo',
       outputKind: 'video' as const,
     },
-    onResult: (r: VideoGenerateResult) => options.onResult?.(r),
+    // The transform's raw return type (`TTransformed`) and the stored output
+    // (`TOutput`, with null/void/undefined stripped) are identical at runtime;
+    // the cast bridges the relationship that the conditional type hides.
+    onResult: ((r: VideoGenerateResult) => options.onResult?.(r)) as (
+      result: VideoGenerateResult,
+    ) => TOutput | null | void,
     onError: (e: Error) => options.onError?.(e),
     onProgress: (p: number, m?: string) => options.onProgress?.(p, m),
     onChunk: (c: StreamChunk) => options.onChunk?.(c),
@@ -227,7 +235,11 @@ export function useGenerateVideo<
 
   return {
     generate,
-    result: readonly(result),
+    // `readonly()` distributes `DeepReadonly`/`UnwrapNestedRefs` over the
+    // `TOutput` conditional, which TS can't prove equal to the declared
+    // `DeepReadonly<ShallowRef<TOutput | null>>` while `TTransformed` is free.
+    // They are identical at runtime; the cast restores the declared shape.
+    result: readonly(result) as UseGenerateVideoReturn<TOutput>['result'],
     jobId: readonly(jobId),
     videoStatus: readonly(videoStatus),
     isLoading: readonly(isLoading),

--- a/packages/ai-vue/src/use-generation.ts
+++ b/packages/ai-vue/src/use-generation.ts
@@ -15,7 +15,7 @@ import type {
   GenerationClientOptions,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
 } from '@tanstack/ai-client'
 import type { DeepReadonly, ShallowRef } from 'vue'
 
@@ -99,16 +99,22 @@ export interface UseGenerationReturn<TOutput> {
  * </script>
  * ```
  */
+// `TTransformed` infers from the `onResult` return position (a covariant
+// inference site that works even for an optional nested property), which types
+// the callback parameter as `TResult` and narrows `result`. Inferring the
+// whole callback as a defaulted type parameter instead collapses to the
+// default, leaving the parameter `any` — a hard error under `strict`. See
+// issue #848.
 export function useGeneration<
   TInput extends Record<string, any>,
   TResult,
-  TOnResult extends ((result: TResult) => any) | undefined = undefined,
+  TTransformed = void,
 >(
   options: Omit<UseGenerationOptions<TInput, TResult>, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TResult) => TTransformed
   },
-): UseGenerationReturn<InferGenerationOutput<TResult, TOnResult>> {
-  type TOutput = InferGenerationOutput<TResult, TOnResult>
+): UseGenerationReturn<InferGenerationOutputFromReturn<TResult, TTransformed>> {
+  type TOutput = InferGenerationOutputFromReturn<TResult, TTransformed>
   const hookId = useId()
   const clientId = options.id || hookId
 
@@ -129,7 +135,12 @@ export function useGeneration<
       framework: 'vue',
       hookName: 'useGeneration',
     },
-    onResult: (r: TResult) => options.onResult?.(r),
+    // The transform's raw return type (`TTransformed`) and the stored output
+    // (`TOutput`, with null/void/undefined stripped) are identical at runtime;
+    // the cast bridges the relationship that the conditional type hides.
+    onResult: ((r: TResult) => options.onResult?.(r)) as (
+      result: TResult,
+    ) => TOutput | null | void,
     onError: (e: Error) => options.onError?.(e),
     onProgress: (p: number, m?: string) => options.onProgress?.(p, m),
     onChunk: (c: StreamChunk) => options.onChunk?.(c),
@@ -200,7 +211,11 @@ export function useGeneration<
 
   return {
     generate: generate as (input: Record<string, any>) => Promise<void>,
-    result: readonly(result),
+    // `readonly()` distributes `DeepReadonly`/`UnwrapNestedRefs` over the
+    // `TOutput` conditional, which TS can't prove equal to the declared
+    // `DeepReadonly<ShallowRef<TOutput | null>>` while `TTransformed` is free.
+    // They are identical at runtime; the cast restores the declared shape.
+    result: readonly(result) as UseGenerationReturn<TOutput>['result'],
     isLoading: readonly(isLoading),
     error: readonly(error),
     status: readonly(status),

--- a/packages/ai-vue/src/use-summarize.ts
+++ b/packages/ai-vue/src/use-summarize.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   SummarizeGenerateInput,
 } from '@tanstack/ai-client'
 import type { DeepReadonly, ShallowRef } from 'vue'
@@ -93,14 +93,13 @@ export interface UseSummarizeReturn<TOutput = SummarizationResult> {
  * </template>
  * ```
  */
-export function useSummarize<
-  TOnResult extends ((result: SummarizationResult) => any) | undefined =
-    undefined,
->(
+export function useSummarize<TTransformed = void>(
   options: Omit<UseSummarizeOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: SummarizationResult) => TTransformed
   },
-): UseSummarizeReturn<InferGenerationOutput<SummarizationResult, TOnResult>> {
+): UseSummarizeReturn<
+  InferGenerationOutputFromReturn<SummarizationResult, TTransformed>
+> {
   const devtools = {
     ...options.devtools,
     framework: 'vue',
@@ -108,7 +107,7 @@ export function useSummarize<
     outputKind: 'text' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<SummarizeGenerateInput, SummarizationResult, TOnResult>({
+    useGeneration<SummarizeGenerateInput, SummarizationResult, TTransformed>({
       ...options,
       devtools,
     })

--- a/packages/ai-vue/src/use-transcription.ts
+++ b/packages/ai-vue/src/use-transcription.ts
@@ -112,9 +112,11 @@ export function useTranscription<TTransformed = void>(
     outputKind: 'text' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<TranscriptionGenerateInput, TranscriptionResult, TTransformed>(
-      { ...options, devtools },
-    )
+    useGeneration<
+      TranscriptionGenerateInput,
+      TranscriptionResult,
+      TTransformed
+    >({ ...options, devtools })
 
   return {
     generate: generate as (input: TranscriptionGenerateInput) => Promise<void>,

--- a/packages/ai-vue/src/use-transcription.ts
+++ b/packages/ai-vue/src/use-transcription.ts
@@ -5,7 +5,7 @@ import type {
   ConnectConnectionAdapter,
   GenerationClientState,
   GenerationFetcher,
-  InferGenerationOutput,
+  InferGenerationOutputFromReturn,
   TranscriptionGenerateInput,
 } from '@tanstack/ai-client'
 import type { DeepReadonly, ShallowRef } from 'vue'
@@ -98,15 +98,12 @@ export interface UseTranscriptionReturn<TOutput = TranscriptionResult> {
  * </template>
  * ```
  */
-export function useTranscription<
-  TOnResult extends ((result: TranscriptionResult) => any) | undefined =
-    undefined,
->(
+export function useTranscription<TTransformed = void>(
   options: Omit<UseTranscriptionOptions, 'onResult'> & {
-    onResult?: TOnResult
+    onResult?: (result: TranscriptionResult) => TTransformed
   },
 ): UseTranscriptionReturn<
-  InferGenerationOutput<TranscriptionResult, TOnResult>
+  InferGenerationOutputFromReturn<TranscriptionResult, TTransformed>
 > {
   const devtools = {
     ...options.devtools,
@@ -115,10 +112,9 @@ export function useTranscription<
     outputKind: 'text' as const,
   }
   const { generate, result, isLoading, error, status, stop, reset } =
-    useGeneration<TranscriptionGenerateInput, TranscriptionResult, TOnResult>({
-      ...options,
-      devtools,
-    })
+    useGeneration<TranscriptionGenerateInput, TranscriptionResult, TTransformed>(
+      { ...options, devtools },
+    )
 
   return {
     generate: generate as (input: TranscriptionGenerateInput) => Promise<void>,

--- a/packages/ai-vue/tests/use-generation.test.ts
+++ b/packages/ai-vue/tests/use-generation.test.ts
@@ -9,11 +9,7 @@ import { useTranscription } from '../src/use-transcription'
 import { useSummarize } from '../src/use-summarize'
 import { useGenerateVideo } from '../src/use-generate-video'
 import { createMockConnectionAdapter } from './test-utils'
-import type {
-  StreamChunk,
-  TTSResult,
-  TranscriptionResult,
-} from '@tanstack/ai'
+import type { StreamChunk, TTSResult, TranscriptionResult } from '@tanstack/ai'
 import type { DeepReadonly } from 'vue'
 
 // Helper to create generation stream chunks
@@ -785,9 +781,11 @@ describe('onResult transform', () => {
         onResult: (raw) => ({ playable: raw.audio.length > 0 }),
       }),
     )
-    expectTypeOf(result.result.value).toEqualTypeOf<DeepReadonly<{
-      playable: boolean
-    } | null>>()
+    expectTypeOf(result.result.value).toEqualTypeOf<
+      DeepReadonly<{
+        playable: boolean
+      } | null>
+    >()
 
     await result.generate({ prompt: 'test' })
     await flushPromises()
@@ -847,9 +845,11 @@ describe('onResult transform', () => {
         onResult: (raw: StreamResult) => ({ count: raw.images.length }),
       }),
     )
-    expectTypeOf(result.result.value).toEqualTypeOf<DeepReadonly<{
-      count: number
-    } | null>>()
+    expectTypeOf(result.result.value).toEqualTypeOf<
+      DeepReadonly<{
+        count: number
+      } | null>
+    >()
 
     await result.generate({ prompt: 'test' })
     await flushPromises()
@@ -878,9 +878,11 @@ describe('onResult transform', () => {
         }),
       }),
     )
-    expectTypeOf(result.result.value).toEqualTypeOf<DeepReadonly<{
-      audioUrl: string
-    } | null>>()
+    expectTypeOf(result.result.value).toEqualTypeOf<
+      DeepReadonly<{
+        audioUrl: string
+      } | null>
+    >()
 
     await result.generate({ text: 'Hello' })
     await flushPromises()

--- a/packages/ai-vue/tests/use-generation.test.ts
+++ b/packages/ai-vue/tests/use-generation.test.ts
@@ -1,6 +1,6 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent, nextTick } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { useGeneration } from '../src/use-generation'
 import { useGenerateImage } from '../src/use-generate-image'
 import { useGenerateAudio } from '../src/use-generate-audio'
@@ -9,7 +9,12 @@ import { useTranscription } from '../src/use-transcription'
 import { useSummarize } from '../src/use-summarize'
 import { useGenerateVideo } from '../src/use-generate-video'
 import { createMockConnectionAdapter } from './test-utils'
-import type { StreamChunk } from '@tanstack/ai'
+import type {
+  StreamChunk,
+  TTSResult,
+  TranscriptionResult,
+} from '@tanstack/ai'
+import type { DeepReadonly } from 'vue'
 
 // Helper to create generation stream chunks
 function createGenerationChunks(result: unknown): Array<StreamChunk> {
@@ -766,5 +771,145 @@ describe('useGenerateVideo', () => {
     }).toThrow(
       'useGenerateVideo requires either a connection or fetcher option',
     )
+  })
+})
+
+describe('onResult transform', () => {
+  it('should transform result when onResult returns a value (fetcher)', async () => {
+    // Inference (issue #848): `onResult`'s parameter is contextually typed from
+    // the fetcher's return, and `result` narrows to the transform's return —
+    // no explicit type arguments needed.
+    const { result } = renderHook(() =>
+      useGeneration({
+        fetcher: async () => ({ id: '1', audio: 'base64data' }),
+        onResult: (raw) => ({ playable: raw.audio.length > 0 }),
+      }),
+    )
+    expectTypeOf(result.result.value).toEqualTypeOf<DeepReadonly<{
+      playable: boolean
+    } | null>>()
+
+    await result.generate({ prompt: 'test' })
+    await flushPromises()
+    await nextTick()
+
+    expect(result.result.value).toEqual({ playable: true })
+    expect(result.status.value).toBe('success')
+  })
+
+  it('should use raw result when onResult returns void', async () => {
+    const onResult = vi.fn()
+
+    const { result } = renderHook(() =>
+      useGeneration({
+        fetcher: async () => ({ id: '1', data: 'test' }),
+        onResult,
+      }),
+    )
+
+    await result.generate({ prompt: 'test' })
+    await flushPromises()
+    await nextTick()
+
+    expect(onResult).toHaveBeenCalledWith({ id: '1', data: 'test' })
+    expect(result.result.value).toEqual({ id: '1', data: 'test' })
+  })
+
+  it('should keep previous result when onResult returns null', async () => {
+    const { result } = renderHook(() =>
+      useGeneration({
+        fetcher: async () => ({ id: '1' }),
+        onResult: () => null,
+      }),
+    )
+
+    await result.generate({ prompt: 'test' })
+    await flushPromises()
+    await nextTick()
+
+    // null return → keep previous (which was null initially)
+    expect(result.result.value).toBeNull()
+    expect(result.status.value).toBe('success')
+  })
+
+  it('should transform result from connection stream', async () => {
+    type StreamResult = { id: string; images: Array<string> }
+    const mockResult: StreamResult = { id: '1', images: ['img1', 'img2'] }
+    const chunks = createGenerationChunks(mockResult)
+    const adapter = createMockConnectionAdapter({ chunks })
+
+    // `connection` is untyped, but annotating the `onResult` parameter gives the
+    // base hook a site to infer `TResult` from (it appears directly in the
+    // callback parameter position) — no explicit type arguments needed.
+    const { result } = renderHook(() =>
+      useGeneration({
+        connection: adapter,
+        onResult: (raw: StreamResult) => ({ count: raw.images.length }),
+      }),
+    )
+    expectTypeOf(result.result.value).toEqualTypeOf<DeepReadonly<{
+      count: number
+    } | null>>()
+
+    await result.generate({ prompt: 'test' })
+    await flushPromises()
+    await nextTick()
+
+    expect(result.result.value).toEqual({ count: 2 })
+  })
+
+  it('should work with useGenerateSpeech transform', async () => {
+    const mockTTSResult: TTSResult = {
+      id: '1',
+      model: 'tts-1',
+      audio: 'base64audio',
+      format: 'mp3',
+      contentType: 'audio/mpeg',
+    }
+
+    // Inference (issue #848): the wrapper hooks infer the output type from
+    // `onResult` with no explicit type argument. `raw` is contextually typed
+    // as `TTSResult`.
+    const { result } = renderHook(() =>
+      useGenerateSpeech({
+        fetcher: async () => mockTTSResult,
+        onResult: (raw) => ({
+          audioUrl: `data:${raw.contentType};base64,${raw.audio}`,
+        }),
+      }),
+    )
+    expectTypeOf(result.result.value).toEqualTypeOf<DeepReadonly<{
+      audioUrl: string
+    } | null>>()
+
+    await result.generate({ text: 'Hello' })
+    await flushPromises()
+    await nextTick()
+
+    expect(result.result.value).toEqual({
+      audioUrl: 'data:audio/mpeg;base64,base64audio',
+    })
+  })
+
+  it('infers the raw result type when no onResult is provided', () => {
+    const { result } = renderHook(() =>
+      useTranscription({
+        fetcher: async () => ({ id: '1', text: 'hi', model: 'whisper-1' }),
+      }),
+    )
+    // Without a transform, `result` stays the raw TranscriptionResult.
+    expectTypeOf(result.result.value).toEqualTypeOf<
+      DeepReadonly<TranscriptionResult | null>
+    >()
+  })
+
+  it('narrows the wrapper result type to the transform return', () => {
+    const { result } = renderHook(() =>
+      useTranscription({
+        fetcher: async () => ({ id: '1', text: 'hi', model: 'whisper-1' }),
+        onResult: (res) => res.text,
+      }),
+    )
+    expectTypeOf(result.result.value).toEqualTypeOf<string | null>()
   })
 })


### PR DESCRIPTION
## Summary

Fixes #848. The `onResult` transform callback on every generation hook (the base generation hook plus `generateImage`, `generateAudio`, `generateSpeech`, `generateVideo`, `transcription`, `summarize`) failed to type-infer: its parameter was implicitly `any` (a hard compile error under `strict`), and the hook's `result` never narrowed to the transform's return type. This affected all five framework packages (React, Vue, Solid `use*`, Svelte `create*`, Angular `inject*`).

### Root cause

The hooks captured the whole callback as a defaulted type parameter inferred from an optional nested property (`onResult?: TOnResult`). TypeScript will not infer a defaulted type parameter from an optional nested property, so it collapsed to its default — which both rejected any function and left the callback parameter with no contextual type.

### Fix

Infer the callback's **return type** instead of the whole callback. The `onResult` parameter is typed as `(result: TResult) => TTransformed`, so:

- the `result` parameter is contextually typed as the raw result type (no `any`, no annotation needed);
- a new `InferGenerationOutputFromReturn<TResult, TReturn>` helper maps `void`/`null`/`undefined` returns back to `TResult` and anything else narrows `result` to it;
- it needs a single signature — no overloads — and wrappers delegate to the base hook with a plain call (no casts).

The only casts are internal and runtime-honest: one per standalone hook (base + video) bridging the transform's raw return type to the stripped output type at the client-forwarding boundary, plus two on Vue's `result` field (its `readonly(ref)` return produces a `DeepReadonly<ShallowRef<…>>` the conditional type can't be proven equal to).

## Test plan

- Added `expectTypeOf` regression assertions per framework: a transform narrows `result` to its return type; omitting the transform keeps the raw result type. These were previously uncovered, which is why the bug went unnoticed.
- No E2E added: this is a compile-time type fix with no observable runtime change, so it can't be exercised via the aimock harness — type assertions are the appropriate coverage.
- Full gate green: `test:types`, `test:lib`, `test:build`, `build`, `test:kiira` (674/674 doc snippets), `test:eslint` (0 errors), `test:sherif`, `test:knip`, `test:docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript inference for `onResult` callbacks across generation, transcription, and summarize APIs.
  * Result values now narrow correctly when transformed, while preserving the original result type when no transform is provided.
  * Added coverage to validate the updated typing behavior across supported frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->