### PR TITLE
fix(ai-sandbox): pass deterministic id into provider.create

### DIFF
--- a/.changeset/sandbox-deterministic-create-id.md
+++ b/.changeset/sandbox-deterministic-create-id.md
@@ -1,0 +1,14 @@
+---
+'@tanstack/ai-sandbox': patch
+'@tanstack/ai-sandbox-cloudflare': patch
+---
+
+Give providers a deterministic sandbox id on create.
+
+`SandboxCreateInput` now carries an optional `id`, and `ensure()` passes the
+compound sandbox key into `provider.create()`. Providers whose native id is
+addressable by name (Cloudflare's DO id) honor it — `input.id ?? <random>` —
+so out-of-band consumers (e.g. attaching a preview iframe) can reconstruct the
+exact sandbox an agent is editing from run context instead of the random id
+previously recoverable only from the sandbox store. Providers that mint their
+own opaque id ignore it, so behavior is unchanged for them.

--- a/.changeset/sandbox-deterministic-create-id.md
+++ b/.changeset/sandbox-deterministic-create-id.md
@@ -1,14 +1,16 @@
 ---
 '@tanstack/ai-sandbox': patch
 '@tanstack/ai-sandbox-cloudflare': patch
+'@tanstack/ai-sandbox-sprites': patch
 ---
 
 Give providers a deterministic sandbox id on create.
 
 `SandboxCreateInput` now carries an optional `id`, and `ensure()` passes the
 compound sandbox key into `provider.create()`. Providers whose native id is
-addressable by name (Cloudflare's DO id) honor it — `input.id ?? <random>` —
-so out-of-band consumers (e.g. attaching a preview iframe) can reconstruct the
+addressable by name **and** expose a preview URL keyed by that id — Cloudflare
+(DO id) and Sprites (sprite name) — honor it (`input.id ?? <random>`), so
+out-of-band consumers (e.g. attaching a preview iframe) can reconstruct the
 exact sandbox an agent is editing from run context instead of the random id
 previously recoverable only from the sandbox store. Providers that mint their
-own opaque id ignore it, so behavior is unchanged for them.
+own opaque id (Daytona, Vercel) ignore it, so behavior is unchanged for them.

--- a/packages/ai-sandbox-cloudflare/src/provider.ts
+++ b/packages/ai-sandbox-cloudflare/src/provider.ts
@@ -56,7 +56,11 @@ class CloudflareProvider implements SandboxProvider {
   }
 
   async create(input: SandboxCreateInput): Promise<SandboxHandle> {
-    const id = crypto.randomUUID()
+    // Honor the deterministic id `ensure()` supplies so reconnecting consumers
+    // (e.g. a preview iframe) address the same DO the agent edits. The DO id is
+    // `idFromName(id)`, so any stable string works; fall back to a random id
+    // when created outside `defineSandbox` (advanced direct use).
+    const id = input.id ?? crypto.randomUUID()
     const sandbox = getSandbox(this.config.binding, id, this.sandboxOptions)
     if (input.env && Object.keys(input.env).length > 0) {
       await sandbox.setEnvVars(input.env)

--- a/packages/ai-sandbox-cloudflare/tests/provider.test.ts
+++ b/packages/ai-sandbox-cloudflare/tests/provider.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Verifies the provider uses the deterministic id `ensure()` supplies (so a
+ * preview reconnect addresses the same DO the agent edits) and falls back to a
+ * random id only when none is given. `getSandbox` is mocked — no Workers runtime.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getSandbox = vi.fn()
+
+vi.mock('@cloudflare/sandbox', () => ({
+  getSandbox: (...args: Array<unknown>) => getSandbox(...args),
+}))
+
+const { cloudflareSandbox } = await import('../src/provider')
+
+function stubSandbox() {
+  return {
+    setEnvVars: vi.fn(() => Promise.resolve()),
+    mkdir: vi.fn(() => Promise.resolve()),
+    destroy: vi.fn(() => Promise.resolve()),
+  }
+}
+
+describe('cloudflareSandbox provider — deterministic id', () => {
+  beforeEach(() => {
+    getSandbox.mockReset()
+  })
+
+  it('uses input.id as the sandbox id when provided', async () => {
+    getSandbox.mockReturnValue(stubSandbox())
+    const provider = cloudflareSandbox({ binding: {} as never })
+
+    const handle = await provider.create({ id: 'deterministic-key' })
+
+    expect(getSandbox).toHaveBeenCalledWith(
+      {},
+      'deterministic-key',
+      expect.anything(),
+    )
+    expect(handle.id).toBe('deterministic-key')
+  })
+
+  it('falls back to a random id when no id is supplied', async () => {
+    getSandbox.mockReturnValue(stubSandbox())
+    const provider = cloudflareSandbox({ binding: {} as never })
+
+    const handle = await provider.create({})
+
+    expect(handle.id).not.toBe('')
+    expect(getSandbox).toHaveBeenCalledWith({}, handle.id, expect.anything())
+  })
+})

--- a/packages/ai-sandbox-sprites/src/provider.ts
+++ b/packages/ai-sandbox-sprites/src/provider.ts
@@ -93,7 +93,8 @@ class SpritesProvider implements SandboxProvider {
     // an out-of-band reconnect (a preview iframe) on a different sprite than the
     // one the agent edits. Fall back to a random name for direct/advanced use.
     const name =
-      input.id ?? `${NAME_PREFIX}-${randomUUID().replace(/-/g, '').slice(0, 12)}`
+      input.id ??
+      `${NAME_PREFIX}-${randomUUID().replace(/-/g, '').slice(0, 12)}`
     const sprite = await this.client.createSprite(name, {
       ...(this.config.waitForCapacity !== undefined
         ? { waitForCapacity: this.config.waitForCapacity }

--- a/packages/ai-sandbox-sprites/src/provider.ts
+++ b/packages/ai-sandbox-sprites/src/provider.ts
@@ -88,7 +88,12 @@ class SpritesProvider implements SandboxProvider {
   }
 
   async create(input: SandboxCreateInput): Promise<SandboxHandle> {
-    const name = `${NAME_PREFIX}-${randomUUID().replace(/-/g, '').slice(0, 12)}`
+    // Honor the deterministic id ensure() supplies (see SandboxCreateInput.id).
+    // The sprite's preview URL is keyed by name, so a random name would strand
+    // an out-of-band reconnect (a preview iframe) on a different sprite than the
+    // one the agent edits. Fall back to a random name for direct/advanced use.
+    const name =
+      input.id ?? `${NAME_PREFIX}-${randomUUID().replace(/-/g, '').slice(0, 12)}`
     const sprite = await this.client.createSprite(name, {
       ...(this.config.waitForCapacity !== undefined
         ? { waitForCapacity: this.config.waitForCapacity }

--- a/packages/ai-sandbox-sprites/tests/provider.test.ts
+++ b/packages/ai-sandbox-sprites/tests/provider.test.ts
@@ -98,6 +98,17 @@ describe('spritesSandbox provider', () => {
     void mkdirWs
   })
 
+  it('create() uses the deterministic id as the sprite name when provided', async () => {
+    installFetch({ auth: 'public' })
+    const provider = spritesSandbox({ apiKey: 'k', apiUrl: 'https://api.test' })
+    const handle = await provider.create({ id: 'deadbeefdeadbeef' })
+    expect(handle.id).toBe('deadbeefdeadbeef')
+    const post = calls.find(
+      (c) => c.method === 'POST' && c.url.endsWith('/v1/sprites'),
+    )
+    expect(post?.body).toContain('"name":"deadbeefdeadbeef"')
+  })
+
   it('create() forces configured urlAuth when the sprite differs', async () => {
     installFetch({ auth: 'public' })
     const provider = spritesSandbox({

--- a/packages/ai-sandbox/src/contracts.ts
+++ b/packages/ai-sandbox/src/contracts.ts
@@ -191,6 +191,18 @@ export interface SandboxHandle {
 
 /** Input passed to {@link SandboxProvider.create}. */
 export interface SandboxCreateInput {
+  /**
+   * Deterministic instance id the caller wants the provider to use. `ensure()`
+   * passes the compound sandbox key here so the provider-assigned id is
+   * reconstructable from run context (thread/workspace/tenant/reuse) instead of
+   * being a random value only recoverable from the sandbox store. Providers
+   * whose native id is addressable by name (e.g. Cloudflare's DO id) SHOULD
+   * honor it (`input.id ?? <random>`); providers that mint their own opaque id
+   * MAY ignore it. Consumers that reconnect out-of-band — e.g. attaching a
+   * preview iframe to the exact sandbox an agent is editing — rely on this being
+   * honored to avoid addressing two different sandboxes.
+   */
+  id?: string
   workspace?: WorkspaceDefinition
   policy?: SandboxPolicy
   env?: Record<string, string>

--- a/packages/ai-sandbox/src/sandbox.ts
+++ b/packages/ai-sandbox/src/sandbox.ts
@@ -187,6 +187,9 @@ export function defineSandbox(config: SandboxConfig): SandboxDefinition {
       }
 
       const created = await config.provider.create({
+        // Deterministic id so consumers can reconstruct the provider sandbox
+        // address from run context (not just from the store record).
+        id: key,
         workspace: config.workspace,
         policy: config.policy,
         env:

--- a/packages/ai-sandbox/tests/ensure.test.ts
+++ b/packages/ai-sandbox/tests/ensure.test.ts
@@ -36,6 +36,20 @@ describe('ensureSandbox algorithm', () => {
     expect(rec?.threadId).toBe('thread-1')
   })
 
+  it('creates with the deterministic compound key as the provider id', async () => {
+    const provider = makeFakeProvider()
+    const def = defineSandbox({ id: 'repo', provider, workspace })
+    const ctx = baseCtx()
+
+    const handle = await def.ensure(ctx)
+
+    // The provider-assigned id equals the reconstructable compound key, so a
+    // consumer that recomputes def.key(ctx) addresses the same sandbox.
+    expect(handle.id).toBe(def.key(ctx))
+    const rec = await ctx.store.get(def.key(ctx))
+    expect(rec?.providerSandboxId).toBe(def.key(ctx))
+  })
+
   it('resumes the same provider sandbox on a second run (reuse: thread)', async () => {
     const provider = makeFakeProvider()
     const def = defineSandbox({ id: 'repo', provider, workspace })

--- a/packages/ai-sandbox/tests/fakes.ts
+++ b/packages/ai-sandbox/tests/fakes.ts
@@ -189,9 +189,11 @@ export function makeFakeProvider(
     calls,
     created,
     capabilities: () => caps,
-    create: (_input: SandboxCreateInput) => {
+    create: (input: SandboxCreateInput) => {
       calls.create++
-      const handle = makeFakeHandle(`${name}-${++counter}`, name, caps)
+      // Honor the deterministic id when supplied (mirrors real providers like
+      // Cloudflare); fall back to a counter for direct/advanced use.
+      const handle = makeFakeHandle(input.id ?? `${name}-${++counter}`, name, caps)
       created.push(handle)
       return Promise.resolve(handle)
     },

--- a/packages/ai-sandbox/tests/fakes.ts
+++ b/packages/ai-sandbox/tests/fakes.ts
@@ -193,7 +193,11 @@ export function makeFakeProvider(
       calls.create++
       // Honor the deterministic id when supplied (mirrors real providers like
       // Cloudflare); fall back to a counter for direct/advanced use.
-      const handle = makeFakeHandle(input.id ?? `${name}-${++counter}`, name, caps)
+      const handle = makeFakeHandle(
+        input.id ?? `${name}-${++counter}`,
+        name,
+        caps,
+      )
       created.push(handle)
       return Promise.resolve(handle)
     },


### PR DESCRIPTION
## Problem

`@tanstack/ai-sandbox` computes a stable compound sandbox key, but `SandboxCreateInput` carried no deterministic id into `provider.create()`. Providers then minted a **random** id (Cloudflare `crypto.randomUUID()`, Sprites `tanstack-ai-<random>`), so the provider-assigned id was recoverable **only** from the sandbox store.

Out-of-band consumers that reconnect without reading the store — e.g. Forge attaching a preview iframe — had no way to reconstruct that random id. The result: the agent (Codex) edited one sandbox while the iframe watched another.

## Fix

- **`SandboxCreateInput`** gains an optional `id`.
- **`ensure()`** passes the *computed compound key* (not raw `defineSandbox({ id })`) into `provider.create({ id, ... })`. The computed key already folds in threadId / runId (for `reuse: 'none'`) / provider / workspace / tenant, so it can't collide across threads or runs.
- Providers that are **name-addressable and expose a preview URL keyed by that id** honor it (`input.id ?? <random>`): **Cloudflare** (DO id) and **Sprites** (sprite name). Consumers can now recompute `definition.key(ctx)` and address the exact sandbox the agent edits.

## Which providers honor it — and why the rest don't

| Provider | Backend id | Preview reconnect | Honors `id`? |
|---|---|---|---|
| **Cloudflare** | `getSandbox(binding, name)` — caller-named | DO/tunnel URL keyed by id | ✅ yes |
| **Sprites** | `createSprite(name)` — caller-named | sprite URL keyed by name | ✅ yes |
| Docker | `createContainer` (could name) | localhost host-port only — no cross-process address | no (store-resume suffices) |
| local-process | dir path (could name) | none (runs on host) | no |
| Daytona | `daytona.create()` mints opaque id | — | can't (no caller id) |
| Vercel | `Sandbox.create()` server-assigns name | — | can't (no caller id) |

So the two providers with the exact "caller-named + URL-addressable preview" shape are fixed; Docker/local-process *could* honor it but have no out-of-band reconnect problem (their store record already covers resume); Daytona/Vercel physically can't, since the backend owns the id.

## Tests

- `ai-sandbox/tests/ensure.test.ts`: asserts the provider id equals `def.key(ctx)`.
- `ai-sandbox-cloudflare/tests/provider.test.ts` (new): `getSandbox` called with `input.id`, random fallback otherwise.
- `ai-sandbox-sprites/tests/provider.test.ts`: create uses `input.id` as the sprite name when provided.

Unit tests, typecheck, and lint pass for all three packages. (One pre-existing, unrelated Windows path-separator failure in `harness-cwd.test.ts` is untouched by this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox creation now supports deterministic IDs, making it easier to reconnect to the same sandbox later.
  * Some sandbox providers now preserve a requested ID when creating a new sandbox, improving consistency across preview and reconnect flows.

* **Bug Fixes**
  * Fixed mismatches where a sandbox could be created with one identifier but referenced with another.
  * Updated test coverage to verify deterministic sandbox IDs are returned and stored correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->