### PR TITLE
chore(renovate): fix lockfile-regen OOM blocking grouped dep PRs (#869)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,6 @@
   "configMigration": true,
   "extends": [
     "config:recommended",
-    "group:allNonMajor",
     "schedule:weekly",
     ":approveMajorUpdates",
     ":automergeMinor",
@@ -15,7 +14,7 @@
   "ignorePresets": [":ignoreModulesAndTests"],
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
-  "postUpdateOptions": ["pnpmDedupe"],
+  "minimumReleaseAge": "1 day",
   "ignoreDeps": [
     "@types/node",
     "@types/react",
@@ -25,5 +24,147 @@
     "react-dom",
     "typescript",
     "vue"
+  ],
+  "packageRules": [
+    {
+      "description": "Fallback: bundle any remaining non-major updates so we don't get one PR per dependency. Ecosystem rules below override this for their packages.",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
+    },
+    {
+      "description": "Lint & formatting toolchain",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": [
+        "eslint",
+        "eslint-**",
+        "@eslint/**",
+        "@eslint-community/**",
+        "@typescript-eslint/**",
+        "@tanstack/eslint-config",
+        "prettier",
+        "prettier-**",
+        "knip",
+        "sherif",
+        "publint"
+      ],
+      "groupName": "lint & format",
+      "groupSlug": "lint-format"
+    },
+    {
+      "description": "Build & test toolchain (Vite/Vitest/Nx)",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": [
+        "vite",
+        "vite-**",
+        "@vitejs/**",
+        "vitest",
+        "@vitest/**",
+        "@tanstack/vite-config",
+        "@tanstack/typedoc-config",
+        "typedoc",
+        "typedoc-**",
+        "nx",
+        "@nx/**",
+        "tsx",
+        "happy-dom",
+        "jsdom",
+        "@testing-library/**",
+        "tinyglobby",
+        "premove"
+      ],
+      "groupName": "build & test tooling",
+      "groupSlug": "build-test-tooling"
+    },
+    {
+      "description": "Unified / markdown ecosystem (the largest transitive cluster in the lockfile)",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": [
+        "unified",
+        "remark**",
+        "rehype**",
+        "mdast**",
+        "@mdx-js/**",
+        "hast**",
+        "micromark**",
+        "unist**",
+        "vfile**",
+        "marked",
+        "marked-**",
+        "highlight.js",
+        "html-**",
+        "markdown-**"
+      ],
+      "groupName": "markdown/unified",
+      "groupSlug": "markdown-unified"
+    },
+    {
+      "description": "Provider / AI SDKs",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": [
+        "openai",
+        "@anthropic-ai/**",
+        "@google/**",
+        "@google-cloud/**",
+        "@aws-sdk/**",
+        "@openrouter/**",
+        "@mistralai/**",
+        "@ai-sdk/**",
+        "groq-sdk",
+        "ollama",
+        "@opentelemetry/**"
+      ],
+      "groupName": "ai provider sdks",
+      "groupSlug": "ai-provider-sdks"
+    },
+    {
+      "description": "React ecosystem",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["react-**", "@react-native/**", "react-native", "react-native-**"],
+      "groupName": "react ecosystem",
+      "groupSlug": "react-ecosystem"
+    },
+    {
+      "description": "Vue ecosystem",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["@vue/**", "vue-**"],
+      "groupName": "vue ecosystem",
+      "groupSlug": "vue-ecosystem"
+    },
+    {
+      "description": "Angular ecosystem",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["@angular/**", "@angular-**", "angular-**"],
+      "groupName": "angular ecosystem",
+      "groupSlug": "angular-ecosystem"
+    },
+    {
+      "description": "Solid ecosystem",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["solid-**", "@solidjs/**", "seroval", "seroval-**"],
+      "groupName": "solid ecosystem",
+      "groupSlug": "solid-ecosystem"
+    },
+    {
+      "description": "Svelte ecosystem",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["svelte", "svelte-**", "@sveltejs/**", "prettier-plugin-svelte"],
+      "groupName": "svelte ecosystem",
+      "groupSlug": "svelte-ecosystem"
+    },
+    {
+      "description": "Tailwind & icon tooling",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["tailwindcss", "@tailwindcss/**", "lucide", "lucide-**", "@lucide/**"],
+      "groupName": "tailwind & icons",
+      "groupSlug": "tailwind-icons"
+    },
+    {
+      "description": "@types packages",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["@types/**"],
+      "groupName": "type definitions",
+      "groupSlug": "type-definitions"
+    }
   ]
 }


### PR DESCRIPTION
Fixes #869

## Problem

Renovate's `renovate/artifacts` step OOMs (heap limit, e.g. #719) while regenerating the lockfile, so the lockfile never updates and every `--frozen-lockfile` check cascades to red.

The root cause: `group:allNonMajor` bundles *every* non-major update into a single PR, so Renovate resolves the whole ~1.1MB lockfile across all workspace manifests in one pnpm pass — and `postUpdateOptions: [pnpmDedupe]` adds a full-lockfile dedupe on top.

## Changes (`.github/renovate.json`)

- **Split `group:allNonMajor` into per-ecosystem groups.** Removed the `group:allNonMajor` preset and added `packageRules` that group non-major updates by ecosystem: markdown/unified (the largest transitive cluster), AI provider SDKs, build & test tooling, lint & format, React/Vue/Angular/Solid/Svelte, Tailwind/icons, and `@types`. A catch-all rule keeps everything else bundled so we don't regress into one-PR-per-dependency. Each resulting PR touches far fewer manifests, shrinking every lockfile pass.
- **Dropped `pnpmDedupe`** from `postUpdateOptions` — the full-lockfile dedupe pass was the main memory driver.
- **Added `minimumReleaseAge: "1 day"`** to match pnpm's `minimumReleaseAge: 1440` (minutes) in `pnpm-workspace.yaml`, so Renovate won't propose freshly-published versions that pnpm would refuse to install.

## Follow-up (not in this repo)

Raising the runner heap (`NODE_OPTIONS=--max-old-space-size=8192`) has to be configured in the **Mend hosted env** — there's no `renovate.json` field for it. This PR reduces per-pass memory enough that it may not be needed, but it's the belt-and-suspenders knob if a group still grows large.

## Validation

`renovate-config-validator` passes:

```
INFO: Validating .github/renovate.json
INFO: Config validated successfully
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling with more consistent grouping by category and ecosystem.
  * Non-major updates now arrive in consolidated batches, making upgrade review simpler.
  * Update timing was adjusted to wait a day before opening certain dependency changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->