### PR TITLE
fix(ai): infer provider options for media activities

### DIFF
--- a/.changeset/soft-falcons-summarize.md
+++ b/.changeset/soft-falcons-summarize.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai': patch
+---
+
+Fix provider-specific model options inference for TTS, transcription, and summarize activities.

--- a/packages/ai/src/activities/generateSpeech/index.ts
+++ b/packages/ai/src/activities/generateSpeech/index.ts
@@ -43,10 +43,11 @@ export const kind = 'tts' as const
 /**
  * Extract provider options from a TTSAdapter via ~types.
  */
-export type TTSProviderOptions<TAdapter> =
-  TAdapter extends TTSAdapter<any, any>
-    ? TAdapter['~types']['providerOptions']
-    : object
+export type TTSProviderOptions<TAdapter> = TAdapter extends {
+  '~types': { providerOptions: infer P extends object }
+}
+  ? P
+  : object
 
 // ===========================
 // Activity Options Type

--- a/packages/ai/src/activities/generateTranscription/index.ts
+++ b/packages/ai/src/activities/generateTranscription/index.ts
@@ -47,10 +47,11 @@ export const kind = 'transcription' as const
 /**
  * Extract provider options from a TranscriptionAdapter via ~types.
  */
-export type TranscriptionProviderOptions<TAdapter> =
-  TAdapter extends TranscriptionAdapter<any, any>
-    ? TAdapter['~types']['providerOptions']
-    : object
+export type TranscriptionProviderOptions<TAdapter> = TAdapter extends {
+  '~types': { providerOptions: infer P extends object }
+}
+  ? P
+  : object
 
 // ===========================
 // Activity Options Type

--- a/packages/ai/src/activities/summarize/index.ts
+++ b/packages/ai/src/activities/summarize/index.ts
@@ -41,10 +41,11 @@ export const kind = 'summarize' as const
 // ===========================
 
 /** Extract provider options from a SummarizeAdapter via ~types */
-export type SummarizeProviderOptions<TAdapter> =
-  TAdapter extends SummarizeAdapter<any, any>
-    ? TAdapter['~types']['providerOptions']
-    : object
+export type SummarizeProviderOptions<TAdapter> = TAdapter extends {
+  '~types': { providerOptions: infer P extends object }
+}
+  ? P
+  : object
 
 // ===========================
 // Activity Options Type
@@ -213,18 +214,12 @@ export function summarize<
 
   if (stream) {
     return runStreamingSummarize(
-      options as SummarizeActivityOptions<
-        SummarizeAdapter<string, object>,
-        true
-      >,
+      options as SummarizeActivityOptions<TAdapter, true>,
     ) as SummarizeActivityResult<TStream>
   }
 
   return runSummarize(
-    options as SummarizeActivityOptions<
-      SummarizeAdapter<string, object>,
-      false
-    >,
+    options as SummarizeActivityOptions<TAdapter, false>,
   ) as SummarizeActivityResult<TStream>
 }
 


### PR DESCRIPTION
Fixes #593.

## Summary

- Use structural `~types.providerOptions` inference for TTS, transcription, and summarize provider options.
- Keep summarize's public adapter constraint broad enough to support runtime-selected adapter unions, while still deriving `modelOptions` from the selected adapter's `~types` metadata.
- Add a patch changeset for `@tanstack/ai`.

## Validation

- [x] `pnpm --filter @tanstack/ai test:types`
- [x] `pnpm --filter @tanstack/ai test:build`
- [x] `pnpm test:sherif`
- [x] `pnpm test:knip`
- [x] `pnpm test:kiira`

## Release impact

- Patch changeset included for `@tanstack/ai`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider-specific `providerOptions` inference for speech, transcription, and summarization based on adapter-provided type metadata.
  * Updated exported provider option types to more accurately reflect adapter configuration, improving compatibility for consumer code.
* **Chores**
  * Marked this release for `@tanstack/ai` as a patch update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
