### PR TITLE
docs(sandbox): include Sprites in provider enumerations

### DIFF
--- a/docs/sandbox/harnesses.md
+++ b/docs/sandbox/harnesses.md
@@ -67,6 +67,6 @@ and protocol coverage). For which agents you can plug in, browse the official
 
 ## Where to go next
 
-- **[Providers](./providers)** — where the harness runs (local, Docker, Daytona, Vercel).
+- **[Providers](./providers)** — where the harness runs (local, Docker, Daytona, Vercel, Sprites).
 - **[Tools](./tools)** — bridge your app's own tools into the in-sandbox agent.
 - **[Events & File Hooks](./events)** — stream the agent's edits and activity to a UI.

--- a/docs/sandbox/overview.md
+++ b/docs/sandbox/overview.md
@@ -107,7 +107,7 @@ Start with the [Quick Start](./quick-start) to get an agent fixing a bug in a
 sandbox on your laptop. Then dive into the piece you need:
 
 - **[Quick Start](./quick-start)** — from a `chat()` app to an agent fixing a bug, in minutes.
-- **[Providers](./providers)** — local process, Docker, Daytona, Vercel: isolation, auth, and capabilities.
+- **[Providers](./providers)** — local process, Docker, Daytona, Vercel, Sprites: isolation, auth, and capabilities.
 - **[Harnesses](./harnesses)** — which agent runs: Grok Build, Claude Code, Codex, OpenCode, or any ACP agent via `acpCompatible`.
 - **[Workspace](./workspace)** — the source repo, clone depth, and serial/parallel setup.
 - **[Provisioning](./provisioning)** — secrets, skills, MCP servers, plugins, and `AGENTS.md`.

--- a/docs/sandbox/quick-start.md
+++ b/docs/sandbox/quick-start.md
@@ -150,7 +150,7 @@ export const repoSandbox = defineSandbox({
 
 Because local-process inherits your host environment, you can drop the
 `XAI_API_KEY` secret and let Grok Build fall back to your grok.com login. For that
-(and for Daytona, Vercel, and Cloudflare runtimes), see [Providers](./providers).
+(and for Daytona, Vercel, Sprites, and Cloudflare runtimes), see [Providers](./providers).
 
 ## Run the working example
 

--- a/docs/sandbox/tools.md
+++ b/docs/sandbox/tools.md
@@ -88,7 +88,7 @@ same path the edge/Cloudflare deployment uses; see [Cloudflare](./cloudflare).
 
 ### A remote cloud sandbox, driven from your laptop
 
-With a cloud provider (Daytona, Vercel) in **local dev**, the sandbox is a remote
+With a cloud provider (Daytona, Vercel, Sprites) in **local dev**, the sandbox is a remote
 VM. It **cannot dial your machine's `localhost`**, and your laptop has no public
 URL, so bridged tools can't reach the host until you expose the bridge.
 


### PR DESCRIPTION
## 🎯 Changes

The Sprites provider (added in #868) was documented in providers.md but omitted from the provider lists in the overview, quick-start, harnesses, and tools pages. List it alongside Daytona/Vercel where the provider set is enumerated. The sandbox-web example picker prose is left unchanged (that example wires docker/local/vercel/daytona only).

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sandbox docs to include **Sprites** across provider and runtime guidance.
  * Added Sprites to navigation and “where to go next” references.
  * Clarified that Sprites is available alongside existing options like local, Docker, Daytona, and Vercel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->