### PR TITLE
feat(ai-gemini): support Nano Banana 2 Lite (gemini-3.1-flash-lite-image)

### DIFF
--- a/.changeset/gemini-nano-banana-2-lite.md
+++ b/.changeset/gemini-nano-banana-2-lite.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-gemini': minor
+---
+
+Add proper support for **Nano Banana 2 Lite** (`gemini-3.1-flash-lite-image`) as a Gemini-native image model. The automated model sync had landed this model mis-classified as a text-only chat model (`output: ['text']`, in `GEMINI_MODELS`); it's now corrected and wired into the image surface — routed through the `generateContent` API with `output: ['text', 'image']`, template-literal sizes (`aspectRatio_resolution`, e.g. `"1:1_2K"`), and image-conditioned prompts, matching the other native image models. Built for ultra-low-latency, low-cost image generation and editing.
+
+Also fixes the OpenRouter model sync (`scripts/sync-provider-models.ts`) so native image models that output both text and image are skipped for manual curation instead of being inserted as chat models.

--- a/docs/adapters/gemini.md
+++ b/docs/adapters/gemini.md
@@ -526,6 +526,7 @@ These models use the `generateContent` API and support resolution tiers (1K, 2K,
 | Model | Description |
 |-------|-------------|
 | `gemini-3.1-flash-image-preview` | Latest and fastest Gemini native image generation |
+| `gemini-3.1-flash-lite-image` | Nano Banana 2 Lite — ultra-low-latency, low-cost image generation |
 | `gemini-3-pro-image-preview` | Higher quality Gemini native image generation |
 | `gemini-2.5-flash-image` | Gemini 2.5 Flash with image generation |
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -274,7 +274,7 @@
           "label": "Image Generation",
           "to": "media/image-generation",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-06-08"
+          "updatedAt": "2026-07-01"
         },
         {
           "label": "Video Generation",
@@ -510,7 +510,8 @@
         {
           "label": "Google Gemini",
           "to": "adapters/gemini",
-          "addedAt": "2026-04-15"
+          "addedAt": "2026-04-15",
+          "updatedAt": "2026-07-01"
         },
         {
           "label": "Ollama",

--- a/docs/media/image-generation.md
+++ b/docs/media/image-generation.md
@@ -447,6 +447,7 @@ if (result.usage?.unitsBilled != null) {
 | Model | Description |
 |-------|-------------|
 | `gemini-3.1-flash-image-preview` | Latest and fastest Gemini native image generation |
+| `gemini-3.1-flash-lite-image` | Nano Banana 2 Lite — ultra-low-latency, low-cost image generation |
 | `gemini-3-pro-image-preview` | Higher quality Gemini native image generation |
 | `gemini-2.5-flash-image` | Gemini 2.5 Flash with image generation |
 

--- a/packages/ai-gemini/src/image/image-provider-options.ts
+++ b/packages/ai-gemini/src/image/image-provider-options.ts
@@ -176,6 +176,7 @@ export type GeminiNativeImageSize =
  */
 export type GeminiNativeImageModels =
   | 'gemini-3.1-flash-image-preview'
+  | 'gemini-3.1-flash-lite-image'
   | 'gemini-3-pro-image-preview'
   | 'gemini-2.5-flash-image'
 

--- a/packages/ai-gemini/src/model-meta.ts
+++ b/packages/ai-gemini/src/model-meta.ts
@@ -173,6 +173,34 @@ const GEMINI_3_1_FLASH_IMAGE = {
     GeminiThinkingOptions
 >
 
+const GEMINI_3_1_FLASH_LITE_IMAGE = {
+  name: 'gemini-3.1-flash-lite-image',
+  max_input_tokens: 65_536,
+  max_output_tokens: 65_536,
+  knowledge_cutoff: '2025-01-01',
+  supports: {
+    input: ['text', 'image'],
+    output: ['text', 'image'],
+    capabilities: ['batch_api', 'structured_output', 'thinking'],
+    tools: ['google_search'],
+  },
+  pricing: {
+    input: {
+      normal: 0.25,
+    },
+    output: {
+      normal: 1.5,
+    },
+  },
+} as const satisfies ModelMeta<
+  GeminiToolConfigOptions &
+    GeminiSafetyOptions &
+    GeminiCommonConfigOptions &
+    GeminiCachedContentOptions &
+    GeminiStructuredOutputOptions &
+    GeminiThinkingOptions
+>
+
 const GEMINI_3_1_FLASH_LITE = {
   name: 'gemini-3.1-flash-lite',
   max_input_tokens: 1_048_576,
@@ -784,39 +812,6 @@ const GEMINI_3_5_FLASH = {
     GeminiThinkingOptions
 >
 
-const GEMINI_3_1_FLASH_LITE_IMAGE = {
-  name: 'gemini-3.1-flash-lite-image',
-  max_input_tokens: 65_536,
-  max_output_tokens: 66_000,
-  supports: {
-    input: ['image', 'text'],
-    output: ['text'],
-    capabilities: [
-      'batch_api',
-      'caching',
-      'function_calling',
-      'structured_output',
-      'thinking',
-    ],
-    tools: ['code_execution', 'file_search', 'google_search', 'url_context'],
-  },
-  pricing: {
-    input: {
-      normal: 0.25,
-    },
-    output: {
-      normal: 1.5,
-    },
-  },
-} as const satisfies ModelMeta<
-  GeminiToolConfigOptions &
-    GeminiSafetyOptions &
-    GeminiCommonConfigOptions &
-    GeminiCachedContentOptions &
-    GeminiStructuredOutputOptions &
-    GeminiThinkingOptions
->
-
 export const GEMINI_MODELS = [
   GEMINI_3_5_FLASH.name,
   GEMINI_3_1_PRO.name,
@@ -826,8 +821,6 @@ export const GEMINI_MODELS = [
   GEMINI_2_5_PRO.name,
   GEMINI_2_5_FLASH.name,
   GEMINI_2_5_FLASH_LITE.name,
-
-  GEMINI_3_1_FLASH_LITE_IMAGE.name,
 ] as const
 
 /**
@@ -851,6 +844,7 @@ export type GeminiImageModels = (typeof GEMINI_IMAGE_MODELS)[number]
 
 export const GEMINI_IMAGE_MODELS = [
   GEMINI_3_1_FLASH_IMAGE.name,
+  GEMINI_3_1_FLASH_LITE_IMAGE.name,
   GEMINI_3_PRO_IMAGE.name,
   GEMINI_2_5_FLASH_IMAGE.name,
   IMAGEN_3.name,
@@ -980,12 +974,6 @@ export type GeminiChatModelProviderOptionsByName = {
     GeminiCachedContentOptions &
     GeminiStructuredOutputOptions &
     GeminiThinkingOptions
-  [GEMINI_3_1_FLASH_LITE_IMAGE.name]: GeminiToolConfigOptions &
-    GeminiSafetyOptions &
-    GeminiCommonConfigOptions &
-    GeminiCachedContentOptions &
-    GeminiStructuredOutputOptions &
-    GeminiThinkingOptions
 }
 
 /**
@@ -1028,5 +1016,4 @@ export type GeminiModelInputModalitiesByName = {
 
   // Models with text, image, audio, video (no document)
   [GEMINI_2_5_FLASH.name]: typeof GEMINI_2_5_FLASH.supports.input
-  [GEMINI_3_1_FLASH_LITE_IMAGE.name]: typeof GEMINI_3_1_FLASH_LITE_IMAGE.supports.input
 }

--- a/packages/ai-gemini/tests/image-adapter.test.ts
+++ b/packages/ai-gemini/tests/image-adapter.test.ts
@@ -303,6 +303,63 @@ describe('Gemini Image Adapter', () => {
       expect(result.images[0]!.b64Json).toBe('gemini-base64-image')
     })
 
+    it('routes Nano Banana 2 Lite (gemini-3.1-flash-lite-image) through the native generateContent path', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  inlineData: {
+                    mimeType: 'image/jpeg',
+                    data: 'lite-base64-image',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }
+
+      const mockGenerateContent = vi.fn().mockResolvedValueOnce(mockResponse)
+
+      const adapter = createGeminiImage(
+        'gemini-3.1-flash-lite-image',
+        'test-api-key',
+      )
+      ;(
+        adapter as unknown as {
+          client: { models: { generateContent: unknown } }
+        }
+      ).client = {
+        models: {
+          generateContent: mockGenerateContent,
+        },
+      }
+
+      const result = await generateImage({
+        adapter,
+        prompt: 'A red circle',
+        size: '1:1_2K',
+      })
+
+      expect(mockGenerateContent).toHaveBeenCalledWith({
+        model: 'gemini-3.1-flash-lite-image',
+        contents: 'A red circle',
+        config: {
+          responseModalities: ['TEXT', 'IMAGE'],
+          imageConfig: {
+            aspectRatio: '1:1',
+            imageSize: '2K',
+          },
+        },
+      })
+
+      expect(result.model).toBe('gemini-3.1-flash-lite-image')
+      expect(result.images).toHaveLength(1)
+      expect(result.images[0]!.b64Json).toBe('lite-base64-image')
+    })
+
     it('surfaces token usage from usageMetadata (#330)', async () => {
       const mockResponse = {
         candidates: [

--- a/packages/ai/skills/ai-core/media-generation/SKILL.md
+++ b/packages/ai/skills/ai-core/media-generation/SKILL.md
@@ -151,7 +151,7 @@ function ImageGenerator() {
 
 Supported adapters: `openaiImage` (dall-e-2, dall-e-3, gpt-image-1,
 gpt-image-1-mini, gpt-image-2) and `geminiImage` (gemini-3.1-flash-image-preview,
-imagen-4.0-generate-001, etc.).
+gemini-3.1-flash-lite-image, imagen-4.0-generate-001, etc.).
 
 ```typescript
 import { generateImage } from '@tanstack/ai'

--- a/scripts/sync-provider-models.ts
+++ b/scripts/sync-provider-models.ts
@@ -261,15 +261,18 @@ function outputsText(model: OpenRouterModel): boolean {
 }
 
 /**
- * Check if an OpenRouter model outputs ONLY images (no text output).
- * Image-only models are skipped entirely because image model arrays
- * require manual curation with specialized type maps (sizes, provider options).
+ * Check if an OpenRouter model produces image output.
+ *
+ * Image-generation models are skipped entirely by the sync — regardless of
+ * whether they ALSO output text — because image model arrays require manual
+ * curation with specialized type maps (sizes, provider options, the native
+ * image union). This covers text+image "native" image models such as the
+ * Gemini "Nano Banana" family (`gemini-*-image`, e.g.
+ * `gemini-3.1-flash-lite-image`), which would otherwise be misclassified as
+ * chat models (they output text) and inserted with a bogus `output: ['text']`.
  */
-function isImageOnlyModel(model: OpenRouterModel): boolean {
-  return (
-    model.architecture.output_modalities.includes('image') &&
-    !model.architecture.output_modalities.includes('text')
-  )
+function outputsImage(model: OpenRouterModel): boolean {
+  return model.architecture.output_modalities.includes('image')
 }
 
 /**
@@ -625,14 +628,15 @@ async function main() {
       console.log(`    - ${strippedId} (${constName})`)
     }
 
-    // Filter out image-only models (they need manual curation for size/provider type maps)
-    const filteredModels = newModels.filter(
-      ({ model }) => !isImageOnlyModel(model),
-    )
-    const skippedImageOnly = newModels.length - filteredModels.length
-    if (skippedImageOnly > 0) {
+    // Filter out image-generation models (they need manual curation for
+    // size/provider type maps + the native image union). This includes
+    // text+image models like the Gemini "Nano Banana" native image family,
+    // not just image-only models.
+    const filteredModels = newModels.filter(({ model }) => !outputsImage(model))
+    const skippedImageModels = newModels.length - filteredModels.length
+    if (skippedImageModels > 0) {
       console.log(
-        `  Skipping ${skippedImageOnly} image-only models (require manual curation)`,
+        `  Skipping ${skippedImageModels} image-generation models (require manual curation)`,
       )
     }
 


### PR DESCRIPTION
## 🎯 Changes

Adds proper support for **Nano Banana 2 Lite** (`gemini-3.1-flash-lite-image`) to the Gemini adapter, and fixes the model-sync bug that mis-landed it.

**Background:** the automated OpenRouter sync (#772) had already added `gemini-3.1-flash-lite-image` to `main` — but mis-classified as a **text-only chat model** (`output: ['text']`, listed in `GEMINI_MODELS` + the chat type maps). Verified against the live Gemini API, it's a native image model (`generateContent` → inline image, ~1120 tokens/1K image).

This PR:

- **Corrects the model entry** and wires it into the image surface — `output: ['text', 'image']`, in the image-model region + `GEMINI_IMAGE_MODELS`, added to the `GeminiNativeImageModels` union (template-literal sizes like `"1:1_2K"`, image-conditioned prompts) — matching the other native image models. Removed from the chat arrays/type maps.
- **Fixes the sync generator** (`scripts/sync-provider-models.ts`): the guard `isImageOnlyModel` (image output **and not** text) → `outputsImage` (any image output), so native text+image image models are skipped for manual curation instead of being inserted as chat models. Verified against `scripts/openrouter.models.json`: all six `gemini-*-image` models flip from "added to chat" → "skipped".
- Unit test asserting native `generateContent` routing + size parsing for the new model.
- Docs (`docs/adapters/gemini.md`, `docs/media/image-generation.md` + `updatedAt`), and the `media-generation` skill model list.

**Scope note:** this issue was split — Gemini **Omni Flash** (`gemini-omni-flash-preview`) needs a separate Interactions-API path and is tracked in #871.

Closes #870.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Gemini native image model, “Nano Banana 2 Lite,” for faster, lower-cost image generation.
  * Improved image generation handling for mixed text-and-image output models, including better size and prompt support.

* **Bug Fixes**
  * Correctly routes the new model through the native image generation flow instead of treating it as a chat model.
  * Prevents image-capable models from being incorrectly included in manual model lists.

* **Documentation**
  * Updated image model availability and Gemini adapter docs to include the new model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->