### PR TITLE
fix(scripts): restore changeset creation in the model-metadata sync

### DIFF
--- a/.changeset/sync-models.md
+++ b/.changeset/sync-models.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/ai-openrouter': patch
+---
+
+Update model metadata from OpenRouter API
+
+Releases the model-metadata syncs from #772 and #883 that were generated
+without a changeset: adds Claude Sonnet 5 (`anthropic/claude-sonnet-5`),
+Claude Fable 5 (`anthropic/claude-fable-5`), DeepSeek V3.2, GLM-5.2,
+Kimi K2.7 Code, Qwen 3.7 Plus, Nemotron 3 Ultra, and other new models;
+refreshes pricing and capability flags; and removes ids retired upstream
+(e.g. `anthropic/claude-3.5-haiku`, `anthropic/claude-opus-4.6-fast`).

--- a/scripts/sync-provider-models.ts
+++ b/scripts/sync-provider-models.ts
@@ -521,7 +521,7 @@ function detectChangedPackages(): Set<string> {
 
     for (const line of diff.split('\n')) {
       // packages/ai-openrouter/... → @tanstack/ai-openrouter
-      const match = line.match(/^packages\/typescript\/([\w-]+)\//)
+      const match = line.match(/^packages\/([\w-]+)\//)
       if (match) {
         changed.add(`@tanstack/${match[1]}`)
       }


### PR DESCRIPTION
## 🎯 Changes

The daily model-metadata sync stopped creating changesets for packages whose meta is regenerated by `convert-openrouter-models.ts`. The safety net, `detectChangedPackages()` in `scripts/sync-provider-models.ts`, still matched the pre-#643 `packages/typescript/<pkg>/` layout — the #643 monorepo flatten updated every `metaFile` path in the script (and even the comment above the regex) but missed the regex itself, so since May 26 it has always returned an empty set.

Consequences:

- Sync #883 (Sonnet 5 / Fable 5 in the OpenRouter meta) produced **no changeset at all**, so `@tanstack/ai-openrouter` was never bumped.
- Sync #772 silently omitted `@tanstack/ai-openrouter` from its changeset despite a 2,043-line meta regeneration (its changeset only listed the packages `sync-provider-models.ts` added models to directly).

This PR:

1. Fixes the regex (`packages/typescript/([\w-]+)/` → `packages/([\w-]+)/`).
2. Adds the missed `.changeset/sync-models.md` patching `@tanstack/ai-openrouter`, covering the unreleased meta changes from #772 and #883 (Claude Sonnet 5, Claude Fable 5, DeepSeek V3.2, GLM-5.2, and other additions/removals/pricing updates). The file reuses the `sync-models` name so the next daily sync merges into it instead of duplicating.

Audited all sync commits since the flatten: `ai-anthropic` / `ai-gemini` changes from #772 were released via #873, so `@tanstack/ai-openrouter` is the only package with unreleased sync changes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed the available model catalog with newly supported models and updated capability/pricing details.
* **Bug Fixes**
  * Removed retired models from the list so the available options better match current provider offerings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->