### PR TITLE
feat(ai-anthropic): first-class Claude Sonnet 5 and Claude Fable 5 support

### DIFF
--- a/.changeset/anthropic-sonnet-5-fable-5-support.md
+++ b/.changeset/anthropic-sonnet-5-fable-5-support.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-anthropic': minor
+---
+
+Add first-class support for Claude Sonnet 5 (`claude-sonnet-5`) and Claude Fable 5 (`claude-fable-5`). Both models now carry accurate metadata (adaptive thinking, sticker pricing for Sonnet 5) and per-model provider-option types that match the API: adaptive-only `thinking` on Fable 5 (explicit `disabled` and `budget_tokens` are rejected), adaptive-or-disabled `thinking` on Sonnet 5, and no `temperature` / `top_p` / `top_k` on either. `output_config.effort` gains the `'xhigh'` level (Opus 4.7+, Sonnet 5, Fable 5). Both models are registered for native combined tools + output-schema requests, and the tool-capability type map now covers `claude-sonnet-5`, `claude-fable-5`, `claude-opus-4.8`, `claude-opus-4.8-fast`, and `claude-opus-4-7-fast` so provider tools type-check on those models. Closes #880.

--- a/docs/adapters/anthropic.md
+++ b/docs/adapters/anthropic.md
@@ -2,18 +2,19 @@
 title: Anthropic
 id: anthropic-adapter
 order: 2
-description: "Use Anthropic Claude models with TanStack AI — Claude Sonnet 4.5, Claude Opus, and more via the @tanstack/ai-anthropic adapter."
+description: "Use Anthropic Claude models with TanStack AI — Claude Fable 5, Claude Sonnet 5, Claude Opus, and more via the @tanstack/ai-anthropic adapter."
 keywords:
   - tanstack ai
   - anthropic
   - claude
-  - claude sonnet 4.5
+  - claude fable 5
+  - claude sonnet 5
   - claude opus
   - adapter
   - llm
 ---
 
-The Anthropic adapter provides access to Claude models, including Claude Sonnet 4.5, Claude Opus 4.5, and more.
+The Anthropic adapter provides access to Claude models, including Claude Fable 5, Claude Sonnet 5, Claude Opus 4.8, and more.
 
 ## Installation
 
@@ -151,6 +152,41 @@ modelOptions: {
 
 **Note:** `budget_tokens` must be less than `modelOptions.max_tokens` — set `max_tokens` high enough to leave room for the visible response alongside the thinking budget, or the request is rejected.
 
+### Adaptive Thinking (Claude Sonnet 5, Claude Fable 5, Claude 4.6+)
+
+Newer Claude models use adaptive thinking — the model decides when and how
+much to think, and depth is tuned with `output_config.effort` instead of a
+token budget:
+
+```typescript
+import { chat } from "@tanstack/ai";
+import { anthropicText } from "@tanstack/ai-anthropic";
+
+const stream = chat({
+  adapter: anthropicText("claude-sonnet-5"),
+  messages: [{ role: "user", content: "Plan a database migration." }],
+  modelOptions: {
+    thinking: { type: "adaptive", display: "summarized" },
+    output_config: { effort: "xhigh" },
+    max_tokens: 64_000,
+  },
+});
+```
+
+Per-model rules (enforced by the adapter's types):
+
+- **`claude-sonnet-5`** — adaptive thinking runs by default when `thinking`
+  is omitted; `{ type: "disabled" }` opts out. The manual
+  `{ type: "enabled", budget_tokens }` shape and the sampling parameters
+  (`temperature`, `top_p`, `top_k`) are rejected by the API.
+- **`claude-fable-5`** — thinking is always on. The only accepted explicit
+  config is `{ type: "adaptive" }` (both `disabled` and `budget_tokens`
+  return a 400), and sampling parameters are rejected.
+- **`display`** defaults to `"omitted"` on these models — set
+  `"summarized"` to stream the reasoning text.
+- **`effort`** accepts `"low"` through `"max"`; `"xhigh"` is available on
+  Claude Opus 4.7+, Claude Sonnet 5, and Claude Fable 5.
+
 ### Prompt Caching
 
 Cache prompts for better performance and reduced costs:
@@ -216,7 +252,7 @@ Creates an Anthropic chat adapter.
 
 **Parameters:**
 
-- `model` - Claude model id (e.g. `"claude-sonnet-4-6"`, `"claude-opus-4.8"`)
+- `model` - Claude model id (e.g. `"claude-sonnet-5"`, `"claude-fable-5"`, `"claude-opus-4.8"`)
 - `config?.baseURL` - Custom base URL (optional)
 
 ### `anthropicSummarize(model, config?)` / `createAnthropicSummarize(model, apiKey, config?)`

--- a/docs/config.json
+++ b/docs/config.json
@@ -507,7 +507,8 @@
         {
           "label": "Anthropic",
           "to": "adapters/anthropic",
-          "addedAt": "2026-04-15"
+          "addedAt": "2026-04-15",
+          "updatedAt": "2026-07-02"
         },
         {
           "label": "Google Gemini",

--- a/packages/ai-anthropic/src/model-meta.ts
+++ b/packages/ai-anthropic/src/model-meta.ts
@@ -1,7 +1,11 @@
 import type {
+  AnthropicAdaptiveOnlyThinkingOptions,
+  AnthropicAdaptiveOrDisabledThinkingOptions,
   AnthropicContainerOptions,
   AnthropicContextManagementOptions,
   AnthropicMCPOptions,
+  AnthropicMaxTokensOptions,
+  AnthropicOutputConfigOptions,
   AnthropicSamplingOptions,
   AnthropicServiceTierOptions,
   AnthropicStopSequencesOptions,
@@ -710,6 +714,11 @@ const CLAUDE_OPUS_4_8_FAST = {
     AnthropicSamplingOptions
 >
 
+// Claude Fable 5: thinking is always on — the only accepted explicit
+// `thinking` config is `{type: 'adaptive'}` (disabled/budget_tokens 400),
+// and the sampling parameters (`temperature`, `top_p`, `top_k`) are
+// rejected. Its provider options therefore use the adaptive-only thinking
+// shape and `max_tokens` without the sampling knobs.
 const CLAUDE_FABLE_5 = {
   name: 'claude-fable-5',
   id: 'claude-fable-5',
@@ -717,7 +726,8 @@ const CLAUDE_FABLE_5 = {
   max_output_tokens: 128_000,
   supports: {
     input: ['text', 'image', 'document'],
-    extended_thinking: true,
+    extended_thinking: false,
+    adaptive_thinking: true,
     priority_tier: true,
     tools: [
       'web_search',
@@ -744,11 +754,18 @@ const CLAUDE_FABLE_5 = {
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
     AnthropicStopSequencesOptions &
-    AnthropicThinkingOptions &
+    AnthropicAdaptiveOnlyThinkingOptions &
     AnthropicToolChoiceOptions &
-    AnthropicSamplingOptions
+    AnthropicMaxTokensOptions &
+    AnthropicOutputConfigOptions
 >
 
+// Claude Sonnet 5: adaptive thinking is the default (omitting `thinking`
+// runs adaptive); `{type: 'disabled'}` opts out, but the manual
+// `{type: 'enabled', budget_tokens}` shape and non-default sampling
+// parameters (`temperature`, `top_p`, `top_k`) are rejected with a 400.
+// Pricing below is the sticker $3/$15 per MTok (an introductory $2/$10
+// applies through 2026-08-31).
 const CLAUDE_SONNET_5 = {
   name: 'claude-sonnet-5',
   id: 'claude-sonnet-5',
@@ -756,7 +773,8 @@ const CLAUDE_SONNET_5 = {
   max_output_tokens: 128_000,
   supports: {
     input: ['text', 'image', 'document'],
-    extended_thinking: true,
+    extended_thinking: false,
+    adaptive_thinking: true,
     priority_tier: true,
     tools: [
       'web_search',
@@ -770,11 +788,11 @@ const CLAUDE_SONNET_5 = {
   },
   pricing: {
     input: {
-      normal: 2,
-      cached: 0.2,
+      normal: 3,
+      cached: 0.3,
     },
     output: {
-      normal: 10,
+      normal: 15,
     },
   },
 } as const satisfies ModelMeta<
@@ -783,9 +801,10 @@ const CLAUDE_SONNET_5 = {
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
     AnthropicStopSequencesOptions &
-    AnthropicThinkingOptions &
+    AnthropicAdaptiveOrDisabledThinkingOptions &
     AnthropicToolChoiceOptions &
-    AnthropicSamplingOptions
+    AnthropicMaxTokensOptions &
+    AnthropicOutputConfigOptions
 >
 
 export const ANTHROPIC_MODELS = [
@@ -827,6 +846,10 @@ export const ANTHROPIC_COMBINED_TOOLS_AND_SCHEMA_MODELS = new Set<string>([
   CLAUDE_OPUS_4_6_FAST.id,
   CLAUDE_OPUS_4_7.id,
   CLAUDE_OPUS_4_7_FAST.id,
+  CLAUDE_OPUS_4_8.id,
+  CLAUDE_OPUS_4_8_FAST.id,
+  CLAUDE_FABLE_5.id,
+  CLAUDE_SONNET_5.id,
   CLAUDE_SONNET_4_5.id,
   CLAUDE_SONNET_4_6.id,
   CLAUDE_HAIKU_4_5.id,
@@ -972,22 +995,29 @@ export type AnthropicChatModelProviderOptionsByName = {
     AnthropicThinkingOptions &
     AnthropicToolChoiceOptions &
     AnthropicSamplingOptions
+  // Claude Fable 5: thinking always on (adaptive-only config); sampling
+  // parameters removed — see the CLAUDE_FABLE_5 constant above.
   [CLAUDE_FABLE_5.id]: AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
     AnthropicStopSequencesOptions &
-    AnthropicThinkingOptions &
+    AnthropicAdaptiveOnlyThinkingOptions &
     AnthropicToolChoiceOptions &
-    AnthropicSamplingOptions
+    AnthropicMaxTokensOptions &
+    AnthropicOutputConfigOptions
+  // Claude Sonnet 5: adaptive thinking by default, explicit disable
+  // allowed; no budget_tokens, no sampling parameters — see the
+  // CLAUDE_SONNET_5 constant above.
   [CLAUDE_SONNET_5.id]: AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
     AnthropicStopSequencesOptions &
-    AnthropicThinkingOptions &
+    AnthropicAdaptiveOrDisabledThinkingOptions &
     AnthropicToolChoiceOptions &
-    AnthropicSamplingOptions
+    AnthropicMaxTokensOptions &
+    AnthropicOutputConfigOptions
 }
 
 export type AnthropicChatModelToolCapabilitiesByName = {
@@ -1004,6 +1034,11 @@ export type AnthropicChatModelToolCapabilitiesByName = {
   [CLAUDE_HAIKU_3.id]: typeof CLAUDE_HAIKU_3.supports.tools
   [CLAUDE_OPUS_4_6_FAST.id]: typeof CLAUDE_OPUS_4_6_FAST.supports.tools
   [CLAUDE_OPUS_4_7.id]: typeof CLAUDE_OPUS_4_7.supports.tools
+  [CLAUDE_OPUS_4_7_FAST.id]: typeof CLAUDE_OPUS_4_7_FAST.supports.tools
+  [CLAUDE_OPUS_4_8.id]: typeof CLAUDE_OPUS_4_8.supports.tools
+  [CLAUDE_OPUS_4_8_FAST.id]: typeof CLAUDE_OPUS_4_8_FAST.supports.tools
+  [CLAUDE_FABLE_5.id]: typeof CLAUDE_FABLE_5.supports.tools
+  [CLAUDE_SONNET_5.id]: typeof CLAUDE_SONNET_5.supports.tools
 }
 
 /**

--- a/packages/ai-anthropic/src/text/text-provider-options.ts
+++ b/packages/ai-anthropic/src/text/text-provider-options.ts
@@ -154,6 +154,66 @@ export interface AnthropicAdaptiveThinkingOptions {
       }
 }
 
+/**
+ * Thinking configuration for models where thinking is always on
+ * (Claude Fable 5).
+ *
+ * On these models the only accepted explicit configuration is
+ * `{type: 'adaptive'}` — both `{type: 'disabled'}` and
+ * `{type: 'enabled', budget_tokens}` are rejected with a 400. Omitting the
+ * `thinking` field entirely also runs adaptive thinking.
+ */
+export interface AnthropicAdaptiveOnlyThinkingOptions {
+  thinking?: {
+    type: 'adaptive'
+    /**
+     * Controls what (if any) thinking content is streamed back.
+     *
+     * - `'summarized'`: stream summarized thinking via `thinking_delta`
+     *   events (the user-visible reasoning text).
+     * - `'omitted'` (default): stream the thinking block's
+     *   `signature_delta` only (no reasoning text reaches the client).
+     */
+    display?: 'summarized' | 'omitted'
+  }
+}
+
+/**
+ * Thinking configuration for models that accept adaptive thinking or an
+ * explicit opt-out, but no manual token budget (Claude Sonnet 5).
+ *
+ * `{type: 'enabled', budget_tokens}` is rejected with a 400 on these
+ * models. Omitting the `thinking` field runs adaptive thinking by default.
+ */
+export interface AnthropicAdaptiveOrDisabledThinkingOptions {
+  thinking?:
+    | {
+        type: 'adaptive'
+        /**
+         * Controls what (if any) thinking content is streamed back.
+         * Defaults to `'omitted'` — set `'summarized'` to receive the
+         * reasoning text.
+         */
+        display?: 'summarized' | 'omitted'
+      }
+    | {
+        type: 'disabled'
+      }
+}
+
+/**
+ * `max_tokens` on its own, for models that reject the sampling parameters
+ * (`temperature`, `top_p`, `top_k`) — Claude Fable 5 and Claude Sonnet 5
+ * return a 400 when a non-default sampling value is sent.
+ */
+export interface AnthropicMaxTokensOptions {
+  /**
+   * The maximum number of tokens to generate before stopping. This parameter only specifies the absolute maximum number of tokens to generate. Required by the API; the adapter defaults to 1024 when omitted.
+   * Range x >= 1.
+   */
+  max_tokens?: number
+}
+
 export interface AnthropicEffortOptions {
   /**
    * Controls the thinking depth for adaptive thinking mode (Opus 4.6+).
@@ -182,7 +242,11 @@ export interface AnthropicOutputConfigOptions {
    * preserved when the engine adds `format`.
    */
   output_config?: {
-    effort?: 'low' | 'medium' | 'high' | 'max' | null
+    /**
+     * `'xhigh'` is accepted on Claude Opus 4.7+, Claude Sonnet 5, and
+     * Claude Fable 5; older models support `'low'`–`'max'` only.
+     */
+    effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | null
   }
 }
 
@@ -275,7 +339,7 @@ export interface InternalTextProviderOptions extends ExternalTextProviderOptions
    * cast.
    */
   output_config?: {
-    effort?: 'low' | 'medium' | 'high' | 'max' | null
+    effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | null
     format?: {
       type: 'json_schema'
       schema: Record<string, unknown>

--- a/packages/ai-anthropic/tests/anthropic-adapter.test.ts
+++ b/packages/ai-anthropic/tests/anthropic-adapter.test.ts
@@ -533,6 +533,20 @@ describe('Anthropic adapter option mapping', () => {
     expect(adapter.supportsCombinedToolsAndSchema()).toBe(false)
   })
 
+  it('native combined mode (#605): claude-sonnet-5 and claude-fable-5 use the single-request path', () => {
+    const sonnet5 = new AnthropicTextAdapter(
+      { apiKey: 'test-key' },
+      'claude-sonnet-5',
+    )
+    expect(sonnet5.supportsCombinedToolsAndSchema()).toBe(true)
+
+    const fable5 = new AnthropicTextAdapter(
+      { apiKey: 'test-key' },
+      'claude-fable-5',
+    )
+    expect(fable5.supportsCombinedToolsAndSchema()).toBe(true)
+  })
+
   it('merges consecutive user messages when tool results precede a follow-up user message', async () => {
     // This is the core multi-turn bug: after a tool call + result, the next user message
     // creates consecutive role:'user' messages (tool_result as user + new user message).

--- a/packages/ai-anthropic/tests/chat-per-model-type-safety.test.ts
+++ b/packages/ai-anthropic/tests/chat-per-model-type-safety.test.ts
@@ -127,6 +127,121 @@ describe('Anthropic per-model chat modelOptions gating', () => {
     })
   })
 
+  describe('claude-sonnet-5 — adaptive thinking, no budget_tokens, no sampling', () => {
+    it('accepts adaptive thinking + output_config effort (incl. xhigh) + base options', () => {
+      chat({
+        adapter: anthropicText('claude-sonnet-5'),
+        messages: [{ role: 'user', content: 'hi' }],
+        modelOptions: {
+          thinking: { type: 'adaptive', display: 'summarized' },
+          output_config: { effort: 'xhigh' },
+          service_tier: 'auto',
+          stop_sequences: ['STOP'],
+          tool_choice: { type: 'auto' },
+          max_tokens: 2048,
+        },
+      })
+    })
+
+    it('accepts explicit thinking opt-out', () => {
+      chat({
+        adapter: anthropicText('claude-sonnet-5'),
+        messages: [{ role: 'user', content: 'hi' }],
+        modelOptions: {
+          thinking: { type: 'disabled' },
+        },
+      })
+    })
+
+    it('rejects manual `budget_tokens` thinking', () => {
+      chat({
+        adapter: anthropicText('claude-sonnet-5'),
+        messages: [{ role: 'user', content: 'hi' }],
+        modelOptions: {
+          // @ts-expect-error - budget_tokens thinking returns a 400 on claude-sonnet-5
+          thinking: { type: 'enabled', budget_tokens: 2048 },
+        },
+      })
+    })
+
+    it('rejects sampling parameters', () => {
+      chat({
+        adapter: anthropicText('claude-sonnet-5'),
+        messages: [{ role: 'user', content: 'hi' }],
+        modelOptions: {
+          // @ts-expect-error - 'temperature' is not available on claude-sonnet-5
+          temperature: 0.5,
+        },
+      })
+      chat({
+        adapter: anthropicText('claude-sonnet-5'),
+        messages: [{ role: 'user', content: 'hi' }],
+        modelOptions: {
+          // @ts-expect-error - 'top_k' is not available on claude-sonnet-5
+          top_k: 5,
+        },
+      })
+    })
+  })
+
+  describe('claude-fable-5 — thinking always on (adaptive-only), no sampling', () => {
+    it('accepts adaptive thinking + output_config effort (incl. xhigh) + base options', () => {
+      chat({
+        adapter: anthropicText('claude-fable-5'),
+        messages: [{ role: 'user', content: 'hi' }],
+        modelOptions: {
+          thinking: { type: 'adaptive', display: 'summarized' },
+          output_config: { effort: 'xhigh' },
+          service_tier: 'auto',
+          stop_sequences: ['STOP'],
+          tool_choice: { type: 'auto' },
+          max_tokens: 2048,
+        },
+      })
+    })
+
+    it('rejects explicit thinking opt-out (400 on claude-fable-5)', () => {
+      chat({
+        adapter: anthropicText('claude-fable-5'),
+        messages: [{ role: 'user', content: 'hi' }],
+        modelOptions: {
+          // @ts-expect-error - thinking cannot be disabled on claude-fable-5
+          thinking: { type: 'disabled' },
+        },
+      })
+    })
+
+    it('rejects manual `budget_tokens` thinking', () => {
+      chat({
+        adapter: anthropicText('claude-fable-5'),
+        messages: [{ role: 'user', content: 'hi' }],
+        modelOptions: {
+          // @ts-expect-error - budget_tokens thinking returns a 400 on claude-fable-5
+          thinking: { type: 'enabled', budget_tokens: 2048 },
+        },
+      })
+    })
+
+    it('rejects sampling parameters', () => {
+      chat({
+        adapter: anthropicText('claude-fable-5'),
+        messages: [{ role: 'user', content: 'hi' }],
+        modelOptions: {
+          // @ts-expect-error - 'temperature' is not available on claude-fable-5
+          temperature: 0.5,
+        },
+      })
+      chat({
+        adapter: anthropicText('claude-fable-5'),
+        messages: [{ role: 'user', content: 'hi' }],
+        modelOptions: {
+          // @ts-expect-error - 'top_k' is not available on claude-fable-5
+          top_k: 5,
+        },
+      })
+    })
+  })
+
   describe('Model name type safety', () => {
     it('rejects unknown model names at the factory', () => {
       // @ts-expect-error - 'claude-fake-9000' is not a valid Anthropic chat model
@@ -187,6 +302,41 @@ describe('Anthropic provider options shape assertions', () => {
     })
     it('does NOT have service_tier', () => {
       expectTypeOf<Options>().not.toHaveProperty('service_tier')
+    })
+  })
+
+  describe('claude-sonnet-5 — adaptive thinking without sampling', () => {
+    type Options = AnthropicChatModelProviderOptionsByName['claude-sonnet-5']
+
+    it('has thinking and output_config', () => {
+      expectTypeOf<Options>().toHaveProperty('thinking')
+      expectTypeOf<Options>().toHaveProperty('output_config')
+    })
+    it('has max_tokens but NOT temperature/top_p/top_k', () => {
+      expectTypeOf<Options>().toHaveProperty('max_tokens')
+      expectTypeOf<Options>().not.toHaveProperty('temperature')
+      expectTypeOf<Options>().not.toHaveProperty('top_p')
+      expectTypeOf<Options>().not.toHaveProperty('top_k')
+    })
+  })
+
+  describe('claude-fable-5 — adaptive-only thinking without sampling', () => {
+    type Options = AnthropicChatModelProviderOptionsByName['claude-fable-5']
+
+    it('has thinking and output_config', () => {
+      expectTypeOf<Options>().toHaveProperty('thinking')
+      expectTypeOf<Options>().toHaveProperty('output_config')
+    })
+    it('thinking accepts only the adaptive shape', () => {
+      expectTypeOf<
+        NonNullable<Options['thinking']>['type']
+      >().toEqualTypeOf<'adaptive'>()
+    })
+    it('has max_tokens but NOT temperature/top_p/top_k', () => {
+      expectTypeOf<Options>().toHaveProperty('max_tokens')
+      expectTypeOf<Options>().not.toHaveProperty('temperature')
+      expectTypeOf<Options>().not.toHaveProperty('top_p')
+      expectTypeOf<Options>().not.toHaveProperty('top_k')
     })
   })
 })

--- a/packages/ai-anthropic/tests/tools-per-model-type-safety.test.ts
+++ b/packages/ai-anthropic/tests/tools-per-model-type-safety.test.ts
@@ -67,6 +67,56 @@ describe('Anthropic per-model tool gating', () => {
     ])
   })
 
+  it('claude-sonnet-5 accepts the full tool superset', () => {
+    const adapter = anthropicText('claude-sonnet-5')
+    typedTools(adapter, [
+      userTool,
+      webSearchTool({ name: 'web_search', type: 'web_search_20250305' }),
+      webFetchTool(),
+      codeExecutionTool({
+        name: 'code_execution',
+        type: 'code_execution_20250825',
+      }),
+      computerUseTool({
+        type: 'computer_20250124',
+        name: 'computer',
+        display_width_px: 1024,
+        display_height_px: 768,
+      }),
+      bashTool({ name: 'bash', type: 'bash_20250124' }),
+      textEditorTool({
+        type: 'text_editor_20250124',
+        name: 'str_replace_editor',
+      }),
+      memoryTool(),
+    ])
+  })
+
+  it('claude-fable-5 accepts the full tool superset', () => {
+    const adapter = anthropicText('claude-fable-5')
+    typedTools(adapter, [
+      userTool,
+      webSearchTool({ name: 'web_search', type: 'web_search_20250305' }),
+      webFetchTool(),
+      codeExecutionTool({
+        name: 'code_execution',
+        type: 'code_execution_20250825',
+      }),
+      computerUseTool({
+        type: 'computer_20250124',
+        name: 'computer',
+        display_width_px: 1024,
+        display_height_px: 768,
+      }),
+      bashTool({ name: 'bash', type: 'bash_20250124' }),
+      textEditorTool({
+        type: 'text_editor_20250124',
+        name: 'str_replace_editor',
+      }),
+      memoryTool(),
+    ])
+  })
+
   it('claude-3-haiku rejects every tool except web_search', () => {
     const adapter = anthropicText('claude-3-haiku')
     typedTools(adapter, [

--- a/packages/ai/skills/ai-core/adapter-configuration/references/anthropic-adapter.md
+++ b/packages/ai/skills/ai-core/adapter-configuration/references/anthropic-adapter.md
@@ -21,17 +21,20 @@ import { anthropicText } from '@tanstack/ai-anthropic'
 
 ## Key Chat Models
 
-| Model               | Context Window | Max Output | Notes                           |
-| ------------------- | -------------- | ---------- | ------------------------------- |
-| `claude-opus-4-6`   | 200K           | 128K       | Most capable, adaptive thinking |
-| `claude-sonnet-4-6` | 1M             | 64K        | Best balance, adaptive thinking |
-| `claude-sonnet-4-5` | 200K           | 64K        | Previous gen balanced           |
-| `claude-opus-4-5`   | 200K           | 32K        | Previous gen most capable       |
-| `claude-haiku-4-5`  | 200K           | 64K        | Fast and affordable             |
-| `claude-sonnet-4`   | 200K           | 64K        | Older balanced model            |
-| `claude-opus-4`     | 200K           | 32K        | Older most capable              |
+| Model               | Context Window | Max Output | Notes                                       |
+| ------------------- | -------------- | ---------- | ------------------------------------------- |
+| `claude-fable-5`    | 1M             | 128K       | Most capable; thinking always on (adaptive) |
+| `claude-sonnet-5`   | 1M             | 128K       | Best balance; adaptive thinking by default  |
+| `claude-opus-4.8`   | 1M             | 128K       | Opus tier, adaptive thinking                |
+| `claude-opus-4-6`   | 200K           | 128K       | Older Opus, adaptive thinking               |
+| `claude-sonnet-4-6` | 1M             | 64K        | Previous gen balanced, adaptive thinking    |
+| `claude-sonnet-4-5` | 200K           | 64K        | Previous gen balanced                       |
+| `claude-opus-4-5`   | 200K           | 32K        | Previous gen most capable                   |
+| `claude-haiku-4-5`  | 200K           | 64K        | Fast and affordable                         |
+| `claude-sonnet-4`   | 200K           | 64K        | Older balanced model                        |
+| `claude-opus-4`     | 200K           | 32K        | Older most capable                          |
 
-Note: Model IDs use the format `claude-opus-4-6`, `claude-sonnet-4-6`, etc.
+Note: Model IDs use the format `claude-sonnet-5`, `claude-opus-4-6`, etc.
 
 ## Provider-Specific modelOptions
 
@@ -90,11 +93,36 @@ chat({
 ANTHROPIC_API_KEY
 ```
 
+## Claude Sonnet 5 / Claude Fable 5 modelOptions
+
+The per-model types restrict `modelOptions` on the 5-generation models:
+
+```typescript
+chat({
+  adapter: anthropicText('claude-sonnet-5'), // or 'claude-fable-5'
+  messages,
+  modelOptions: {
+    // Adaptive thinking only — budget_tokens is rejected (400).
+    // On claude-fable-5, { type: 'disabled' } is also rejected;
+    // on claude-sonnet-5 it opts out of the adaptive default.
+    thinking: { type: 'adaptive', display: 'summarized' },
+    // Effort lives under output_config; 'xhigh' is available on
+    // Opus 4.7+, Sonnet 5, and Fable 5.
+    output_config: { effort: 'xhigh' },
+    max_tokens: 64_000,
+    // NO temperature / top_p / top_k — the API rejects them on these models
+  },
+})
+```
+
 ## Gotchas
 
 - `thinking.budget_tokens` must be >= 1024 AND less than `modelOptions.max_tokens`.
   Failing either check throws a validation error.
 - Cannot set both `top_p` and `temperature` at the same time (throws error).
+- `claude-sonnet-5` and `claude-fable-5` do NOT accept `temperature`, `top_p`,
+  `top_k`, or `thinking: { type: 'enabled', budget_tokens }` — adaptive
+  thinking + `output_config.effort` replace them (typed per model).
 - `claude-3-5-haiku` and `claude-3-haiku` do NOT support extended thinking.
 - System prompts support prompt caching via `cache_control` on `TextBlockParam[]`.
 - All Claude models accept `text`, `image`, and `document` (PDF) input.


### PR DESCRIPTION
## 🎯 Changes

Closes #880.

The `claude-sonnet-5` and `claude-fable-5` entries landed mechanically via the OpenRouter metadata sync (#772), but the models were never wired into the adapter's capability maps — they were selectable without per-model type safety, provider-tool typing, or the native combined tools+schema path. This PR adds proper support:

- **Per-model provider options** now match the API surface, enforced at compile time:
  - `claude-fable-5`: thinking is always on — only `{ type: 'adaptive' }` is accepted (`disabled` and `budget_tokens` both 400 on the API and are now type errors).
  - `claude-sonnet-5`: adaptive thinking by default with an explicit `disabled` opt-out; `budget_tokens` rejected.
  - Neither model accepts `temperature` / `top_p` / `top_k` (the API rejects them); `max_tokens` is kept via a new `AnthropicMaxTokensOptions`.
- **`output_config.effort`** gains the `'xhigh'` level (Opus 4.7+, Sonnet 5, Fable 5).
- **Native combined tools + output-schema** (#605 path): both models registered in `ANTHROPIC_COMBINED_TOOLS_AND_SCHEMA_MODELS`, plus the missing `claude-opus-4.8` / `claude-opus-4.8-fast` entries.
- **Tool-capability type map** now covers `claude-sonnet-5`, `claude-fable-5`, `claude-opus-4-7-fast`, `claude-opus-4.8`, and `claude-opus-4.8-fast` — previously these resolved to an empty capability list, so provider tools (web search, bash, etc.) failed to type-check on them.
- **Model metadata**: `adaptive_thinking` flags on both entries; Sonnet 5 pricing corrected to the sticker $3/$15 per MTok (the synced values were the introductory $2/$10 that expires 2026-08-31).
- **Tests**: per-model type-safety coverage (modelOptions gating + tool superset) for both models, and runtime assertions that `supportsCombinedToolsAndSchema()` is true for them.
- **Docs + skill**: `docs/adapters/anthropic.md` gains an Adaptive Thinking section covering the per-model rules (kiira-checked snippet), and the `adapter-configuration` skill reference is updated in the same PR.

E2E note: the aimock-based e2e suite pins a fixed recorded model per provider, so model-metadata additions have no e2e-observable surface; coverage follows the repo's established pattern of compile-time per-model tests plus adapter unit tests. Full e2e suite run locally to confirm no regressions (339 passed, 1 skipped).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class support for Claude Sonnet 5 and Claude Fable 5, including improved tool and output-schema handling.
  * Extended `output_config.effort` with a new `xhigh` level for supported models.
* **Documentation**
  * Updated Anthropic adapter references and examples for the latest Claude model options, including adaptive thinking and `xhigh` effort behavior.
* **Bug Fixes**
  * Enforced stricter, model-specific validation for “thinking” and disallowed unsupported sampling-related settings.
* **Tests**
  * Added type-safety and behavior coverage for the new models’ options and tool support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->