### PR TITLE
feat: configurable client-side message queue for useChat

### DIFF
--- a/.changeset/message-queue.md
+++ b/.changeset/message-queue.md
@@ -1,0 +1,13 @@
+---
+'@tanstack/ai-client': minor
+'@tanstack/ai-react': minor
+'@tanstack/ai-solid': minor
+'@tanstack/ai-vue': minor
+'@tanstack/ai-svelte': minor
+---
+
+Messages sent while a stream is already in flight are now queued by default and automatically sent once the in-flight stream settles, instead of being silently dropped. **This is a behavior change.**
+
+The behavior is configurable via a new `queue` option, which accepts `whenBusy: 'queue' | 'drop' | 'interrupt'`, `drain: 'fifo' | 'batch'`, `maxSize`, and `onOverflow`, or a custom strategy function for full control.
+
+Queued messages are exposed on the hook as `queue` and can be cancelled before they send via `cancelQueued(id)`. `sendMessage` also accepts a per-call `{ whenBusy }` override.

--- a/.changeset/message-queue.md
+++ b/.changeset/message-queue.md
@@ -4,6 +4,7 @@
 '@tanstack/ai-solid': minor
 '@tanstack/ai-vue': minor
 '@tanstack/ai-svelte': minor
+'@tanstack/ai-preact': minor
 ---
 
 Messages sent while a stream is already in flight are now queued by default and automatically sent once the in-flight stream settles, instead of being silently dropped. **This is a behavior change.**

--- a/.changeset/message-queue.md
+++ b/.changeset/message-queue.md
@@ -5,9 +5,10 @@
 '@tanstack/ai-vue': minor
 '@tanstack/ai-svelte': minor
 '@tanstack/ai-preact': minor
+'@tanstack/ai-angular': minor
 ---
 
-Messages sent while a stream is already in flight are now queued by default and automatically sent once the in-flight stream settles, instead of being silently dropped. **This is a behavior change.**
+Messages sent while a stream is already in flight are now queued by default and automatically sent once the in-flight stream settles, instead of being silently dropped. **This is a behavior change.** Restore the previous drop-while-busy behavior with `queue: 'drop'`.
 
 The behavior is configurable via a new `queue` option, which accepts `whenBusy: 'queue' | 'drop' | 'interrupt'`, `drain: 'fifo' | 'batch'`, `maxSize`, and `onOverflow`, or a custom strategy function for full control.
 

--- a/docs/chat/streaming.md
+++ b/docs/chat/streaming.md
@@ -224,7 +224,7 @@ const { messages, queue, sendMessage, cancelQueued, isLoading } = useChat({
 - **`maxSize`** — caps how many messages can be queued.
 - **`onOverflow`** — `"reject"` (default) ignores a send once `maxSize` is reached; `"drop-oldest"` evicts the oldest queued item to make room.
 
-You can also pass a plain `WhenBusy` string as shorthand for `queue: "interrupt"`, or a `QueueStrategy` function for full control over the per-send decision (the drain order stays FIFO for the function form).
+You can also pass a plain `WhenBusy` string (e.g. `queue: "interrupt"`) as shorthand for `{ whenBusy: "interrupt" }` — this applies for any `WhenBusy` value (`"queue"`, `"drop"`, or `"interrupt"`), not just `"interrupt"` — or a `QueueStrategy` function for full control over the per-send decision (the drain order stays FIFO for the function form).
 
 `useChat` exposes the pending queue as `queue` so you can render it distinctly from `messages`, along with `cancelQueued(id)` to cancel an item before it sends:
 

--- a/docs/chat/streaming.md
+++ b/docs/chat/streaming.md
@@ -218,13 +218,19 @@ const { messages, queue, sendMessage, cancelQueued, isLoading } = useChat({
 
 - **`whenBusy`** — what happens to a send that arrives mid-stream:
   - `"queue"` (default) — hold the message; it sends once the stream settles.
-  - `"drop"` — ignore the send.
-  - `"interrupt"` — abort the current stream (like calling `stop()`) and send the new message immediately.
-- **`drain`** — how queued items leave the queue: `"fifo"` (default) sends them one at a time in order; `"batch"` merges everything currently queued into a single send once the stream settles (string contents joined with `\n`, multimodal content concatenated in order).
-- **`maxSize`** — caps how many messages can be queued.
-- **`onOverflow`** — `"reject"` (default) ignores a send once `maxSize` is reached; `"drop-oldest"` evicts the oldest queued item to make room.
+  - `"drop"` — ignore the send (promise still resolves; do not clear the composer until the message appears in `messages` or `queue`).
+  - `"interrupt"` — abort the current stream and send the new message immediately. Unlike `stop()`, this does **not** clear already-queued messages — they still drain after the interrupting send succeeds.
+- **`drain`** — how queued items leave the queue: `"fifo"` (default) sends them one at a time in order; `"batch"` merges everything currently queued into a single send once the stream settles (string contents joined with `\n`, multimodal content concatenated in order; when sending via `ChatClient` with per-message `body`, the last item's `body` wins).
+- **`maxSize`** — caps how many messages can be queued (`0` means never queue).
+- **`onOverflow`** — `"reject"` (default) silently ignores a send once `maxSize` is reached; `"drop-oldest"` evicts the oldest queued item to make room.
 
-You can also pass a plain `WhenBusy` string (e.g. `queue: "interrupt"`) as shorthand for `{ whenBusy: "interrupt" }` — this applies for any `WhenBusy` value (`"queue"`, `"drop"`, or `"interrupt"`), not just `"interrupt"` — or a `QueueStrategy` function for full control over the per-send decision (the drain order stays FIFO for the function form).
+You can also pass a plain `WhenBusy` string (e.g. `queue: "interrupt"`) as shorthand for `{ whenBusy: "interrupt" }`, or a `QueueStrategy` function for per-send action control. Strategy form always drains FIFO (no `batch`); returning `"send"` while busy is coerced to `"enqueue"` (no concurrent streams). Per-call `whenBusy` overrides both config and strategy.
+
+### When the queue drains vs flushes
+
+- **Drain (auto-send)** — only after a **successful** stream settle (including after tool continuations finish).
+- **Flush (discard without sending)** — on stream **error/abort** of the active generation, `stop()`, `clear()`, `unsubscribe()`, and `reload()`.
+- **`interrupt` does not flush** — existing queued items remain and drain after the interrupting turn.
 
 `useChat` exposes the pending queue as `queue` so you can render it distinctly from `messages`, along with `cancelQueued(id)` to cancel an item before it sends:
 
@@ -249,7 +255,7 @@ Override the configured policy for a single send with the second argument to `se
 sendMessage("Never mind, do this instead", { whenBusy: "interrupt" });
 ```
 
-> **Note:** This is a default-behavior change — messages sent while streaming used to be silently dropped. They are now queued unless you opt into `whenBusy: "drop"` or `"interrupt"`.
+> **Note:** This is a default-behavior change — messages sent while streaming used to be silently dropped. They are now queued unless you opt into `queue: "drop"` (or `{ whenBusy: "drop" }`) to restore the old behavior, or `queue: "interrupt"`.
 
 ## Best Practices
 

--- a/docs/chat/streaming.md
+++ b/docs/chat/streaming.md
@@ -203,6 +203,54 @@ export async function POST(request: Request) {
 }
 ```
 
+## Queueing Messages
+
+By default, calling `sendMessage` while a stream is already in flight **queues** the message instead of dropping it — it sends automatically once the current run settles. Configure this with the `queue` option, which accepts a `QueueConfig` object, a plain shorthand string, or a strategy function:
+
+```tsx group=queueing-messages
+import { useChat, fetchServerSentEvents } from "@tanstack/ai-react";
+
+const { messages, queue, sendMessage, cancelQueued, isLoading } = useChat({
+  connection: fetchServerSentEvents("/api/chat"),
+  queue: { whenBusy: "queue", drain: "fifo", maxSize: 5 },
+});
+```
+
+- **`whenBusy`** — what happens to a send that arrives mid-stream:
+  - `"queue"` (default) — hold the message; it sends once the stream settles.
+  - `"drop"` — ignore the send.
+  - `"interrupt"` — abort the current stream (like calling `stop()`) and send the new message immediately.
+- **`drain`** — how queued items leave the queue: `"fifo"` (default) sends them one at a time in order; `"batch"` merges everything currently queued into a single send once the stream settles (string contents joined with `\n`, multimodal content concatenated in order).
+- **`maxSize`** — caps how many messages can be queued.
+- **`onOverflow`** — `"reject"` (default) ignores a send once `maxSize` is reached; `"drop-oldest"` evicts the oldest queued item to make room.
+
+You can also pass a plain `WhenBusy` string as shorthand for `queue: "interrupt"`, or a `QueueStrategy` function for full control over the per-send decision (the drain order stays FIFO for the function form).
+
+`useChat` exposes the pending queue as `queue` so you can render it distinctly from `messages`, along with `cancelQueued(id)` to cancel an item before it sends:
+
+```tsx group=queueing-messages
+function PendingQueue() {
+  return (
+    <>
+      {queue.map((q) => (
+        <div key={q.id} className="pending">
+          {typeof q.content === "string" ? q.content : "[attachment]"}
+          <button onClick={() => cancelQueued(q.id)}>Cancel</button>
+        </div>
+      ))}
+    </>
+  );
+}
+```
+
+Override the configured policy for a single send with the second argument to `sendMessage`:
+
+```tsx group=queueing-messages
+sendMessage("Never mind, do this instead", { whenBusy: "interrupt" });
+```
+
+> **Note:** This is a default-behavior change — messages sent while streaming used to be silently dropped. They are now queued unless you opt into `whenBusy: "drop"` or `"interrupt"`.
+
 ## Best Practices
 
 1. **Handle loading states** - Use `isLoading` to show loading indicators
@@ -210,6 +258,7 @@ export async function POST(request: Request) {
 3. **Cancel on unmount** - Clean up streams when components unmount
 4. **Optimize rendering** - Batch updates if needed for performance
 5. **Show progress** - Display partial content as it streams
+6. **Render queued messages distinctly** - Use `queue` to show pending sends separately from `messages`
 
 ## Next Steps
 

--- a/docs/chat/streaming.md
+++ b/docs/chat/streaming.md
@@ -205,7 +205,7 @@ export async function POST(request: Request) {
 
 ## Queueing Messages
 
-By default, calling `sendMessage` while a stream is already in flight **queues** the message instead of dropping it — it sends automatically once the current run settles. Configure this with the `queue` option, which accepts a `QueueConfig` object, a plain shorthand string, or a strategy function:
+By default, calling `sendMessage` while a stream is already in flight **queues** the message instead of dropping it — it sends automatically once the current run settles **successfully**. Configure this with the `queue` option, which accepts a `QueueConfig` object, a plain shorthand string, or a strategy function:
 
 ```tsx group=queueing-messages
 import { useChat, fetchServerSentEvents } from "@tanstack/ai-react";
@@ -216,21 +216,21 @@ const { messages, queue, sendMessage, cancelQueued, isLoading } = useChat({
 });
 ```
 
-- **`whenBusy`** — what happens to a send that arrives mid-stream:
-  - `"queue"` (default) — hold the message; it sends once the stream settles.
-  - `"drop"` — ignore the send (promise still resolves; do not clear the composer until the message appears in `messages` or `queue`).
+- **`whenBusy`** — what happens to a send that arrives while the client is busy (streaming, claiming a send, or draining the queue):
+  - `"queue"` (default) — hold the message; it sends once the run settles **successfully**. Clear the composer once the message appears in `queue` or `messages`.
+  - `"drop"` — ignore the send (promise still resolves; does not throw). The message never appears in `queue` or `messages` — keep the composer text and show feedback if you want the user to retry.
   - `"interrupt"` — abort the current stream and send the new message immediately. Unlike `stop()`, this does **not** clear already-queued messages — they still drain after the interrupting send succeeds.
-- **`drain`** — how queued items leave the queue: `"fifo"` (default) sends them one at a time in order; `"batch"` merges everything currently queued into a single send once the stream settles (string contents joined with `\n`, multimodal content concatenated in order; when sending via `ChatClient` with per-message `body`, the last item's `body` wins).
+- **`drain`** — how queued items leave the queue: `"fifo"` (default) sends them one at a time in order; `"batch"` merges everything currently queued into a single send once the run settles successfully (string contents joined with `\n`, multimodal content concatenated in order; when sending via `ChatClient` with per-message `body`, the last item's `body` wins — framework hooks do not forward per-send `body`).
 - **`maxSize`** — caps how many messages can be queued (`0` means never queue).
-- **`onOverflow`** — `"reject"` (default) silently ignores a send once `maxSize` is reached; `"drop-oldest"` evicts the oldest queued item to make room.
+- **`onOverflow`** — `"reject"` (default) silently ignores a send once `maxSize` is reached (does not throw); `"drop-oldest"` evicts the oldest queued item to make room.
 
-You can also pass a plain `WhenBusy` string (e.g. `queue: "interrupt"`) as shorthand for `{ whenBusy: "interrupt" }`, or a `QueueStrategy` function for per-send action control. Strategy form always drains FIFO (no `batch`); returning `"send"` while busy is coerced to `"enqueue"` (no concurrent streams). Per-call `whenBusy` overrides both config and strategy.
+You can also pass a plain `WhenBusy` string (e.g. `queue: "interrupt"`) as shorthand for `{ whenBusy: "interrupt" }`, or a `QueueStrategy` function for per-send action control. Strategy form always drains FIFO (no `batch`); actions are `'queue' | 'drop' | 'interrupt'` (no concurrent streams). Per-call `whenBusy` overrides both config and strategy.
 
 ### When the queue drains vs flushes
 
 - **Drain (auto-send)** — only after a **successful** stream settle (including after tool continuations finish).
-- **Flush (discard without sending)** — on stream **error/abort** of the active generation, `stop()`, `clear()`, `unsubscribe()`, and `reload()`.
-- **`interrupt` does not flush** — existing queued items remain and drain after the interrupting turn.
+- **Flush (discard without sending)** — on **error/abort of the active generation** (user `stop()`, real stream errors), `clear()`, `unsubscribe()`, and `reload()`. Interrupt aborts the old run without flushing; remaining items drain after a **successful** interrupting turn.
+- **`interrupt` does not flush** — existing queued items remain and drain after the interrupting turn succeeds.
 
 `useChat` exposes the pending queue as `queue` so you can render it distinctly from `messages`, along with `cancelQueued(id)` to cancel an item before it sends:
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -161,7 +161,7 @@
           "label": "Streaming",
           "to": "chat/streaming",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-03"
+          "updatedAt": "2026-07-06"
         },
         {
           "label": "Connection Adapters",

--- a/docs/config.json
+++ b/docs/config.json
@@ -161,7 +161,7 @@
           "label": "Streaming",
           "to": "chat/streaming",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-06"
+          "updatedAt": "2026-07-17"
         },
         {
           "label": "Connection Adapters",

--- a/examples/ts-react-chat/src/components/Header.tsx
+++ b/examples/ts-react-chat/src/components/Header.tsx
@@ -11,6 +11,7 @@ import {
   Guitar,
   Home,
   Image,
+  Layers,
   Menu,
   LayoutGrid,
   Mic,
@@ -243,6 +244,19 @@ export default function Header() {
           >
             <MessageSquare size={20} />
             <span className="font-medium">Persistent Chats</span>
+          </Link>
+
+          <Link
+            to="/queueing"
+            onClick={() => setIsOpen(false)}
+            className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-800 transition-colors mb-2"
+            activeProps={{
+              className:
+                'flex items-center gap-3 p-3 rounded-lg bg-cyan-600 hover:bg-cyan-700 transition-colors mb-2',
+            }}
+          >
+            <Layers size={20} />
+            <span className="font-medium">Queueing Strategies</span>
           </Link>
 
           <Link

--- a/examples/ts-react-chat/src/routeTree.gen.ts
+++ b/examples/ts-react-chat/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as ThreadsRouteImport } from './routes/threads'
 import { Route as ServerFnChatRouteImport } from './routes/server-fn-chat'
 import { Route as SandboxesRouteImport } from './routes/sandboxes'
 import { Route as RealtimeRouteImport } from './routes/realtime'
+import { Route as QueueingRouteImport } from './routes/queueing'
 import { Route as McpDemoRouteImport } from './routes/mcp-demo'
 import { Route as McpAppsRouteImport } from './routes/mcp-apps'
 import { Route as Issue176ToolResultRouteImport } from './routes/issue-176-tool-result'
@@ -78,6 +79,11 @@ const SandboxesRoute = SandboxesRouteImport.update({
 const RealtimeRoute = RealtimeRouteImport.update({
   id: '/realtime',
   path: '/realtime',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QueueingRoute = QueueingRouteImport.update({
+  id: '/queueing',
+  path: '/queueing',
   getParentRoute: () => rootRouteImport,
 } as any)
 const McpDemoRoute = McpDemoRouteImport.update({
@@ -293,6 +299,7 @@ export interface FileRoutesByFullPath {
   '/issue-176-tool-result': typeof Issue176ToolResultRoute
   '/mcp-apps': typeof McpAppsRoute
   '/mcp-demo': typeof McpDemoRoute
+  '/queueing': typeof QueueingRoute
   '/realtime': typeof RealtimeRoute
   '/sandboxes': typeof SandboxesRoute
   '/server-fn-chat': typeof ServerFnChatRoute
@@ -340,6 +347,7 @@ export interface FileRoutesByTo {
   '/issue-176-tool-result': typeof Issue176ToolResultRoute
   '/mcp-apps': typeof McpAppsRoute
   '/mcp-demo': typeof McpDemoRoute
+  '/queueing': typeof QueueingRoute
   '/realtime': typeof RealtimeRoute
   '/sandboxes': typeof SandboxesRoute
   '/server-fn-chat': typeof ServerFnChatRoute
@@ -388,6 +396,7 @@ export interface FileRoutesById {
   '/issue-176-tool-result': typeof Issue176ToolResultRoute
   '/mcp-apps': typeof McpAppsRoute
   '/mcp-demo': typeof McpDemoRoute
+  '/queueing': typeof QueueingRoute
   '/realtime': typeof RealtimeRoute
   '/sandboxes': typeof SandboxesRoute
   '/server-fn-chat': typeof ServerFnChatRoute
@@ -437,6 +446,7 @@ export interface FileRouteTypes {
     | '/issue-176-tool-result'
     | '/mcp-apps'
     | '/mcp-demo'
+    | '/queueing'
     | '/realtime'
     | '/sandboxes'
     | '/server-fn-chat'
@@ -484,6 +494,7 @@ export interface FileRouteTypes {
     | '/issue-176-tool-result'
     | '/mcp-apps'
     | '/mcp-demo'
+    | '/queueing'
     | '/realtime'
     | '/sandboxes'
     | '/server-fn-chat'
@@ -531,6 +542,7 @@ export interface FileRouteTypes {
     | '/issue-176-tool-result'
     | '/mcp-apps'
     | '/mcp-demo'
+    | '/queueing'
     | '/realtime'
     | '/sandboxes'
     | '/server-fn-chat'
@@ -579,6 +591,7 @@ export interface RootRouteChildren {
   Issue176ToolResultRoute: typeof Issue176ToolResultRoute
   McpAppsRoute: typeof McpAppsRoute
   McpDemoRoute: typeof McpDemoRoute
+  QueueingRoute: typeof QueueingRoute
   RealtimeRoute: typeof RealtimeRoute
   SandboxesRoute: typeof SandboxesRoute
   ServerFnChatRoute: typeof ServerFnChatRoute
@@ -653,6 +666,13 @@ declare module '@tanstack/react-router' {
       path: '/realtime'
       fullPath: '/realtime'
       preLoaderRoute: typeof RealtimeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/queueing': {
+      id: '/queueing'
+      path: '/queueing'
+      fullPath: '/queueing'
+      preLoaderRoute: typeof QueueingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/mcp-demo': {
@@ -947,6 +967,7 @@ const rootRouteChildren: RootRouteChildren = {
   Issue176ToolResultRoute: Issue176ToolResultRoute,
   McpAppsRoute: McpAppsRoute,
   McpDemoRoute: McpDemoRoute,
+  QueueingRoute: QueueingRoute,
   RealtimeRoute: RealtimeRoute,
   SandboxesRoute: SandboxesRoute,
   ServerFnChatRoute: ServerFnChatRoute,

--- a/examples/ts-react-chat/src/routes/queueing.tsx
+++ b/examples/ts-react-chat/src/routes/queueing.tsx
@@ -37,7 +37,7 @@ const FIFO: StrategyMeta = {
 const INTERRUPT: StrategyMeta = {
   title: 'interrupt',
   blurb:
-    'A message sent while streaming aborts the in-flight response and sends immediately. The queue never fills.',
+    'A message sent while streaming aborts the in-flight response and sends immediately. Unlike stop(), already-queued items are kept and still drain afterward.',
   config: { whenBusy: 'interrupt' },
 }
 const BATCH: StrategyMeta = {

--- a/examples/ts-react-chat/src/routes/queueing.tsx
+++ b/examples/ts-react-chat/src/routes/queueing.tsx
@@ -3,8 +3,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Send, Square, X, Zap } from 'lucide-react'
 import { fetchServerSentEvents, useChat } from '@tanstack/ai-react'
 import type { QueueConfig, QueuedMessage, UIMessage } from '@tanstack/ai-react'
-import { DEFAULT_MODEL_OPTION, MODEL_OPTIONS } from '@/lib/model-selection'
 import type { ModelOption } from '@/lib/model-selection'
+import { DEFAULT_MODEL_OPTION, MODEL_OPTIONS } from '@/lib/model-selection'
 
 /**
  * Showcase route for the client-side message queue.
@@ -49,8 +49,7 @@ const BATCH: StrategyMeta = {
 
 function textOf(message: UIMessage): string {
   return message.parts
-    .filter((part) => part.type === 'text')
-    .map((part) => (part.type === 'text' ? part.content : ''))
+    .flatMap((part) => (part.type === 'text' ? [part.content] : []))
     .join('')
 }
 

--- a/examples/ts-react-chat/src/routes/queueing.tsx
+++ b/examples/ts-react-chat/src/routes/queueing.tsx
@@ -1,0 +1,288 @@
+import { useMemo, useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { Send, Square, X, Zap } from 'lucide-react'
+import { fetchServerSentEvents, useChat } from '@tanstack/ai-react'
+import type { QueueConfig, QueuedMessage, UIMessage } from '@tanstack/ai-react'
+import { DEFAULT_MODEL_OPTION, MODEL_OPTIONS } from '@/lib/model-selection'
+import type { ModelOption } from '@/lib/model-selection'
+
+/**
+ * Showcase route for the client-side message queue.
+ *
+ * Three chats run side by side against the same endpoint, each hardwired to a
+ * different `queue` strategy. A shared composer broadcasts the same message to
+ * all three at once, so you can send a message, then send another WHILE the
+ * first is still streaming, and watch each strategy diverge:
+ *
+ * - queue/fifo  → the second message is held and auto-sent after the first
+ *   settles; it shows up as a cancellable pending item.
+ * - interrupt   → the in-flight stream is aborted and the new message sends
+ *   immediately (the queue never fills).
+ * - queue/batch → multiple mid-stream messages are held, then merged into a
+ *   single send when the stream settles.
+ */
+
+interface StrategyMeta {
+  title: string
+  blurb: string
+  config: QueueConfig
+}
+
+const FIFO: StrategyMeta = {
+  title: 'queue · fifo',
+  blurb:
+    'Messages sent while streaming are held and auto-sent one at a time, in order. Pending messages are cancellable until they drain.',
+  config: { whenBusy: 'queue', drain: 'fifo' },
+}
+const INTERRUPT: StrategyMeta = {
+  title: 'interrupt',
+  blurb:
+    'A message sent while streaming aborts the in-flight response and sends immediately. The queue never fills.',
+  config: { whenBusy: 'interrupt' },
+}
+const BATCH: StrategyMeta = {
+  title: 'queue · batch',
+  blurb:
+    'Messages sent while streaming are held, then merged into a single send (joined by newlines) when the stream settles.',
+  config: { whenBusy: 'queue', drain: 'batch' },
+}
+
+function textOf(message: UIMessage): string {
+  return message.parts
+    .filter((part) => part.type === 'text')
+    .map((part) => (part.type === 'text' ? part.content : ''))
+    .join('')
+}
+
+interface PanelChat {
+  messages: Array<UIMessage>
+  isLoading: boolean
+  queue: Array<QueuedMessage>
+  cancelQueued: (id: string) => void
+  stop: () => void
+  error: Error | undefined
+}
+
+function StrategyPanel({
+  strategy,
+  chat,
+}: {
+  strategy: StrategyMeta
+  chat: PanelChat
+}) {
+  const { messages, isLoading, queue, cancelQueued, stop, error } = chat
+  const visible = messages.filter(
+    (message) => textOf(message).trim().length > 0,
+  )
+
+  return (
+    <div className="flex flex-1 flex-col rounded-lg border border-orange-500/20 bg-gray-800/40 min-w-0">
+      <div className="border-b border-orange-500/10 px-3 py-2">
+        <div className="flex items-center justify-between">
+          <span className="font-mono text-sm font-semibold text-orange-400">
+            {strategy.title}
+          </span>
+          {isLoading && (
+            <button
+              onClick={stop}
+              className="flex items-center gap-1 rounded bg-red-600/80 px-2 py-1 text-xs text-white hover:bg-red-600"
+            >
+              <Square className="h-3 w-3 fill-current" />
+              Stop
+            </button>
+          )}
+        </div>
+        <p className="mt-1 text-xs leading-snug text-gray-400">
+          {strategy.blurb}
+        </p>
+      </div>
+
+      <div className="flex-1 space-y-2 overflow-y-auto px-3 py-3">
+        {visible.length === 0 && (
+          <p className="text-xs text-gray-500">No messages yet.</p>
+        )}
+        {visible.map((message) => (
+          <div
+            key={message.id}
+            className={`rounded-lg px-3 py-2 text-sm ${
+              message.role === 'assistant'
+                ? 'bg-orange-500/5 text-gray-100'
+                : 'bg-gray-700/40 text-gray-200'
+            }`}
+          >
+            <span className="mr-1 text-xs font-medium text-gray-500">
+              {message.role === 'assistant' ? 'AI' : 'You'}:
+            </span>
+            {textOf(message)}
+          </div>
+        ))}
+        {isLoading && (
+          <p className="text-xs text-orange-400/80">⏳ streaming…</p>
+        )}
+      </div>
+
+      {error && (
+        <div className="mx-3 mb-2 rounded border border-red-500/30 bg-red-500/10 px-2 py-1 text-xs text-red-400">
+          {error.message}
+        </div>
+      )}
+
+      <div className="border-t border-orange-500/10 px-3 py-2">
+        <p className="mb-1 text-xs font-medium text-gray-400">
+          Queue ({queue.length})
+        </p>
+        {queue.length === 0 ? (
+          <p className="text-xs text-gray-600">empty</p>
+        ) : (
+          <ul className="space-y-1">
+            {queue.map((item) => (
+              <li
+                key={item.id}
+                className="flex items-center justify-between gap-2 rounded bg-gray-900/60 px-2 py-1 text-xs text-gray-300"
+              >
+                <span className="truncate">
+                  {typeof item.content === 'string'
+                    ? item.content
+                    : '[multimodal]'}
+                </span>
+                <button
+                  onClick={() => cancelQueued(item.id)}
+                  className="shrink-0 text-gray-500 hover:text-red-400"
+                  title="Cancel queued message"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function QueueingPage() {
+  const [selectedModel, setSelectedModel] =
+    useState<ModelOption>(DEFAULT_MODEL_OPTION)
+  const [input, setInput] = useState('')
+
+  const body = useMemo(
+    () => ({ provider: selectedModel.provider, model: selectedModel.model }),
+    [selectedModel.provider, selectedModel.model],
+  )
+
+  // One chat per strategy, called explicitly (fixed count, fixed order) so the
+  // rules of hooks hold. The shared composer broadcasts the same text to all
+  // three via their sendMessage functions.
+  const fifo = useChat({
+    connection: fetchServerSentEvents('/api/tanchat'),
+    body,
+    queue: FIFO.config,
+  })
+  const interrupt = useChat({
+    connection: fetchServerSentEvents('/api/tanchat'),
+    body,
+    queue: INTERRUPT.config,
+  })
+  const batch = useChat({
+    connection: fetchServerSentEvents('/api/tanchat'),
+    body,
+    queue: BATCH.config,
+  })
+
+  const panels = [
+    { meta: FIFO, chat: fifo },
+    { meta: INTERRUPT, chat: interrupt },
+    { meta: BATCH, chat: batch },
+  ]
+
+  const broadcast = () => {
+    const text = input.trim()
+    if (!text) return
+    void fifo.sendMessage(text)
+    void interrupt.sendMessage(text)
+    void batch.sendMessage(text)
+    setInput('')
+  }
+
+  return (
+    <div className="flex h-[calc(100vh-72px)] flex-col bg-gray-900">
+      <div className="border-b border-orange-500/20 bg-gray-800 px-4 py-3">
+        <h1 className="text-lg font-semibold text-white">
+          Queueing Strategies
+        </h1>
+        <p className="mt-1 text-sm text-gray-400">
+          Send a message, then send another <em>while it is still streaming</em>{' '}
+          — each panel reacts differently based on its <code>queue</code>{' '}
+          config.
+        </p>
+        <div className="mt-3 max-w-sm">
+          <label className="mb-1 block text-xs text-gray-400">Model</label>
+          <select
+            value={MODEL_OPTIONS.findIndex(
+              (option) =>
+                option.provider === selectedModel.provider &&
+                option.model === selectedModel.model,
+            )}
+            onChange={(event) =>
+              setSelectedModel(MODEL_OPTIONS[parseInt(event.target.value)])
+            }
+            className="w-full rounded-lg border border-orange-500/20 bg-gray-900 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-orange-500/50"
+          >
+            {MODEL_OPTIONS.map((option, index) => (
+              <option key={index} value={index}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="flex flex-1 gap-3 overflow-hidden p-3">
+        {panels.map((panel) => (
+          <StrategyPanel
+            key={panel.meta.title}
+            strategy={panel.meta}
+            chat={panel.chat}
+          />
+        ))}
+      </div>
+
+      <div className="border-t border-orange-500/10 bg-gray-900/80 px-4 py-3">
+        <div className="flex items-end gap-2">
+          <textarea
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            placeholder="Type a message and send it to all three panels…"
+            rows={1}
+            className="flex-1 resize-none rounded-lg border border-orange-500/20 bg-gray-800/50 px-4 py-3 text-sm text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-500/50"
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault()
+                broadcast()
+              }
+            }}
+          />
+          <button
+            onClick={broadcast}
+            disabled={!input.trim()}
+            className="flex items-center gap-2 rounded-lg bg-orange-500 px-4 py-3 text-sm font-medium text-white hover:bg-orange-400 disabled:bg-gray-700 disabled:text-gray-500"
+            title="Send to all panels"
+          >
+            <Send className="h-4 w-4" />
+            Send to all
+          </button>
+        </div>
+        <p className="mt-2 flex items-center gap-1 text-xs text-gray-500">
+          <Zap className="h-3 w-3" />
+          Tip: send once, wait for streaming to start, then send again to see
+          queueing, interrupting, and batching in action.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/queueing')({
+  component: QueueingPage,
+})

--- a/packages/ai-angular/src/index.ts
+++ b/packages/ai-angular/src/index.ts
@@ -65,6 +65,11 @@ export type {
   UIMessage,
   ChatRequestBody,
   MultimodalContent,
+  QueueConfig,
+  QueuedMessage,
+  QueueOption,
+  QueueStrategy,
+  WhenBusy,
   ReactiveOption,
 } from './types'
 

--- a/packages/ai-angular/src/index.ts
+++ b/packages/ai-angular/src/index.ts
@@ -69,6 +69,7 @@ export type {
   QueuedMessage,
   QueueOption,
   QueueStrategy,
+  SendMessageOptions,
   WhenBusy,
   ReactiveOption,
 } from './types'

--- a/packages/ai-angular/src/inject-chat.ts
+++ b/packages/ai-angular/src/inject-chat.ts
@@ -23,8 +23,8 @@ import type {
   ConnectionStatus,
   InferredClientContext,
   QueuedMessage,
+  SendMessageOptions,
   StructuredOutputPart,
-  WhenBusy,
 } from '@tanstack/ai-client'
 import type {
   DeepPartial,
@@ -210,7 +210,7 @@ export function injectChat<
 
   const sendMessage = async (
     content: string | MultimodalContent,
-    sendOptions?: { whenBusy?: WhenBusy },
+    sendOptions?: SendMessageOptions,
   ) => {
     await client.sendMessage(content, undefined, sendOptions)
   }

--- a/packages/ai-angular/src/inject-chat.ts
+++ b/packages/ai-angular/src/inject-chat.ts
@@ -22,7 +22,9 @@ import type {
   ChatClientState,
   ConnectionStatus,
   InferredClientContext,
+  QueuedMessage,
   StructuredOutputPart,
+  WhenBusy,
 } from '@tanstack/ai-client'
 import type {
   DeepPartial,
@@ -63,6 +65,7 @@ export function injectChat<
   const isSubscribed = signal(false)
   const connectionStatus = signal<ConnectionStatus>('disconnected')
   const sessionGenerating = signal(false)
+  const queue = signal<Array<QueuedMessage>>([])
 
   // Reactive option sources. Plain values become constant computeds.
   const bodySource =
@@ -119,6 +122,8 @@ export function injectChat<
     onSubscriptionChange: (v: boolean) => isSubscribed.set(v),
     onConnectionStatusChange: (v: ConnectionStatus) => connectionStatus.set(v),
     onSessionGeneratingChange: (v: boolean) => sessionGenerating.set(v),
+    ...(options.queue !== undefined && { queue: options.queue }),
+    onQueueChange: (nextQueue: Array<QueuedMessage>) => queue.set(nextQueue),
   })
 
   messages.set(client.getMessages())
@@ -203,9 +208,13 @@ export function injectChat<
     return part.data as Final
   })
 
-  const sendMessage = async (content: string | MultimodalContent) => {
-    await client.sendMessage(content)
+  const sendMessage = async (
+    content: string | MultimodalContent,
+    sendOptions?: { whenBusy?: WhenBusy },
+  ) => {
+    await client.sendMessage(content, undefined, sendOptions)
   }
+  const cancelQueued = (id: string) => client.cancelQueued(id)
   const append = async (message: ModelMessage | UIMessage<TTools>) => {
     await client.append(message)
   }
@@ -236,6 +245,8 @@ export function injectChat<
   return {
     messages: messages.asReadonly(),
     sendMessage,
+    queue: queue.asReadonly(),
+    cancelQueued,
     append,
     reload,
     stop,

--- a/packages/ai-angular/src/types.ts
+++ b/packages/ai-angular/src/types.ts
@@ -14,12 +14,26 @@ import type {
   DistributedOmit,
   InferredClientContext,
   MultimodalContent,
+  QueueConfig,
+  QueueOption,
+  QueueStrategy,
+  QueuedMessage,
   UIMessage,
+  WhenBusy,
 } from '@tanstack/ai-client'
 import type { Signal } from '@angular/core'
 import type { ReactiveOption } from './internal/to-reactive'
 
-export type { ChatRequestBody, MultimodalContent, UIMessage }
+export type {
+  ChatRequestBody,
+  MultimodalContent,
+  QueueConfig,
+  QueuedMessage,
+  QueueOption,
+  QueueStrategy,
+  UIMessage,
+  WhenBusy,
+}
 export type { ReactiveOption }
 
 /**
@@ -55,6 +69,7 @@ export type InjectChatOptions<
   | 'onSubscriptionChange'
   | 'onConnectionStatusChange'
   | 'onSessionGeneratingChange'
+  | 'onQueueChange'
   | 'context'
   | 'devtools'
   | 'body'
@@ -102,7 +117,14 @@ interface BaseInjectChatResult<
   /** Current messages in the conversation. */
   messages: Signal<Array<UIMessage<TTools, TData>>>
   /** Send a message (string or multimodal content). */
-  sendMessage: (content: string | MultimodalContent) => Promise<void>
+  sendMessage: (
+    content: string | MultimodalContent,
+    options?: { whenBusy?: WhenBusy },
+  ) => Promise<void>
+  /** Pending messages queued while a stream is in flight. */
+  queue: Signal<ReadonlyArray<QueuedMessage>>
+  /** Cancel a queued message before it drains. */
+  cancelQueued: (id: string) => void
   /** Append a message to the conversation. */
   append: (message: ModelMessage | UIMessage<TTools, TData>) => Promise<void>
   /** Add the result of a client-side tool execution. */

--- a/packages/ai-angular/src/types.ts
+++ b/packages/ai-angular/src/types.ts
@@ -18,6 +18,7 @@ import type {
   QueueOption,
   QueueStrategy,
   QueuedMessage,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'
@@ -31,6 +32,7 @@ export type {
   QueuedMessage,
   QueueOption,
   QueueStrategy,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 }
@@ -119,7 +121,7 @@ interface BaseInjectChatResult<
   /** Send a message (string or multimodal content). */
   sendMessage: (
     content: string | MultimodalContent,
-    options?: { whenBusy?: WhenBusy },
+    options?: SendMessageOptions,
   ) => Promise<void>
   /** Pending messages queued while a stream is in flight. */
   queue: Signal<ReadonlyArray<QueuedMessage>>

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -40,8 +40,8 @@ import type {
   MessagePart,
   MultimodalContent,
   QueueOption,
-  QueuedMessage,
   QueueStrategy,
+  QueuedMessage,
   SendMessageOptions,
   ToolCallPart,
   UIMessage,
@@ -142,6 +142,9 @@ export class ChatClient<
   private forwardedPropsOption: Record<string, any> = {}
   private context: TContext | undefined = undefined
   private pendingMessageBody: Record<string, any> | undefined = undefined
+  private readonly queueConfig: NormalizedQueueConfig
+  private messageQueue: Array<QueuedMessage & { body?: Record<string, any> }> =
+    []
   private isLoading = false
   private isSubscribed = false
   private error: Error | undefined = undefined
@@ -191,6 +194,7 @@ export class ChatClient<
       onSubscriptionChange: (isSubscribed: boolean) => void
       onConnectionStatusChange: (status: ConnectionStatus) => void
       onSessionGeneratingChange: (isGenerating: boolean) => void
+      onQueueChange: (queue: Array<QueuedMessage>) => void
       onCustomEvent: (
         eventType: string,
         data: unknown,
@@ -217,6 +221,7 @@ export class ChatClient<
     this.bodyOption = options.body || {}
     this.forwardedPropsOption = options.forwardedProps || {}
     this.context = options.context
+    this.queueConfig = normalizeQueueOption(options.queue)
     this.connection = normalizeConnectionAdapter(resolveTransport(options))
 
     // Build client tools map
@@ -247,6 +252,7 @@ export class ChatClient<
           options.onConnectionStatusChange || (() => {}),
         onSessionGeneratingChange:
           options.onSessionGeneratingChange || (() => {}),
+        onQueueChange: options.onQueueChange || (() => {}),
         onCustomEvent: options.onCustomEvent || (() => {}),
       },
     }
@@ -803,26 +809,84 @@ export class ChatClient<
   async sendMessage(
     content: string | MultimodalContent,
     body?: Record<string, any>,
+    sendOptions?: SendMessageOptions,
   ): Promise<void> {
     this.mountDevtools()
     const emptyMessage = typeof content === 'string' && !content.trim()
-    if (emptyMessage || this.isLoading) {
+    if (emptyMessage) {
       return
     }
-    // Normalize input to extract content, id, and validate
+
+    if (this.isLoading) {
+      const action = this.decideWhenBusy(content, sendOptions)
+      if (action === 'drop') {
+        return
+      }
+      if (action === 'enqueue') {
+        this.enqueueMessage(content, body)
+        return
+      }
+      // 'interrupt': abort the current stream, then fall through to send now.
+      this.cancelInFlightStream({ setReadyStatus: true })
+      this.resetSessionGenerating()
+    }
+
     const normalizedContent = this.normalizeMessageInput(content)
-
-    // Store the per-message body for use in streamResponse
     this.pendingMessageBody = body
-
-    // Add user message via processor
     const userMessage = this.processor.addUserMessage(
       normalizedContent.content,
       normalizedContent.id,
     )
     this.events.messageSent(userMessage.id, normalizedContent.content)
-
     await this.streamResponse()
+  }
+
+  /**
+   * Resolve the effective action for a send that arrives while streaming.
+   * A strategy that returns `'send'` while streaming is coerced to
+   * `'enqueue'` — you cannot start a second concurrent stream.
+   */
+  private decideWhenBusy(
+    content: string | MultimodalContent,
+    sendOptions?: SendMessageOptions,
+  ): 'drop' | 'enqueue' | 'interrupt' {
+    if (sendOptions?.whenBusy) {
+      return sendOptions.whenBusy === 'queue' ? 'enqueue' : sendOptions.whenBusy
+    }
+    const { strategy, whenBusy } = this.queueConfig
+    if (strategy) {
+      const { action } = strategy({
+        pending: {
+          id: this.generateUniqueId('queued'),
+          content,
+          createdAt: Date.now(),
+        },
+        isStreaming: true,
+        queued: this.getQueue(),
+      })
+      return action === 'send' ? 'enqueue' : action
+    }
+    return whenBusy === 'queue' ? 'enqueue' : whenBusy
+  }
+
+  private enqueueMessage(
+    content: string | MultimodalContent,
+    body?: Record<string, any>,
+  ): void {
+    const { maxSize, onOverflow } = this.queueConfig
+    if (maxSize !== undefined && this.messageQueue.length >= maxSize) {
+      if (onOverflow === 'reject') {
+        return
+      }
+      this.messageQueue.shift() // drop-oldest
+    }
+    this.messageQueue.push({
+      id: this.generateUniqueId('queued'),
+      content,
+      createdAt: Date.now(),
+      ...(body !== undefined ? { body } : {}),
+    })
+    this.emitQueueChange()
   }
 
   /**
@@ -1406,6 +1470,38 @@ export class ChatClient<
    */
   getMessages(): Array<UIMessage<TTools>> {
     return this.processor.getMessages() as Array<UIMessage<TTools>>
+  }
+
+  /**
+   * Get the current send queue (messages held while a stream was in flight).
+   */
+  getQueue(): Array<QueuedMessage> {
+    return this.messageQueue.map(({ id, content, createdAt }) => ({
+      id,
+      content,
+      createdAt,
+    }))
+  }
+
+  private emitQueueChange(): void {
+    this.callbacksRef.current.onQueueChange(this.getQueue())
+    this.devtoolsBridge.emitSnapshot()
+  }
+
+  /**
+   * Remove a queued message by id before it drains.
+   */
+  cancelQueued(id: string): void {
+    const index = this.messageQueue.findIndex((m) => m.id === id)
+    if (index === -1) return
+    this.messageQueue.splice(index, 1)
+    this.emitQueueChange()
+  }
+
+  protected flushQueue(): void {
+    if (this.messageQueue.length === 0) return
+    this.messageQueue = []
+    this.emitQueueChange()
   }
 
   /**

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -39,8 +39,13 @@ import type {
   ConnectionStatus,
   MessagePart,
   MultimodalContent,
+  QueueOption,
+  QueuedMessage,
+  QueueStrategy,
+  SendMessageOptions,
   ToolCallPart,
   UIMessage,
+  WhenBusy,
 } from './types'
 
 type ChatClientUpdateOptionsWithoutContext<
@@ -87,6 +92,33 @@ function resolveTransport(transport: {
   if (connection) return connection
   if (fetcher) return fetcherToConnectionAdapter(fetcher)
   throw new Error('ChatClient: either `connection` or `fetcher` is required.')
+}
+
+export interface NormalizedQueueConfig {
+  whenBusy: WhenBusy
+  drain: 'fifo' | 'batch'
+  onOverflow: 'reject' | 'drop-oldest'
+  maxSize?: number
+  strategy?: QueueStrategy
+}
+
+export function normalizeQueueOption(
+  option: QueueOption | undefined,
+): NormalizedQueueConfig {
+  const base: NormalizedQueueConfig = {
+    whenBusy: 'queue',
+    drain: 'fifo',
+    onOverflow: 'reject',
+  }
+  if (!option) return base
+  if (typeof option === 'string') return { ...base, whenBusy: option }
+  if (typeof option === 'function') return { ...base, strategy: option }
+  return {
+    whenBusy: option.whenBusy ?? 'queue',
+    drain: option.drain ?? 'fifo',
+    onOverflow: option.onOverflow ?? 'reject',
+    ...(option.maxSize !== undefined ? { maxSize: option.maxSize } : {}),
+  }
 }
 
 export class ChatClient<

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -57,6 +57,7 @@ type ChatClientUpdateOptionsWithoutContext<
   body?: Record<string, any>
   forwardedProps?: Record<string, any>
   tools?: TTools
+  queue?: QueueOption
   onResponse?: (response?: Response) => void | Promise<void>
   onChunk?: (chunk: StreamChunk) => void
   onFinish?: (message: UIMessage) => void
@@ -64,6 +65,7 @@ type ChatClientUpdateOptionsWithoutContext<
   onSubscriptionChange?: (isSubscribed: boolean) => void
   onConnectionStatusChange?: (status: ConnectionStatus) => void
   onSessionGeneratingChange?: (isGenerating: boolean) => void
+  onQueueChange?: (queue: Array<QueuedMessage>) => void
   onCustomEvent?: (
     eventType: string,
     data: unknown,
@@ -113,11 +115,21 @@ export function normalizeQueueOption(
   if (!option) return base
   if (typeof option === 'string') return { ...base, whenBusy: option }
   if (typeof option === 'function') return { ...base, strategy: option }
+
+  const maxSize = option.maxSize
+  if (maxSize !== undefined) {
+    if (!Number.isInteger(maxSize) || maxSize < 0) {
+      throw new Error(
+        'ChatClient: queue.maxSize must be a non-negative integer',
+      )
+    }
+  }
+
   return {
     whenBusy: option.whenBusy ?? 'queue',
     drain: option.drain ?? 'fifo',
     onOverflow: option.onOverflow ?? 'reject',
-    ...(option.maxSize !== undefined ? { maxSize: option.maxSize } : {}),
+    ...(maxSize !== undefined ? { maxSize } : {}),
   }
 }
 
@@ -174,9 +186,27 @@ export class ChatClient<
   private forwardedPropsOption: Record<string, any> = {}
   private context: TContext | undefined = undefined
   private pendingMessageBody: Record<string, any> | undefined = undefined
-  private readonly queueConfig: NormalizedQueueConfig
+  private queueConfig: NormalizedQueueConfig
   private messageQueue: Array<QueuedMessage & { body?: Record<string, any> }> =
     []
+  /**
+   * True from the moment `sendMessage` claims the client until its
+   * `streamResponse` settles. Closes the race where concurrent callers both
+   * see `isLoading === false`, both append a user message, and only one stream
+   * actually runs (leaving stranded user messages with no reply).
+   */
+  private sendInFlight = false
+  /**
+   * True while `drainQueue` is delivering queued messages. Concurrent
+   * `sendMessage` calls during a drain are treated as busy and follow
+   * `whenBusy` (default: enqueue).
+   */
+  private messageQueueDraining = false
+  /**
+   * Set by `whenBusy: 'interrupt'` so an in-progress FIFO drain loop stops
+   * before starting the next queued item (the interrupting send owns the client).
+   */
+  private stopMessageQueueDrain = false
   private isLoading = false
   private isSubscribed = false
   private error: Error | undefined = undefined
@@ -809,6 +839,8 @@ export class ChatClient<
    *   - A MultimodalContent object with content array and optional custom ID
    * @param body - Optional body parameters to merge with the client's base body for this request.
    *               Uses shallow merge with per-message body taking priority.
+   * @param sendOptions - Per-call overrides, e.g. `{ whenBusy: 'interrupt' }` to
+   *                      override the configured queue policy for this one send.
    *
    * @example
    * ```ts
@@ -817,6 +849,9 @@ export class ChatClient<
    *
    * // Text message with custom body params
    * await client.sendMessage('Hello!', { temperature: 0.7 })
+   *
+   * // Per-call whenBusy override (body must still be the 2nd arg on ChatClient)
+   * await client.sendMessage('Urgent', undefined, { whenBusy: 'interrupt' })
    *
    * // Multimodal message with image
    * await client.sendMessage({
@@ -850,20 +885,53 @@ export class ChatClient<
       return
     }
 
-    if (this.isLoading) {
-      const action = this.decideWhenBusy(content, sendOptions)
+    if (this.isSendBusy()) {
+      const { action, id } = this.decideWhenBusy(content, sendOptions)
       if (action === 'drop') {
         return
       }
       if (action === 'enqueue') {
-        this.enqueueMessage(content, body)
+        this.enqueueMessage(content, body, id)
         return
       }
-      // 'interrupt': abort the current stream, then fall through to send now.
+      // 'interrupt': abort the current stream, then send now.
+      // Unlike stop(), does not flush already-queued messages — they drain
+      // after this interrupting send settles successfully.
+      // Claim sendInFlight *before* cancelling so a concurrent send cannot
+      // slip in between cancel and the deliver below.
+      this.stopMessageQueueDrain = true
+      this.sendInFlight = true
       this.cancelInFlightStream({ setReadyStatus: true })
       this.resetSessionGenerating()
+      try {
+        await this.deliverMessage(content, body)
+      } finally {
+        this.sendInFlight = false
+      }
+      return
     }
 
+    this.sendInFlight = true
+    try {
+      await this.deliverMessage(content, body)
+    } finally {
+      this.sendInFlight = false
+    }
+  }
+
+  /** True while a stream is active, a send is claiming the client, or the queue is draining. */
+  private isSendBusy(): boolean {
+    return this.isLoading || this.sendInFlight || this.messageQueueDraining
+  }
+
+  /**
+   * Append a user message and run the stream. Used by both direct sends and
+   * queue drains — callers are responsible for busy/queue policy.
+   */
+  private async deliverMessage(
+    content: string | MultimodalContent,
+    body?: Record<string, any>,
+  ): Promise<boolean> {
     const normalizedContent = this.normalizeMessageInput(content)
     this.pendingMessageBody = body
     const userMessage = this.processor.addUserMessage(
@@ -871,50 +939,64 @@ export class ChatClient<
       normalizedContent.id,
     )
     this.events.messageSent(userMessage.id, normalizedContent.content)
-    await this.streamResponse()
+    return await this.streamResponse()
   }
 
   /**
-   * Resolve the effective action for a send that arrives while streaming.
+   * Resolve the effective action for a send that arrives while busy.
    * A strategy that returns `'send'` while streaming is coerced to
    * `'enqueue'` — you cannot start a second concurrent stream.
+   * The returned `id` is the id that will be stored if the action is enqueue.
    */
   private decideWhenBusy(
     content: string | MultimodalContent,
     sendOptions?: SendMessageOptions,
-  ): 'drop' | 'enqueue' | 'interrupt' {
+  ): { action: 'drop' | 'enqueue' | 'interrupt'; id: string } {
+    const id = this.generateUniqueId('queued')
     if (sendOptions?.whenBusy) {
-      return sendOptions.whenBusy === 'queue' ? 'enqueue' : sendOptions.whenBusy
+      return {
+        action:
+          sendOptions.whenBusy === 'queue' ? 'enqueue' : sendOptions.whenBusy,
+        id,
+      }
     }
     const { strategy, whenBusy } = this.queueConfig
     if (strategy) {
       const { action } = strategy({
         pending: {
-          id: this.generateUniqueId('queued'),
+          id,
           content,
           createdAt: Date.now(),
         },
         isStreaming: true,
         queued: this.getQueue(),
       })
-      return action === 'send' ? 'enqueue' : action
+      return {
+        action: action === 'send' ? 'enqueue' : action,
+        id,
+      }
     }
-    return whenBusy === 'queue' ? 'enqueue' : whenBusy
+    return {
+      action: whenBusy === 'queue' ? 'enqueue' : whenBusy,
+      id,
+    }
   }
 
   private enqueueMessage(
     content: string | MultimodalContent,
     body?: Record<string, any>,
+    id?: string,
   ): void {
     const { maxSize, onOverflow } = this.queueConfig
     if (maxSize !== undefined && this.messageQueue.length >= maxSize) {
-      if (onOverflow === 'reject') {
+      // maxSize 0 is a hard cap (never queue). drop-oldest cannot make room.
+      if (onOverflow === 'reject' || maxSize === 0) {
         return
       }
       this.messageQueue.shift() // drop-oldest
     }
     this.messageQueue.push({
-      id: this.generateUniqueId('queued'),
+      id: id ?? this.generateUniqueId('queued'),
       content,
       createdAt: Date.now(),
       ...(body !== undefined ? { body } : {}),
@@ -1201,6 +1283,11 @@ export class ChatClient<
               await this.checkForContinuation()
             } catch (error) {
               console.error('Failed to continue flow after tool result:', error)
+              // Continuation failed without starting a new stream — don't
+              // leave queued user messages stranded forever.
+              if (!this.isLoading) {
+                await this.drainQueue()
+              }
             }
           } else {
             if (this.status !== 'ready') {
@@ -1212,8 +1299,11 @@ export class ChatClient<
             }
             // Auto-send queued messages once the run fully settles. When a
             // continuation runs instead (tool-result branch above), that
-            // continuation's own finally drains the queue.
-            await this.drainQueue()
+            // continuation's own finally drains the queue. Skip if a drain
+            // loop is already walking the queue (avoids nested re-entry).
+            if (!this.messageQueueDraining) {
+              await this.drainQueue()
+            }
           }
         } else {
           // Error/abort settle for the active generation: don't strand or
@@ -1256,6 +1346,7 @@ export class ChatClient<
       setReadyStatus: true,
       abortSubscription: true,
     })
+    this.sendInFlight = false
     this.flushQueue()
     this.resetSessionGenerating()
     this.setIsSubscribed(false)
@@ -1280,6 +1371,10 @@ export class ChatClient<
     if (this.isLoading) {
       this.cancelInFlightStream()
     }
+    this.sendInFlight = false
+    // Discard pending follow-ups so "regenerate last answer" does not also
+    // auto-send messages that were typed during the previous stream.
+    this.flushQueue()
 
     this.events.reloaded(lastUserMessageIndex)
 
@@ -1297,6 +1392,7 @@ export class ChatClient<
   stop(): void {
     const hadLocalStream = this.abortController !== null
     this.cancelInFlightStream({ setReadyStatus: true })
+    this.sendInFlight = false
     this.flushQueue()
     if (hadLocalStream) {
       this.resetSessionGenerating()
@@ -1325,6 +1421,7 @@ export class ChatClient<
       this.persistor.beginClear()
     }
     this.processor.clearMessages()
+    this.sendInFlight = false
     this.flushQueue()
     this.persistor?.remove()
     this.setError(undefined)
@@ -1522,26 +1619,59 @@ export class ChatClient<
   }
 
   /**
-   * Send the next queued message (fifo) or all queued messages merged into one
-   * (batch). Called from streamResponse's finally once the run has settled;
-   * the fifo case relies on the resulting stream's own finally to continue the
-   * chain.
+   * Deliver queued messages after a successful settle.
+   * - `batch`: merge everything currently queued into one send.
+   * - `fifo`: walk the queue in a loop, one stream at a time, until empty
+   *   (or until another send claims the client via interrupt).
+   *
+   * Uses `deliverMessage` directly so drains do not re-enter `sendMessage`'s
+   * busy/queue policy (which would re-enqueue items and strand the rest).
    */
   private async drainQueue(): Promise<void> {
-    if (this.isLoading || this.messageQueue.length === 0) {
+    // Note: do not gate on `sendInFlight`. Normal sends still hold
+    // `sendInFlight` while `streamResponse`'s finally invokes drain; blocking
+    // on it would permanently strand the queue.
+    if (
+      this.messageQueueDraining ||
+      this.isLoading ||
+      this.messageQueue.length === 0
+    ) {
       return
     }
-    if (this.queueConfig.drain === 'batch') {
-      const items = this.messageQueue.splice(0)
-      this.emitQueueChange()
-      const merged = mergeQueuedMessages(items)
-      await this.sendMessage(merged.content, merged.body)
-      return
-    }
-    const next = this.messageQueue.shift()
-    this.emitQueueChange()
-    if (next) {
-      await this.sendMessage(next.content, next.body)
+
+    this.messageQueueDraining = true
+    this.stopMessageQueueDrain = false
+    try {
+      if (this.queueConfig.drain === 'batch') {
+        const items = this.messageQueue.splice(0)
+        this.emitQueueChange()
+        if (items.length > 0) {
+          const merged = mergeQueuedMessages(items)
+          await this.deliverMessage(merged.content, merged.body)
+        }
+        return
+      }
+
+      while (this.messageQueue.length > 0) {
+        // Interrupt (or a new direct send) claimed the client — stop draining;
+        // remaining items stay queued and will drain after that send settles.
+        if (this.isLoading || this.stopMessageQueueDrain) {
+          return
+        }
+        const next = this.messageQueue.shift()
+        this.emitQueueChange()
+        if (!next) {
+          return
+        }
+        const completed = await this.deliverMessage(next.content, next.body)
+        // Failed/aborted deliver flushes the rest of the queue in streamResponse.
+        if (!completed || this.stopMessageQueueDrain) {
+          return
+        }
+      }
+    } finally {
+      this.messageQueueDraining = false
+      this.stopMessageQueueDrain = false
     }
   }
 
@@ -1571,6 +1701,11 @@ export class ChatClient<
     this.emitQueueChange()
   }
 
+  /**
+   * Discard all pending queued messages (stop / error / clear / unsubscribe /
+   * reload). Does not send them. Emits `onQueueChange([])` when anything was
+   * removed.
+   */
   private flushQueue(): void {
     if (this.messageQueue.length === 0) return
     this.messageQueue = []
@@ -1689,6 +1824,9 @@ export class ChatClient<
       }
       this.devtoolsBridge.notifyToolsChanged()
     }
+    if (options.queue !== undefined) {
+      this.queueConfig = normalizeQueueOption(options.queue)
+    }
     if (options.onResponse !== undefined) {
       this.callbacksRef.current.onResponse = options.onResponse
     }
@@ -1712,6 +1850,9 @@ export class ChatClient<
     if (options.onSessionGeneratingChange !== undefined) {
       this.callbacksRef.current.onSessionGeneratingChange =
         options.onSessionGeneratingChange
+    }
+    if (options.onQueueChange !== undefined) {
+      this.callbacksRef.current.onQueueChange = options.onQueueChange
     }
     if (options.onCustomEvent !== undefined) {
       this.callbacksRef.current.onCustomEvent = options.onCustomEvent

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -1215,6 +1215,12 @@ export class ChatClient<
             // continuation's own finally drains the queue.
             await this.drainQueue()
           }
+        } else {
+          // Error/abort settle for the active generation: don't strand or
+          // later mis-order queued messages. A failed turn flushes the queue
+          // (consistent with stop()); it must NOT auto-drain into a likely
+          // broken endpoint.
+          this.flushQueue()
         }
       }
     }

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -1284,10 +1284,9 @@ export class ChatClient<
             } catch (error) {
               console.error('Failed to continue flow after tool result:', error)
               // Continuation failed without starting a new stream — don't
-              // leave queued user messages stranded forever.
-              if (!this.isLoading) {
-                await this.drainQueue()
-              }
+              // leave queued user messages stranded forever. (isLoading is
+              // already false in this finally block.)
+              await this.drainQueue()
             }
           } else {
             if (this.status !== 'ready') {
@@ -1619,6 +1618,15 @@ export class ChatClient<
   }
 
   /**
+   * True when an interrupt (or another direct send) claimed the client during
+   * a drain. Read via a method so cross-await mutations are not constant-folded
+   * by control-flow analysis.
+   */
+  private shouldAbortMessageQueueDrain(): boolean {
+    return this.isLoading || this.stopMessageQueueDrain
+  }
+
+  /**
    * Deliver queued messages after a successful settle.
    * - `batch`: merge everything currently queued into one send.
    * - `fifo`: walk the queue in a loop, one stream at a time, until empty
@@ -1655,17 +1663,17 @@ export class ChatClient<
       while (this.messageQueue.length > 0) {
         // Interrupt (or a new direct send) claimed the client — stop draining;
         // remaining items stay queued and will drain after that send settles.
-        if (this.isLoading || this.stopMessageQueueDrain) {
+        if (this.shouldAbortMessageQueueDrain()) {
           return
         }
         const next = this.messageQueue.shift()
-        this.emitQueueChange()
-        if (!next) {
+        if (next === undefined) {
           return
         }
+        this.emitQueueChange()
         const completed = await this.deliverMessage(next.content, next.body)
         // Failed/aborted deliver flushes the rest of the queue in streamResponse.
-        if (!completed || this.stopMessageQueueDrain) {
+        if (!completed || this.shouldAbortMessageQueueDrain()) {
           return
         }
       }

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -121,6 +121,38 @@ export function normalizeQueueOption(
   }
 }
 
+/**
+ * Merge a run of queued messages into a single send for `drain: 'batch'`.
+ * All-string content is joined with newlines; mixed/multimodal content is
+ * flattened into a single `ContentPart` array. The last item's `body` wins.
+ */
+function mergeQueuedMessages(
+  items: Array<QueuedMessage & { body?: Record<string, any> }>,
+): { content: string | MultimodalContent; body?: Record<string, any> } {
+  const body = items.at(-1)?.body
+  const allString = items.every((i) => typeof i.content === 'string')
+  if (allString) {
+    return {
+      content: items.map((i) => i.content as string).join('\n'),
+      ...(body !== undefined ? { body } : {}),
+    }
+  }
+  const parts: Array<ContentPart> = []
+  for (const item of items) {
+    if (typeof item.content === 'string') {
+      parts.push({ type: 'text', content: item.content })
+    } else if (typeof item.content.content === 'string') {
+      parts.push({ type: 'text', content: item.content.content })
+    } else {
+      parts.push(...item.content.content)
+    }
+  }
+  return {
+    content: { content: parts },
+    ...(body !== undefined ? { body } : {}),
+  }
+}
+
 export class ChatClient<
   TTools extends ReadonlyArray<AnyClientTool> = any,
   TContext = unknown,
@@ -609,6 +641,7 @@ export class ChatClient<
       connectionStatus: this.connectionStatus,
       sessionGenerating: this.sessionGenerating,
       activeRunIds: Array.from(this.activeRunIds),
+      queue: this.getQueue(),
       ...(this.error ? { error: this.error.message } : {}),
     }
   }
@@ -1169,11 +1202,18 @@ export class ChatClient<
             } catch (error) {
               console.error('Failed to continue flow after tool result:', error)
             }
-          } else if (this.status !== 'ready') {
-            // Terminal run, but onStreamEnd never fired: the processor had no
-            // assistant message to emit it for (e.g. a bare RUN_FINISHED{stop},
-            // #421). The normal path already set 'ready', so this is a no-op.
-            this.setStatus('ready')
+          } else {
+            if (this.status !== 'ready') {
+              // Terminal run, but onStreamEnd never fired: the processor had
+              // no assistant message to emit it for (e.g. a bare
+              // RUN_FINISHED{stop}, #421). The normal path already set
+              // 'ready', so this is a no-op.
+              this.setStatus('ready')
+            }
+            // Auto-send queued messages once the run fully settles. When a
+            // continuation runs instead (tool-result branch above), that
+            // continuation's own finally drains the queue.
+            await this.drainQueue()
           }
         }
       }
@@ -1210,6 +1250,7 @@ export class ChatClient<
       setReadyStatus: true,
       abortSubscription: true,
     })
+    this.flushQueue()
     this.resetSessionGenerating()
     this.setIsSubscribed(false)
     this.setConnectionStatus('disconnected')
@@ -1250,6 +1291,7 @@ export class ChatClient<
   stop(): void {
     const hadLocalStream = this.abortController !== null
     this.cancelInFlightStream({ setReadyStatus: true })
+    this.flushQueue()
     if (hadLocalStream) {
       this.resetSessionGenerating()
     }
@@ -1277,6 +1319,7 @@ export class ChatClient<
       this.persistor.beginClear()
     }
     this.processor.clearMessages()
+    this.flushQueue()
     this.persistor?.remove()
     this.setError(undefined)
     this.events.messagesCleared()
@@ -1473,6 +1516,30 @@ export class ChatClient<
   }
 
   /**
+   * Send the next queued message (fifo) or all queued messages merged into one
+   * (batch). Called from streamResponse's finally once the run has settled;
+   * the fifo case relies on the resulting stream's own finally to continue the
+   * chain.
+   */
+  private async drainQueue(): Promise<void> {
+    if (this.isLoading || this.messageQueue.length === 0) {
+      return
+    }
+    if (this.queueConfig.drain === 'batch') {
+      const items = this.messageQueue.splice(0)
+      this.emitQueueChange()
+      const merged = mergeQueuedMessages(items)
+      await this.sendMessage(merged.content, merged.body)
+      return
+    }
+    const next = this.messageQueue.shift()
+    this.emitQueueChange()
+    if (next) {
+      await this.sendMessage(next.content, next.body)
+    }
+  }
+
+  /**
    * Get the current send queue (messages held while a stream was in flight).
    */
   getQueue(): Array<QueuedMessage> {
@@ -1498,7 +1565,7 @@ export class ChatClient<
     this.emitQueueChange()
   }
 
-  protected flushQueue(): void {
+  private flushQueue(): void {
     if (this.messageQueue.length === 0) return
     this.messageQueue = []
     this.emitQueueChange()

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -144,9 +144,10 @@ export function normalizeQueueOption(
  * All-string content is joined with newlines; mixed/multimodal content is
  * flattened into a single `ContentPart` array. The last item's `body` wins.
  */
-function mergeQueuedMessages(
-  items: Array<InternalQueuedMessage>,
-): { content: string | MultimodalContent; body?: Record<string, any> } {
+function mergeQueuedMessages(items: Array<InternalQueuedMessage>): {
+  content: string | MultimodalContent
+  body?: Record<string, any>
+} {
   const body = items.at(-1)?.body
   const stringContents: Array<string> = []
   for (const item of items) {

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -39,6 +39,7 @@ import type {
   ConnectionStatus,
   MessagePart,
   MultimodalContent,
+  QueueBusyReason,
   QueueOption,
   QueueStrategy,
   QueuedMessage,
@@ -47,6 +48,11 @@ import type {
   UIMessage,
   WhenBusy,
 } from './types'
+
+/** Internal queue entry — public {@link QueuedMessage} plus optional per-send body. */
+interface InternalQueuedMessage extends QueuedMessage {
+  body?: Record<string, any>
+}
 
 type ChatClientUpdateOptionsWithoutContext<
   TTools extends ReadonlyArray<AnyClientTool>,
@@ -139,13 +145,19 @@ export function normalizeQueueOption(
  * flattened into a single `ContentPart` array. The last item's `body` wins.
  */
 function mergeQueuedMessages(
-  items: Array<QueuedMessage & { body?: Record<string, any> }>,
+  items: Array<InternalQueuedMessage>,
 ): { content: string | MultimodalContent; body?: Record<string, any> } {
   const body = items.at(-1)?.body
-  const allString = items.every((i) => typeof i.content === 'string')
-  if (allString) {
+  const stringContents: Array<string> = []
+  for (const item of items) {
+    if (typeof item.content !== 'string') {
+      break
+    }
+    stringContents.push(item.content)
+  }
+  if (stringContents.length === items.length) {
     return {
-      content: items.map((i) => i.content as string).join('\n'),
+      content: stringContents.join('\n'),
       ...(body !== undefined ? { body } : {}),
     }
   }
@@ -187,8 +199,7 @@ export class ChatClient<
   private context: TContext | undefined = undefined
   private pendingMessageBody: Record<string, any> | undefined = undefined
   private queueConfig: NormalizedQueueConfig
-  private messageQueue: Array<QueuedMessage & { body?: Record<string, any> }> =
-    []
+  private messageQueue: Array<InternalQueuedMessage> = []
   /**
    * True from the moment `sendMessage` claims the client until its
    * `streamResponse` settles. Closes the race where concurrent callers both
@@ -199,7 +210,7 @@ export class ChatClient<
   /**
    * True while `drainQueue` is delivering queued messages. Concurrent
    * `sendMessage` calls during a drain are treated as busy and follow
-   * `whenBusy` (default: enqueue).
+   * `whenBusy` (default: queue).
    */
   private messageQueueDraining = false
   /**
@@ -207,6 +218,11 @@ export class ChatClient<
    * before starting the next queued item (the interrupting send owns the client).
    */
   private stopMessageQueueDrain = false
+  /**
+   * Sync claim held for the duration of `deliverMessage` so concurrent
+   * deliverers cannot both append a user message before only one stream runs.
+   */
+  private deliverClaim = false
   private isLoading = false
   private isSubscribed = false
   private error: Error | undefined = undefined
@@ -709,6 +725,9 @@ export class ChatClient<
     }
     this.resolveProcessing()
     this.setIsLoading(false)
+    // Release deliver claim so an interrupting `deliverMessage` can append
+    // after abort (the superseded deliver's finally also clears the claim).
+    this.deliverClaim = false
     if (options?.setReadyStatus) {
       this.setStatus('ready')
     }
@@ -890,7 +909,7 @@ export class ChatClient<
       if (action === 'drop') {
         return
       }
-      if (action === 'enqueue') {
+      if (action === 'queue') {
         this.enqueueMessage(content, body, id)
         return
       }
@@ -903,15 +922,10 @@ export class ChatClient<
       this.sendInFlight = true
       this.cancelInFlightStream({ setReadyStatus: true })
       this.resetSessionGenerating()
-      try {
-        await this.deliverMessage(content, body)
-      } finally {
-        this.sendInFlight = false
-      }
-      return
+    } else {
+      this.sendInFlight = true
     }
 
-    this.sendInFlight = true
     try {
       await this.deliverMessage(content, body)
     } finally {
@@ -924,41 +938,52 @@ export class ChatClient<
     return this.isLoading || this.sendInFlight || this.messageQueueDraining
   }
 
+  private resolveBusyReason(): QueueBusyReason {
+    if (this.isLoading) return 'streaming'
+    if (this.messageQueueDraining) return 'draining'
+    return 'sendInFlight'
+  }
+
   /**
    * Append a user message and run the stream. Used by both direct sends and
    * queue drains — callers are responsible for busy/queue policy.
+   *
+   * Claims delivery synchronously before appending so concurrent callers
+   * cannot both add a user message when only one stream can run.
    */
   private async deliverMessage(
     content: string | MultimodalContent,
     body?: Record<string, any>,
   ): Promise<boolean> {
-    const normalizedContent = this.normalizeMessageInput(content)
-    this.pendingMessageBody = body
-    const userMessage = this.processor.addUserMessage(
-      normalizedContent.content,
-      normalizedContent.id,
-    )
-    this.events.messageSent(userMessage.id, normalizedContent.content)
-    return await this.streamResponse()
+    if (this.isLoading || this.deliverClaim) {
+      return false
+    }
+    this.deliverClaim = true
+    try {
+      const normalizedContent = this.normalizeMessageInput(content)
+      this.pendingMessageBody = body
+      const userMessage = this.processor.addUserMessage(
+        normalizedContent.content,
+        normalizedContent.id,
+      )
+      this.events.messageSent(userMessage.id, normalizedContent.content)
+      return await this.streamResponse()
+    } finally {
+      this.deliverClaim = false
+    }
   }
 
   /**
    * Resolve the effective action for a send that arrives while busy.
-   * A strategy that returns `'send'` while streaming is coerced to
-   * `'enqueue'` — you cannot start a second concurrent stream.
-   * The returned `id` is the id that will be stored if the action is enqueue.
+   * The returned `id` is the id that will be stored if the action is `queue`.
    */
   private decideWhenBusy(
     content: string | MultimodalContent,
     sendOptions?: SendMessageOptions,
-  ): { action: 'drop' | 'enqueue' | 'interrupt'; id: string } {
+  ): { action: WhenBusy; id: string } {
     const id = this.generateUniqueId('queued')
     if (sendOptions?.whenBusy) {
-      return {
-        action:
-          sendOptions.whenBusy === 'queue' ? 'enqueue' : sendOptions.whenBusy,
-        id,
-      }
+      return { action: sendOptions.whenBusy, id }
     }
     const { strategy, whenBusy } = this.queueConfig
     if (strategy) {
@@ -968,18 +993,12 @@ export class ChatClient<
           content,
           createdAt: Date.now(),
         },
-        isStreaming: true,
+        busyReason: this.resolveBusyReason(),
         queued: this.getQueue(),
       })
-      return {
-        action: action === 'send' ? 'enqueue' : action,
-        id,
-      }
+      return { action, id }
     }
-    return {
-      action: whenBusy === 'queue' ? 'enqueue' : whenBusy,
-      id,
-    }
+    return { action: whenBusy, id }
   }
 
   private enqueueMessage(
@@ -1069,6 +1088,10 @@ export class ChatClient<
     this.currentRunId = runId
 
     this.setIsLoading(true)
+    // Hand off from deliverClaim to isLoading so nested drain can call
+    // deliverMessage after this stream settles (while the outer deliver
+    // is still on the stack).
+    this.deliverClaim = false
     this.setStatus('submitted')
     this.setError(undefined)
     this.errorReportedGeneration = null
@@ -1345,8 +1368,7 @@ export class ChatClient<
       setReadyStatus: true,
       abortSubscription: true,
     })
-    this.sendInFlight = false
-    this.flushQueue()
+    this.discardPendingSends()
     this.resetSessionGenerating()
     this.setIsSubscribed(false)
     this.setConnectionStatus('disconnected')
@@ -1370,10 +1392,9 @@ export class ChatClient<
     if (this.isLoading) {
       this.cancelInFlightStream()
     }
-    this.sendInFlight = false
     // Discard pending follow-ups so "regenerate last answer" does not also
     // auto-send messages that were typed during the previous stream.
-    this.flushQueue()
+    this.discardPendingSends()
 
     this.events.reloaded(lastUserMessageIndex)
 
@@ -1391,8 +1412,7 @@ export class ChatClient<
   stop(): void {
     const hadLocalStream = this.abortController !== null
     this.cancelInFlightStream({ setReadyStatus: true })
-    this.sendInFlight = false
-    this.flushQueue()
+    this.discardPendingSends()
     if (hadLocalStream) {
       this.resetSessionGenerating()
     }
@@ -1420,8 +1440,7 @@ export class ChatClient<
       this.persistor.beginClear()
     }
     this.processor.clearMessages()
-    this.sendInFlight = false
-    this.flushQueue()
+    this.discardPendingSends()
     this.persistor?.remove()
     this.setError(undefined)
     this.events.messagesCleared()
@@ -1628,12 +1647,13 @@ export class ChatClient<
 
   /**
    * Deliver queued messages after a successful settle.
-   * - `batch`: merge everything currently queued into one send.
+   * - `batch`: merge everything currently queued into one send, looping so
+   *   messages enqueued during that batch stream are not stranded.
    * - `fifo`: walk the queue in a loop, one stream at a time, until empty
    *   (or until another send claims the client via interrupt).
    *
    * Uses `deliverMessage` directly so drains do not re-enter `sendMessage`'s
-   * busy/queue policy (which would re-enqueue items and strand the rest).
+   * busy/queue policy (which would re-queue items and strand the rest).
    */
   private async drainQueue(): Promise<void> {
     // Note: do not gate on `sendInFlight`. Normal sends still hold
@@ -1651,11 +1671,21 @@ export class ChatClient<
     this.stopMessageQueueDrain = false
     try {
       if (this.queueConfig.drain === 'batch') {
-        const items = this.messageQueue.splice(0)
-        this.emitQueueChange()
-        if (items.length > 0) {
+        while (this.messageQueue.length > 0) {
+          if (this.shouldAbortMessageQueueDrain()) {
+            return
+          }
+          const items = this.messageQueue.splice(0)
+          this.emitQueueChange()
           const merged = mergeQueuedMessages(items)
-          await this.deliverMessage(merged.content, merged.body)
+          const completed = await this.deliverMessage(
+            merged.content,
+            merged.body,
+          )
+          // Failed/aborted deliver flushes the rest of the queue in streamResponse.
+          if (!completed || this.shouldAbortMessageQueueDrain()) {
+            return
+          }
         }
         return
       }
@@ -1681,6 +1711,15 @@ export class ChatClient<
       this.messageQueueDraining = false
       this.stopMessageQueueDrain = false
     }
+  }
+
+  /**
+   * Drop any in-flight send claim and discard pending queued messages
+   * (stop / error / clear / unsubscribe / reload).
+   */
+  private discardPendingSends(): void {
+    this.sendInFlight = false
+    this.flushQueue()
   }
 
   /**

--- a/packages/ai-client/src/devtools.ts
+++ b/packages/ai-client/src/devtools.ts
@@ -16,6 +16,7 @@ import type {
   ChatClientState,
   ConnectionStatus,
   MessagePart,
+  QueuedMessage,
   ToolCallPart,
   UIMessage,
 } from './types'
@@ -114,6 +115,7 @@ export interface AIDevtoolsChatSnapshot {
   connectionStatus: ConnectionStatus
   sessionGenerating: boolean
   activeRunIds: Array<string>
+  queue?: Array<QueuedMessage>
   error?: string
 }
 

--- a/packages/ai-client/src/index.ts
+++ b/packages/ai-client/src/index.ts
@@ -37,6 +37,7 @@ export type {
   MultimodalContent,
   QueuedMessage,
   WhenBusy,
+  QueueBusyReason,
   QueueConfig,
   QueueStrategy,
   QueueOption,

--- a/packages/ai-client/src/index.ts
+++ b/packages/ai-client/src/index.ts
@@ -35,6 +35,12 @@ export type {
   ChatTransport,
   DistributedOmit,
   MultimodalContent,
+  QueuedMessage,
+  WhenBusy,
+  QueueConfig,
+  QueueStrategy,
+  QueueOption,
+  SendMessageOptions,
 } from './types'
 // Generation client types
 export type {

--- a/packages/ai-client/src/types.ts
+++ b/packages/ai-client/src/types.ts
@@ -145,14 +145,24 @@ export interface MultimodalContent {
 }
 
 /**
- * Action taken when `sendMessage` is called while a stream is in flight.
- * - `queue`: hold the message; it auto-sends when the stream settles.
- * - `drop`: ignore the send.
+ * Action taken when `sendMessage` is called while the client is busy
+ * (streaming, claiming a send, or draining the queue).
+ * - `queue`: hold the message; it auto-sends when the current run settles
+ *   **successfully**.
+ * - `drop`: ignore the send (promise still resolves; does not throw).
  * - `interrupt`: abort the current stream and send immediately. Unlike
  *   `stop()`, does **not** flush already-queued messages — they still drain
  *   after the interrupting send settles successfully.
  */
 export type WhenBusy = 'queue' | 'drop' | 'interrupt'
+
+/**
+ * Why the client is busy when a {@link QueueStrategy} runs.
+ * - `streaming` — an LLM stream is active (`isLoading`).
+ * - `sendInFlight` — a send has claimed the client but is not yet loading.
+ * - `draining` — the queue drain loop is delivering pending messages.
+ */
+export type QueueBusyReason = 'streaming' | 'sendInFlight' | 'draining'
 
 /**
  * A user message held in the send queue while a stream is active.
@@ -169,17 +179,26 @@ export interface QueuedMessage {
  * Declarative queue policy.
  */
 export interface QueueConfig {
-  /** Action when a stream is in flight. Default `'queue'`. */
+  /**
+   * Action when the client is busy (streaming, claiming a send, or draining).
+   * Default `'queue'`.
+   */
   whenBusy?: WhenBusy
   /**
    * How queued items leave the queue.
    * - `'fifo'`: one at a time, in order (default).
-   * - `'batch'`: merge all queued items into one send when the stream settles.
+   * - `'batch'`: merge all queued items into one send when the run settles
+   *   successfully.
    */
   drain?: 'fifo' | 'batch'
-  /** Max queued items. Unlimited when omitted. */
+  /** Max queued items. Unlimited when omitted. `0` means never queue. */
   maxSize?: number
-  /** Behavior when `maxSize` is reached. Default `'reject'`. */
+  /**
+   * Behavior when `maxSize` is reached. Default `'reject'`.
+   * `'reject'` silently discards the new send (does not throw);
+   * `'drop-oldest'` evicts the oldest queued item to make room.
+   * Only meaningful when `maxSize` is set.
+   */
   onOverflow?: 'reject' | 'drop-oldest'
 }
 
@@ -188,15 +207,15 @@ export interface QueueConfig {
  * function form (no `batch` via function). Per-call `sendOptions.whenBusy`
  * overrides the strategy for that send.
  *
- * Returning `'send'` while a stream is in flight is coerced to `'enqueue'` —
- * concurrent streams are not supported. `pending.id` is the id that will be
- * stored if the action is `'enqueue'` (safe to pass to `cancelQueued`).
+ * Actions match {@link WhenBusy}: `'queue' | 'drop' | 'interrupt'`. Concurrent
+ * streams are not supported. `pending.id` is the id that will be stored if the
+ * action is `'queue'` (safe to pass to `cancelQueued`).
  */
 export type QueueStrategy = (ctx: {
   pending: QueuedMessage
-  isStreaming: boolean
+  busyReason: QueueBusyReason
   queued: ReadonlyArray<QueuedMessage>
-}) => { action: 'send' | 'enqueue' | 'drop' | 'interrupt' }
+}) => { action: WhenBusy }
 
 /** A `WhenBusy` shorthand, a full config, or a strategy function. */
 export type QueueOption = WhenBusy | QueueConfig | QueueStrategy
@@ -556,9 +575,13 @@ export interface ChatClientBaseOptions<
   onSessionGeneratingChange?: (isGenerating: boolean) => void
 
   /**
-   * Policy for messages sent while a stream is in flight. Accepts a
-   * `WhenBusy` string, a `QueueConfig`, or a `QueueStrategy` function.
+   * Policy for messages sent while the client is busy (streaming, claiming
+   * a send, or draining the queue). Accepts a `WhenBusy` string, a
+   * `QueueConfig`, or a `QueueStrategy` function.
    * Default: `{ whenBusy: 'queue', drain: 'fifo' }`.
+   * Queued items auto-send only after a **successful** settle; they are
+   * discarded on error/abort, `stop()`, `clear()`, `unsubscribe()`, and
+   * `reload()`.
    */
   queue?: QueueOption
 

--- a/packages/ai-client/src/types.ts
+++ b/packages/ai-client/src/types.ts
@@ -148,7 +148,9 @@ export interface MultimodalContent {
  * Action taken when `sendMessage` is called while a stream is in flight.
  * - `queue`: hold the message; it auto-sends when the stream settles.
  * - `drop`: ignore the send.
- * - `interrupt`: abort the current stream (like `stop()`) and send now.
+ * - `interrupt`: abort the current stream and send immediately. Unlike
+ *   `stop()`, does **not** flush already-queued messages — they still drain
+ *   after the interrupting send settles successfully.
  */
 export type WhenBusy = 'queue' | 'drop' | 'interrupt'
 
@@ -183,7 +185,12 @@ export interface QueueConfig {
 
 /**
  * Escape hatch: decide the action for a single send. Drain stays FIFO for the
- * function form (no `batch` via function).
+ * function form (no `batch` via function). Per-call `sendOptions.whenBusy`
+ * overrides the strategy for that send.
+ *
+ * Returning `'send'` while a stream is in flight is coerced to `'enqueue'` —
+ * concurrent streams are not supported. `pending.id` is the id that will be
+ * stored if the action is `'enqueue'` (safe to pass to `cancelQueued`).
  */
 export type QueueStrategy = (ctx: {
   pending: QueuedMessage

--- a/packages/ai-client/src/types.ts
+++ b/packages/ai-client/src/types.ts
@@ -145,6 +145,62 @@ export interface MultimodalContent {
 }
 
 /**
+ * Action taken when `sendMessage` is called while a stream is in flight.
+ * - `queue`: hold the message; it auto-sends when the stream settles.
+ * - `drop`: ignore the send.
+ * - `interrupt`: abort the current stream (like `stop()`) and send now.
+ */
+export type WhenBusy = 'queue' | 'drop' | 'interrupt'
+
+/**
+ * A user message held in the send queue while a stream is active.
+ * Rendered separately from `messages`; cancellable via `cancelQueued(id)`
+ * until it drains.
+ */
+export interface QueuedMessage {
+  id: string
+  content: string | MultimodalContent
+  createdAt: number
+}
+
+/**
+ * Declarative queue policy.
+ */
+export interface QueueConfig {
+  /** Action when a stream is in flight. Default `'queue'`. */
+  whenBusy?: WhenBusy
+  /**
+   * How queued items leave the queue.
+   * - `'fifo'`: one at a time, in order (default).
+   * - `'batch'`: merge all queued items into one send when the stream settles.
+   */
+  drain?: 'fifo' | 'batch'
+  /** Max queued items. Unlimited when omitted. */
+  maxSize?: number
+  /** Behavior when `maxSize` is reached. Default `'reject'`. */
+  onOverflow?: 'reject' | 'drop-oldest'
+}
+
+/**
+ * Escape hatch: decide the action for a single send. Drain stays FIFO for the
+ * function form (no `batch` via function).
+ */
+export type QueueStrategy = (ctx: {
+  pending: QueuedMessage
+  isStreaming: boolean
+  queued: ReadonlyArray<QueuedMessage>
+}) => { action: 'send' | 'enqueue' | 'drop' | 'interrupt' }
+
+/** A `WhenBusy` shorthand, a full config, or a strategy function. */
+export type QueueOption = WhenBusy | QueueConfig | QueueStrategy
+
+/** Per-call overrides for `sendMessage`. */
+export interface SendMessageOptions {
+  /** Overrides the configured `whenBusy` for this one send. */
+  whenBusy?: WhenBusy
+}
+
+/**
  * Message parts - building blocks of UIMessage
  */
 export interface TextPart {
@@ -491,6 +547,19 @@ export interface ChatClientBaseOptions<
    * activity visible to all subscribers (e.g. across tabs/devices).
    */
   onSessionGeneratingChange?: (isGenerating: boolean) => void
+
+  /**
+   * Policy for messages sent while a stream is in flight. Accepts a
+   * `WhenBusy` string, a `QueueConfig`, or a `QueueStrategy` function.
+   * Default: `{ whenBusy: 'queue', drain: 'fifo' }`.
+   */
+  queue?: QueueOption
+
+  /**
+   * Callback when the pending send queue changes (enqueue, cancel, drain,
+   * or flush).
+   */
+  onQueueChange?: (queue: Array<QueuedMessage>) => void
 
   /**
    * Callback when a custom event is received from a server-side tool.

--- a/packages/ai-client/tests/chat-client-queue.test.ts
+++ b/packages/ai-client/tests/chat-client-queue.test.ts
@@ -36,6 +36,11 @@ describe('normalizeQueueOption', () => {
       maxSize: 3,
     })
   })
+
+  it('rejects invalid maxSize', () => {
+    expect(() => normalizeQueueOption({ maxSize: -1 })).toThrow(/maxSize/)
+    expect(() => normalizeQueueOption({ maxSize: 1.5 })).toThrow(/maxSize/)
+  })
 })
 
 /**
@@ -324,5 +329,239 @@ describe('ChatClient queue drain', () => {
     expect(userMessages.map((m) => m.parts[0])).toEqual([
       { type: 'text', content: 'first' },
     ])
+  })
+
+  it('flushes the queue on clear()', async () => {
+    const { connection, release } = createHoldingConnection()
+    const client = new ChatClient({ connection })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('second')
+    expect(client.getQueue()).toHaveLength(1)
+
+    client.clear()
+    expect(client.getQueue()).toEqual([])
+
+    release()
+    await firstSend
+  })
+})
+
+describe('ChatClient queue policy branches', () => {
+  it("whenBusy: 'interrupt' aborts the in-flight stream and sends immediately", async () => {
+    const { connection, release } = createSequencedHoldingConnection()
+    const client = new ChatClient({ connection, queue: 'interrupt' })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    const secondSend = client.sendMessage('urgent')
+    // Interrupt does not enqueue.
+    expect(client.getQueue()).toEqual([])
+
+    // The interrupting send should be in messages immediately (and loading).
+    await vi.waitFor(() => {
+      const users = client.getMessages().filter((m) => m.role === 'user')
+      expect(users.map((m) => m.parts[0])).toEqual([
+        { type: 'text', content: 'first' },
+        { type: 'text', content: 'urgent' },
+      ])
+    })
+
+    release()
+    await Promise.all([firstSend, secondSend])
+
+    expect(client.getQueue()).toEqual([])
+  })
+
+  it('per-call whenBusy override beats the client default', async () => {
+    const { connection, release } = createSequencedHoldingConnection()
+    // Default is queue; override one send to interrupt.
+    const client = new ChatClient({ connection })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('queued-one')
+    expect(client.getQueue()).toHaveLength(1)
+
+    const interruptSend = client.sendMessage('urgent', undefined, {
+      whenBusy: 'interrupt',
+    })
+    // Interrupt does not flush existing queue; item stays pending.
+    expect(client.getQueue()).toHaveLength(1)
+
+    release()
+    await Promise.all([firstSend, interruptSend])
+
+    // After interrupt settles, the previously queued item drains.
+    await vi.waitFor(() => {
+      expect(client.getQueue()).toEqual([])
+    })
+
+    const userMessages = client.getMessages().filter((m) => m.role === 'user')
+    expect(userMessages.map((m) => m.parts[0])).toEqual([
+      { type: 'text', content: 'first' },
+      { type: 'text', content: 'urgent' },
+      { type: 'text', content: 'queued-one' },
+    ])
+  })
+
+  it("maxSize + onOverflow: 'reject' drops the newest when full", async () => {
+    const { connection, release } = createHoldingConnection()
+    const client = new ChatClient({
+      connection,
+      queue: { maxSize: 1, onOverflow: 'reject' },
+    })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('a')
+    await client.sendMessage('b')
+    expect(client.getQueue().map((m) => m.content)).toEqual(['a'])
+
+    release()
+    await firstSend
+  })
+
+  it("maxSize + onOverflow: 'drop-oldest' rotates the queue", async () => {
+    const { connection, release } = createHoldingConnection()
+    const client = new ChatClient({
+      connection,
+      queue: { maxSize: 1, onOverflow: 'drop-oldest' },
+    })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('a')
+    await client.sendMessage('b')
+    expect(client.getQueue().map((m) => m.content)).toEqual(['b'])
+
+    release()
+    await firstSend
+  })
+
+  it('maxSize: 0 never enqueues under drop-oldest', async () => {
+    const { connection, release } = createHoldingConnection()
+    const client = new ChatClient({
+      connection,
+      queue: { maxSize: 0, onOverflow: 'drop-oldest' },
+    })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('should-not-queue')
+    expect(client.getQueue()).toEqual([])
+
+    release()
+    await firstSend
+  })
+
+  it('QueueStrategy pending.id matches the enqueued item id', async () => {
+    const { connection, release } = createHoldingConnection()
+    let seenId: string | undefined
+    const client = new ChatClient({
+      connection,
+      queue: ({ pending }) => {
+        seenId = pending.id
+        return { action: 'enqueue' }
+      },
+    })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('second')
+    const queue = client.getQueue()
+    expect(queue).toHaveLength(1)
+    expect(seenId).toBe(queue[0]?.id)
+
+    // cancelQueued with the strategy-visible id must work.
+    client.cancelQueued(seenId!)
+    expect(client.getQueue()).toEqual([])
+
+    release()
+    await firstSend
+  })
+
+  it('concurrent rapid sends do not strand user messages without streams', async () => {
+    const { connection, release } = createSequencedHoldingConnection()
+    const client = new ChatClient({ connection })
+
+    // Fire several sends without awaiting between them (composer spam).
+    const sends = [
+      client.sendMessage('first'),
+      client.sendMessage('second'),
+      client.sendMessage('third'),
+    ]
+
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    // Only one should be in-flight as a user message initially; the rest queue
+    // (or all become user messages only as they drain in order).
+    await vi.waitFor(() => {
+      expect(client.getQueue().length + 1).toBeGreaterThanOrEqual(1)
+    })
+
+    release()
+    await Promise.all(sends)
+
+    // Every user message must have been delivered with no stranded leftovers
+    // in the queue, and all three must appear in order.
+    expect(client.getQueue()).toEqual([])
+    const userMessages = client.getMessages().filter((m) => m.role === 'user')
+    expect(userMessages.map((m) => m.parts[0])).toEqual([
+      { type: 'text', content: 'first' },
+      { type: 'text', content: 'second' },
+      { type: 'text', content: 'third' },
+    ])
+    // Each user message should have a corresponding assistant reply after
+    // the full FIFO drain completes.
+    const assistantMessages = client
+      .getMessages()
+      .filter((m) => m.role === 'assistant')
+    expect(assistantMessages.length).toBe(3)
+  })
+
+  it('flushes the queue on reload()', async () => {
+    const { connection, release } = createSequencedHoldingConnection()
+    const client = new ChatClient({ connection })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('queued')
+    expect(client.getQueue()).toHaveLength(1)
+
+    // Reload while the first stream is held open and something is queued.
+    const reloadPromise = client.reload()
+    expect(client.getQueue()).toEqual([])
+
+    release()
+    await Promise.all([firstSend, reloadPromise])
+    expect(client.getQueue()).toEqual([])
   })
 })

--- a/packages/ai-client/tests/chat-client-queue.test.ts
+++ b/packages/ai-client/tests/chat-client-queue.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest'
-import { normalizeQueueOption } from '../src/chat-client'
+import { describe, expect, it, vi } from 'vitest'
+import { ChatClient, normalizeQueueOption } from '../src/chat-client'
+import { createTextChunks } from './test-utils'
+import type { ConnectConnectionAdapter } from '../src/connection-adapters'
 
 describe('normalizeQueueOption', () => {
   it('defaults to queue + fifo + reject', () => {
@@ -31,5 +33,98 @@ describe('normalizeQueueOption', () => {
       onOverflow: 'reject',
       maxSize: 3,
     })
+  })
+})
+
+/**
+ * Creates a deferred promise. `resolve` releases anything awaiting `promise`.
+ */
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
+/**
+ * A `ConnectConnectionAdapter` whose stream stays open (keeping `isLoading`
+ * true) until `release()` is called, at which point it finishes with a
+ * simple text response.
+ */
+function createHoldingConnection(): {
+  connection: ConnectConnectionAdapter
+  release: () => void
+} {
+  const deferred = createDeferred<void>()
+  const connection: ConnectConnectionAdapter = {
+    async *connect() {
+      await deferred.promise
+      yield* createTextChunks('done', 'msg-1')
+    },
+  }
+  return { connection, release: () => deferred.resolve() }
+}
+
+describe('ChatClient message queue', () => {
+  it('enqueues (not drops) a send while streaming and reports via onQueueChange', async () => {
+    const { connection, release } = createHoldingConnection()
+    const onQueueChange = vi.fn()
+    const client = new ChatClient({ connection, onQueueChange })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('second')
+
+    const queue = client.getQueue()
+    expect(queue).toHaveLength(1)
+    expect(queue[0]?.content).toBe('second')
+    expect(onQueueChange).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ content: 'second' })]),
+    )
+    expect(onQueueChange.mock.calls.at(-1)?.[0]).toHaveLength(1)
+
+    release()
+    await firstSend
+  })
+
+  it('cancelQueued removes a queued item before it drains', async () => {
+    const { connection, release } = createHoldingConnection()
+    const client = new ChatClient({ connection })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('second')
+    const queued = client.getQueue()
+    expect(queued).toHaveLength(1)
+    const queuedId = queued[0]!.id
+
+    client.cancelQueued(queuedId)
+    expect(client.getQueue()).toEqual([])
+
+    release()
+    await firstSend
+  })
+
+  it("whenBusy: 'drop' ignores a mid-stream send", async () => {
+    const { connection, release } = createHoldingConnection()
+    const client = new ChatClient({ connection, queue: 'drop' })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('second')
+    expect(client.getQueue()).toEqual([])
+
+    release()
+    await firstSend
   })
 })

--- a/packages/ai-client/tests/chat-client-queue.test.ts
+++ b/packages/ai-client/tests/chat-client-queue.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeQueueOption } from '../src/chat-client'
+
+describe('normalizeQueueOption', () => {
+  it('defaults to queue + fifo + reject', () => {
+    expect(normalizeQueueOption(undefined)).toEqual({
+      whenBusy: 'queue',
+      drain: 'fifo',
+      onOverflow: 'reject',
+    })
+  })
+
+  it('treats a string as whenBusy shorthand', () => {
+    expect(normalizeQueueOption('interrupt')).toMatchObject({
+      whenBusy: 'interrupt',
+      drain: 'fifo',
+    })
+  })
+
+  it('carries a function as strategy and forces fifo', () => {
+    const fn = () => ({ action: 'enqueue' as const })
+    const cfg = normalizeQueueOption(fn)
+    expect(cfg.strategy).toBe(fn)
+    expect(cfg.drain).toBe('fifo')
+  })
+
+  it('merges a config object over defaults', () => {
+    expect(normalizeQueueOption({ whenBusy: 'drop', maxSize: 3 })).toEqual({
+      whenBusy: 'drop',
+      drain: 'fifo',
+      onOverflow: 'reject',
+      maxSize: 3,
+    })
+  })
+})

--- a/packages/ai-client/tests/chat-client-queue.test.ts
+++ b/packages/ai-client/tests/chat-client-queue.test.ts
@@ -131,9 +131,7 @@ describe('ChatClient message queue', () => {
 
     // The dropped message must never have become a real message either —
     // it should be gone entirely, not just missing from the queue.
-    const userMessages = client
-      .getMessages()
-      .filter((m) => m.role === 'user')
+    const userMessages = client.getMessages().filter((m) => m.role === 'user')
     expect(userMessages.map((m) => m.parts[0])).toEqual([
       { type: 'text', content: 'first' },
     ])
@@ -200,18 +198,13 @@ describe('ChatClient queue drain', () => {
 
     await client.sendMessage('second')
     await client.sendMessage('third')
-    expect(client.getQueue().map((m) => m.content)).toEqual([
-      'second',
-      'third',
-    ])
+    expect(client.getQueue().map((m) => m.content)).toEqual(['second', 'third'])
 
     release()
     await firstSend
 
     expect(client.getQueue()).toEqual([])
-    const userMessages = client
-      .getMessages()
-      .filter((m) => m.role === 'user')
+    const userMessages = client.getMessages().filter((m) => m.role === 'user')
     expect(userMessages.map((m) => m.parts[0])).toEqual([
       { type: 'text', content: 'first' },
       { type: 'text', content: 'second' },
@@ -236,9 +229,7 @@ describe('ChatClient queue drain', () => {
     await firstSend
 
     expect(client.getQueue()).toEqual([])
-    const userMessages = client
-      .getMessages()
-      .filter((m) => m.role === 'user')
+    const userMessages = client.getMessages().filter((m) => m.role === 'user')
     expect(userMessages).toHaveLength(2)
     expect(userMessages[1]?.parts[0]).toEqual({
       type: 'text',
@@ -273,9 +264,7 @@ describe('ChatClient queue drain', () => {
     await firstSend
 
     expect(client.getQueue()).toEqual([])
-    const userMessages = client
-      .getMessages()
-      .filter((m) => m.role === 'user')
+    const userMessages = client.getMessages().filter((m) => m.role === 'user')
     // 'first' streamed immediately; the two queued sends above are merged
     // into a single batched send, so there should be exactly 2 user messages.
     expect(userMessages).toHaveLength(2)
@@ -331,9 +320,7 @@ describe('ChatClient queue drain', () => {
     // The queue must be flushed, not stranded or auto-drained into the
     // now-broken endpoint.
     expect(client.getQueue()).toEqual([])
-    const userMessages = client
-      .getMessages()
-      .filter((m) => m.role === 'user')
+    const userMessages = client.getMessages().filter((m) => m.role === 'user')
     expect(userMessages.map((m) => m.parts[0])).toEqual([
       { type: 'text', content: 'first' },
     ])

--- a/packages/ai-client/tests/chat-client-queue.test.ts
+++ b/packages/ai-client/tests/chat-client-queue.test.ts
@@ -128,3 +128,106 @@ describe('ChatClient message queue', () => {
     await firstSend
   })
 })
+
+/**
+ * Like {@link createHoldingConnection}, but only the first `connect()` call
+ * waits on the deferred; every subsequent call (i.e. a drained queue item's
+ * own send) resolves immediately with a unique messageId so chained drains
+ * don't collide on the same assistant message id.
+ */
+function createSequencedHoldingConnection(): {
+  connection: ConnectConnectionAdapter
+  release: () => void
+} {
+  const deferred = createDeferred<void>()
+  let call = 0
+  const connection: ConnectConnectionAdapter = {
+    async *connect() {
+      call += 1
+      if (call === 1) {
+        await deferred.promise
+      }
+      yield* createTextChunks('done', `msg-${call}`)
+    },
+  }
+  return { connection, release: () => deferred.resolve() }
+}
+
+describe('ChatClient queue drain', () => {
+  it('drains FIFO after the stream settles, in order', async () => {
+    const { connection, release } = createSequencedHoldingConnection()
+    const client = new ChatClient({ connection })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('second')
+    await client.sendMessage('third')
+    expect(client.getQueue().map((m) => m.content)).toEqual([
+      'second',
+      'third',
+    ])
+
+    release()
+    await firstSend
+
+    expect(client.getQueue()).toEqual([])
+    const userMessages = client
+      .getMessages()
+      .filter((m) => m.role === 'user')
+    expect(userMessages.map((m) => m.parts[0])).toEqual([
+      { type: 'text', content: 'first' },
+      { type: 'text', content: 'second' },
+      { type: 'text', content: 'third' },
+    ])
+  })
+
+  it('batch drain merges string queued items with newlines', async () => {
+    const { connection, release } = createSequencedHoldingConnection()
+    const client = new ChatClient({ connection, queue: { drain: 'batch' } })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('a')
+    await client.sendMessage('b')
+    expect(client.getQueue().map((m) => m.content)).toEqual(['a', 'b'])
+
+    release()
+    await firstSend
+
+    expect(client.getQueue()).toEqual([])
+    const userMessages = client
+      .getMessages()
+      .filter((m) => m.role === 'user')
+    expect(userMessages).toHaveLength(2)
+    expect(userMessages[1]?.parts[0]).toEqual({
+      type: 'text',
+      content: 'a\nb',
+    })
+  })
+
+  it('flushes the queue on stop()', async () => {
+    const { connection, release } = createHoldingConnection()
+    const client = new ChatClient({ connection })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('second')
+    expect(client.getQueue()).toHaveLength(1)
+
+    client.stop()
+    expect(client.getQueue()).toEqual([])
+
+    // Let the held-open stream settle so it doesn't leak into other tests.
+    release()
+    await firstSend
+  })
+})

--- a/packages/ai-client/tests/chat-client-queue.test.ts
+++ b/packages/ai-client/tests/chat-client-queue.test.ts
@@ -22,7 +22,7 @@ describe('normalizeQueueOption', () => {
   })
 
   it('carries a function as strategy and forces fifo', () => {
-    const fn = () => ({ action: 'enqueue' as const })
+    const fn = () => ({ action: 'queue' as const })
     const cfg = normalizeQueueOption(fn)
     expect(cfg.strategy).toBe(fn)
     expect(cfg.drain).toBe('fifo')
@@ -477,11 +477,13 @@ describe('ChatClient queue policy branches', () => {
   it('QueueStrategy pending.id matches the enqueued item id', async () => {
     const { connection, release } = createHoldingConnection()
     let seenId: string | undefined
+    let seenBusyReason: string | undefined
     const client = new ChatClient({
       connection,
-      queue: ({ pending }) => {
+      queue: ({ pending, busyReason }) => {
         seenId = pending.id
-        return { action: 'enqueue' }
+        seenBusyReason = busyReason
+        return { action: 'queue' }
       },
     })
 
@@ -494,10 +496,38 @@ describe('ChatClient queue policy branches', () => {
     const queue = client.getQueue()
     expect(queue).toHaveLength(1)
     expect(seenId).toBe(queue[0]?.id)
+    expect(seenBusyReason).toBe('streaming')
 
     // cancelQueued with the strategy-visible id must work.
     client.cancelQueued(seenId!)
     expect(client.getQueue()).toEqual([])
+
+    release()
+    await firstSend
+  })
+
+  it('QueueStrategy drop and per-call whenBusy override', async () => {
+    const { connection, release } = createHoldingConnection()
+    const client = new ChatClient({
+      connection,
+      queue: () => ({ action: 'drop' }),
+    })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('ignored-by-strategy')
+    expect(client.getQueue()).toEqual([])
+
+    // Per-call override beats strategy.
+    await client.sendMessage('queued-via-override', undefined, {
+      whenBusy: 'queue',
+    })
+    expect(client.getQueue().map((m) => m.content)).toEqual([
+      'queued-via-override',
+    ])
 
     release()
     await firstSend
@@ -518,10 +548,10 @@ describe('ChatClient queue policy branches', () => {
       expect(client.getIsLoading()).toBe(true)
     })
 
-    // Only one should be in-flight as a user message initially; the rest queue
-    // (or all become user messages only as they drain in order).
+    // While the first stream is open, at least one of the later sends must be
+    // sitting in the queue (not all three racing as concurrent streams).
     await vi.waitFor(() => {
-      expect(client.getQueue().length + 1).toBeGreaterThanOrEqual(1)
+      expect(client.getQueue().length).toBeGreaterThanOrEqual(1)
     })
 
     release()
@@ -563,5 +593,251 @@ describe('ChatClient queue policy branches', () => {
     release()
     await Promise.all([firstSend, reloadPromise])
     expect(client.getQueue()).toEqual([])
+  })
+
+  it('flushes the queue on unsubscribe()', async () => {
+    const { connection, release } = createHoldingConnection()
+    const client = new ChatClient({ connection })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('queued')
+    expect(client.getQueue()).toHaveLength(1)
+
+    client.unsubscribe()
+    expect(client.getQueue()).toEqual([])
+
+    release()
+    await firstSend
+  })
+
+  it('preserves per-message body through FIFO drain and batch last-wins', async () => {
+    const seenBodies: Array<Record<string, unknown> | undefined> = []
+    const deferred = createDeferred<void>()
+    let call = 0
+    const connection: ConnectConnectionAdapter = {
+      async *connect(_messages, data) {
+        call += 1
+        seenBodies.push(
+          data && typeof data === 'object'
+            ? (data as Record<string, unknown>)
+            : undefined,
+        )
+        if (call === 1) {
+          await deferred.promise
+        }
+        yield* createTextChunks('done', `msg-${call}`)
+      },
+    }
+
+    // FIFO: each drained send keeps its own body.
+    const fifoClient = new ChatClient({ connection })
+    const firstFifo = fifoClient.sendMessage('first', { tag: 'seed' })
+    await vi.waitFor(() => {
+      expect(fifoClient.getIsLoading()).toBe(true)
+    })
+    await fifoClient.sendMessage('a', { tag: 'a' })
+    await fifoClient.sendMessage('b', { tag: 'b' })
+    deferred.resolve()
+    await firstFifo
+    await vi.waitFor(() => {
+      expect(fifoClient.getQueue()).toEqual([])
+    })
+    // First send + two drained: tags seed, a, b (merged with base body).
+    expect(seenBodies.map((b) => b?.tag)).toEqual(['seed', 'a', 'b'])
+
+    // Batch: last item's body wins.
+    seenBodies.length = 0
+    call = 0
+    const deferredBatch = createDeferred<void>()
+    const batchConnection: ConnectConnectionAdapter = {
+      async *connect(_messages, data) {
+        call += 1
+        seenBodies.push(
+          data && typeof data === 'object'
+            ? (data as Record<string, unknown>)
+            : undefined,
+        )
+        if (call === 1) {
+          await deferredBatch.promise
+        }
+        yield* createTextChunks('done', `batch-${call}`)
+      },
+    }
+    const batchClient = new ChatClient({
+      connection: batchConnection,
+      queue: { drain: 'batch' },
+    })
+    const firstBatch = batchClient.sendMessage('first', { tag: 'seed' })
+    await vi.waitFor(() => {
+      expect(batchClient.getIsLoading()).toBe(true)
+    })
+    await batchClient.sendMessage('x', { tag: 'x' })
+    await batchClient.sendMessage('y', { tag: 'y' })
+    deferredBatch.resolve()
+    await firstBatch
+    await vi.waitFor(() => {
+      expect(batchClient.getQueue()).toEqual([])
+    })
+    expect(seenBodies.map((b) => b?.tag)).toEqual(['seed', 'y'])
+  })
+
+  it('batch drain does not strand messages enqueued during the batch stream', async () => {
+    const deferred1 = createDeferred<void>()
+    const deferred2 = createDeferred<void>()
+    let call = 0
+    const connection: ConnectConnectionAdapter = {
+      async *connect() {
+        call += 1
+        if (call === 1) {
+          await deferred1.promise
+        } else if (call === 2) {
+          await deferred2.promise
+        }
+        yield* createTextChunks('done', `msg-${call}`)
+      },
+    }
+    const client = new ChatClient({ connection, queue: { drain: 'batch' } })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+    await client.sendMessage('a')
+    await client.sendMessage('b')
+
+    deferred1.resolve()
+    // Wait until the batch of a+b is streaming.
+    await vi.waitFor(() => {
+      const users = client.getMessages().filter((m) => m.role === 'user')
+      expect(users).toHaveLength(2)
+      expect(users[1]?.parts[0]).toEqual({ type: 'text', content: 'a\nb' })
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('during-batch')
+    expect(client.getQueue().map((m) => m.content)).toEqual(['during-batch'])
+
+    deferred2.resolve()
+    await firstSend
+    await vi.waitFor(() => {
+      expect(client.getQueue()).toEqual([])
+    })
+
+    const users = client.getMessages().filter((m) => m.role === 'user')
+    expect(users.map((m) => m.parts[0])).toEqual([
+      { type: 'text', content: 'first' },
+      { type: 'text', content: 'a\nb' },
+      { type: 'text', content: 'during-batch' },
+    ])
+  })
+
+  it('error during FIFO drain flushes remaining queued items', async () => {
+    const deferred = createDeferred<void>()
+    let call = 0
+    const connection: ConnectConnectionAdapter = {
+      async *connect(): AsyncGenerator<StreamChunk> {
+        call += 1
+        if (call === 1) {
+          await deferred.promise
+          yield* createTextChunks('done', 'msg-1')
+          return
+        }
+        if (call === 2) {
+          yield {
+            type: EventType.RUN_ERROR,
+            threadId: 'thread-1',
+            timestamp: Date.now(),
+            message: 'boom',
+            error: { message: 'boom' },
+          }
+          return
+        }
+        yield* createTextChunks('should-not-run', `msg-${call}`)
+      },
+    }
+    const client = new ChatClient({ connection })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+    await client.sendMessage('drains-then-errors')
+    await client.sendMessage('should-be-flushed')
+    expect(client.getQueue()).toHaveLength(2)
+
+    deferred.resolve()
+    await firstSend
+    await vi.waitFor(() => {
+      expect(client.getQueue()).toEqual([])
+    })
+
+    const users = client.getMessages().filter((m) => m.role === 'user')
+    // first + the drained item that errored; the third never sends.
+    expect(users.map((m) => m.parts[0])).toEqual([
+      { type: 'text', content: 'first' },
+      { type: 'text', content: 'drains-then-errors' },
+    ])
+  })
+
+  it('interrupt during FIFO drain keeps remaining items for after the interrupt', async () => {
+    const deferred1 = createDeferred<void>()
+    const deferred2 = createDeferred<void>()
+    let call = 0
+    const connection: ConnectConnectionAdapter = {
+      async *connect() {
+        call += 1
+        if (call === 1) {
+          await deferred1.promise
+        } else if (call === 2) {
+          await deferred2.promise
+        }
+        yield* createTextChunks('done', `msg-${call}`)
+      },
+    }
+    const client = new ChatClient({ connection })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+    await client.sendMessage('second')
+    await client.sendMessage('third')
+
+    deferred1.resolve()
+    // Wait until FIFO drain has started streaming "second".
+    await vi.waitFor(() => {
+      const users = client.getMessages().filter((m) => m.role === 'user')
+      expect(users.map((m) => m.parts[0])).toEqual([
+        { type: 'text', content: 'first' },
+        { type: 'text', content: 'second' },
+      ])
+      expect(client.getIsLoading()).toBe(true)
+    })
+    // "third" should still be queued while "second" streams.
+    expect(client.getQueue().map((m) => m.content)).toEqual(['third'])
+
+    const interruptSend = client.sendMessage('urgent', undefined, {
+      whenBusy: 'interrupt',
+    })
+    // Interrupt does not flush remaining queue.
+    expect(client.getQueue().map((m) => m.content)).toEqual(['third'])
+
+    deferred2.resolve()
+    await Promise.all([firstSend, interruptSend])
+    await vi.waitFor(() => {
+      expect(client.getQueue()).toEqual([])
+    })
+
+    const users = client.getMessages().filter((m) => m.role === 'user')
+    expect(users.map((m) => m.parts[0])).toEqual([
+      { type: 'text', content: 'first' },
+      { type: 'text', content: 'second' },
+      { type: 'text', content: 'urgent' },
+      { type: 'text', content: 'third' },
+    ])
   })
 })

--- a/packages/ai-client/tests/chat-client-queue.test.ts
+++ b/packages/ai-client/tests/chat-client-queue.test.ts
@@ -185,7 +185,7 @@ function createErroringHoldingConnection(): {
         timestamp: Date.now(),
         message: 'boom',
         error: { message: 'boom' },
-      } as StreamChunk
+      }
     },
   }
   return { connection, release: () => deferred.resolve() }

--- a/packages/ai-client/tests/chat-client-queue.test.ts
+++ b/packages/ai-client/tests/chat-client-queue.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
+import { EventType } from '@tanstack/ai/client'
 import { ChatClient, normalizeQueueOption } from '../src/chat-client'
 import { createTextChunks } from './test-utils'
 import type { ConnectConnectionAdapter } from '../src/connection-adapters'
+import type { StreamChunk } from '@tanstack/ai/client'
 
 describe('normalizeQueueOption', () => {
   it('defaults to queue + fifo + reject', () => {
@@ -126,6 +128,15 @@ describe('ChatClient message queue', () => {
 
     release()
     await firstSend
+
+    // The dropped message must never have become a real message either —
+    // it should be gone entirely, not just missing from the queue.
+    const userMessages = client
+      .getMessages()
+      .filter((m) => m.role === 'user')
+    expect(userMessages.map((m) => m.parts[0])).toEqual([
+      { type: 'text', content: 'first' },
+    ])
   })
 })
 
@@ -148,6 +159,30 @@ function createSequencedHoldingConnection(): {
         await deferred.promise
       }
       yield* createTextChunks('done', `msg-${call}`)
+    },
+  }
+  return { connection, release: () => deferred.resolve() }
+}
+
+/**
+ * Like {@link createHoldingConnection}, but `release()` settles the stream
+ * with a `RUN_ERROR` chunk instead of a successful text response.
+ */
+function createErroringHoldingConnection(): {
+  connection: ConnectConnectionAdapter
+  release: () => void
+} {
+  const deferred = createDeferred<void>()
+  const connection: ConnectConnectionAdapter = {
+    async *connect(): AsyncGenerator<StreamChunk> {
+      await deferred.promise
+      yield {
+        type: EventType.RUN_ERROR,
+        threadId: 'thread-1',
+        timestamp: Date.now(),
+        message: 'boom',
+        error: { message: 'boom' },
+      } as StreamChunk
     },
   }
   return { connection, release: () => deferred.resolve() }
@@ -229,5 +264,31 @@ describe('ChatClient queue drain', () => {
     // Let the held-open stream settle so it doesn't leak into other tests.
     release()
     await firstSend
+  })
+
+  it('flushes the queue when the stream errors', async () => {
+    const { connection, release } = createErroringHoldingConnection()
+    const client = new ChatClient({ connection })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    await client.sendMessage('second')
+    expect(client.getQueue()).toHaveLength(1)
+
+    release()
+    await firstSend
+
+    // The queue must be flushed, not stranded or auto-drained into the
+    // now-broken endpoint.
+    expect(client.getQueue()).toEqual([])
+    const userMessages = client
+      .getMessages()
+      .filter((m) => m.role === 'user')
+    expect(userMessages.map((m) => m.parts[0])).toEqual([
+      { type: 'text', content: 'first' },
+    ])
   })
 })

--- a/packages/ai-client/tests/chat-client-queue.test.ts
+++ b/packages/ai-client/tests/chat-client-queue.test.ts
@@ -246,6 +246,53 @@ describe('ChatClient queue drain', () => {
     })
   })
 
+  it('batch drain flattens multimodal queued items into ContentPart[]', async () => {
+    const { connection, release } = createSequencedHoldingConnection()
+    const client = new ChatClient({ connection, queue: { drain: 'batch' } })
+
+    const firstSend = client.sendMessage('first')
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+
+    // Queued item 1: multimodal content (array of ContentPart).
+    await client.sendMessage({
+      content: [
+        { type: 'text', content: 'look' },
+        {
+          type: 'image',
+          source: { type: 'url', value: 'https://example.com/a.png' },
+        },
+      ],
+    })
+    // Queued item 2: plain string content.
+    await client.sendMessage('note')
+    expect(client.getQueue()).toHaveLength(2)
+
+    release()
+    await firstSend
+
+    expect(client.getQueue()).toEqual([])
+    const userMessages = client
+      .getMessages()
+      .filter((m) => m.role === 'user')
+    // 'first' streamed immediately; the two queued sends above are merged
+    // into a single batched send, so there should be exactly 2 user messages.
+    expect(userMessages).toHaveLength(2)
+    // The merged message's parts must be the multimodal item's parts
+    // (flattened, in order) followed by the string item flattened to text —
+    // proving the MULTIMODAL branch of `mergeQueuedMessages` ran, not just
+    // the all-string join.
+    expect(userMessages[1]?.parts).toEqual([
+      { type: 'text', content: 'look' },
+      {
+        type: 'image',
+        source: { type: 'url', value: 'https://example.com/a.png' },
+      },
+      { type: 'text', content: 'note' },
+    ])
+  })
+
   it('flushes the queue on stop()', async () => {
     const { connection, release } = createHoldingConnection()
     const client = new ChatClient({ connection })

--- a/packages/ai-client/tests/chat-client.test.ts
+++ b/packages/ai-client/tests/chat-client.test.ts
@@ -2137,7 +2137,7 @@ describe('ChatClient', () => {
       expect(client.getMessages().length).toBe(0)
     })
 
-    it('should not send message while loading', async () => {
+    it('should queue (not send immediately) a message sent while loading, then auto-send it once the stream settles', async () => {
       const adapter = createMockConnectionAdapter({
         chunks: createTextChunks('Response'),
         chunkDelay: 100,
@@ -2149,9 +2149,14 @@ describe('ChatClient', () => {
 
       await Promise.all([promise1, promise2])
 
-      // Should only have one user message since second was blocked
+      // The second send is queued (default `whenBusy: 'queue'`) rather than
+      // started concurrently, then auto-drains once the first stream settles
+      // — both end up sent, in order.
       const userMessages = client.getMessages().filter((m) => m.role === 'user')
-      expect(userMessages.length).toBe(1)
+      expect(userMessages.map((m) => m.parts[0])).toEqual([
+        { type: 'text', content: 'First' },
+        { type: 'text', content: 'Second' },
+      ])
     })
   })
 

--- a/packages/ai-preact/src/index.ts
+++ b/packages/ai-preact/src/index.ts
@@ -7,6 +7,7 @@ export type {
   UIMessage,
   ChatRequestBody,
   QueuedMessage,
+  SendMessageOptions,
   WhenBusy,
   QueueConfig,
   QueueStrategy,

--- a/packages/ai-preact/src/index.ts
+++ b/packages/ai-preact/src/index.ts
@@ -6,6 +6,11 @@ export type {
   UseChatReturn,
   UIMessage,
   ChatRequestBody,
+  QueuedMessage,
+  WhenBusy,
+  QueueConfig,
+  QueueStrategy,
+  QueueOption,
 } from './types'
 
 export {

--- a/packages/ai-preact/src/types.ts
+++ b/packages/ai-preact/src/types.ts
@@ -9,7 +9,10 @@ import type {
   DistributedOmit,
   InferredClientContext,
   MultimodalContent,
+  QueueConfig,
   QueuedMessage,
+  QueueOption,
+  QueueStrategy,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'
@@ -18,7 +21,10 @@ import type {
 export type {
   ChatRequestBody,
   MultimodalContent,
+  QueueConfig,
   QueuedMessage,
+  QueueOption,
+  QueueStrategy,
   UIMessage,
   WhenBusy,
 }

--- a/packages/ai-preact/src/types.ts
+++ b/packages/ai-preact/src/types.ts
@@ -9,11 +9,19 @@ import type {
   DistributedOmit,
   InferredClientContext,
   MultimodalContent,
+  QueuedMessage,
   UIMessage,
+  WhenBusy,
 } from '@tanstack/ai-client'
 
 // Re-export types from ai-client
-export type { ChatRequestBody, MultimodalContent, UIMessage }
+export type {
+  ChatRequestBody,
+  MultimodalContent,
+  QueuedMessage,
+  UIMessage,
+  WhenBusy,
+}
 
 /**
  * Options for the useChat hook.
@@ -43,6 +51,7 @@ export type UseChatOptions<
   | 'onSubscriptionChange'
   | 'onConnectionStatusChange'
   | 'onSessionGeneratingChange'
+  | 'onQueueChange'
   | 'context'
   | 'devtools'
 > & {
@@ -70,7 +79,20 @@ export interface UseChatReturn<
    * Send a message and get a response.
    * Can be a simple string or multimodal content with images, audio, etc.
    */
-  sendMessage: (content: string | MultimodalContent) => Promise<void>
+  sendMessage: (
+    content: string | MultimodalContent,
+    options?: { whenBusy?: WhenBusy },
+  ) => Promise<void>
+
+  /**
+   * Pending messages queued while a stream is in flight.
+   */
+  queue: Array<QueuedMessage>
+
+  /**
+   * Cancel a queued message before it drains. No-op if already sent.
+   */
+  cancelQueued: (id: string) => void
 
   /**
    * Append a message to the conversation

--- a/packages/ai-preact/src/types.ts
+++ b/packages/ai-preact/src/types.ts
@@ -10,9 +10,9 @@ import type {
   InferredClientContext,
   MultimodalContent,
   QueueConfig,
-  QueuedMessage,
   QueueOption,
   QueueStrategy,
+  QueuedMessage,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'

--- a/packages/ai-preact/src/types.ts
+++ b/packages/ai-preact/src/types.ts
@@ -13,6 +13,7 @@ import type {
   QueueOption,
   QueueStrategy,
   QueuedMessage,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'
@@ -25,6 +26,7 @@ export type {
   QueuedMessage,
   QueueOption,
   QueueStrategy,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 }
@@ -87,7 +89,7 @@ export interface UseChatReturn<
    */
   sendMessage: (
     content: string | MultimodalContent,
-    options?: { whenBusy?: WhenBusy },
+    options?: SendMessageOptions,
   ) => Promise<void>
 
   /**

--- a/packages/ai-preact/src/use-chat.ts
+++ b/packages/ai-preact/src/use-chat.ts
@@ -12,6 +12,8 @@ import type {
   ChatClientState,
   ConnectionStatus,
   InferredClientContext,
+  QueuedMessage,
+  WhenBusy,
 } from '@tanstack/ai-client'
 import type { AnyClientTool, ModelMessage } from '@tanstack/ai'
 
@@ -39,6 +41,7 @@ export function useChat<
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>('disconnected')
   const [sessionGenerating, setSessionGenerating] = useState(false)
+  const [queue, setQueue] = useState<Array<QueuedMessage>>([])
 
   // Track current messages in a ref to preserve them when client is recreated
   const messagesRef = useRef<Array<UIMessage<TTools>>>(
@@ -151,6 +154,13 @@ export function useChat<
         if (activeClientRef.current !== instance) return
         setSessionGenerating(isGenerating)
       },
+      ...(optionsRef.current.queue !== undefined && {
+        queue: optionsRef.current.queue,
+      }),
+      onQueueChange: (nextQueue: Array<QueuedMessage>) => {
+        if (activeClientRef.current !== instance) return
+        setQueue(nextQueue)
+      },
     })
     activeClientRef.current = instance
     return instance
@@ -221,8 +231,18 @@ export function useChat<
   // All callback options are read through optionsRef at call time, so fresh
   // closures from each render are picked up without recreating the client.
   const sendMessage = useCallback(
-    async (content: string | MultimodalContent) => {
-      await client.sendMessage(content)
+    async (
+      content: string | MultimodalContent,
+      sendOptions?: { whenBusy?: WhenBusy },
+    ) => {
+      await client.sendMessage(content, undefined, sendOptions)
+    },
+    [client],
+  )
+
+  const cancelQueued = useCallback(
+    (id: string) => {
+      client.cancelQueued(id)
     },
     [client],
   )
@@ -291,5 +311,7 @@ export function useChat<
     clear,
     addToolResult,
     addToolApprovalResponse,
+    queue,
+    cancelQueued,
   }
 }

--- a/packages/ai-preact/src/use-chat.ts
+++ b/packages/ai-preact/src/use-chat.ts
@@ -13,7 +13,7 @@ import type {
   ConnectionStatus,
   InferredClientContext,
   QueuedMessage,
-  WhenBusy,
+  SendMessageOptions,
 } from '@tanstack/ai-client'
 import type { AnyClientTool, ModelMessage } from '@tanstack/ai'
 
@@ -240,7 +240,7 @@ export function useChat<
   const sendMessage = useCallback(
     async (
       content: string | MultimodalContent,
-      sendOptions?: { whenBusy?: WhenBusy },
+      sendOptions?: SendMessageOptions,
     ) => {
       await client.sendMessage(content, undefined, sendOptions)
     },

--- a/packages/ai-preact/src/use-chat.ts
+++ b/packages/ai-preact/src/use-chat.ts
@@ -185,8 +185,15 @@ export function useChat<
         forwardedProps: options.forwardedProps,
       }),
       context: options.context,
+      ...(options.queue !== undefined && { queue: options.queue }),
     })
-  }, [client, options.body, options.forwardedProps, options.context])
+  }, [
+    client,
+    options.body,
+    options.forwardedProps,
+    options.context,
+    options.queue,
+  ])
 
   useEffect(() => {
     if (options.live) {

--- a/packages/ai-preact/tests/use-chat.test.ts
+++ b/packages/ai-preact/tests/use-chat.test.ts
@@ -397,7 +397,7 @@ describe('useChat', () => {
       expect(result.current.messages.length).toBe(0)
     })
 
-    it('should not send message while loading', async () => {
+    it('should queue a message sent while loading and send it after', async () => {
       const adapter = createMockConnectionAdapter({
         chunks: createTextChunks('Response'),
         chunkDelay: 100,
@@ -410,11 +410,16 @@ describe('useChat', () => {
         await Promise.all([promise1, promise2])
       })
 
-      // Should only have one user message since second was blocked
+      // The second send is queued (default `whenBusy: 'queue'`) while the
+      // first stream is in flight, then auto-drains once it settles — both
+      // end up sent, in order.
       const userMessages = result.current.messages.filter(
         (m) => m.role === 'user',
       )
-      expect(userMessages.length).toBe(1)
+      expect(userMessages.map((m) => m.parts[0])).toEqual([
+        { type: 'text', content: 'First' },
+        { type: 'text', content: 'Second' },
+      ])
     })
 
     it('should handle errors during sendMessage', async () => {
@@ -1261,7 +1266,7 @@ describe('useChat', () => {
     })
 
     describe('concurrent operations', () => {
-      it('should handle multiple sendMessage calls', async () => {
+      it('should queue and then deliver multiple sendMessage calls in order', async () => {
         const adapter = createMockConnectionAdapter({
           chunks: createTextChunks('Response'),
           chunkDelay: 50,
@@ -1274,11 +1279,15 @@ describe('useChat', () => {
           await Promise.all([promise1, promise2])
         })
 
-        // Should only have one user message (second should be blocked)
+        // The second call is queued while the first stream is in flight,
+        // then auto-sent once it settles — both land, in order.
         const userMessages = result.current.messages.filter(
           (m) => m.role === 'user',
         )
-        expect(userMessages.length).toBe(1)
+        expect(userMessages.map((m) => m.parts[0])).toEqual([
+          { type: 'text', content: 'First' },
+          { type: 'text', content: 'Second' },
+        ])
       })
 
       it('should handle stop during sendMessage', async () => {

--- a/packages/ai-react/src/index.ts
+++ b/packages/ai-react/src/index.ts
@@ -8,6 +8,11 @@ export type {
   UseChatReturn,
   UIMessage,
   ChatRequestBody,
+  QueuedMessage,
+  WhenBusy,
+  QueueConfig,
+  QueueStrategy,
+  QueueOption,
 } from './types'
 export type {
   UseRealtimeChatOptions,

--- a/packages/ai-react/src/index.ts
+++ b/packages/ai-react/src/index.ts
@@ -9,6 +9,7 @@ export type {
   UIMessage,
   ChatRequestBody,
   QueuedMessage,
+  SendMessageOptions,
   WhenBusy,
   QueueConfig,
   QueueStrategy,

--- a/packages/ai-react/src/types.ts
+++ b/packages/ai-react/src/types.ts
@@ -14,7 +14,10 @@ import type {
   DistributedOmit,
   InferredClientContext,
   MultimodalContent,
+  QueueConfig,
   QueuedMessage,
+  QueueOption,
+  QueueStrategy,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'
@@ -23,7 +26,10 @@ import type {
 export type {
   ChatRequestBody,
   MultimodalContent,
+  QueueConfig,
   QueuedMessage,
+  QueueOption,
+  QueueStrategy,
   UIMessage,
   WhenBusy,
 }

--- a/packages/ai-react/src/types.ts
+++ b/packages/ai-react/src/types.ts
@@ -14,11 +14,19 @@ import type {
   DistributedOmit,
   InferredClientContext,
   MultimodalContent,
+  QueuedMessage,
   UIMessage,
+  WhenBusy,
 } from '@tanstack/ai-client'
 
 // Re-export types from ai-client
-export type { ChatRequestBody, MultimodalContent, UIMessage }
+export type {
+  ChatRequestBody,
+  MultimodalContent,
+  QueuedMessage,
+  UIMessage,
+  WhenBusy,
+}
 
 /**
  * Recursive partial — every property and every nested array element is optional.
@@ -71,6 +79,7 @@ export type UseChatOptions<
   | 'onSubscriptionChange'
   | 'onConnectionStatusChange'
   | 'onSessionGeneratingChange'
+  | 'onQueueChange'
   | 'context'
   | 'devtools'
 > & {
@@ -135,7 +144,20 @@ interface BaseUseChatReturn<
    * Send a message and get a response.
    * Can be a simple string or multimodal content with images, audio, etc.
    */
-  sendMessage: (content: string | MultimodalContent) => Promise<void>
+  sendMessage: (
+    content: string | MultimodalContent,
+    options?: { whenBusy?: WhenBusy },
+  ) => Promise<void>
+
+  /**
+   * Pending messages queued while a stream is in flight.
+   */
+  queue: Array<QueuedMessage>
+
+  /**
+   * Cancel a queued message before it drains. No-op if already sent.
+   */
+  cancelQueued: (id: string) => void
 
   /**
    * Append a message to the conversation

--- a/packages/ai-react/src/types.ts
+++ b/packages/ai-react/src/types.ts
@@ -15,9 +15,9 @@ import type {
   InferredClientContext,
   MultimodalContent,
   QueueConfig,
-  QueuedMessage,
   QueueOption,
   QueueStrategy,
+  QueuedMessage,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'

--- a/packages/ai-react/src/types.ts
+++ b/packages/ai-react/src/types.ts
@@ -18,6 +18,7 @@ import type {
   QueueOption,
   QueueStrategy,
   QueuedMessage,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'
@@ -30,6 +31,7 @@ export type {
   QueuedMessage,
   QueueOption,
   QueueStrategy,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 }
@@ -149,14 +151,18 @@ interface BaseUseChatReturn<
   /**
    * Send a message and get a response.
    * Can be a simple string or multimodal content with images, audio, etc.
+   * By default, sends while busy are queued until the run settles successfully
+   * (`queue: 'drop'` restores the old drop-while-busy behavior).
+   * Pass `{ whenBusy }` to override the policy for a single send.
    */
   sendMessage: (
     content: string | MultimodalContent,
-    options?: { whenBusy?: WhenBusy },
+    options?: SendMessageOptions,
   ) => Promise<void>
 
   /**
-   * Pending messages queued while a stream is in flight.
+   * Pending messages queued while the client is busy (streaming, claiming a
+   * send, or draining). Separate from `messages` until they drain.
    */
   queue: Array<QueuedMessage>
 

--- a/packages/ai-react/src/use-chat.ts
+++ b/packages/ai-react/src/use-chat.ts
@@ -203,6 +203,12 @@ export function useChat<
   }, [client, options.context])
 
   useEffect(() => {
+    if (options.queue !== undefined) {
+      client.updateOptions({ queue: options.queue })
+    }
+  }, [client, options.queue])
+
+  useEffect(() => {
     if (options.live) {
       client.subscribe()
     } else {

--- a/packages/ai-react/src/use-chat.ts
+++ b/packages/ai-react/src/use-chat.ts
@@ -12,7 +12,9 @@ import type {
   ChatClientState,
   ConnectionStatus,
   InferredClientContext,
+  QueuedMessage,
   StructuredOutputPart,
+  WhenBusy,
 } from '@tanstack/ai-client'
 
 import type {
@@ -43,6 +45,7 @@ export function useChat<
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>('disconnected')
   const [sessionGenerating, setSessionGenerating] = useState(false)
+  const [queue, setQueue] = useState<Array<QueuedMessage>>([])
 
   type Partial = DeepPartial<InferSchemaType<NonNullable<TSchema>>>
   type Final = InferSchemaType<NonNullable<TSchema>>
@@ -156,6 +159,13 @@ export function useChat<
         if (activeClientRef.current !== instance) return
         setSessionGenerating(isGenerating)
       },
+      ...(optionsRef.current.queue !== undefined && {
+        queue: optionsRef.current.queue,
+      }),
+      onQueueChange: (nextQueue: Array<QueuedMessage>) => {
+        if (activeClientRef.current !== instance) return
+        setQueue(nextQueue)
+      },
     })
     activeClientRef.current = instance
     return instance
@@ -229,8 +239,18 @@ export function useChat<
   }, [client])
 
   const sendMessage = useCallback(
-    async (content: string | MultimodalContent) => {
-      await client.sendMessage(content)
+    async (
+      content: string | MultimodalContent,
+      sendOptions?: { whenBusy?: WhenBusy },
+    ) => {
+      await client.sendMessage(content, undefined, sendOptions)
+    },
+    [client],
+  )
+
+  const cancelQueued = useCallback(
+    (id: string) => {
+      client.cancelQueued(id)
     },
     [client],
   )
@@ -346,6 +366,8 @@ export function useChat<
     clear,
     addToolResult,
     addToolApprovalResponse,
+    queue,
+    cancelQueued,
     partial,
     final,
   } as unknown as UseChatReturn<TTools, TSchema>

--- a/packages/ai-react/src/use-chat.ts
+++ b/packages/ai-react/src/use-chat.ts
@@ -13,8 +13,8 @@ import type {
   ConnectionStatus,
   InferredClientContext,
   QueuedMessage,
+  SendMessageOptions,
   StructuredOutputPart,
-  WhenBusy,
 } from '@tanstack/ai-client'
 
 import type {
@@ -247,7 +247,7 @@ export function useChat<
   const sendMessage = useCallback(
     async (
       content: string | MultimodalContent,
-      sendOptions?: { whenBusy?: WhenBusy },
+      sendOptions?: SendMessageOptions,
     ) => {
       await client.sendMessage(content, undefined, sendOptions)
     },

--- a/packages/ai-react/tests/use-chat.test.ts
+++ b/packages/ai-react/tests/use-chat.test.ts
@@ -375,7 +375,7 @@ describe('useChat', () => {
       expect(result.current.messages.length).toBe(0)
     })
 
-    it('should not send message while loading', async () => {
+    it('should queue a message sent while loading and send it after', async () => {
       const adapter = createMockConnectionAdapter({
         chunks: createTextChunks('Response'),
         chunkDelay: 100,
@@ -387,11 +387,16 @@ describe('useChat', () => {
 
       await Promise.all([promise1, promise2])
 
-      // Should only have one user message since second was blocked
+      // The second send is queued (default `whenBusy: 'queue'`) while the
+      // first stream is in flight, then auto-drains once it settles — both
+      // end up sent, in order.
       const userMessages = result.current.messages.filter(
         (m) => m.role === 'user',
       )
-      expect(userMessages.length).toBe(1)
+      expect(userMessages.map((m) => m.parts[0])).toEqual([
+        { type: 'text', content: 'First' },
+        { type: 'text', content: 'Second' },
+      ])
     })
 
     it('should handle errors during sendMessage', async () => {
@@ -1189,7 +1194,7 @@ describe('useChat', () => {
     })
 
     describe('concurrent operations', () => {
-      it('should handle multiple sendMessage calls', async () => {
+      it('should queue and then deliver multiple sendMessage calls in order', async () => {
         const adapter = createMockConnectionAdapter({
           chunks: createTextChunks('Response'),
           chunkDelay: 50,
@@ -1201,11 +1206,15 @@ describe('useChat', () => {
 
         await Promise.all([promise1, promise2])
 
-        // Should only have one user message (second should be blocked)
+        // The second call is queued while the first stream is in flight,
+        // then auto-sent once it settles — both land, in order.
         const userMessages = result.current.messages.filter(
           (m) => m.role === 'user',
         )
-        expect(userMessages.length).toBe(1)
+        expect(userMessages.map((m) => m.parts[0])).toEqual([
+          { type: 'text', content: 'First' },
+          { type: 'text', content: 'Second' },
+        ])
       })
 
       it('should handle stop during sendMessage', async () => {

--- a/packages/ai-solid/src/index.ts
+++ b/packages/ai-solid/src/index.ts
@@ -5,6 +5,11 @@ export type {
   UseChatReturn,
   UIMessage,
   ChatRequestBody,
+  QueuedMessage,
+  WhenBusy,
+  QueueConfig,
+  QueueStrategy,
+  QueueOption,
 } from './types'
 
 // Generation hooks

--- a/packages/ai-solid/src/index.ts
+++ b/packages/ai-solid/src/index.ts
@@ -6,6 +6,7 @@ export type {
   UIMessage,
   ChatRequestBody,
   QueuedMessage,
+  SendMessageOptions,
   WhenBusy,
   QueueConfig,
   QueueStrategy,

--- a/packages/ai-solid/src/types.ts
+++ b/packages/ai-solid/src/types.ts
@@ -127,8 +127,7 @@ interface BaseUseChatReturn<
   messages: Accessor<Array<UIMessage<TTools, TData>>>
 
   /**
-   * Messages currently queued because a request was in flight when they
-   * were sent (see `sendMessage`'s `whenBusy: 'enqueue'` option).
+   * Pending messages queued while a stream is in flight.
    */
   queue: Accessor<Array<QueuedMessage>>
 

--- a/packages/ai-solid/src/types.ts
+++ b/packages/ai-solid/src/types.ts
@@ -15,9 +15,9 @@ import type {
   InferredClientContext,
   MultimodalContent,
   QueueConfig,
-  QueuedMessage,
   QueueOption,
   QueueStrategy,
+  QueuedMessage,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'

--- a/packages/ai-solid/src/types.ts
+++ b/packages/ai-solid/src/types.ts
@@ -14,7 +14,10 @@ import type {
   DistributedOmit,
   InferredClientContext,
   MultimodalContent,
+  QueueConfig,
   QueuedMessage,
+  QueueOption,
+  QueueStrategy,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'
@@ -24,7 +27,10 @@ import type { Accessor } from 'solid-js'
 export type {
   ChatRequestBody,
   MultimodalContent,
+  QueueConfig,
   QueuedMessage,
+  QueueOption,
+  QueueStrategy,
   UIMessage,
   WhenBusy,
 }

--- a/packages/ai-solid/src/types.ts
+++ b/packages/ai-solid/src/types.ts
@@ -14,12 +14,20 @@ import type {
   DistributedOmit,
   InferredClientContext,
   MultimodalContent,
+  QueuedMessage,
   UIMessage,
+  WhenBusy,
 } from '@tanstack/ai-client'
 import type { Accessor } from 'solid-js'
 
 // Re-export types from ai-client
-export type { ChatRequestBody, MultimodalContent, UIMessage }
+export type {
+  ChatRequestBody,
+  MultimodalContent,
+  QueuedMessage,
+  UIMessage,
+  WhenBusy,
+}
 
 /**
  * Recursive partial — every property and every nested array element is optional.
@@ -67,6 +75,7 @@ export type UseChatOptions<
   | 'onSubscriptionChange'
   | 'onConnectionStatusChange'
   | 'onSessionGeneratingChange'
+  | 'onQueueChange'
   | 'context'
   | 'devtools'
 > & {
@@ -118,10 +127,24 @@ interface BaseUseChatReturn<
   messages: Accessor<Array<UIMessage<TTools, TData>>>
 
   /**
+   * Messages currently queued because a request was in flight when they
+   * were sent (see `sendMessage`'s `whenBusy: 'enqueue'` option).
+   */
+  queue: Accessor<Array<QueuedMessage>>
+
+  /**
+   * Cancel a previously queued message by id.
+   */
+  cancelQueued: (id: string) => void
+
+  /**
    * Send a message and get a response.
    * Can be a simple string or multimodal content with images, audio, etc.
    */
-  sendMessage: (content: string | MultimodalContent) => Promise<void>
+  sendMessage: (
+    content: string | MultimodalContent,
+    options?: { whenBusy?: WhenBusy },
+  ) => Promise<void>
 
   /**
    * Append a message to the conversation

--- a/packages/ai-solid/src/types.ts
+++ b/packages/ai-solid/src/types.ts
@@ -18,6 +18,7 @@ import type {
   QueueOption,
   QueueStrategy,
   QueuedMessage,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'
@@ -31,6 +32,7 @@ export type {
   QueuedMessage,
   QueueOption,
   QueueStrategy,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 }
@@ -133,22 +135,26 @@ interface BaseUseChatReturn<
   messages: Accessor<Array<UIMessage<TTools, TData>>>
 
   /**
-   * Pending messages queued while a stream is in flight.
+   * Pending messages queued while the client is busy (streaming, claiming a
+   * send, or draining). Separate from `messages` until they drain.
    */
   queue: Accessor<Array<QueuedMessage>>
 
   /**
-   * Cancel a previously queued message by id.
+   * Cancel a queued message before it drains. No-op if already sent.
    */
   cancelQueued: (id: string) => void
 
   /**
    * Send a message and get a response.
    * Can be a simple string or multimodal content with images, audio, etc.
+   * By default, sends while busy are queued until the run settles successfully
+   * (`queue: 'drop'` restores the old drop-while-busy behavior).
+   * Pass `{ whenBusy }` to override the policy for a single send.
    */
   sendMessage: (
     content: string | MultimodalContent,
-    options?: { whenBusy?: WhenBusy },
+    options?: SendMessageOptions,
   ) => Promise<void>
 
   /**

--- a/packages/ai-solid/src/use-chat.ts
+++ b/packages/ai-solid/src/use-chat.ts
@@ -13,7 +13,9 @@ import type {
   ChatClientState,
   ConnectionStatus,
   InferredClientContext,
+  QueuedMessage,
   StructuredOutputPart,
+  WhenBusy,
 } from '@tanstack/ai-client'
 import type {
   AnyClientTool,
@@ -54,6 +56,7 @@ export function useChat<
   const [connectionStatus, setConnectionStatus] =
     createSignal<ConnectionStatus>('disconnected')
   const [sessionGenerating, setSessionGenerating] = createSignal(false)
+  const [queue, setQueue] = createSignal<Array<QueuedMessage>>([])
 
   // Structured-output `partial` / `final` are derived from `messages` —
   // specifically from the structured-output part on the latest assistant
@@ -135,6 +138,10 @@ export function useChat<
       onSessionGeneratingChange: (isGenerating: boolean) => {
         setSessionGenerating(isGenerating)
       },
+      ...(options.queue !== undefined && { queue: options.queue }),
+      onQueueChange: (nextQueue: Array<QueuedMessage>) => {
+        setQueue(nextQueue)
+      },
     })
     // Only recreate when clientId changes
     // Connection and other options are captured at creation time
@@ -189,8 +196,11 @@ export function useChat<
   // Callback options are read through `options.xxx` at call time, so reactive
   // or mutated options propagate without recreating the client.
 
-  const sendMessage = async (content: string | MultimodalContent) => {
-    await client().sendMessage(content)
+  const sendMessage = async (
+    content: string | MultimodalContent,
+    sendOptions?: { whenBusy?: WhenBusy },
+  ) => {
+    await client().sendMessage(content, undefined, sendOptions)
   }
 
   const append = async (message: ModelMessage | UIMessage<TTools>) => {
@@ -229,6 +239,8 @@ export function useChat<
   }) => {
     await client().addToolApprovalResponse(response)
   }
+
+  const cancelQueued = (id: string) => client().cancelQueued(id)
 
   // The "active" structured-output part is on the assistant message after
   // the latest user message. When no user message exists yet, return null
@@ -273,6 +285,7 @@ export function useChat<
   // eslint-disable-next-line no-restricted-syntax -- primitive return shape diverges from generic UseChatReturn<TTools, TSchema>; TS can't structurally narrow the conditional partial/final fields
   return {
     messages,
+    queue,
     sendMessage,
     append,
     reload,
@@ -287,6 +300,7 @@ export function useChat<
     clear,
     addToolResult,
     addToolApprovalResponse,
+    cancelQueued,
     partial,
     final,
   } as unknown as UseChatReturn<TTools, TSchema>

--- a/packages/ai-solid/src/use-chat.ts
+++ b/packages/ai-solid/src/use-chat.ts
@@ -161,6 +161,7 @@ export function useChat<
         forwardedProps: options.forwardedProps,
       }),
       context: options.context,
+      ...(options.queue !== undefined && { queue: options.queue }),
     })
   })
 

--- a/packages/ai-solid/src/use-chat.ts
+++ b/packages/ai-solid/src/use-chat.ts
@@ -14,8 +14,8 @@ import type {
   ConnectionStatus,
   InferredClientContext,
   QueuedMessage,
+  SendMessageOptions,
   StructuredOutputPart,
-  WhenBusy,
 } from '@tanstack/ai-client'
 import type {
   AnyClientTool,
@@ -199,7 +199,7 @@ export function useChat<
 
   const sendMessage = async (
     content: string | MultimodalContent,
-    sendOptions?: { whenBusy?: WhenBusy },
+    sendOptions?: SendMessageOptions,
   ) => {
     await client().sendMessage(content, undefined, sendOptions)
   }

--- a/packages/ai-solid/tests/use-chat.test.ts
+++ b/packages/ai-solid/tests/use-chat.test.ts
@@ -308,7 +308,7 @@ describe('useChat', () => {
       expect(result.current.messages.length).toBe(0)
     })
 
-    it('should not send message while loading', async () => {
+    it('should queue a message sent while loading and send it after', async () => {
       const adapter = createMockConnectionAdapter({
         chunks: createTextChunks('Response'),
         chunkDelay: 100,
@@ -320,11 +320,16 @@ describe('useChat', () => {
 
       await Promise.all([promise1, promise2])
 
-      // Should only have one user message since second was blocked
+      // The second send is queued (default `whenBusy: 'queue'`) while the
+      // first stream is in flight, then auto-drains once it settles — both
+      // end up sent, in order.
       const userMessages = result.current.messages.filter(
         (m) => m.role === 'user',
       )
-      expect(userMessages.length).toBe(1)
+      expect(userMessages.map((m) => m.parts[0])).toEqual([
+        { type: 'text', content: 'First' },
+        { type: 'text', content: 'Second' },
+      ])
     })
 
     it('should handle errors during sendMessage', async () => {
@@ -927,7 +932,7 @@ describe('useChat', () => {
     })
 
     describe('concurrent operations', () => {
-      it('should handle multiple sendMessage calls', async () => {
+      it('should queue and then deliver multiple sendMessage calls in order', async () => {
         const adapter = createMockConnectionAdapter({
           chunks: createTextChunks('Response'),
           chunkDelay: 50,
@@ -939,11 +944,15 @@ describe('useChat', () => {
 
         await Promise.all([promise1, promise2])
 
-        // Should only have one user message (second should be blocked)
+        // The second call is queued while the first stream is in flight,
+        // then auto-sent once it settles — both land, in order.
         const userMessages = result.current.messages.filter(
           (m) => m.role === 'user',
         )
-        expect(userMessages.length).toBe(1)
+        expect(userMessages.map((m) => m.parts[0])).toEqual([
+          { type: 'text', content: 'First' },
+          { type: 'text', content: 'Second' },
+        ])
       })
 
       it('should handle stop during sendMessage', async () => {

--- a/packages/ai-svelte/src/create-chat.svelte.ts
+++ b/packages/ai-svelte/src/create-chat.svelte.ts
@@ -5,8 +5,8 @@ import type {
   ConnectionStatus,
   InferredClientContext,
   QueuedMessage,
+  SendMessageOptions,
   StructuredOutputPart,
-  WhenBusy,
 } from '@tanstack/ai-client'
 import type {
   AnyClientTool,
@@ -178,7 +178,7 @@ export function createChat<
   // Define methods
   const sendMessage = async (
     content: string | MultimodalContent,
-    sendOptions?: { whenBusy?: WhenBusy },
+    sendOptions?: SendMessageOptions,
   ) => {
     await client.sendMessage(content, undefined, sendOptions)
   }

--- a/packages/ai-svelte/src/create-chat.svelte.ts
+++ b/packages/ai-svelte/src/create-chat.svelte.ts
@@ -4,7 +4,9 @@ import type {
   ChatClientState,
   ConnectionStatus,
   InferredClientContext,
+  QueuedMessage,
   StructuredOutputPart,
+  WhenBusy,
 } from '@tanstack/ai-client'
 import type {
   AnyClientTool,
@@ -71,6 +73,7 @@ export function createChat<
   let isSubscribed = $state(false)
   let connectionStatus = $state<ConnectionStatus>('disconnected')
   let sessionGenerating = $state(false)
+  let queue = $state<Array<QueuedMessage>>([])
 
   // Structured-output `partial` / `final` are derived from `messages` —
   // specifically from the structured-output part on the latest assistant
@@ -153,6 +156,10 @@ export function createChat<
     onSessionGeneratingChange: (isGenerating: boolean) => {
       sessionGenerating = isGenerating
     },
+    ...(options.queue !== undefined && { queue: options.queue }),
+    onQueueChange: (nextQueue: Array<QueuedMessage>) => {
+      queue = nextQueue
+    },
   })
 
   messages = client.getMessages()
@@ -169,9 +176,14 @@ export function createChat<
   // Users should call chat.stop() in their component's cleanup if needed.
 
   // Define methods
-  const sendMessage = async (content: string | MultimodalContent) => {
-    await client.sendMessage(content)
+  const sendMessage = async (
+    content: string | MultimodalContent,
+    sendOptions?: { whenBusy?: WhenBusy },
+  ) => {
+    await client.sendMessage(content, undefined, sendOptions)
   }
+
+  const cancelQueued = (id: string) => client.cancelQueued(id)
 
   const append = async (message: ModelMessage | UIMessage<TTools>) => {
     await client.append(message)
@@ -293,6 +305,9 @@ export function createChat<
     get sessionGenerating() {
       return sessionGenerating
     },
+    get queue() {
+      return queue
+    },
     get partial() {
       return partial
     },
@@ -300,6 +315,7 @@ export function createChat<
       return final
     },
     sendMessage,
+    cancelQueued,
     append,
     reload,
     stop,

--- a/packages/ai-svelte/src/index.ts
+++ b/packages/ai-svelte/src/index.ts
@@ -5,6 +5,11 @@ export type {
   DeepPartial,
   UIMessage,
   ChatRequestBody,
+  QueuedMessage,
+  WhenBusy,
+  QueueConfig,
+  QueueStrategy,
+  QueueOption,
 } from './types'
 
 // Generation hooks

--- a/packages/ai-svelte/src/index.ts
+++ b/packages/ai-svelte/src/index.ts
@@ -6,6 +6,7 @@ export type {
   UIMessage,
   ChatRequestBody,
   QueuedMessage,
+  SendMessageOptions,
   WhenBusy,
   QueueConfig,
   QueueStrategy,

--- a/packages/ai-svelte/src/types.ts
+++ b/packages/ai-svelte/src/types.ts
@@ -14,7 +14,10 @@ import type {
   DistributedOmit,
   InferredClientContext,
   MultimodalContent,
+  QueueConfig,
   QueuedMessage,
+  QueueOption,
+  QueueStrategy,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'
@@ -23,7 +26,10 @@ import type {
 export type {
   ChatRequestBody,
   MultimodalContent,
+  QueueConfig,
   QueuedMessage,
+  QueueOption,
+  QueueStrategy,
   UIMessage,
   WhenBusy,
 }

--- a/packages/ai-svelte/src/types.ts
+++ b/packages/ai-svelte/src/types.ts
@@ -149,7 +149,7 @@ interface BaseCreateChatReturn<
   /**
    * Pending messages queued while a stream is in flight.
    */
-  queue: Array<QueuedMessage>
+  readonly queue: Array<QueuedMessage>
 
   /**
    * Cancel a queued message before it drains. No-op if already sent.

--- a/packages/ai-svelte/src/types.ts
+++ b/packages/ai-svelte/src/types.ts
@@ -14,11 +14,19 @@ import type {
   DistributedOmit,
   InferredClientContext,
   MultimodalContent,
+  QueuedMessage,
   UIMessage,
+  WhenBusy,
 } from '@tanstack/ai-client'
 
 // Re-export types from ai-client
-export type { ChatRequestBody, MultimodalContent, UIMessage }
+export type {
+  ChatRequestBody,
+  MultimodalContent,
+  QueuedMessage,
+  UIMessage,
+  WhenBusy,
+}
 
 /**
  * Recursive partial — every property and every nested array element is
@@ -66,6 +74,7 @@ export type CreateChatOptions<
   | 'onSubscriptionChange'
   | 'onConnectionStatusChange'
   | 'onSessionGeneratingChange'
+  | 'onQueueChange'
   | 'context'
   | 'devtools'
 > & {
@@ -126,7 +135,20 @@ interface BaseCreateChatReturn<
    * Send a message and get a response.
    * Can be a simple string or multimodal content with images, audio, etc.
    */
-  sendMessage: (content: string | MultimodalContent) => Promise<void>
+  sendMessage: (
+    content: string | MultimodalContent,
+    options?: { whenBusy?: WhenBusy },
+  ) => Promise<void>
+
+  /**
+   * Pending messages queued while a stream is in flight.
+   */
+  queue: Array<QueuedMessage>
+
+  /**
+   * Cancel a queued message before it drains. No-op if already sent.
+   */
+  cancelQueued: (id: string) => void
 
   /**
    * Append a message to the conversation

--- a/packages/ai-svelte/src/types.ts
+++ b/packages/ai-svelte/src/types.ts
@@ -18,6 +18,7 @@ import type {
   QueueOption,
   QueueStrategy,
   QueuedMessage,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'
@@ -30,6 +31,7 @@ export type {
   QueuedMessage,
   QueueOption,
   QueueStrategy,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 }
@@ -143,7 +145,7 @@ interface BaseCreateChatReturn<
    */
   sendMessage: (
     content: string | MultimodalContent,
-    options?: { whenBusy?: WhenBusy },
+    options?: SendMessageOptions,
   ) => Promise<void>
 
   /**

--- a/packages/ai-svelte/src/types.ts
+++ b/packages/ai-svelte/src/types.ts
@@ -15,9 +15,9 @@ import type {
   InferredClientContext,
   MultimodalContent,
   QueueConfig,
-  QueuedMessage,
   QueueOption,
   QueueStrategy,
+  QueuedMessage,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'

--- a/packages/ai-vue/src/index.ts
+++ b/packages/ai-vue/src/index.ts
@@ -5,6 +5,11 @@ export type {
   UseChatReturn,
   UIMessage,
   ChatRequestBody,
+  QueuedMessage,
+  WhenBusy,
+  QueueConfig,
+  QueueStrategy,
+  QueueOption,
 } from './types'
 
 // Generation hooks

--- a/packages/ai-vue/src/index.ts
+++ b/packages/ai-vue/src/index.ts
@@ -6,6 +6,7 @@ export type {
   UIMessage,
   ChatRequestBody,
   QueuedMessage,
+  SendMessageOptions,
   WhenBusy,
   QueueConfig,
   QueueStrategy,

--- a/packages/ai-vue/src/types.ts
+++ b/packages/ai-vue/src/types.ts
@@ -14,12 +14,14 @@ import type {
   DistributedOmit,
   InferredClientContext,
   MultimodalContent,
+  QueuedMessage,
   UIMessage,
+  WhenBusy,
 } from '@tanstack/ai-client'
 import type { DeepReadonly, ShallowRef } from 'vue'
 
 // Re-export types from ai-client
-export type { ChatRequestBody, MultimodalContent, UIMessage }
+export type { ChatRequestBody, MultimodalContent, QueuedMessage, UIMessage, WhenBusy }
 
 /**
  * Recursive partial — every property and every nested array element is optional.
@@ -68,6 +70,7 @@ export type UseChatOptions<
   | 'onSubscriptionChange'
   | 'onConnectionStatusChange'
   | 'onSessionGeneratingChange'
+  | 'onQueueChange'
   | 'context'
   | 'devtools'
 > & {
@@ -124,7 +127,20 @@ interface BaseUseChatReturn<
    * Send a message and get a response.
    * Can be a simple string or multimodal content with images, audio, etc.
    */
-  sendMessage: (content: string | MultimodalContent) => Promise<void>
+  sendMessage: (
+    content: string | MultimodalContent,
+    options?: { whenBusy?: WhenBusy },
+  ) => Promise<void>
+
+  /**
+   * Pending messages queued while a stream is in flight.
+   */
+  queue: Readonly<ShallowRef<Array<QueuedMessage>>>
+
+  /**
+   * Cancel a queued message before it drains. No-op if already sent.
+   */
+  cancelQueued: (id: string) => void
 
   /**
    * Append a message to the conversation

--- a/packages/ai-vue/src/types.ts
+++ b/packages/ai-vue/src/types.ts
@@ -14,7 +14,10 @@ import type {
   DistributedOmit,
   InferredClientContext,
   MultimodalContent,
+  QueueConfig,
   QueuedMessage,
+  QueueOption,
+  QueueStrategy,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'
@@ -24,7 +27,10 @@ import type { DeepReadonly, ShallowRef } from 'vue'
 export type {
   ChatRequestBody,
   MultimodalContent,
+  QueueConfig,
   QueuedMessage,
+  QueueOption,
+  QueueStrategy,
   UIMessage,
   WhenBusy,
 }

--- a/packages/ai-vue/src/types.ts
+++ b/packages/ai-vue/src/types.ts
@@ -21,7 +21,13 @@ import type {
 import type { DeepReadonly, ShallowRef } from 'vue'
 
 // Re-export types from ai-client
-export type { ChatRequestBody, MultimodalContent, QueuedMessage, UIMessage, WhenBusy }
+export type {
+  ChatRequestBody,
+  MultimodalContent,
+  QueuedMessage,
+  UIMessage,
+  WhenBusy,
+}
 
 /**
  * Recursive partial — every property and every nested array element is optional.

--- a/packages/ai-vue/src/types.ts
+++ b/packages/ai-vue/src/types.ts
@@ -18,6 +18,7 @@ import type {
   QueueOption,
   QueueStrategy,
   QueuedMessage,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'
@@ -31,6 +32,7 @@ export type {
   QueuedMessage,
   QueueOption,
   QueueStrategy,
+  SendMessageOptions,
   UIMessage,
   WhenBusy,
 }
@@ -141,7 +143,7 @@ interface BaseUseChatReturn<
    */
   sendMessage: (
     content: string | MultimodalContent,
-    options?: { whenBusy?: WhenBusy },
+    options?: SendMessageOptions,
   ) => Promise<void>
 
   /**

--- a/packages/ai-vue/src/types.ts
+++ b/packages/ai-vue/src/types.ts
@@ -15,9 +15,9 @@ import type {
   InferredClientContext,
   MultimodalContent,
   QueueConfig,
-  QueuedMessage,
   QueueOption,
   QueueStrategy,
+  QueuedMessage,
   UIMessage,
   WhenBusy,
 } from '@tanstack/ai-client'

--- a/packages/ai-vue/src/use-chat.ts
+++ b/packages/ai-vue/src/use-chat.ts
@@ -21,8 +21,8 @@ import type {
   ConnectionStatus,
   InferredClientContext,
   QueuedMessage,
+  SendMessageOptions,
   StructuredOutputPart,
-  WhenBusy,
 } from '@tanstack/ai-client'
 import type {
   DeepPartial,
@@ -206,7 +206,7 @@ export function useChat<
 
   const sendMessage = async (
     content: string | MultimodalContent,
-    sendOptions?: { whenBusy?: WhenBusy },
+    sendOptions?: SendMessageOptions,
   ) => {
     await client.sendMessage(content, undefined, sendOptions)
   }

--- a/packages/ai-vue/src/use-chat.ts
+++ b/packages/ai-vue/src/use-chat.ts
@@ -155,14 +155,21 @@ export function useChat<
   // Conditional spread: `updateOptions` declares strict-optional fields and
   // rejects explicit `undefined` under EOPT.
   watch(
-    () => [options.body, options.forwardedProps, options.context] as const,
-    ([newBody, newForwardedProps, newContext]) => {
+    () =>
+      [
+        options.body,
+        options.forwardedProps,
+        options.context,
+        options.queue,
+      ] as const,
+    ([newBody, newForwardedProps, newContext, newQueue]) => {
       client.updateOptions({
         body: newBody,
         ...(newForwardedProps !== undefined && {
           forwardedProps: newForwardedProps,
         }),
         context: newContext,
+        ...(newQueue !== undefined && { queue: newQueue }),
       })
     },
   )

--- a/packages/ai-vue/src/use-chat.ts
+++ b/packages/ai-vue/src/use-chat.ts
@@ -20,7 +20,9 @@ import type {
   ChatClientState,
   ConnectionStatus,
   InferredClientContext,
+  QueuedMessage,
   StructuredOutputPart,
+  WhenBusy,
 } from '@tanstack/ai-client'
 import type {
   DeepPartial,
@@ -53,6 +55,7 @@ export function useChat<
   const isSubscribed = shallowRef(false)
   const connectionStatus = shallowRef<ConnectionStatus>('disconnected')
   const sessionGenerating = shallowRef(false)
+  const queue = shallowRef<Array<QueuedMessage>>([])
 
   // Structured-output `partial` / `final` are derived from `messages` —
   // specifically from the structured-output part on the latest assistant
@@ -138,6 +141,10 @@ export function useChat<
     onSessionGeneratingChange: (isGenerating: boolean) => {
       sessionGenerating.value = isGenerating
     },
+    ...(options.queue !== undefined && { queue: options.queue }),
+    onQueueChange: (nextQueue: Array<QueuedMessage>) => {
+      queue.value = nextQueue
+    },
   })
 
   messages.value = client.getMessages()
@@ -190,9 +197,14 @@ export function useChat<
   // Callback options are read through `options.xxx` at call time, so reactive
   // or mutated options propagate without recreating the client.
 
-  const sendMessage = async (content: string | MultimodalContent) => {
-    await client.sendMessage(content)
+  const sendMessage = async (
+    content: string | MultimodalContent,
+    sendOptions?: { whenBusy?: WhenBusy },
+  ) => {
+    await client.sendMessage(content, undefined, sendOptions)
   }
+
+  const cancelQueued = (id: string) => client.cancelQueued(id)
 
   const append = async (message: ModelMessage | UIMessage<TTools>) => {
     await client.append(message)
@@ -279,6 +291,8 @@ export function useChat<
   return {
     messages: readonly(messages),
     sendMessage,
+    queue: readonly(queue),
+    cancelQueued,
     append,
     reload,
     stop,

--- a/packages/ai-vue/tests/use-chat.test.ts
+++ b/packages/ai-vue/tests/use-chat.test.ts
@@ -289,7 +289,7 @@ describe('useChat', () => {
       expect(result.current.messages.length).toBe(0)
     })
 
-    it('should not send message while loading', async () => {
+    it('should queue a message sent while loading and send it after', async () => {
       const adapter = createMockConnectionAdapter({
         chunks: createTextChunks('Response'),
         chunkDelay: 100,
@@ -302,11 +302,16 @@ describe('useChat', () => {
       await Promise.all([promise1, promise2])
       await flushPromises()
 
-      // Should only have one user message since second was blocked
+      // The second send is queued (default `whenBusy: 'queue'`) while the
+      // first stream is in flight, then auto-drains once it settles — both
+      // end up sent, in order.
       const userMessages = result.current.messages.filter(
         (m) => m.role === 'user',
       )
-      expect(userMessages.length).toBe(1)
+      expect(userMessages.map((m) => m.parts[0])).toEqual([
+        { type: 'text', content: 'First' },
+        { type: 'text', content: 'Second' },
+      ])
     })
 
     it('should handle errors during sendMessage', async () => {
@@ -872,7 +877,7 @@ describe('useChat', () => {
     })
 
     describe('concurrent operations', () => {
-      it('should handle multiple sendMessage calls', async () => {
+      it('should queue and then deliver multiple sendMessage calls in order', async () => {
         const adapter = createMockConnectionAdapter({
           chunks: createTextChunks('Response'),
           chunkDelay: 50,
@@ -885,11 +890,15 @@ describe('useChat', () => {
         await Promise.all([promise1, promise2])
         await flushPromises()
 
-        // Should only have one user message (second should be blocked)
+        // The second call is queued while the first stream is in flight,
+        // then auto-sent once it settles — both land, in order.
         const userMessages = result.current.messages.filter(
           (m) => m.role === 'user',
         )
-        expect(userMessages.length).toBe(1)
+        expect(userMessages.map((m) => m.parts[0])).toEqual([
+          { type: 'text', content: 'First' },
+          { type: 'text', content: 'Second' },
+        ])
       })
 
       it('should handle stop during sendMessage', async () => {

--- a/packages/ai/skills/ai-core/chat-experience/SKILL.md
+++ b/packages/ai/skills/ai-core/chat-experience/SKILL.md
@@ -409,6 +409,53 @@ export const Route = createFileRoute('/api/chat')({
 })
 ```
 
+### 7. Queueing Messages Sent While Streaming
+
+By default, a `sendMessage` call that arrives while a stream is in flight is
+**queued** and sent automatically once the stream settles — this is a
+behavior change: such sends used to be silently dropped. Configure it with
+the `queue` option on `useChat`:
+
+```typescript
+import { useChat, fetchServerSentEvents } from '@tanstack/ai-react'
+
+const { messages, queue, sendMessage, cancelQueued, isLoading } = useChat({
+  connection: fetchServerSentEvents('/api/chat'),
+  queue: { whenBusy: 'queue', drain: 'fifo', maxSize: 5, onOverflow: 'reject' },
+})
+```
+
+- **`whenBusy`** — `'queue'` (default) holds the message; `'drop'` ignores
+  the send; `'interrupt'` aborts the current stream (like `stop()`) and
+  sends immediately. Also accepts a plain `WhenBusy` string as shorthand, or
+  a `QueueStrategy` function for full per-send control.
+- **`drain`** — `'fifo'` (default) sends queued items one at a time in
+  order; `'batch'` merges everything queued into a single send once the
+  stream settles.
+- **`maxSize`** / **`onOverflow`** — cap the queue length; `'reject'`
+  (default) ignores overflow sends, `'drop-oldest'` evicts the oldest
+  queued item to make room.
+
+`queue: Array<QueuedMessage>` (`{ id, content, createdAt }`) is separate
+from `messages` — render pending sends distinctly and cancel with
+`cancelQueued(id)`:
+
+```typescript
+{queue.map((q) => (
+  <div key={q.id}>
+    {typeof q.content === 'string' ? q.content : '[attachment]'}
+    <button onClick={() => cancelQueued(q.id)}>Cancel</button>
+  </div>
+))}
+```
+
+Override the configured policy for a single send with the second argument
+to `sendMessage`:
+
+```typescript
+sendMessage('Never mind, do this instead', { whenBusy: 'interrupt' })
+```
+
 ## Common Mistakes
 
 ### a. CRITICAL: Using Vercel AI SDK patterns (streamText, generateText)

--- a/packages/ai/skills/ai-core/chat-experience/SKILL.md
+++ b/packages/ai/skills/ai-core/chat-experience/SKILL.md
@@ -426,15 +426,23 @@ const { messages, queue, sendMessage, cancelQueued, isLoading } = useChat({
 ```
 
 - **`whenBusy`** — `'queue'` (default) holds the message; `'drop'` ignores
-  the send; `'interrupt'` aborts the current stream (like `stop()`) and
-  sends immediately. Also accepts a plain `WhenBusy` string as shorthand, or
-  a `QueueStrategy` function for full per-send control.
+  the send; `'interrupt'` aborts the current stream and sends immediately
+  (unlike `stop()`, does **not** flush already-queued items).
 - **`drain`** — `'fifo'` (default) sends queued items one at a time in
   order; `'batch'` merges everything queued into a single send once the
   stream settles.
 - **`maxSize`** / **`onOverflow`** — cap the queue length; `'reject'`
   (default) ignores overflow sends, `'drop-oldest'` evicts the oldest
   queued item to make room.
+
+The top-level `queue` option also accepts a plain `WhenBusy` string
+shorthand (e.g. `queue: 'interrupt'`) or a `QueueStrategy` function for
+per-send action control. Strategy form always drains FIFO; `'send'` while
+busy is coerced to `'enqueue'`.
+
+**Drain vs flush:** queued messages auto-send only after a **successful**
+settle. They are **discarded** on stream error/abort, `stop()`, `clear()`,
+`unsubscribe()`, and `reload()`. `interrupt` does not flush.
 
 `queue: Array<QueuedMessage>` (`{ id, content, createdAt }`) is separate
 from `messages` — render pending sends distinctly and cancel with

--- a/packages/ai/skills/ai-core/chat-experience/SKILL.md
+++ b/packages/ai/skills/ai-core/chat-experience/SKILL.md
@@ -412,9 +412,9 @@ export const Route = createFileRoute('/api/chat')({
 ### 7. Queueing Messages Sent While Streaming
 
 By default, a `sendMessage` call that arrives while a stream is in flight is
-**queued** and sent automatically once the stream settles — this is a
-behavior change: such sends used to be silently dropped. Configure it with
-the `queue` option on `useChat`:
+**queued** and sent automatically once the run settles **successfully** —
+this is a behavior change: such sends used to be silently dropped. Configure
+it with the `queue` option on `useChat`:
 
 ```typescript
 import { useChat, fetchServerSentEvents } from '@tanstack/ai-react'
@@ -425,24 +425,27 @@ const { messages, queue, sendMessage, cancelQueued, isLoading } = useChat({
 })
 ```
 
-- **`whenBusy`** — `'queue'` (default) holds the message; `'drop'` ignores
-  the send; `'interrupt'` aborts the current stream and sends immediately
-  (unlike `stop()`, does **not** flush already-queued items).
+- **`whenBusy`** — `'queue'` (default) holds the message until a successful
+  settle; `'drop'` ignores the send (never appears in `queue`/`messages`);
+  `'interrupt'` aborts the current stream and sends immediately (unlike
+  `stop()`, does **not** flush already-queued items — they drain after the
+  interrupting send **succeeds**).
 - **`drain`** — `'fifo'` (default) sends queued items one at a time in
   order; `'batch'` merges everything queued into a single send once the
-  stream settles.
+  run settles successfully.
 - **`maxSize`** / **`onOverflow`** — cap the queue length; `'reject'`
-  (default) ignores overflow sends, `'drop-oldest'` evicts the oldest
-  queued item to make room.
+  (default) silently ignores overflow sends (does not throw),
+  `'drop-oldest'` evicts the oldest queued item to make room.
 
 The top-level `queue` option also accepts a plain `WhenBusy` string
 shorthand (e.g. `queue: 'interrupt'`) or a `QueueStrategy` function for
-per-send action control. Strategy form always drains FIFO; `'send'` while
-busy is coerced to `'enqueue'`.
+per-send action control. Strategy form always drains FIFO; actions are
+`'queue' | 'drop' | 'interrupt'`.
 
 **Drain vs flush:** queued messages auto-send only after a **successful**
-settle. They are **discarded** on stream error/abort, `stop()`, `clear()`,
-`unsubscribe()`, and `reload()`. `interrupt` does not flush.
+settle. They are **discarded** on stream error/abort of the active
+generation, `stop()`, `clear()`, `unsubscribe()`, and `reload()`.
+`interrupt` does not flush.
 
 `queue: Array<QueuedMessage>` (`{ id, content, createdAt }`) is separate
 from `messages` — render pending sends distinctly and cancel with

--- a/testing/e2e/fixtures/queue/basic.json
+++ b/testing/e2e/fixtures/queue/basic.json
@@ -1,0 +1,22 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "[queue] first message"
+      },
+      "response": {
+        "content": "This is the first response and it keeps streaming for a good while so that the follow-up messages sent during this in-flight run land in the client queue instead of starting a second concurrent request right away, giving the test plenty of time to send more messages and cancel one before this run settles."
+      },
+      "chunkSize": 2,
+      "streamingProfile": { "tps": 6 }
+    },
+    {
+      "match": {
+        "userMessage": "[queue] third message"
+      },
+      "response": {
+        "content": "This is the third response, delivered after the queue drained."
+      }
+    }
+  ]
+}

--- a/testing/e2e/src/components/ChatUI.tsx
+++ b/testing/e2e/src/components/ChatUI.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
-import type { UIMessage } from '@tanstack/ai-react'
 import ReactMarkdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize from 'rehype-sanitize'
 import remarkGfm from 'remark-gfm'
+import type { UIMessage } from '@tanstack/ai-react'
+import type { QueuedMessage } from '@tanstack/ai-client'
 import { ToolCallDisplay } from '@/components/ToolCallDisplay'
 import { ApprovalPrompt } from '@/components/ApprovalPrompt'
 
@@ -25,6 +26,13 @@ interface ChatUIProps {
   /** Number of TEXT_MESSAGE_CONTENT chunks observed. Used by streaming e2e
    *  tests to verify the response actually streamed in multiple deltas. */
   contentDeltaCount?: number
+  /** Messages sent while a stream was already in flight — held here by
+   *  `useChat` and auto-sent FIFO once the run settles. Rendered in a
+   *  region separate from `messages` so e2e tests can assert queued state
+   *  distinctly from the delivered conversation. */
+  queue?: Array<QueuedMessage>
+  /** Remove a queued message before it drains. */
+  cancelQueued?: (id: string) => void
 }
 
 export function ChatUI({
@@ -37,6 +45,8 @@ export function ChatUI({
   onStop,
   structuredObject,
   contentDeltaCount,
+  queue,
+  cancelQueued,
 }: ChatUIProps) {
   const [input, setInput] = useState('')
   const messagesRef = useRef<HTMLDivElement>(null)
@@ -141,13 +151,13 @@ export function ChatUI({
                 return (
                   <ApprovalPrompt
                     key={i}
-                    part={part as any}
+                    part={part}
                     onRespond={addToolApprovalResponse}
                   />
                 )
               }
               if (part.type === 'tool-call') {
-                return <ToolCallDisplay key={i} part={part as any} />
+                return <ToolCallDisplay key={i} part={part} />
               }
               if (part.type === 'tool-result') {
                 return (
@@ -195,6 +205,37 @@ export function ChatUI({
         </div>
       )}
 
+      {queue != null && queue.length > 0 && (
+        <div
+          data-testid="queue-list"
+          className="border-t border-gray-700 p-2 space-y-1"
+        >
+          {queue.map((queued) => (
+            <div
+              key={queued.id}
+              data-testid="queued-message"
+              className="flex items-center justify-between gap-2 text-xs text-gray-400 bg-gray-800/40 rounded px-2 py-1"
+            >
+              <span data-testid="queued-message-text">
+                {typeof queued.content === 'string'
+                  ? queued.content
+                  : JSON.stringify(queued.content)}
+              </span>
+              {cancelQueued && (
+                <button
+                  type="button"
+                  data-testid="cancel-queued-button"
+                  onClick={() => cancelQueued(queued.id)}
+                  className="px-2 py-0.5 bg-gray-700 text-white rounded text-xs"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
       <div className="border-t border-gray-700 p-3 flex gap-2">
         {showImageInput && (
           <input
@@ -234,7 +275,12 @@ export function ChatUI({
         <button
           data-testid="send-button"
           onClick={handleSubmit}
-          disabled={!input.trim() || isLoading}
+          // Intentionally clickable while `isLoading` — sending here doesn't
+          // start a second concurrent stream; `useChat`/`ChatClient` queues
+          // it (default `whenBusy: 'queue'`) and auto-sends it FIFO once the
+          // in-flight run settles. Disabling on `isLoading` would make the
+          // queue feature unreachable from the UI.
+          disabled={!input.trim()}
           className="px-4 py-2 bg-orange-500 text-white rounded text-sm font-medium disabled:opacity-50"
         >
           Send

--- a/testing/e2e/src/routes/$provider/$feature.tsx
+++ b/testing/e2e/src/routes/$provider/$feature.tsx
@@ -293,6 +293,8 @@ function ChatFeature({
     addToolApprovalResponse,
     stop,
     clear,
+    queue,
+    cancelQueued,
   } = useChat({
     id: chatId,
     ...transport,
@@ -357,6 +359,8 @@ function ChatFeature({
         isLoading={isLoading}
         structuredObject={structuredObject}
         contentDeltaCount={contentDeltaCount}
+        queue={queue}
+        cancelQueued={cancelQueued}
         onSendMessage={(text) => {
           sendMessage(text)
         }}

--- a/testing/e2e/tests/queue.spec.ts
+++ b/testing/e2e/tests/queue.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from './fixtures'
+import { sendMessage, waitForAssistantText, featureUrl } from './helpers'
+
+// Fixture: fixtures/queue/basic.json
+// - "[queue] first message" streams slowly (tps: 6, chunkSize: 2) so the run
+//   stays in flight long enough to send follow-up messages while it streams.
+// - "[queue] third message" resolves immediately.
+// "[queue] second message" has no fixture on purpose — it's cancelled before
+// it ever drains, so if a regression let it send anyway the request would
+// fail to match and the test would fail loudly instead of silently passing.
+
+test.describe('client message queue', () => {
+  test('queues messages sent while streaming, supports cancel, and drains FIFO', async ({
+    page,
+    testId,
+    aimockPort,
+  }) => {
+    // A's fixture streams slowly on purpose (see fixtures/queue/basic.json)
+    // so there's a window to send/cancel queued messages; give the whole
+    // scenario more room than the default 30s test timeout.
+    test.setTimeout(60_000)
+
+    await page.goto(featureUrl('openai', 'chat', testId, aimockPort))
+
+    // Send A and wait for its stream to start.
+    await sendMessage(page, '[queue] first message')
+    await page
+      .getByTestId('loading-indicator')
+      .waitFor({ state: 'visible', timeout: 10_000 })
+
+    // While A is still streaming, send B then C. Both should be queued
+    // rather than starting a second concurrent request.
+    await sendMessage(page, '[queue] second message')
+    await sendMessage(page, '[queue] third message')
+
+    const queued = page.getByTestId('queued-message')
+    await expect(queued).toHaveCount(2)
+    await expect(queued.nth(0)).toContainText('second message')
+    await expect(queued.nth(1)).toContainText('third message')
+
+    // The queue region is distinct from the delivered message list — only
+    // A's user message has landed there so far.
+    await expect(page.getByTestId('user-message')).toHaveCount(1)
+
+    // Cancel B before it drains.
+    await queued
+      .filter({ hasText: 'second message' })
+      .getByTestId('cancel-queued-button')
+      .click()
+
+    await expect(queued).toHaveCount(1)
+    await expect(queued.first()).toContainText('third message')
+
+    // Let A's stream settle. The queue only auto-drains C once A's run fully
+    // completes, and draining adds C's user message immediately (before its
+    // own response streams back) — so waiting for a second user message is
+    // a reliable settle signal that doesn't fire early on A's own streamed
+    // text (which contains the substring "first response" from its very
+    // first chunk, long before the run actually finishes).
+    await expect(page.getByTestId('user-message')).toHaveCount(2, {
+      timeout: 40_000,
+    })
+    await waitForAssistantText(page, 'first response', 5_000)
+    await expect(queued).toHaveCount(0)
+    await waitForAssistantText(page, 'third response', 20_000)
+
+    // Final conversation: exactly A and C, in order — B was never sent.
+    const userMessages = page.getByTestId('user-message')
+    await expect(userMessages).toHaveCount(2)
+    await expect(userMessages.nth(0)).toContainText('first message')
+    await expect(userMessages.nth(1)).toContainText('third message')
+    await expect(
+      page.getByTestId('user-message').filter({ hasText: 'second message' }),
+    ).toHaveCount(0)
+
+    const assistantMessages = page.getByTestId('assistant-message')
+    await expect(assistantMessages).toHaveCount(2)
+    await expect(assistantMessages.nth(0)).toContainText('first response')
+    await expect(assistantMessages.nth(1)).toContainText('third response')
+
+    // Cross-check ordering across the whole transcript, not just per-role
+    // counts — proves A's turn fully precedes C's turn in the DOM.
+    const transcript = await page.getByTestId('message-list').innerText()
+    const iFirstMsg = transcript.indexOf('first message')
+    const iFirstResp = transcript.indexOf('first response')
+    const iThirdMsg = transcript.indexOf('third message')
+    const iThirdResp = transcript.indexOf('third response')
+    expect(iFirstMsg).toBeGreaterThanOrEqual(0)
+    expect(iFirstResp).toBeGreaterThan(iFirstMsg)
+    expect(iThirdMsg).toBeGreaterThan(iFirstResp)
+    expect(iThirdResp).toBeGreaterThan(iThirdMsg)
+    expect(transcript).not.toContain('second message')
+  })
+})


### PR DESCRIPTION
## What & why

Today `sendMessage` **silently drops** any message sent while a stream is in flight. This adds a first-class, observable, configurable **message queue**: messages sent mid-stream are queued by default, rendered separately, auto-sent when the stream settles, and cancellable before they go out.

```ts
const { messages, queue, sendMessage, cancelQueued } = useChat({
  connection: fetchServerSentEvents('/api/chat'),
  queue: {
    whenBusy: 'queue',       // 'queue' | 'drop' | 'interrupt'
    drain: 'fifo',           // 'fifo' | 'batch'
    maxSize: 5,
    onOverflow: 'reject',    // 'reject' | 'drop-oldest'
  },
})

// shorthand: queue: 'interrupt'   |   escape hatch: queue: (ctx) => ({ action })
sendMessage('urgent', { whenBusy: 'interrupt' })       // per-send override
queue.map((q) => <Pending key={q.id} onCancel={() => cancelQueued(q.id)} />)
```

## Behavior

- **`whenBusy`** — `queue` (hold + auto-send), `drop` (ignore, the old behavior), `interrupt` (abort current stream, send now).
- **`drain`** — `fifo` (one at a time, in order) or `batch` (merge all queued into one send: strings joined by `\n`, multimodal content concatenated).
- **`maxSize` / `onOverflow`** — cap the queue; `reject` the incoming send or evict the oldest.
- Accepts a `WhenBusy` string shorthand or a `QueueStrategy` function for full control.
- Queue **flushes** on `stop()` / `clear()` / `unsubscribe()` and on stream **error** (never strands or mis-orders queued sends).
- Queued items live in their own array — never mixed into `messages`, never sent to the wire until drained.

## ⚠️ Behavior change

Sends while streaming are now **queued by default** (previously dropped). Opt back into the old behavior with `queue: 'drop'`. Flagged as a **minor** bump in the changeset.

## Surface

- **`@tanstack/ai-client`** — core: `queue` option, `QueuedMessage`, `getQueue()`, `cancelQueued()`, `onQueueChange`, FIFO/batch drain, lifecycle + error flush, devtools snapshot.
- **`@tanstack/ai-react` / `-solid` / `-vue` / `-svelte` / `-preact`** — expose `queue` + `cancelQueued`, per-send `{ whenBusy }` override; `ai-vue-ui` forwards automatically.

## Tests & docs

- Unit tests in `ai-client` (each `whenBusy` mode, FIFO order, batch merge incl. multimodal, `maxSize`/overflow, cancel, flush-on-stop/clear/error) + framework hook tests updated for queue-by-default.
- **E2E** (`testing/e2e/tests/queue.spec.ts`): send → queue-while-streaming → cancel one → assert only the uncancelled message is delivered, in order.
- Docs: new "Queueing messages" section in `docs/chat/streaming.md`; `chat-experience` agent skill updated.
- `pnpm test:pr` green across all 50 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default queueing for `sendMessage` while a stream is active, with configurable `whenBusy` (queue/drop/interrupt) and drain/overflow strategies.
  * Added queued-message controls: exposed `queue` state, `cancelQueued(id)`, and per-send `{ whenBusy }` overrides across chat hooks/components.
  * Extended devtools snapshots and demo UI to display and cancel pending items.
* **Bug Fixes**
  * Busy sends are no longer silently dropped; queued items drain automatically, with flush on stop/error/clear/reload.
* **Documentation**
  * Added “Queueing Messages” guidance, including drain vs flush and queue strategy behavior.
* **Tests**
  * Added/updated unit and Playwright coverage for queuing, cancellation, ordering, drain/batch merging, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->