### PR TITLE
feat(ai-claude-code): stream tool-call arguments (+ fix processor id-rename orphaning tool results)

### DIFF
--- a/.changeset/claude-code-stream-tool-args.md
+++ b/.changeset/claude-code-stream-tool-args.md
@@ -1,0 +1,22 @@
+---
+'@tanstack/ai-claude-code': patch
+---
+
+Stream tool-call arguments in the Claude Code adapter instead of surfacing each
+tool call whole. The stream translator only handled `text_delta` and
+`thinking_delta` partial events, so a `tool_use` block arrived as a single
+completed `TOOL_CALL_START/ARGS/END` at the end of the message. It now also
+translates the SDK's partial tool input — `content_block_start` (tool_use),
+`content_block_delta` with `input_json_delta`, and `content_block_stop` — into
+incremental `TOOL_CALL_ARGS` deltas, matching how the model adapters
+(`@tanstack/ai-anthropic`, `@tanstack/ai-openai`) already stream tool args.
+
+The complete `assistant` message dedupes any tool call that already streamed via
+partials (tracked by tool-call id, mirroring the existing `text`/`thinking`
+message-id dedup), so nothing is emitted twice. With `streamPartials: false`
+(partials disabled) tool calls still emit whole from the complete message as
+before.
+
+This unblocks streaming structured output on the Claude Code harness: routing
+structured data through a tool call now paints incrementally as the model writes
+it, rather than atomically at run end.

--- a/.changeset/processor-message-id-rename.md
+++ b/.changeset/processor-message-id-rename.md
@@ -1,0 +1,13 @@
+---
+'@tanstack/ai': patch
+---
+
+Rename message ids atomically across all id-keyed processor state, fixing a silently dropped tool
+result. When a tool call streams before any text and without `parentMessageId` (which the AG-UI spec
+allows to be optional), the `StreamProcessor` creates a placeholder assistant message and later
+renames it to the real provider id on `TEXT_MESSAGE_START`. That rename updated `messages`,
+`messageStates`, and `activeMessageIds` but not `toolCallToMessage` / `structuredMessageIds` /
+`structuredOutputUpdateBatches`, so a `TOOL_CALL_RESULT` arriving after the rename resolved to the
+vanished placeholder id and was discarded. The rename now goes through a single `renameMessageId`
+seam that remaps every id-keyed structure (the same set enumerated by `pruneToMessages()` and
+`reset()`), so no adapter that legitimately omits `parentMessageId` can orphan a tool result.

--- a/packages/ai-claude-code/src/stream/sdk-types.ts
+++ b/packages/ai-claude-code/src/stream/sdk-types.ts
@@ -60,12 +60,17 @@ export type SdkRawStreamEvent =
   | {
       type: 'content_block_start'
       index: number
-      content_block: { type: string }
+      content_block: { type: string; id?: string; name?: string }
     }
   | {
       type: 'content_block_delta'
       index: number
-      delta: { type: string; text?: string; thinking?: string }
+      delta: {
+        type: string
+        text?: string
+        thinking?: string
+        partial_json?: string
+      }
     }
   | { type: 'content_block_stop'; index: number }
   | { type: 'message_delta' }

--- a/packages/ai-claude-code/src/stream/translate.ts
+++ b/packages/ai-claude-code/src/stream/translate.ts
@@ -111,6 +111,8 @@ export async function* translateSdkStream(
   const unresolvedToolCalls = new Set<string>()
   /** Anthropic message ids whose text/thinking already streamed via partials. */
   const streamedMessageIds = new Set<string>()
+  /** Tool-call ids already streamed via partials, so the complete message dedupes them. */
+  const streamedToolCallIds = new Set<string>()
 
   // Partial-stream state
   let partialMessageId: string | null = null
@@ -119,6 +121,9 @@ export async function* translateSdkStream(
   let partialTextContent = ''
   let partialTextStarted = false
   let partialReasoningId: string | null = null
+  let partialToolCallId: string | null = null
+  let partialToolCallName: string | null = null
+  let partialToolArgs = ''
 
   function* startRun(): Generator<StreamChunk> {
     if (runStarted) return
@@ -177,6 +182,33 @@ export async function* translateSdkStream(
       }
     }
     partialReasoningId = null
+  }
+
+  function* closePartialToolUse(): Generator<StreamChunk> {
+    if (partialToolCallId) {
+      // At content_block_stop the accumulated JSON is complete; the try/catch
+      // mirrors the model adapters and only guards a truncated/aborted stream.
+      let input: unknown = {}
+      try {
+        const parsed = partialToolArgs ? JSON.parse(partialToolArgs) : {}
+        input = parsed && typeof parsed === 'object' ? parsed : {}
+      } catch {
+        input = {}
+      }
+      yield {
+        type: EventType.TOOL_CALL_END,
+        toolCallId: partialToolCallId,
+        toolCallName: partialToolCallName ?? '',
+        toolName: partialToolCallName ?? '',
+        model,
+        timestamp: now(),
+        input,
+      }
+      unresolvedToolCalls.add(partialToolCallId)
+    }
+    partialToolCallId = null
+    partialToolCallName = null
+    partialToolArgs = ''
   }
 
   function* emitToolUse(block: {
@@ -284,9 +316,10 @@ export async function* translateSdkStream(
           timestamp: now(),
         }
       } else if (block.type === 'tool_use') {
-        yield* emitToolUse(
-          block as { id: string; name: string; input: unknown },
-        )
+        const toolBlock = block as { id: string; name: string; input: unknown }
+        // Skip the tool call if the partial stream already emitted it.
+        if (streamedToolCallIds.has(toolBlock.id)) continue
+        yield* emitToolUse(toolBlock)
       }
     }
   }
@@ -317,6 +350,7 @@ export async function* translateSdkStream(
   function* handleResult(message: SdkResultMessage): Generator<StreamChunk> {
     yield* closePartialText()
     yield* closePartialReasoning()
+    yield* closePartialToolUse()
     yield* synthesizeUnresolvedResults()
 
     const usage = buildUsage(message.usage, message.total_cost_usd)
@@ -393,6 +427,30 @@ export async function* translateSdkStream(
           model,
           timestamp: now(),
         }
+      } else if (partialBlockType === 'tool_use') {
+        // The partial content_block_start carries the tool id + name; stream
+        // the call so its args paint incrementally instead of arriving whole.
+        const block = event.content_block
+        if (block.id) {
+          partialToolCallId = block.id
+          partialToolCallName = stripMcpPrefix(block.name ?? '')
+          partialToolArgs = ''
+          streamedToolCallIds.add(block.id)
+          yield {
+            type: EventType.TOOL_CALL_START,
+            toolCallId: block.id,
+            toolCallName: partialToolCallName,
+            toolName: partialToolCallName,
+            model,
+            timestamp: now(),
+            // Group under the same message as sibling text/thinking blocks (as
+            // the partial text path does) so a downstream message rename can't
+            // orphan this call's later result.
+            ...(partialMessageId !== null && {
+              parentMessageId: partialMessageId,
+            }),
+          }
+        }
       }
     } else if (event.type === 'content_block_delta') {
       if (
@@ -422,12 +480,28 @@ export async function* translateSdkStream(
           model,
           timestamp: now(),
         }
+      } else if (
+        event.delta.type === 'input_json_delta' &&
+        partialToolCallId &&
+        typeof event.delta.partial_json === 'string'
+      ) {
+        partialToolArgs += event.delta.partial_json
+        yield {
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: partialToolCallId,
+          model,
+          timestamp: now(),
+          delta: event.delta.partial_json,
+          args: partialToolArgs,
+        }
       }
     } else if (event.type === 'content_block_stop') {
       if (partialBlockType === 'text') {
         yield* closePartialText()
       } else if (partialBlockType === 'thinking') {
         yield* closePartialReasoning()
+      } else if (partialBlockType === 'tool_use') {
+        yield* closePartialToolUse()
       }
       partialBlockType = null
     }
@@ -473,10 +547,13 @@ export async function* translateSdkStream(
       // harness-internal and intentionally ignored.
     }
   } catch (error) {
-    // The run is dying (abort or SDK failure). Pair any started tool calls
-    // with a synthetic result first so the next request's pending-tool-call
-    // scan doesn't try to execute them, then let the adapter surface the
-    // error as RUN_ERROR.
+    // The run is dying (abort or SDK failure). Close any in-flight partial
+    // tool call first (mirrors handleResult) so its TOOL_CALL_START is paired
+    // with a TOOL_CALL_END and registered as unresolved, then synthesize
+    // results for every started-but-unresolved tool call so the next request's
+    // pending-tool-call scan doesn't try to execute them. Finally let the
+    // adapter surface the error as RUN_ERROR.
+    yield* closePartialToolUse()
     yield* synthesizeUnresolvedResults()
     throw error
   }

--- a/packages/ai-claude-code/tests/translate.test.ts
+++ b/packages/ai-claude-code/tests/translate.test.ts
@@ -433,6 +433,107 @@ describe('translateSdkStream', () => {
     expect(chunks[4]).toMatchObject({ delta: 'lo', content: 'Hello' })
   })
 
+  it('streams partial tool-call args and dedupes the complete assistant message', async () => {
+    const chunks = await collect([
+      init,
+      {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg-1' } },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_1', name: 'Read' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '{"file":' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '"a.ts"}' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+        parent_tool_use_id: null,
+      },
+      // The complete assistant message restates the tool call; it must be deduped.
+      {
+        type: 'assistant',
+        message: {
+          id: 'msg-1',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'Read',
+              input: { file: 'a.ts' },
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+      // The harness executes the tool and feeds the result back.
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_1',
+              content: 'file contents',
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+      resultSuccess,
+    ])
+
+    expect(chunks.map((c) => c.type)).toEqual([
+      'RUN_STARTED',
+      'CUSTOM',
+      'TOOL_CALL_START',
+      'TOOL_CALL_ARGS',
+      'TOOL_CALL_ARGS',
+      'TOOL_CALL_END',
+      'TOOL_CALL_RESULT',
+      'RUN_FINISHED',
+    ])
+    // Args stream incrementally, accumulating to the full JSON.
+    expect(chunks[3]).toMatchObject({ delta: '{"file":', args: '{"file":' })
+    expect(chunks[4]).toMatchObject({
+      delta: '"a.ts"}',
+      args: '{"file":"a.ts"}',
+    })
+    // END carries the parsed input; the complete message re-emitted nothing.
+    expect(chunks[5]).toMatchObject({
+      type: 'TOOL_CALL_END',
+      toolCallId: 'toolu_1',
+      toolCallName: 'Read',
+      input: { file: 'a.ts' },
+    })
+    expect(chunks.filter((c) => c.type === 'TOOL_CALL_START')).toHaveLength(1)
+    expect(chunks.filter((c) => c.type === 'TOOL_CALL_END')).toHaveLength(1)
+  })
+
   it('emits synthetic tool results then rethrows when the SDK stream throws mid-run', async () => {
     async function* throwing(): AsyncIterable<AgentSdkMessage> {
       yield init
@@ -481,5 +582,235 @@ describe('translateSdkStream', () => {
       'TEXT_MESSAGE_END',
       'RUN_FINISHED',
     ])
+  })
+
+  it('synthesizes an interrupted result when the stream throws mid partial tool-args', async () => {
+    async function* throwing(): AsyncIterable<AgentSdkMessage> {
+      yield init
+      yield {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg-1' } },
+        parent_tool_use_id: null,
+      }
+      yield {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_9', name: 'Read' },
+        },
+        parent_tool_use_id: null,
+      }
+      yield {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '{"file":' },
+        },
+        parent_tool_use_id: null,
+      }
+      throw new Error('aborted')
+    }
+
+    const chunks: Array<StreamChunk> = []
+    await expect(async () => {
+      for await (const chunk of translateSdkStream(throwing(), makeContext())) {
+        chunks.push(chunk)
+      }
+    }).rejects.toThrow('aborted')
+
+    // START was emitted for the partial tool call; the abort must still pair it
+    // with a TOOL_CALL_END and an interrupted TOOL_CALL_RESULT (the module
+    // invariant documented at the top of translate.ts).
+    expect(chunks.filter((c) => c.type === 'TOOL_CALL_START')).toHaveLength(1)
+    expect(chunks.find((c) => c.type === 'TOOL_CALL_END')).toMatchObject({
+      toolCallId: 'toolu_9',
+    })
+    expect(chunks.find((c) => c.type === 'TOOL_CALL_RESULT')).toMatchObject({
+      toolCallId: 'toolu_9',
+      content: JSON.stringify({ status: 'interrupted' }),
+    })
+  })
+
+  it('tags a streamed tool call with the parent message id shared with sibling text', async () => {
+    const chunks = await collect([
+      init,
+      {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg-1' } },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'text' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'Reading…' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 1,
+          content_block: { type: 'tool_use', id: 'toolu_7', name: 'Read' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'input_json_delta', partial_json: '{"file":"a.ts"}' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 1 },
+        parent_tool_use_id: null,
+      },
+      resultSuccess,
+    ])
+
+    // The tool call must be grouped under the same message as the sibling text,
+    // so a downstream message rename can't orphan its later result.
+    expect(chunks.find((c) => c.type === 'TEXT_MESSAGE_START')).toMatchObject({
+      messageId: 'msg-1',
+    })
+    expect(chunks.find((c) => c.type === 'TOOL_CALL_START')).toMatchObject({
+      parentMessageId: 'msg-1',
+    })
+  })
+
+  it('streams two sequential tool_use blocks without arg bleed', async () => {
+    const chunks = await collect([
+      init,
+      {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg-1' } },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_a', name: 'Read' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '{"file":"a.ts"}' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 1,
+          content_block: { type: 'tool_use', id: 'toolu_b', name: 'Bash' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'input_json_delta', partial_json: '{"cmd":"ls"}' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 1 },
+        parent_tool_use_id: null,
+      },
+      resultSuccess,
+    ])
+
+    const ends = chunks.filter((c) => c.type === 'TOOL_CALL_END')
+    expect(ends).toHaveLength(2)
+    expect(ends[0]).toMatchObject({
+      toolCallId: 'toolu_a',
+      input: { file: 'a.ts' },
+    })
+    expect(ends[1]).toMatchObject({
+      toolCallId: 'toolu_b',
+      input: { cmd: 'ls' },
+    })
+
+    const args = chunks.filter((c) => c.type === 'TOOL_CALL_ARGS')
+    expect(args[0]).toMatchObject({ args: '{"file":"a.ts"}' })
+    expect(args[1]).toMatchObject({ args: '{"cmd":"ls"}' })
+  })
+
+  it('streams a zero-argument tool call as START → END with no args frame', async () => {
+    const chunks = await collect([
+      init,
+      {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg-1' } },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_z', name: 'Now' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+        parent_tool_use_id: null,
+      },
+      resultSuccess,
+    ])
+
+    // Mirrors the @tanstack/ai-anthropic streaming path: no input_json_delta
+    // means no ARGS frame — START → END(input={}), never a synthesized one.
+    const toolTypes = chunks
+      .map((c) => c.type)
+      .filter((t) => t.startsWith('TOOL_CALL_'))
+    expect(toolTypes).toEqual([
+      'TOOL_CALL_START',
+      'TOOL_CALL_END',
+      'TOOL_CALL_RESULT',
+    ])
+    expect(chunks.find((c) => c.type === 'TOOL_CALL_END')).toMatchObject({
+      toolCallId: 'toolu_z',
+      input: {},
+    })
   })
 })

--- a/packages/ai/src/activities/chat/stream/processor.ts
+++ b/packages/ai/src/activities/chat/stream/processor.ts
@@ -761,6 +761,49 @@ export class StreamProcessor {
     return { messageId: id, state }
   }
 
+  /**
+   * Rename a message id across every structure keyed by it.
+   *
+   * A placeholder id (from ensureAssistantMessage / startAssistantMessage) is
+   * renamed to the real provider id on TEXT_MESSAGE_START. Every structure that
+   * holds that id must move together — miss one and the data it holds is
+   * silently orphaned onto the vanished id (e.g. a tool result whose
+   * toolCallToMessage entry still points at the placeholder). This is the same
+   * id-keyed set enumerated by pruneToMessages() and reset().
+   */
+  private renameMessageId(oldId: string, newId: string): void {
+    if (oldId === newId) return
+
+    this.messages = this.messages.map((msg) =>
+      msg.id === oldId ? { ...msg, id: newId } : msg,
+    )
+
+    const state = this.messageStates.get(oldId)
+    if (state) {
+      state.id = newId
+      this.messageStates.delete(oldId)
+      this.messageStates.set(newId, state)
+    }
+
+    this.activeMessageIds.delete(oldId)
+    this.activeMessageIds.add(newId)
+
+    // toolCallToMessage is keyed by toolCallId with the message id as the value.
+    for (const [toolCallId, msgId] of this.toolCallToMessage) {
+      if (msgId === oldId) this.toolCallToMessage.set(toolCallId, newId)
+    }
+
+    if (this.structuredMessageIds.delete(oldId)) {
+      this.structuredMessageIds.add(newId)
+    }
+
+    const batch = this.structuredOutputUpdateBatches.get(oldId)
+    if (batch !== undefined) {
+      this.structuredOutputUpdateBatches.delete(oldId)
+      this.structuredOutputUpdateBatches.set(newId, batch)
+    }
+  }
+
   // ============================================
   // Event Handlers
   // ============================================
@@ -784,24 +827,9 @@ export class StreamProcessor {
       const pendingId = this.pendingManualMessageId
       this.pendingManualMessageId = null
 
-      if (pendingId !== messageId) {
-        // Update the message's ID in the messages array
-        this.messages = this.messages.map((msg) =>
-          msg.id === pendingId ? { ...msg, id: messageId } : msg,
-        )
-
-        // Move state to the new key
-        const existingState = this.messageStates.get(pendingId)
-        if (existingState) {
-          existingState.id = messageId
-          this.messageStates.delete(pendingId)
-          this.messageStates.set(messageId, existingState)
-        }
-
-        // Update activeMessageIds
-        this.activeMessageIds.delete(pendingId)
-        this.activeMessageIds.add(messageId)
-      }
+      // Rename the placeholder to the real provider id across every id-keyed
+      // structure (no-op when they already match).
+      this.renameMessageId(pendingId, messageId)
 
       // Ensure state exists
       if (!this.messageStates.has(messageId)) {

--- a/packages/ai/tests/stream-processor.test.ts
+++ b/packages/ai/tests/stream-processor.test.ts
@@ -3081,6 +3081,49 @@ describe('StreamProcessor', () => {
         },
       ])
     })
+
+    it('routes a tool result to the renamed message in tool-first flows without parentMessageId', () => {
+      const processor = new StreamProcessor()
+
+      // Tool call arrives BEFORE any text and WITHOUT parentMessageId, so the
+      // processor auto-creates a placeholder assistant message and registers
+      // the tool call under that placeholder id.
+      processor.processChunk(ev.toolStart('tc-1', 'lookupWeather'))
+      processor.processChunk(ev.toolArgs('tc-1', '{"location":"Berlin"}'))
+      processor.processChunk(ev.toolEnd('tc-1', 'lookupWeather'))
+
+      // The real provider message id arrives on TEXT_MESSAGE_START, renaming
+      // the placeholder. The rename must remap toolCallToMessage too, or the
+      // later result is orphaned onto the vanished placeholder id.
+      processor.processChunk(
+        chunk(EventType.TEXT_MESSAGE_START, {
+          messageId: 'anthropic-msg-1',
+          role: 'assistant' as const,
+        }),
+      )
+      processor.processChunk(ev.textContent('It is sunny.', 'anthropic-msg-1'))
+      processor.processChunk(ev.textEnd('anthropic-msg-1'))
+
+      // The tool result arrives after the rename.
+      processor.processChunk(
+        chunk(EventType.TOOL_CALL_RESULT, {
+          toolCallId: 'tc-1',
+          content: '{"temp":72}',
+        }),
+      )
+      processor.finalizeStream()
+
+      const messages = processor.getMessages()
+      expect(messages).toHaveLength(1)
+      expect(messages[0]?.id).toBe('anthropic-msg-1')
+
+      const toolResultPart = messages[0]?.parts.find(
+        (p) => p.type === 'tool-result',
+      ) as ToolResultPart
+      expect(toolResultPart).toBeDefined()
+      expect(toolResultPart.content).toBe('{"temp":72}')
+      expect(toolResultPart.state).toBe('complete')
+    })
   })
 
   describe('double onStreamEnd guard', () => {


### PR DESCRIPTION
## What

Two related changes, surfaced by wiring structured output through the Claude Code harness:

### 1. `@tanstack/ai-claude-code` — stream tool-call arguments (`feat`, patch)

The stream translator only forwarded `text_delta`/`thinking_delta` partial events, so a `tool_use` block surfaced as a single completed `TOOL_CALL_START/ARGS/END` at the *end* of the message. It now also translates the SDK's partial tool input — `content_block_start` (tool_use) → `TOOL_CALL_START`, `input_json_delta` → incremental `TOOL_CALL_ARGS`, `content_block_stop` → `TOOL_CALL_END` — matching how `@tanstack/ai-anthropic` / `@tanstack/ai-openai` already stream tool args. The complete `assistant` message dedupes anything already streamed via partials (tracked by tool-call id, mirroring the existing text/thinking message-id dedup). With `streamPartials: false`, tool calls still emit whole from the complete message.

This unblocks **streaming structured output on the Claude Code harness**: routing structured data through a tool call now paints incrementally as the model writes it, instead of arriving atomically at run end.

Also in this commit:
- The partial `TOOL_CALL_START` carries `parentMessageId` (mirroring the partial text path and every other adapter), so a tool-first stream groups the call under the correct message.
- On abort mid-tool-args, the `catch` flushes the in-flight partial tool call (mirroring `handleResult`) so its `TOOL_CALL_START` is still paired with a `TOOL_CALL_END` + interrupted `TOOL_CALL_RESULT`, upholding the module's documented invariant.

### 2. `@tanstack/ai` — atomic message-id rename (`fix`, patch)

Independently reachable from any adapter that omits `parentMessageId` (optional per the AG-UI spec — Mistral omits it today). When a tool call streams before any text, the `StreamProcessor` creates a placeholder assistant message and renames it to the real provider id on `TEXT_MESSAGE_START`. That rename updated `messages` / `messageStates` / `activeMessageIds` but **not** `toolCallToMessage` / `structuredMessageIds` / `structuredOutputUpdateBatches`, so a `TOOL_CALL_RESULT` arriving after the rename resolved to the vanished placeholder id and was silently dropped. The rename now goes through a single `renameMessageId()` seam that remaps **every** id-keyed structure — the same set already enumerated by `pruneToMessages()` and `reset()`. Complements the adapter-side fix in #480.

## Why

Routing structured output through a tool call is the sanctioned way to stream it on the Claude Code harness (native `structured_output` only appears in the final `ResultMessage`, not as deltas). Getting there surfaced (1) the translator dropping `input_json_delta`, and (2) the processor's rename orphaning a tool result when `parentMessageId` is absent.

## Test plan

- **`@tanstack/ai-claude-code`** — new `translate` tests: partial tool-arg streaming + dedup, abort-mid-tool-args pairs an interrupted result, `parentMessageId` grouping, sequential tool blocks, zero-arg `START→END`. **6 files / 39 tests pass.**
- **`@tanstack/ai`** — new `stream-processor` regression test: tool-first without `parentMessageId` → rename → tool result attaches (was silently dropped); the existing provided-`parentMessageId` test still passes (`renameMessageId` no-ops when ids match). **63 files / 1133 tests pass.**
- Both: `test:types`, `test:eslint` (0 errors), `build` clean.
- Two changesets (`@tanstack/ai-claude-code` patch, `@tanstack/ai` patch).

Closes #901.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Code tool calls now stream tool input arguments incrementally, producing smoother, earlier tool activity during generation.
* **Bug Fixes**
  * Prevented duplicate/competing tool-call frames when partial tool input arrives before completion.
  * Fixed edge cases where tool results could be orphaned when tool calls started before any text message (including early/aborted streams), ensuring placeholder-to-real message renames keep tool results attached.
* **Tests**
  * Added/extended regression coverage for incremental tool-args streaming, deduping, ordering, and interruption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->