### PR TITLE
docs(comparison): cover coding-agent sandboxes and MCP Apps vs Vercel AI SDK

### DIFF
--- a/docs/comparison/vercel-ai-sdk.md
+++ b/docs/comparison/vercel-ai-sdk.md
@@ -53,10 +53,12 @@ Versions referenced below: TanStack AI as of this writing; Vercel AI SDK `ai@6.x
 | Summarization | Dedicated `summarize()` with streaming and style options | - |
 | Code Execution | Node.js, Cloudflare Workers, QuickJS sandboxes you run yourself | Provider-hosted code-execution tools (Anthropic, xAI, OpenAI) |
 | Code Mode Skills | LLM-writable persistent skill library | - |
+| Coding Agent Sandboxes | First-party Grok Build, Claude Code, Codex, OpenCode harnesses **+ any ACP agent** via `acpCompatible`; runs on local-process, Docker, Daytona, Vercel, Sprites, or Cloudflare | `HarnessAgent` (experimental) — Claude Code, Codex, Pi, OpenCode, Deep Agents; centered on Vercel Sandbox |
 | Realtime Voice | OpenAI, Grok, and ElevenLabs with VAD modes and tool support | - |
 | DevTools | Isomorphic in-app panel via TanStack DevTools (all frameworks, media previews) | `devToolsMiddleware` + local inspector (server-side, dev-only) |
 | Debug Logging | One flag, per-category toggles, pluggable logger | Warning logs + experimental telemetry hooks |
 | MCP Client | Standalone host-side client (`@tanstack/ai-mcp`) + provider-routed `mcpTool()` | Built-in (`@ai-sdk/mcp`, stable) |
+| MCP Apps (Interactive Widgets) | `ui://` widgets via `@mcp-ui/client`; React + Preact + framework-agnostic bridge; multi-server routing, pluggable session store, link-scheme hardening | `experimental_MCPAppRenderer` (React only); model-vs-app tool split; iframe sandbox + allowlist |
 | Platform Association | None - pure library | Optional Vercel integration |
 
 ## Where TanStack AI Excels
@@ -242,6 +244,53 @@ const stream = chat({
 
 Vercel AI SDK's `@ai-sdk/mcp` (`createMCPClient`) is a stable host-side client with HTTP/SSE transports, OAuth, resource reading, and prompt templates. TanStack AI's `@tanstack/ai-mcp` matches that surface and adds generated end-to-end types, multi-server pools, lazy discovery, a managed `chat()` lifecycle, and the provider-routed `mcpTool()` alternative.
 
+### MCP Apps (Interactive Widgets)
+
+Both SDKs implement [MCP Apps](https://modelcontextprotocol.io) — the ratified MCP extension (standardized 2026-01-26) where a server returns a `ui://` resource so a tool result renders as an interactive widget in a sandboxed iframe instead of raw JSON. Both keep the widget HTML out of model input and render it in a sandboxed iframe with a tool allowlist and safe link handling. TanStack AI's implementation is more built out along three axes:
+
+- **More than one framework.** Widgets render via `@tanstack/ai-react/mcp-apps` and `@tanstack/ai-preact/mcp-apps`, and the bridge that routes widget actions (`createMcpAppBridge`) lives in the framework-agnostic `@tanstack/ai-client`, so a new framework only needs a thin renderer. Vercel's `experimental_MCPAppRenderer` and its bridge live in `@ai-sdk/react` — React only.
+- **Multi-server routing.** Each `UIResourcePart` carries a `serverId` (the pool prefix from `createMCPClients`), and interactive calls route back to the exact server that produced the widget — automatically when you run a multi-server pool. The call handler also enforces an unconditional same-server exposure check (`toolName` must be a tool that server actually exposes) with an optional `allowTool` restriction AND-ed on top.
+- **Session persistence & serverless-safety.** The call handler reconnects per call from a transport descriptor (stateless, serverless-safe by default), and stateful transports opt into a pluggable `McpSessionStore` — an `inMemoryMcpSessionStore` ships, and SQL/KV backends drop in behind the same interface.
+
+```tsx
+import { useChat, useMcpAppBridge } from '@tanstack/ai-react'
+import { fetchServerSentEvents } from '@tanstack/ai-client'
+import { MCPAppResource } from '@tanstack/ai-react/mcp-apps'
+
+export function Chat() {
+  const { messages, sendMessage } = useChat({
+    connection: fetchServerSentEvents('/api/chat'),
+  })
+
+  // Routes widget tool-calls to /api/mcp-apps/call by serverId; only http/https/mailto links pass through.
+  const bridge = useMcpAppBridge({
+    threadId: 'weather-chat',
+    callEndpoint: '/api/mcp-apps/call',
+    chat: { sendMessage: async (content) => void sendMessage({ content }) },
+    onLink: (url) => window.open(url, '_blank', 'noopener'),
+  })
+
+  return (
+    <>
+      {messages.map((m) =>
+        m.parts.map((part, i) =>
+          part.type === 'ui-resource' ? (
+            <MCPAppResource
+              key={i}
+              part={part}
+              bridge={bridge}
+              sandbox={{ url: new URL('https://your-app.example.com/mcp-sandbox.html') }}
+            />
+          ) : null,
+        ),
+      )}
+    </>
+  )
+}
+```
+
+Vercel AI SDK 7 covers the core flow and adds one thing TanStack AI doesn't: `splitMCPAppTools`, which separates *model-visible* tools from *app-only* tools the widget can call but the model never sees. Both implementations are new — Vercel marks its renderer `experimental_`, and TanStack AI's writeback of widget tool-calls into chat history is still out of scope. See the [MCP Apps guide](../mcp/apps) for the full API.
+
 ### Headless Client Architecture
 
 `ChatClient` is a framework-agnostic class that manages the entire chat lifecycle - streaming, message state, tool execution, approval flows, and connection management. Every framework integration wraps this single client:
@@ -399,6 +448,41 @@ TanStack AI provides three isolate drivers for safe code execution in AI workflo
 All three implement the same `IsolateDriver` interface, so you can swap execution environments without changing application code. This powers TanStack AI's code mode - where the LLM writes and executes code as part of the agent loop. A companion `@tanstack/ai-code-mode-skills` package lets you give code mode a persistent, reusable library of runtime skills. Skills are LLM-writable: the model can save working TypeScript snippets, list and reuse them across sessions, with trust strategies controlling what gets promoted to a first-class tool. The closest AI SDK analogues - Anthropic's provider-hosted code execution and developer-uploaded skills, or pre-authored file skills loaded into a sandbox - are provider-specific and static; none give the model a persistent, provider-agnostic skill library it builds itself.
 
 Vercel AI SDK does not provide built-in code execution sandboxes (though some providers expose their own server-side code execution as provider-executed tools).
+
+### Coding Agent Sandboxes
+
+Separately from the JS isolates above, TanStack AI can put a full **coding-agent CLI** — Claude Code, Codex, Grok Build, OpenCode, or any ACP-compliant agent — inside an isolated sandbox with a real filesystem, shell, and a cloned repo, and stream its work back through `chat()` like any other run. A sandboxed run composes three swappable pieces: a **provider** (where it runs), a **workspace** (what the agent sees), and a **harness adapter** (which agent runs). The sandbox is a `chat()` middleware, so the agent's edits and commands arrive as the same AG-UI stream every `useChat` UI already renders.
+
+```ts
+import { chat } from '@tanstack/ai'
+import { grokBuildText } from '@tanstack/ai-grok-build'
+import { defineSandbox, defineWorkspace, githubRepo, withSandbox } from '@tanstack/ai-sandbox'
+import { dockerSandbox } from '@tanstack/ai-sandbox-docker'
+import { messages, threadId } from './chat-context'
+
+const sandbox = defineSandbox({
+  id: 'repo-agent',
+  provider: dockerSandbox({ image: 'node:22' }),
+  workspace: defineWorkspace({
+    source: githubRepo({ repo: 'TanStack/ai' }),
+    packageManager: 'pnpm',
+  }),
+})
+
+const stream = chat({
+  threadId,
+  adapter: grokBuildText('grok-build'),
+  messages,
+  middleware: [withSandbox(sandbox)],
+})
+```
+
+Two axes are open where the AI SDK's is narrower:
+
+- **Any agent, not a fixed list.** Grok Build, Claude Code, Codex, and OpenCode ship as first-party harness packages, and `acpCompatible` (from `@tanstack/ai-acp`) turns *any* [Agent Client Protocol](https://agentclientprotocol.com) agent — `pi`, `gemini --acp`, and [dozens of others](https://agentclientprotocol.com/get-started/agents) — into a harness by describing how to launch it. Adding an agent doesn't require a dedicated adapter to exist.
+- **Any sandbox, not one cloud.** The same run executes on `localProcessSandbox` (host dev loop), `dockerSandbox` (real container isolation), Daytona, Vercel Sandbox, Sprites, or Cloudflare — swap the provider without touching the harness or workspace. Providers declare their `capabilities()` (`fs`, `exec`, `ports`, `snapshots`, `fork`, `durableFilesystem`, …) so code degrades gracefully across them.
+
+Vercel AI SDK 7 added a `HarnessAgent` API for the same idea — running a coding-agent harness in a sandbox and returning AI SDK-compatible `generate()` / `stream()` results. It's marked experimental, ships harnesses for Claude Code, Codex, Pi, OpenCode, and Deep Agents, and the documented path runs them in Vercel Sandbox. There's no generic ACP-compatible escape hatch (each supported harness is its own dedicated package), and sandbox support centers on Vercel's own microVM rather than a provider-swappable contract.
 
 ### Media Generation
 
@@ -648,6 +732,7 @@ In TanStack AI, each activity (chat, image, speech, video, transcription, summar
 - **No vendor association** - Pure library with no platform layer
 - **Per-model type safety** - TypeScript narrows options per model, not per provider
 - **Code execution** - Built-in sandboxed execution environments
+- **Coding agent sandboxes** - Run Claude Code, Codex, Grok Build, OpenCode, or any ACP agent in a swappable sandbox (local, Docker, Daytona, Vercel, Sprites, Cloudflare), streamed through `chat()`
 - **Flexible transport** - SSE, HTTP streams, XHR, RPC, direct iterables, or custom adapters
 - **MCP, two ways** - A standalone host-side client (`@tanstack/ai-mcp`) with pools, codegen, and managed `chat()` lifecycle, plus a provider-routed `mcpTool()`
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -62,7 +62,8 @@
         {
           "label": "TanStack AI vs Vercel AI SDK",
           "to": "comparison/vercel-ai-sdk",
-          "addedAt": "2026-04-15"
+          "addedAt": "2026-04-15",
+          "updatedAt": "2026-07-01"
         }
       ]
     },


### PR DESCRIPTION
## What

Vercel AI SDK 7 shipped two features that overlap with existing TanStack AI capabilities: a **`HarnessAgent`** API (run a coding-agent harness in a sandbox) and **MCP Apps** support (interactive `ui://` widgets). This updates the TanStack AI vs Vercel AI SDK comparison page to cover both, honestly.

## Changes

**Coding Agent Sandboxes** (new matrix row + section)
- First-party Grok Build / Claude Code / Codex / OpenCode harnesses **+ any ACP agent** via `acpCompatible`
- Runs on local-process, Docker, Daytona, Vercel, Sprites, or Cloudflare — provider-swappable behind one contract
- vs Vercel's experimental `HarnessAgent`: fixed harness list (Claude Code, Codex, Pi, OpenCode, Deep Agents), no generic ACP escape hatch, centered on Vercel Sandbox

**MCP Apps** (new matrix row + section)
- Multi-framework: React + Preact + framework-agnostic bridge in `@tanstack/ai-client`
- Multi-server routing by `serverId`, pluggable `McpSessionStore`, link-scheme hardening
- vs Vercel's React-only `experimental_MCPAppRenderer`
- Credits Vercel's `splitMCPAppTools` (model-vs-app tool split) as a capability we don't have

Also: a "When to Choose TanStack AI" bullet, and `updatedAt` bumped on the docs config entry.

## Verification
- `pnpm test:docs` — no broken links
- `pnpm kiira check docs/comparison/vercel-ai-sdk.md` — 22/22 snippets pass

Docs-only; no behavior change (both features already have E2E coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the TanStack AI vs. Vercel AI SDK comparison with new details on interactive widgets and coding agent sandboxes.
  * Added clearer coverage of framework support, sandboxed widget rendering, session persistence, and multi-server routing.
  * Included updated examples and notes to help readers better understand when TanStack AI is a fit.
  * Refreshed the documentation navigation metadata to reflect the latest update date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->