### PR TITLE
feat(ai-anthropic): add Claude Sonnet 5, Fable 5 and other missing models to type maps

### DIFF
--- a/.changeset/spotty-maps-walk.md
+++ b/.changeset/spotty-maps-walk.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/ai-anthropic": patch
+---
+
+Added Claude Sonnet 5, Claude Fable 5, Opus 4.7 Fast, Opus 4.8, and Opus 4.8 Fast to `ANTHROPIC_COMBINED_TOOLS_AND_SCHEMA_MODELS` and `AnthropicChatModelToolCapabilitiesByName`

--- a/.changeset/spotty-maps-walk.md
+++ b/.changeset/spotty-maps-walk.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/ai-anthropic": patch
+'@tanstack/ai-anthropic': patch
 ---
 
 Added Claude Sonnet 5, Claude Fable 5, Opus 4.7 Fast, Opus 4.8, and Opus 4.8 Fast to `ANTHROPIC_COMBINED_TOOLS_AND_SCHEMA_MODELS` and `AnthropicChatModelToolCapabilitiesByName`

--- a/packages/ai-anthropic/src/model-meta.ts
+++ b/packages/ai-anthropic/src/model-meta.ts
@@ -830,6 +830,10 @@ export const ANTHROPIC_COMBINED_TOOLS_AND_SCHEMA_MODELS = new Set<string>([
   CLAUDE_SONNET_4_5.id,
   CLAUDE_SONNET_4_6.id,
   CLAUDE_HAIKU_4_5.id,
+  CLAUDE_OPUS_4_8.id,
+  CLAUDE_OPUS_4_8_FAST.id,
+  CLAUDE_FABLE_5.id,
+  CLAUDE_SONNET_5.id,
 ])
 
 // const ANTHROPIC_IMAGE_MODELS = [] as const
@@ -1004,6 +1008,11 @@ export type AnthropicChatModelToolCapabilitiesByName = {
   [CLAUDE_HAIKU_3.id]: typeof CLAUDE_HAIKU_3.supports.tools
   [CLAUDE_OPUS_4_6_FAST.id]: typeof CLAUDE_OPUS_4_6_FAST.supports.tools
   [CLAUDE_OPUS_4_7.id]: typeof CLAUDE_OPUS_4_7.supports.tools
+  [CLAUDE_OPUS_4_7_FAST.id]: typeof CLAUDE_OPUS_4_7_FAST.supports.tools
+  [CLAUDE_OPUS_4_8.id]: typeof CLAUDE_OPUS_4_8.supports.tools
+  [CLAUDE_OPUS_4_8_FAST.id]: typeof CLAUDE_OPUS_4_8_FAST.supports.tools
+  [CLAUDE_FABLE_5.id]: typeof CLAUDE_FABLE_5.supports.tools
+  [CLAUDE_SONNET_5.id]: typeof CLAUDE_SONNET_5.supports.tools
 }
 
 /**

--- a/packages/ai-anthropic/tests/model-meta.test.ts
+++ b/packages/ai-anthropic/tests/model-meta.test.ts
@@ -160,6 +160,40 @@ describe('Anthropic Model Provider Options Type Assertions', () => {
       expectTypeOf<Options>().toHaveProperty('tool_choice')
       expectTypeOf<Options>().toHaveProperty('top_k')
     })
+
+    it('claude-sonnet-5 should support thinking options', () => {
+      type Options = AnthropicChatModelProviderOptionsByName['claude-sonnet-5']
+
+      expectTypeOf<Options>().toExtend<AnthropicThinkingOptions>()
+      expectTypeOf<Options>().toExtend<AnthropicServiceTierOptions>()
+      expectTypeOf<Options>().toExtend<BaseOptions>()
+
+      expectTypeOf<Options>().toHaveProperty('thinking')
+      expectTypeOf<Options>().toHaveProperty('service_tier')
+      expectTypeOf<Options>().toHaveProperty('container')
+      expectTypeOf<Options>().toHaveProperty('context_management')
+      expectTypeOf<Options>().toHaveProperty('mcp_servers')
+      expectTypeOf<Options>().toHaveProperty('stop_sequences')
+      expectTypeOf<Options>().toHaveProperty('tool_choice')
+      expectTypeOf<Options>().toHaveProperty('top_k')
+    })
+
+    it('claude-fable-5 should support thinking options', () => {
+      type Options = AnthropicChatModelProviderOptionsByName['claude-fable-5']
+
+      expectTypeOf<Options>().toExtend<AnthropicThinkingOptions>()
+      expectTypeOf<Options>().toExtend<AnthropicServiceTierOptions>()
+      expectTypeOf<Options>().toExtend<BaseOptions>()
+
+      expectTypeOf<Options>().toHaveProperty('thinking')
+      expectTypeOf<Options>().toHaveProperty('service_tier')
+      expectTypeOf<Options>().toHaveProperty('container')
+      expectTypeOf<Options>().toHaveProperty('context_management')
+      expectTypeOf<Options>().toHaveProperty('mcp_servers')
+      expectTypeOf<Options>().toHaveProperty('stop_sequences')
+      expectTypeOf<Options>().toHaveProperty('tool_choice')
+      expectTypeOf<Options>().toHaveProperty('top_k')
+    })
   })
 
   describe('Models WITHOUT extended_thinking support', () => {
@@ -221,6 +255,8 @@ describe('Anthropic Model Provider Options Type Assertions', () => {
       expectTypeOf<'claude-opus-4'>().toExtend<Keys>()
       expectTypeOf<'claude-3-5-haiku'>().toExtend<Keys>()
       expectTypeOf<'claude-3-haiku'>().toExtend<Keys>()
+      expectTypeOf<'claude-sonnet-5'>().toExtend<Keys>()
+      expectTypeOf<'claude-fable-5'>().toExtend<Keys>()
     })
   })
 
@@ -256,6 +292,12 @@ describe('Anthropic Model Provider Options Type Assertions', () => {
       expectTypeOf<
         AnthropicChatModelProviderOptionsByName['claude-3-haiku']
       >().toHaveProperty('container')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-sonnet-5']
+      >().toHaveProperty('container')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-fable-5']
+      >().toHaveProperty('container')
     })
 
     it('all models should have context management options', () => {
@@ -288,6 +330,12 @@ describe('Anthropic Model Provider Options Type Assertions', () => {
       >().toHaveProperty('context_management')
       expectTypeOf<
         AnthropicChatModelProviderOptionsByName['claude-3-haiku']
+      >().toHaveProperty('context_management')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-sonnet-5']
+      >().toHaveProperty('context_management')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-fable-5']
       >().toHaveProperty('context_management')
     })
 
@@ -322,6 +370,12 @@ describe('Anthropic Model Provider Options Type Assertions', () => {
       expectTypeOf<
         AnthropicChatModelProviderOptionsByName['claude-3-haiku']
       >().toHaveProperty('mcp_servers')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-sonnet-5']
+      >().toHaveProperty('mcp_servers')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-fable-5']
+      >().toHaveProperty('mcp_servers')
     })
 
     it('all models should have stop sequences options', () => {
@@ -354,6 +408,12 @@ describe('Anthropic Model Provider Options Type Assertions', () => {
       >().toHaveProperty('stop_sequences')
       expectTypeOf<
         AnthropicChatModelProviderOptionsByName['claude-3-haiku']
+      >().toHaveProperty('stop_sequences')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-sonnet-5']
+      >().toHaveProperty('stop_sequences')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-fable-5']
       >().toHaveProperty('stop_sequences')
     })
 
@@ -388,6 +448,12 @@ describe('Anthropic Model Provider Options Type Assertions', () => {
       expectTypeOf<
         AnthropicChatModelProviderOptionsByName['claude-3-haiku']
       >().toHaveProperty('tool_choice')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-sonnet-5']
+      >().toHaveProperty('tool_choice')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-fable-5']
+      >().toHaveProperty('tool_choice')
     })
 
     it('all models should have sampling options (top_k)', () => {
@@ -421,6 +487,12 @@ describe('Anthropic Model Provider Options Type Assertions', () => {
       expectTypeOf<
         AnthropicChatModelProviderOptionsByName['claude-3-haiku']
       >().toHaveProperty('top_k')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-sonnet-5']
+      >().toHaveProperty('top_k')
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-fable-5']
+      >().toHaveProperty('top_k')
     })
   })
 
@@ -449,6 +521,12 @@ describe('Anthropic Model Provider Options Type Assertions', () => {
       >().toExtend<AnthropicThinkingOptions>()
       expectTypeOf<
         AnthropicChatModelProviderOptionsByName['claude-opus-4']
+      >().toExtend<AnthropicThinkingOptions>()
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-sonnet-5']
+      >().toExtend<AnthropicThinkingOptions>()
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-fable-5']
       >().toExtend<AnthropicThinkingOptions>()
     })
 
@@ -489,6 +567,12 @@ describe('Anthropic Model Provider Options Type Assertions', () => {
       expectTypeOf<
         AnthropicChatModelProviderOptionsByName['claude-3-5-haiku']
       >().toExtend<AnthropicServiceTierOptions>()
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-sonnet-5']
+      >().toExtend<AnthropicServiceTierOptions>()
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-fable-5']
+      >().toExtend<AnthropicServiceTierOptions>()
     })
 
     it('models without priority_tier should NOT extend AnthropicServiceTierOptions', () => {
@@ -527,6 +611,12 @@ describe('Anthropic Model Provider Options Type Assertions', () => {
       >().toExtend<BaseOptions>()
       expectTypeOf<
         AnthropicChatModelProviderOptionsByName['claude-3-haiku']
+      >().toExtend<BaseOptions>()
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-sonnet-5']
+      >().toExtend<BaseOptions>()
+      expectTypeOf<
+        AnthropicChatModelProviderOptionsByName['claude-fable-5']
       >().toExtend<BaseOptions>()
     })
   })
@@ -760,6 +850,50 @@ describe('Anthropic Model Input Modality Type Assertions', () => {
 
   describe('Claude 3 Haiku (text + image + document)', () => {
     type Modalities = AnthropicModelInputModalitiesByName['claude-3-haiku']
+    type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
+
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
+      expectTypeOf<MessageWithContent<AnthropicTextPart>>().toExtend<Message>()
+      expectTypeOf<MessageWithContent<AnthropicImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<AnthropicDocumentPart>
+      >().toExtend<Message>()
+    })
+
+    it('should NOT allow AudioPart or VideoPart', () => {
+      expectTypeOf<
+        MessageWithContent<AnthropicAudioPart>
+      >().not.toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<AnthropicVideoPart>
+      >().not.toExtend<Message>()
+    })
+  })
+
+  describe('Claude Sonnet 5 (text + image + document)', () => {
+    type Modalities = AnthropicModelInputModalitiesByName['claude-sonnet-5']
+    type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
+
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
+      expectTypeOf<MessageWithContent<AnthropicTextPart>>().toExtend<Message>()
+      expectTypeOf<MessageWithContent<AnthropicImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<AnthropicDocumentPart>
+      >().toExtend<Message>()
+    })
+
+    it('should NOT allow AudioPart or VideoPart', () => {
+      expectTypeOf<
+        MessageWithContent<AnthropicAudioPart>
+      >().not.toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<AnthropicVideoPart>
+      >().not.toExtend<Message>()
+    })
+  })
+
+  describe('Claude Fable 5 (text + image + document)', () => {
+    type Modalities = AnthropicModelInputModalitiesByName['claude-fable-5']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
     it('should allow TextPart, ImagePart, and DocumentPart', () => {


### PR DESCRIPTION
Closes #880

Added the following models to `ANTHROPIC_COMBINED_TOOLS_AND_SCHEMA_MODELS`
and `AnthropicChatModelToolCapabilitiesByName`:

- Claude Sonnet 5
- Claude Fable 5
- Opus 4.8
- Opus 4.8 Fast
- Opus 4.7 Fast (tool capabilities only)

Added type assertion tests for Sonnet 5 and Fable 5 covering provider
options, extended thinking, priority tier, base options, and input
modality constraints.

Note: Could not run `pnpm test:pr` locally due to disk space constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional Anthropic model variants, including Claude Sonnet 5, Claude Fable 5, and newer Opus 4.7/4.8 fast options.
  * Expanded tool and schema compatibility so these models share the same supported capabilities as other Anthropic chat models.
  * Improved model option coverage to better recognize supported settings and input types for the newly added models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->