### PR TITLE
feat(ai-ollama): enhance error handling in chatStream to emit RUN_ERROR events

### DIFF
--- a/.changeset/ollama-prestream-run-error.md
+++ b/.changeset/ollama-prestream-run-error.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-ollama': patch
+---
+
+Emit a `RUN_ERROR` event instead of throwing when the Ollama text adapter's `chatStream` fails before streaming begins (e.g. the initial `client.chat` call is rejected because the host is unreachable). The error is now surfaced as a structured chunk — with `message`, `code`, and any available `rawEvent` — so failures flow through the stream consistently with other adapters rather than escaping as an unhandled exception.

--- a/packages/ai-ollama/src/adapters/text.ts
+++ b/packages/ai-ollama/src/adapters/text.ts
@@ -1,4 +1,8 @@
 import { EventType, normalizeSystemPrompts } from '@tanstack/ai'
+import {
+  toRunErrorPayload,
+  toRunErrorRawEvent,
+} from '@tanstack/ai/adapter-internals'
 import { BaseTextAdapter } from '@tanstack/ai/adapters'
 import { buildOllamaUsage } from '../usage'
 import { createOllamaClient, generateId, getOllamaHostFromEnv } from '../utils'
@@ -112,11 +116,27 @@ export class OllamaTextAdapter<TModel extends string> extends BaseTextAdapter<
       })
       yield* this.processOllamaStreamChunks(response, options, logger)
     } catch (error: unknown) {
+      const errorPayload = toRunErrorPayload(
+        error,
+        'An unknown error occurred during the chat stream.',
+      )
+      const rawEvent = toRunErrorRawEvent(error)
       logger.errors('ollama.chatStream fatal', {
         error,
         source: 'ollama.chatStream',
       })
-      throw error
+      yield {
+        type: EventType.RUN_ERROR,
+        model: options.model,
+        timestamp: Date.now(),
+        message: errorPayload.message,
+        code: errorPayload.code,
+        ...(rawEvent !== undefined && { rawEvent }),
+        error: {
+          message: errorPayload.message,
+          code: errorPayload.code,
+        },
+      }
     }
   }
 

--- a/packages/ai-ollama/tests/text-adapter.test.ts
+++ b/packages/ai-ollama/tests/text-adapter.test.ts
@@ -590,3 +590,24 @@ describe('OllamaTextAdapter system prompts', () => {
     expect(roles).not.toContain('system')
   })
 })
+
+describe('Ollama adapter error handling', () => {
+  it('emits RUN_ERROR on pre-stream client.chat rejection without throwing', async () => {
+    chatMock.mockRejectedValueOnce(new Error('connection refused'))
+    const adapter = createOllamaChat('llama3.2')
+    const chunks = await collectStream(
+      adapter.chatStream({
+        logger: testLogger,
+        model: 'llama3.2',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    )
+
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]?.type).toBe('RUN_ERROR')
+    if (chunks[0]?.type === 'RUN_ERROR') {
+      expect(chunks[0].message).toBe('connection refused')
+      expect(chunks[0].error?.message).toBe('connection refused')
+    }
+  })
+})


### PR DESCRIPTION
- Added error handling in the OllamaTextAdapter's chatStream method to yield RUN_ERROR events instead of throwing errors directly.
- Introduced utility functions to format error payloads and raw events for better error reporting.
- Added a new test suite to verify the correct emission of RUN_ERROR events on chat stream rejections.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ollama chat streaming behavior: pre-stream failures now emit a structured stream error event instead of throwing.
  * Error output includes clear details (message, code, and any available raw event data) for more consistent handling.
* **Tests**
  * Added coverage to verify that when the chat request rejects before streaming starts, the adapter emits exactly one error event and does not raise an exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->