### PR TITLE
refactor(ai-react): construct useChat ChatClient via useState lazy init

### DIFF
--- a/.changeset/usechat-lazy-client-instance.md
+++ b/.changeset/usechat-lazy-client-instance.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-react': patch
+---
+
+`useChat` now constructs its internal `ChatClient` via a `useState` lazy initializer instead of `useMemo`. `useMemo` is documented as a performance hint that React may discard and recompute, which could spuriously build a second client (each owns a `StreamProcessor`, a devtools bridge, and a connection); `useState`'s initializer is a per-mount "runs once" guarantee. The client is still recreated synchronously when `id` changes, via the "adjust state during render" pattern. Also removes an unused internal ref. No public API or behavior change.

--- a/packages/ai-react/src/use-chat.ts
+++ b/packages/ai-react/src/use-chat.ts
@@ -51,23 +51,29 @@ export function useChat<
   const messagesRef = useRef<Array<UIMessage<TTools>>>(
     options.initialMessages || [],
   )
-  const isFirstMountRef = useRef(true)
   const activeClientRef = useRef<ChatClient | null>(null)
   const cleanupInvalidationRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   )
 
-  // Update ref synchronously during render so it's always current when useMemo runs.
+  // Update ref synchronously during render so it's always current when the
+  // client is created (createClient runs during render via the useState lazy
+  // initializer / the clientId-reset below).
   messagesRef.current = messages
 
   // Track current options in a ref to avoid recreating client when options change
   const optionsRef = useRef<UseChatOptions<TTools, TSchema, TContext>>(options)
   optionsRef.current = options
 
-  // Create ChatClient instance with callbacks to sync state
-  const client = useMemo(() => {
+  // Create the ChatClient eagerly, but exactly once per `clientId`.
+  // `useState`'s lazy initializer runs once per mount (a semantic guarantee),
+  // whereas `useMemo` is only a performance hint React may discard and
+  // recompute — which would spuriously construct a second ChatClient (it owns
+  // a StreamProcessor, a devtools bridge, and a connection). When `clientId`
+  // changes we swap synchronously via the "adjust state during render"
+  // pattern; the `[client]` effect below disposes the superseded instance.
+  const createClient = (): ChatClient<TTools, TContext> => {
     const messagesToUse = options.initialMessages || []
-    isFirstMountRef.current = false
 
     // Build options with conditional spreads for fields whose source
     // type is `T | undefined` but the ChatClient target uses a strict
@@ -159,7 +165,18 @@ export function useChat<
     })
     activeClientRef.current = instance
     return instance
-  }, [clientId])
+  }
+
+  const [client, setClient] =
+    useState<ChatClient<TTools, TContext>>(createClient)
+  const [trackedClientId, setTrackedClientId] = useState(clientId)
+  if (clientId !== trackedClientId) {
+    // `clientId` changed (e.g. `options.id` was swapped): build a fresh client
+    // for the new identity during this render. React re-renders immediately,
+    // and the `[client]` effect disposes the previous instance.
+    setTrackedClientId(clientId)
+    setClient(createClient())
+  }
 
   useEffect(() => {
     const clientMessages = client.getMessages()


### PR DESCRIPTION
## Summary

`useChat` constructs its internal `ChatClient` with `useMemo(() => …, [clientId])`. React's docs are explicit that [`useMemo` is a performance hint, not a semantic guarantee](https://react.dev/reference/react/useMemo#caveats) — React may discard a memoized value and recompute it. For an instance you need to keep stable, that's the wrong contract: a spurious recompute constructs a *second* `ChatClient`, and each one owns a `StreamProcessor`, a devtools bridge, and a connection.

This switches client construction to a `useState` lazy initializer — the documented "runs once per mount" guarantee, which is what React recommends for [creating instances](https://react.dev/reference/react/useState#avoiding-recreating-the-initial-state). The client is still recreated synchronously when `id` changes: `useState` has no dependency array, so this uses the documented ["adjust state during render"](https://react.dev/reference/react/useState#storing-information-from-previous-renders) pattern (track the previous `id`, swap during render when it differs). The existing `[client]` effect still disposes the superseded instance, so lifecycle is unchanged.

While here, also removes an unused `isFirstMountRef`.

## Changes

- `packages/ai-react/src/use-chat.ts`:
  - Replace `const client = useMemo(() => {…}, [clientId])` with a `createClient()` factory + `useState(createClient)` lazy initializer, recreating on `id` change via the previous-`clientId`-in-state pattern.
  - Remove the unused `isFirstMountRef`.
  - Update the adjacent `messagesRef` render-sync comment (it referenced `useMemo`).

## Test plan

- `@tanstack/ai-react` unit suite: **152/152 pass, unchanged** — including the `client recreation` tests, notably *"return new client messages during the id change render"*, which asserts the swap stays synchronous.
- `tsc`, `eslint`, `build`, and `publint` all green.

No public API change and no observable behavior change — the instance is still created during render (same timing as `useMemo`); this only upgrades the memoization primitive to the one with a runtime guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat hook stability by making its internal client creation more predictable during React renders.
  * When the chat identifier changes, the client is now refreshed immediately and consistently.
  * Removed an unnecessary internal dependency, reducing the chance of extra recomputation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->