### PR TITLE
feat(ai-claude-code): stream tool-call arguments

### DIFF
--- a/.changeset/stream-tool-call-args.md
+++ b/.changeset/stream-tool-call-args.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-claude-code': minor
+---
+
+Stream Claude Code tool-call arguments incrementally from the SDK's partial
+`tool_use` events. Structured output routed through a tool call can now render as
+its JSON arrives instead of appearing only after the complete message.

--- a/docs/adapters/claude-code.md
+++ b/docs/adapters/claude-code.md
@@ -62,7 +62,7 @@ const stream = chat({
 | `apiKey`                     | Anthropic API key for the harness subprocess.                                                                                                       |
 | `env`                        | Extra environment variables for the harness subprocess.                                                                                            |
 | `pathToClaudeCodeExecutable` | Use a specific Claude Code executable instead of the SDK's bundled one.                                                                             |
-| `streamPartials`             | Emit true token-level text deltas (default `true`).                                                                                                 |
+| `streamPartials`             | Emit true token-level deltas for text and tool-call arguments (default `true`). When `false`, both emit whole from the complete message.            |
 | `canUseTool`                 | Custom permission handler; replaces the adapter's default handler.                                                                                  |
 | `settingSources`             | Claude Code settings tiers to load. Default `['project']`: the `cwd`'s CLAUDE.md and project settings apply, but user-level config on the host (`~/.claude` plugins, hooks, skills) is ignored. Pass `['user', 'project', 'local']` for CLI-equivalent behavior, or `[]` for full isolation. |
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -337,7 +337,7 @@
           "label": "Overview",
           "to": "sandbox/overview",
           "addedAt": "2026-06-16",
-          "updatedAt": "2026-07-15"
+          "updatedAt": "2026-06-30"
         },
         {
           "label": "Quick Start",
@@ -592,7 +592,7 @@
           "label": "Claude Code",
           "to": "adapters/claude-code",
           "addedAt": "2026-06-12",
-          "updatedAt": "2026-06-30"
+          "updatedAt": "2026-07-15"
         },
         {
           "label": "Codex",

--- a/docs/config.json
+++ b/docs/config.json
@@ -337,7 +337,7 @@
           "label": "Overview",
           "to": "sandbox/overview",
           "addedAt": "2026-06-16",
-          "updatedAt": "2026-06-30"
+          "updatedAt": "2026-07-15"
         },
         {
           "label": "Quick Start",

--- a/packages/ai-claude-code/src/stream/sdk-types.ts
+++ b/packages/ai-claude-code/src/stream/sdk-types.ts
@@ -60,12 +60,17 @@ export type SdkRawStreamEvent =
   | {
       type: 'content_block_start'
       index: number
-      content_block: { type: string }
+      content_block: { type: string; id?: string; name?: string }
     }
   | {
       type: 'content_block_delta'
       index: number
-      delta: { type: string; text?: string; thinking?: string }
+      delta: {
+        type: string
+        text?: string
+        thinking?: string
+        partial_json?: string
+      }
     }
   | { type: 'content_block_stop'; index: number }
   | { type: 'message_delta' }

--- a/packages/ai-claude-code/src/stream/sdk-types.ts
+++ b/packages/ai-claude-code/src/stream/sdk-types.ts
@@ -60,17 +60,12 @@ export type SdkRawStreamEvent =
   | {
       type: 'content_block_start'
       index: number
-      content_block: { type: string; id?: string; name?: string }
+      content_block: { type: string; [key: string]: unknown }
     }
   | {
       type: 'content_block_delta'
       index: number
-      delta: {
-        type: string
-        text?: string
-        thinking?: string
-        partial_json?: string
-      }
+      delta: { type: string; [key: string]: unknown }
     }
   | { type: 'content_block_stop'; index: number }
   | { type: 'message_delta' }

--- a/packages/ai-claude-code/src/stream/translate.ts
+++ b/packages/ai-claude-code/src/stream/translate.ts
@@ -218,14 +218,11 @@ export async function* translateSdkStream(
     }
   }
 
-  function* emitToolUse(
-    block: {
-      id: string
-      name: string
-      input: unknown
-    },
-    parentMessageId: string | undefined,
-  ): Generator<StreamChunk> {
+  function* emitToolUse(block: {
+    id: string
+    name: string
+    input: unknown
+  }): Generator<StreamChunk> {
     const toolCallName = stripMcpPrefix(block.name)
     const args = JSON.stringify(block.input ?? {})
     yield {
@@ -235,7 +232,6 @@ export async function* translateSdkStream(
       toolName: toolCallName,
       model,
       timestamp: now(),
-      ...(parentMessageId !== undefined && { parentMessageId }),
     }
     yield {
       type: EventType.TOOL_CALL_ARGS,
@@ -330,7 +326,7 @@ export async function* translateSdkStream(
         const toolBlock = block as { id: string; name: string; input: unknown }
         // Skip the tool call if the partial stream already emitted it.
         if (streamedToolCallIds.has(toolBlock.id)) continue
-        yield* emitToolUse(toolBlock, message.message.id)
+        yield* emitToolUse(toolBlock)
       }
     }
   }
@@ -409,7 +405,8 @@ export async function* translateSdkStream(
       partialMessageId = event.message.id ?? genId()
       streamedMessageIds.add(partialMessageId)
     } else if (event.type === 'content_block_start') {
-      const partialBlockType = event.content_block.type
+      const block = event.content_block
+      const partialBlockType = block.type
       partialBlockTypes.set(event.index, partialBlockType)
       if (partialBlockType === 'text') {
         partialTextMessageId = partialMessageId ?? genId()
@@ -439,31 +436,32 @@ export async function* translateSdkStream(
           model,
           timestamp: now(),
         }
-      } else if (partialBlockType === 'tool_use') {
-        const block = event.content_block
-        if (block.id) {
-          const name = stripMcpPrefix(block.name ?? '')
-          partialToolCalls.set(event.index, { id: block.id, name, args: '' })
-          streamedToolCallIds.add(block.id)
-          yield {
-            type: EventType.TOOL_CALL_START,
-            toolCallId: block.id,
-            toolCallName: name,
-            toolName: name,
-            model,
-            timestamp: now(),
-            ...(partialMessageId !== null && {
-              parentMessageId: partialMessageId,
-            }),
-          }
+      } else if (
+        partialBlockType === 'tool_use' &&
+        typeof block.id === 'string' &&
+        typeof block.name === 'string'
+      ) {
+        const name = stripMcpPrefix(block.name)
+        partialToolCalls.set(event.index, { id: block.id, name, args: '' })
+        streamedToolCallIds.add(block.id)
+        yield {
+          type: EventType.TOOL_CALL_START,
+          toolCallId: block.id,
+          toolCallName: name,
+          toolName: name,
+          model,
+          timestamp: now(),
+          ...(partialMessageId !== null && {
+            parentMessageId: partialMessageId,
+          }),
         }
       }
     } else if (event.type === 'content_block_delta') {
       if (
         event.delta.type === 'text_delta' &&
+        typeof event.delta.text === 'string' &&
         partialTextStarted &&
-        partialTextMessageId &&
-        typeof event.delta.text === 'string'
+        partialTextMessageId
       ) {
         partialTextContent += event.delta.text
         yield {
@@ -476,8 +474,8 @@ export async function* translateSdkStream(
         }
       } else if (
         event.delta.type === 'thinking_delta' &&
-        partialReasoningId &&
-        typeof event.delta.thinking === 'string'
+        typeof event.delta.thinking === 'string' &&
+        partialReasoningId
       ) {
         yield {
           type: EventType.REASONING_MESSAGE_CONTENT,
@@ -555,13 +553,8 @@ export async function* translateSdkStream(
       // harness-internal and intentionally ignored.
     }
   } catch (error) {
-    // The run is dying (abort or SDK failure). Close every in-flight partial
-    // (mirrors handleResult) so each START is paired with its END, then
-    // synthesize results for every started-but-unresolved tool call so the
-    // next request's pending-tool-call scan doesn't try to execute them.
-    // Finally let the adapter surface the error as RUN_ERROR.
-    yield* closePartialText()
-    yield* closePartialReasoning()
+    // Pair partial tool starts with an end and a synthetic result before the
+    // adapter surfaces the error.
     yield* closePartialToolUses(true)
     yield* synthesizeUnresolvedResults()
     throw error

--- a/packages/ai-claude-code/src/stream/translate.ts
+++ b/packages/ai-claude-code/src/stream/translate.ts
@@ -111,14 +111,20 @@ export async function* translateSdkStream(
   const unresolvedToolCalls = new Set<string>()
   /** Anthropic message ids whose text/thinking already streamed via partials. */
   const streamedMessageIds = new Set<string>()
+  /** Tool-call ids already streamed via partials, so the complete message dedupes them. */
+  const streamedToolCallIds = new Set<string>()
 
   // Partial-stream state
   let partialMessageId: string | null = null
-  let partialBlockType: string | null = null
+  const partialBlockTypes = new Map<number, string>()
   let partialTextMessageId: string | null = null
   let partialTextContent = ''
   let partialTextStarted = false
   let partialReasoningId: string | null = null
+  const partialToolCalls = new Map<
+    number,
+    { id: string; name: string; args: string }
+  >()
 
   function* startRun(): Generator<StreamChunk> {
     if (runStarted) return
@@ -179,11 +185,47 @@ export async function* translateSdkStream(
     partialReasoningId = null
   }
 
-  function* emitToolUse(block: {
-    id: string
-    name: string
-    input: unknown
-  }): Generator<StreamChunk> {
+  function* closePartialToolUse(
+    index: number,
+    interrupted = false,
+  ): Generator<StreamChunk> {
+    const toolCall = partialToolCalls.get(index)
+    if (toolCall) {
+      let input: unknown = {}
+      try {
+        const parsed = toolCall.args ? JSON.parse(toolCall.args) : {}
+        input = parsed && typeof parsed === 'object' ? parsed : {}
+      } catch (error) {
+        if (!interrupted) throw error
+      }
+      partialToolCalls.delete(index)
+      yield {
+        type: EventType.TOOL_CALL_END,
+        toolCallId: toolCall.id,
+        toolCallName: toolCall.name,
+        toolName: toolCall.name,
+        model,
+        timestamp: now(),
+        input,
+      }
+      unresolvedToolCalls.add(toolCall.id)
+    }
+  }
+
+  function* closePartialToolUses(interrupted = false): Generator<StreamChunk> {
+    for (const index of [...partialToolCalls.keys()]) {
+      yield* closePartialToolUse(index, interrupted)
+    }
+  }
+
+  function* emitToolUse(
+    block: {
+      id: string
+      name: string
+      input: unknown
+    },
+    parentMessageId: string | undefined,
+  ): Generator<StreamChunk> {
     const toolCallName = stripMcpPrefix(block.name)
     const args = JSON.stringify(block.input ?? {})
     yield {
@@ -193,6 +235,7 @@ export async function* translateSdkStream(
       toolName: toolCallName,
       model,
       timestamp: now(),
+      ...(parentMessageId !== undefined && { parentMessageId }),
     }
     yield {
       type: EventType.TOOL_CALL_ARGS,
@@ -284,9 +327,10 @@ export async function* translateSdkStream(
           timestamp: now(),
         }
       } else if (block.type === 'tool_use') {
-        yield* emitToolUse(
-          block as { id: string; name: string; input: unknown },
-        )
+        const toolBlock = block as { id: string; name: string; input: unknown }
+        // Skip the tool call if the partial stream already emitted it.
+        if (streamedToolCallIds.has(toolBlock.id)) continue
+        yield* emitToolUse(toolBlock, message.message.id)
       }
     }
   }
@@ -317,6 +361,7 @@ export async function* translateSdkStream(
   function* handleResult(message: SdkResultMessage): Generator<StreamChunk> {
     yield* closePartialText()
     yield* closePartialReasoning()
+    yield* closePartialToolUses()
     yield* synthesizeUnresolvedResults()
 
     const usage = buildUsage(message.usage, message.total_cost_usd)
@@ -364,7 +409,8 @@ export async function* translateSdkStream(
       partialMessageId = event.message.id ?? genId()
       streamedMessageIds.add(partialMessageId)
     } else if (event.type === 'content_block_start') {
-      partialBlockType = event.content_block.type
+      const partialBlockType = event.content_block.type
+      partialBlockTypes.set(event.index, partialBlockType)
       if (partialBlockType === 'text') {
         partialTextMessageId = partialMessageId ?? genId()
         partialTextContent = ''
@@ -392,6 +438,24 @@ export async function* translateSdkStream(
           role: 'reasoning' as const,
           model,
           timestamp: now(),
+        }
+      } else if (partialBlockType === 'tool_use') {
+        const block = event.content_block
+        if (block.id) {
+          const name = stripMcpPrefix(block.name ?? '')
+          partialToolCalls.set(event.index, { id: block.id, name, args: '' })
+          streamedToolCallIds.add(block.id)
+          yield {
+            type: EventType.TOOL_CALL_START,
+            toolCallId: block.id,
+            toolCallName: name,
+            toolName: name,
+            model,
+            timestamp: now(),
+            ...(partialMessageId !== null && {
+              parentMessageId: partialMessageId,
+            }),
+          }
         }
       }
     } else if (event.type === 'content_block_delta') {
@@ -422,14 +486,32 @@ export async function* translateSdkStream(
           model,
           timestamp: now(),
         }
+      } else if (
+        event.delta.type === 'input_json_delta' &&
+        typeof event.delta.partial_json === 'string'
+      ) {
+        const toolCall = partialToolCalls.get(event.index)
+        if (toolCall) {
+          toolCall.args += event.delta.partial_json
+          yield {
+            type: EventType.TOOL_CALL_ARGS,
+            toolCallId: toolCall.id,
+            model,
+            timestamp: now(),
+            delta: event.delta.partial_json,
+          }
+        }
       }
     } else if (event.type === 'content_block_stop') {
+      const partialBlockType = partialBlockTypes.get(event.index)
+      partialBlockTypes.delete(event.index)
       if (partialBlockType === 'text') {
         yield* closePartialText()
       } else if (partialBlockType === 'thinking') {
         yield* closePartialReasoning()
+      } else if (partialBlockType === 'tool_use') {
+        yield* closePartialToolUse(event.index)
       }
-      partialBlockType = null
     }
   }
 
@@ -473,10 +555,14 @@ export async function* translateSdkStream(
       // harness-internal and intentionally ignored.
     }
   } catch (error) {
-    // The run is dying (abort or SDK failure). Pair any started tool calls
-    // with a synthetic result first so the next request's pending-tool-call
-    // scan doesn't try to execute them, then let the adapter surface the
-    // error as RUN_ERROR.
+    // The run is dying (abort or SDK failure). Close every in-flight partial
+    // (mirrors handleResult) so each START is paired with its END, then
+    // synthesize results for every started-but-unresolved tool call so the
+    // next request's pending-tool-call scan doesn't try to execute them.
+    // Finally let the adapter surface the error as RUN_ERROR.
+    yield* closePartialText()
+    yield* closePartialReasoning()
+    yield* closePartialToolUses(true)
     yield* synthesizeUnresolvedResults()
     throw error
   }

--- a/packages/ai-claude-code/tests/text-adapter.test.ts
+++ b/packages/ai-claude-code/tests/text-adapter.test.ts
@@ -36,7 +36,14 @@ const FAKE_CLAUDE = [
   `  w({ type: 'system', subtype: 'init', session_id: 'sess-abc', model: 'haiku', tools: [] })`,
   // Echo IS_SANDBOX so the test can assert the adapter sets it (claude refuses
   // bypassPermissions as root without it).
-  `  w({ type: 'assistant', message: { id: 'msg-1', content: [{ type: 'text', text: 'pong IS_SANDBOX=' + process.env.IS_SANDBOX }] }, parent_tool_use_id: null })`,
+  `  w({ type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-1' } }, parent_tool_use_id: null })`,
+  `  w({ type: 'stream_event', event: { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'toolu-1', name: 'Read' } }, parent_tool_use_id: null })`,
+  `  w({ type: 'stream_event', event: { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"file":' } }, parent_tool_use_id: null })`,
+  `  w({ type: 'stream_event', event: { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '"a.ts"}' } }, parent_tool_use_id: null })`,
+  `  w({ type: 'stream_event', event: { type: 'content_block_stop', index: 0 }, parent_tool_use_id: null })`,
+  `  w({ type: 'assistant', message: { id: 'msg-1', content: [{ type: 'tool_use', id: 'toolu-1', name: 'Read', input: { file: 'a.ts' } }] }, parent_tool_use_id: null })`,
+  `  w({ type: 'user', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu-1', content: 'file contents' }] }, parent_tool_use_id: null })`,
+  `  w({ type: 'assistant', message: { id: 'msg-2', content: [{ type: 'text', text: 'pong IS_SANDBOX=' + process.env.IS_SANDBOX }] }, parent_tool_use_id: null })`,
   `  w({ type: 'result', subtype: 'success', result: 'pong', usage: { input_tokens: 1, output_tokens: 1 } })`,
   `})`,
 ].join('\n')
@@ -76,7 +83,6 @@ describe('claude-code in-sandbox adapter', () => {
     const adapter = claudeCodeText('haiku', {
       // Relative executable + cwd=/workspace (mapped to the sandbox root).
       claudeExecutable: 'node fake-claude.mjs',
-      streamPartials: false,
       emitDiff: false,
     })
 
@@ -110,6 +116,10 @@ describe('claude-code in-sandbox adapter', () => {
     // The adapter must set IS_SANDBOX=1 in the CLI env (claude refuses
     // `--dangerously-skip-permissions`/bypassPermissions as root otherwise).
     expect(text).toContain('IS_SANDBOX=1')
+
+    const args = chunks.filter((c) => c.type === 'TOOL_CALL_ARGS')
+    expect(args.map((chunk) => chunk.delta)).toEqual(['{"file":', '"a.ts"}'])
+    expect(args.every((chunk) => !('args' in chunk))).toBe(true)
 
     expect(chunks.some((c) => c.type === 'RUN_FINISHED')).toBe(true)
 

--- a/packages/ai-claude-code/tests/translate.test.ts
+++ b/packages/ai-claude-code/tests/translate.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { translateSdkStream } from '../src/stream/translate'
-import type { AgentSdkMessage } from '../src/stream/sdk-types'
+import type {
+  AgentSdkMessage,
+  SdkRawStreamEvent,
+} from '../src/stream/sdk-types'
 import type { StreamChunk } from '@tanstack/ai'
 
 function makeContext() {
@@ -54,6 +57,61 @@ function assistantText(text: string, messageId = 'msg-1'): AgentSdkMessage {
   return {
     type: 'assistant',
     message: { id: messageId, content: [{ type: 'text', text }] },
+    parent_tool_use_id: null,
+  }
+}
+
+function streamEvent(event: SdkRawStreamEvent): AgentSdkMessage {
+  return { type: 'stream_event', event, parent_tool_use_id: null }
+}
+
+function messageStart(messageId = 'msg-1'): AgentSdkMessage {
+  return streamEvent({ type: 'message_start', message: { id: messageId } })
+}
+
+function toolStart(index: number, id: string, name: string): AgentSdkMessage {
+  return streamEvent({
+    type: 'content_block_start',
+    index,
+    content_block: { type: 'tool_use', id, name },
+  })
+}
+
+function toolArgs(index: number, partialJson: string): AgentSdkMessage {
+  return streamEvent({
+    type: 'content_block_delta',
+    index,
+    delta: { type: 'input_json_delta', partial_json: partialJson },
+  })
+}
+
+function blockStop(index: number): AgentSdkMessage {
+  return streamEvent({ type: 'content_block_stop', index })
+}
+
+function assistantTool(
+  id: string,
+  name: string,
+  input: unknown,
+  messageId = 'msg-1',
+): AgentSdkMessage {
+  return {
+    type: 'assistant',
+    message: {
+      id: messageId,
+      content: [{ type: 'tool_use', id, name, input }],
+    },
+    parent_tool_use_id: null,
+  }
+}
+
+function toolResult(id: string, content = 'done'): AgentSdkMessage {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: id, content }],
+    },
     parent_tool_use_id: null,
   }
 }
@@ -177,7 +235,6 @@ describe('translateSdkStream', () => {
     expect(chunks[2]).toMatchObject({
       toolCallId: 'toolu_1',
       toolCallName: 'Bash',
-      parentMessageId: 'msg-1',
     })
     expect(chunks[3]).toMatchObject({
       toolCallId: 'toolu_1',
@@ -437,74 +494,13 @@ describe('translateSdkStream', () => {
   it('streams partial tool-call args and dedupes the complete assistant message', async () => {
     const chunks = await collect([
       init,
-      {
-        type: 'stream_event',
-        event: { type: 'message_start', message: { id: 'msg-1' } },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_start',
-          index: 0,
-          content_block: { type: 'tool_use', id: 'toolu_1', name: 'Read' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_delta',
-          index: 0,
-          delta: { type: 'input_json_delta', partial_json: '{"file":' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_delta',
-          index: 0,
-          delta: { type: 'input_json_delta', partial_json: '"a.ts"}' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: { type: 'content_block_stop', index: 0 },
-        parent_tool_use_id: null,
-      },
-      // The complete assistant message restates the tool call; it must be deduped.
-      {
-        type: 'assistant',
-        message: {
-          id: 'msg-1',
-          content: [
-            {
-              type: 'tool_use',
-              id: 'toolu_1',
-              name: 'Read',
-              input: { file: 'a.ts' },
-            },
-          ],
-        },
-        parent_tool_use_id: null,
-      },
-      // The harness executes the tool and feeds the result back.
-      {
-        type: 'user',
-        message: {
-          role: 'user',
-          content: [
-            {
-              type: 'tool_result',
-              tool_use_id: 'toolu_1',
-              content: 'file contents',
-            },
-          ],
-        },
-        parent_tool_use_id: null,
-      },
+      messageStart(),
+      toolStart(0, 'toolu_1', 'Read'),
+      toolArgs(0, '{"file":'),
+      toolArgs(0, '"a.ts"}'),
+      blockStop(0),
+      assistantTool('toolu_1', 'Read', { file: 'a.ts' }),
+      toolResult('toolu_1', 'file contents'),
       resultSuccess,
     ])
 
@@ -518,11 +514,9 @@ describe('translateSdkStream', () => {
       'TOOL_CALL_RESULT',
       'RUN_FINISHED',
     ])
-    // Args stream as deltas only; consumers accumulate them.
     expect(chunks[3]).toMatchObject({ delta: '{"file":' })
     expect(chunks[4]).toMatchObject({ delta: '"a.ts"}' })
     expect(chunks[3]).not.toHaveProperty('args')
-    // END carries the parsed input; the complete message re-emitted nothing.
     expect(chunks[5]).toMatchObject({
       type: 'TOOL_CALL_END',
       toolCallId: 'toolu_1',
@@ -535,36 +529,70 @@ describe('translateSdkStream', () => {
     await expect(
       collect([
         init,
-        {
-          type: 'stream_event',
-          event: { type: 'message_start', message: { id: 'msg-1' } },
-          parent_tool_use_id: null,
-        },
-        {
-          type: 'stream_event',
-          event: {
-            type: 'content_block_start',
-            index: 0,
-            content_block: { type: 'tool_use', id: 'toolu_1', name: 'Read' },
-          },
-          parent_tool_use_id: null,
-        },
-        {
-          type: 'stream_event',
-          event: {
-            type: 'content_block_delta',
-            index: 0,
-            delta: { type: 'input_json_delta', partial_json: '{"file":' },
-          },
-          parent_tool_use_id: null,
-        },
-        {
-          type: 'stream_event',
-          event: { type: 'content_block_stop', index: 0 },
-          parent_tool_use_id: null,
-        },
+        messageStart(),
+        toolStart(0, 'toolu_1', 'Read'),
+        toolArgs(0, '{"file":'),
+        blockStop(0),
       ]),
     ).rejects.toThrow()
+  })
+
+  it('correlates interleaved tool-call deltas by block index', async () => {
+    const chunks = await collect([
+      init,
+      messageStart(),
+      toolStart(0, 'toolu_a', 'Read'),
+      toolStart(1, 'toolu_b', 'Bash'),
+      toolArgs(1, '{"cmd":'),
+      toolArgs(0, '{"file":'),
+      toolArgs(1, '"ls"}'),
+      toolArgs(0, '"a.ts"}'),
+      blockStop(1),
+      blockStop(0),
+      resultSuccess,
+    ])
+
+    expect(
+      chunks
+        .filter((chunk) => chunk.type === 'TOOL_CALL_ARGS')
+        .map((chunk) => [chunk.toolCallId, chunk.delta]),
+    ).toEqual([
+      ['toolu_b', '{"cmd":'],
+      ['toolu_a', '{"file":'],
+      ['toolu_b', '"ls"}'],
+      ['toolu_a', '"a.ts"}'],
+    ])
+    expect(
+      chunks
+        .filter((chunk) => chunk.type === 'TOOL_CALL_END')
+        .map((chunk) => [chunk.toolCallId, chunk.input]),
+    ).toEqual([
+      ['toolu_b', { cmd: 'ls' }],
+      ['toolu_a', { file: 'a.ts' }],
+    ])
+  })
+
+  it('ignores unsupported partial content blocks', async () => {
+    const chunks = await collect([
+      init,
+      messageStart(),
+      streamEvent({
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'redacted_thinking', data: 'opaque' },
+      }),
+      streamEvent({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'signature_delta', signature: 'opaque' },
+      }),
+      blockStop(0),
+      resultSuccess,
+    ])
+
+    expect(chunks.some((chunk) => chunk.type.startsWith('TOOL_CALL_'))).toBe(
+      false,
+    )
   })
 
   it('emits synthetic tool results then rethrows when the SDK stream throws mid-run', async () => {
@@ -620,29 +648,9 @@ describe('translateSdkStream', () => {
   it('synthesizes an interrupted result when the stream throws mid partial tool-args', async () => {
     async function* throwing(): AsyncIterable<AgentSdkMessage> {
       yield init
-      yield {
-        type: 'stream_event',
-        event: { type: 'message_start', message: { id: 'msg-1' } },
-        parent_tool_use_id: null,
-      }
-      yield {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_start',
-          index: 0,
-          content_block: { type: 'tool_use', id: 'toolu_9', name: 'Read' },
-        },
-        parent_tool_use_id: null,
-      }
-      yield {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_delta',
-          index: 0,
-          delta: { type: 'input_json_delta', partial_json: '{"file":' },
-        },
-        parent_tool_use_id: null,
-      }
+      yield messageStart()
+      yield toolStart(0, 'toolu_9', 'Read')
+      yield toolArgs(0, '{"file":')
       throw new Error('aborted')
     }
 
@@ -653,10 +661,6 @@ describe('translateSdkStream', () => {
       }
     }).rejects.toThrow('aborted')
 
-    // START was emitted for the partial tool call; the abort must still pair it
-    // with a TOOL_CALL_END and an interrupted TOOL_CALL_RESULT (the module
-    // invariant documented at the top of translate.ts).
-    expect(chunks.filter((c) => c.type === 'TOOL_CALL_START')).toHaveLength(1)
     expect(chunks.find((c) => c.type === 'TOOL_CALL_END')).toMatchObject({
       toolCallId: 'toolu_9',
     })
@@ -666,222 +670,30 @@ describe('translateSdkStream', () => {
     })
   })
 
-  it('closes an open partial text segment when the stream throws mid-text', async () => {
-    async function* throwing(): AsyncIterable<AgentSdkMessage> {
-      yield init
-      yield {
-        type: 'stream_event',
-        event: { type: 'message_start', message: { id: 'msg-1' } },
-        parent_tool_use_id: null,
-      }
-      yield {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_start',
-          index: 0,
-          content_block: { type: 'text' },
-        },
-        parent_tool_use_id: null,
-      }
-      yield {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_delta',
-          index: 0,
-          delta: { type: 'text_delta', text: 'Half a sent' },
-        },
-        parent_tool_use_id: null,
-      }
-      throw new Error('aborted')
-    }
-
-    const chunks: Array<StreamChunk> = []
-    await expect(async () => {
-      for await (const chunk of translateSdkStream(throwing(), makeContext())) {
-        chunks.push(chunk)
-      }
-    }).rejects.toThrow('aborted')
-
-    // TEXT_MESSAGE_START was emitted; the abort must still pair it with a
-    // TEXT_MESSAGE_END or the consumer's message stays open forever.
-    expect(chunks.find((c) => c.type === 'TEXT_MESSAGE_END')).toMatchObject({
-      messageId: 'msg-1',
-    })
-  })
-
-  it('tags a streamed tool call with the parent message id shared with sibling text', async () => {
+  it('tags a streamed tool call with its parent message id', async () => {
     const chunks = await collect([
       init,
-      {
-        type: 'stream_event',
-        event: { type: 'message_start', message: { id: 'msg-1' } },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_start',
-          index: 0,
-          content_block: { type: 'text' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_delta',
-          index: 0,
-          delta: { type: 'text_delta', text: 'Reading…' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: { type: 'content_block_stop', index: 0 },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_start',
-          index: 1,
-          content_block: { type: 'tool_use', id: 'toolu_7', name: 'Read' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_delta',
-          index: 1,
-          delta: { type: 'input_json_delta', partial_json: '{"file":"a.ts"}' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: { type: 'content_block_stop', index: 1 },
-        parent_tool_use_id: null,
-      },
+      messageStart(),
+      toolStart(0, 'toolu_7', 'Read'),
+      toolArgs(0, '{"file":"a.ts"}'),
+      blockStop(0),
       resultSuccess,
     ])
 
-    // The tool call must be grouped under the same message as the sibling text,
-    // so a downstream message rename can't orphan its later result.
-    expect(chunks.find((c) => c.type === 'TEXT_MESSAGE_START')).toMatchObject({
-      messageId: 'msg-1',
-    })
     expect(chunks.find((c) => c.type === 'TOOL_CALL_START')).toMatchObject({
       parentMessageId: 'msg-1',
-    })
-  })
-
-  it('correlates interleaved tool_use blocks by event index', async () => {
-    const chunks = await collect([
-      init,
-      {
-        type: 'stream_event',
-        event: { type: 'message_start', message: { id: 'msg-1' } },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_start',
-          index: 0,
-          content_block: { type: 'tool_use', id: 'toolu_a', name: 'Read' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_start',
-          index: 1,
-          content_block: { type: 'tool_use', id: 'toolu_b', name: 'Bash' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_delta',
-          index: 0,
-          delta: { type: 'input_json_delta', partial_json: '{"file":"a.ts"}' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_delta',
-          index: 1,
-          delta: { type: 'input_json_delta', partial_json: '{"cmd":"ls"}' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: { type: 'content_block_stop', index: 0 },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: { type: 'content_block_stop', index: 1 },
-        parent_tool_use_id: null,
-      },
-      resultSuccess,
-    ])
-
-    const ends = chunks.filter((c) => c.type === 'TOOL_CALL_END')
-    expect(ends).toHaveLength(2)
-    expect(ends[0]).toMatchObject({
-      toolCallId: 'toolu_a',
-      input: { file: 'a.ts' },
-    })
-    expect(ends[1]).toMatchObject({
-      toolCallId: 'toolu_b',
-      input: { cmd: 'ls' },
-    })
-
-    const args = chunks.filter((c) => c.type === 'TOOL_CALL_ARGS')
-    expect(args[0]).toMatchObject({
-      toolCallId: 'toolu_a',
-      delta: '{"file":"a.ts"}',
-    })
-    expect(args[1]).toMatchObject({
-      toolCallId: 'toolu_b',
-      delta: '{"cmd":"ls"}',
     })
   })
 
   it('streams a zero-argument tool call as START → END with no args frame', async () => {
     const chunks = await collect([
       init,
-      {
-        type: 'stream_event',
-        event: { type: 'message_start', message: { id: 'msg-1' } },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_start',
-          index: 0,
-          content_block: { type: 'tool_use', id: 'toolu_z', name: 'Now' },
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: 'stream_event',
-        event: { type: 'content_block_stop', index: 0 },
-        parent_tool_use_id: null,
-      },
+      messageStart(),
+      toolStart(0, 'toolu_z', 'Now'),
+      blockStop(0),
       resultSuccess,
     ])
 
-    // Mirrors the @tanstack/ai-anthropic streaming path: no input_json_delta
-    // means no ARGS frame: START then END(input={}), never a synthesized one.
     const toolTypes = chunks
       .map((c) => c.type)
       .filter((t) => t.startsWith('TOOL_CALL_'))

--- a/packages/ai-claude-code/tests/translate.test.ts
+++ b/packages/ai-claude-code/tests/translate.test.ts
@@ -177,6 +177,7 @@ describe('translateSdkStream', () => {
     expect(chunks[2]).toMatchObject({
       toolCallId: 'toolu_1',
       toolCallName: 'Bash',
+      parentMessageId: 'msg-1',
     })
     expect(chunks[3]).toMatchObject({
       toolCallId: 'toolu_1',
@@ -433,6 +434,139 @@ describe('translateSdkStream', () => {
     expect(chunks[4]).toMatchObject({ delta: 'lo', content: 'Hello' })
   })
 
+  it('streams partial tool-call args and dedupes the complete assistant message', async () => {
+    const chunks = await collect([
+      init,
+      {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg-1' } },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_1', name: 'Read' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '{"file":' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '"a.ts"}' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+        parent_tool_use_id: null,
+      },
+      // The complete assistant message restates the tool call; it must be deduped.
+      {
+        type: 'assistant',
+        message: {
+          id: 'msg-1',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'Read',
+              input: { file: 'a.ts' },
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+      // The harness executes the tool and feeds the result back.
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_1',
+              content: 'file contents',
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+      resultSuccess,
+    ])
+
+    expect(chunks.map((c) => c.type)).toEqual([
+      'RUN_STARTED',
+      'CUSTOM',
+      'TOOL_CALL_START',
+      'TOOL_CALL_ARGS',
+      'TOOL_CALL_ARGS',
+      'TOOL_CALL_END',
+      'TOOL_CALL_RESULT',
+      'RUN_FINISHED',
+    ])
+    // Args stream as deltas only; consumers accumulate them.
+    expect(chunks[3]).toMatchObject({ delta: '{"file":' })
+    expect(chunks[4]).toMatchObject({ delta: '"a.ts"}' })
+    expect(chunks[3]).not.toHaveProperty('args')
+    // END carries the parsed input; the complete message re-emitted nothing.
+    expect(chunks[5]).toMatchObject({
+      type: 'TOOL_CALL_END',
+      toolCallId: 'toolu_1',
+      toolCallName: 'Read',
+      input: { file: 'a.ts' },
+    })
+  })
+
+  it('fails instead of completing malformed streamed tool input as an empty object', async () => {
+    await expect(
+      collect([
+        init,
+        {
+          type: 'stream_event',
+          event: { type: 'message_start', message: { id: 'msg-1' } },
+          parent_tool_use_id: null,
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_start',
+            index: 0,
+            content_block: { type: 'tool_use', id: 'toolu_1', name: 'Read' },
+          },
+          parent_tool_use_id: null,
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'input_json_delta', partial_json: '{"file":' },
+          },
+          parent_tool_use_id: null,
+        },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_stop', index: 0 },
+          parent_tool_use_id: null,
+        },
+      ]),
+    ).rejects.toThrow()
+  })
+
   it('emits synthetic tool results then rethrows when the SDK stream throws mid-run', async () => {
     async function* throwing(): AsyncIterable<AgentSdkMessage> {
       yield init
@@ -481,5 +615,284 @@ describe('translateSdkStream', () => {
       'TEXT_MESSAGE_END',
       'RUN_FINISHED',
     ])
+  })
+
+  it('synthesizes an interrupted result when the stream throws mid partial tool-args', async () => {
+    async function* throwing(): AsyncIterable<AgentSdkMessage> {
+      yield init
+      yield {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg-1' } },
+        parent_tool_use_id: null,
+      }
+      yield {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_9', name: 'Read' },
+        },
+        parent_tool_use_id: null,
+      }
+      yield {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '{"file":' },
+        },
+        parent_tool_use_id: null,
+      }
+      throw new Error('aborted')
+    }
+
+    const chunks: Array<StreamChunk> = []
+    await expect(async () => {
+      for await (const chunk of translateSdkStream(throwing(), makeContext())) {
+        chunks.push(chunk)
+      }
+    }).rejects.toThrow('aborted')
+
+    // START was emitted for the partial tool call; the abort must still pair it
+    // with a TOOL_CALL_END and an interrupted TOOL_CALL_RESULT (the module
+    // invariant documented at the top of translate.ts).
+    expect(chunks.filter((c) => c.type === 'TOOL_CALL_START')).toHaveLength(1)
+    expect(chunks.find((c) => c.type === 'TOOL_CALL_END')).toMatchObject({
+      toolCallId: 'toolu_9',
+    })
+    expect(chunks.find((c) => c.type === 'TOOL_CALL_RESULT')).toMatchObject({
+      toolCallId: 'toolu_9',
+      content: JSON.stringify({ status: 'interrupted' }),
+    })
+  })
+
+  it('closes an open partial text segment when the stream throws mid-text', async () => {
+    async function* throwing(): AsyncIterable<AgentSdkMessage> {
+      yield init
+      yield {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg-1' } },
+        parent_tool_use_id: null,
+      }
+      yield {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'text' },
+        },
+        parent_tool_use_id: null,
+      }
+      yield {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'Half a sent' },
+        },
+        parent_tool_use_id: null,
+      }
+      throw new Error('aborted')
+    }
+
+    const chunks: Array<StreamChunk> = []
+    await expect(async () => {
+      for await (const chunk of translateSdkStream(throwing(), makeContext())) {
+        chunks.push(chunk)
+      }
+    }).rejects.toThrow('aborted')
+
+    // TEXT_MESSAGE_START was emitted; the abort must still pair it with a
+    // TEXT_MESSAGE_END or the consumer's message stays open forever.
+    expect(chunks.find((c) => c.type === 'TEXT_MESSAGE_END')).toMatchObject({
+      messageId: 'msg-1',
+    })
+  })
+
+  it('tags a streamed tool call with the parent message id shared with sibling text', async () => {
+    const chunks = await collect([
+      init,
+      {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg-1' } },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'text' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'Reading…' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 1,
+          content_block: { type: 'tool_use', id: 'toolu_7', name: 'Read' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'input_json_delta', partial_json: '{"file":"a.ts"}' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 1 },
+        parent_tool_use_id: null,
+      },
+      resultSuccess,
+    ])
+
+    // The tool call must be grouped under the same message as the sibling text,
+    // so a downstream message rename can't orphan its later result.
+    expect(chunks.find((c) => c.type === 'TEXT_MESSAGE_START')).toMatchObject({
+      messageId: 'msg-1',
+    })
+    expect(chunks.find((c) => c.type === 'TOOL_CALL_START')).toMatchObject({
+      parentMessageId: 'msg-1',
+    })
+  })
+
+  it('correlates interleaved tool_use blocks by event index', async () => {
+    const chunks = await collect([
+      init,
+      {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg-1' } },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_a', name: 'Read' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 1,
+          content_block: { type: 'tool_use', id: 'toolu_b', name: 'Bash' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '{"file":"a.ts"}' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'input_json_delta', partial_json: '{"cmd":"ls"}' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 1 },
+        parent_tool_use_id: null,
+      },
+      resultSuccess,
+    ])
+
+    const ends = chunks.filter((c) => c.type === 'TOOL_CALL_END')
+    expect(ends).toHaveLength(2)
+    expect(ends[0]).toMatchObject({
+      toolCallId: 'toolu_a',
+      input: { file: 'a.ts' },
+    })
+    expect(ends[1]).toMatchObject({
+      toolCallId: 'toolu_b',
+      input: { cmd: 'ls' },
+    })
+
+    const args = chunks.filter((c) => c.type === 'TOOL_CALL_ARGS')
+    expect(args[0]).toMatchObject({
+      toolCallId: 'toolu_a',
+      delta: '{"file":"a.ts"}',
+    })
+    expect(args[1]).toMatchObject({
+      toolCallId: 'toolu_b',
+      delta: '{"cmd":"ls"}',
+    })
+  })
+
+  it('streams a zero-argument tool call as START → END with no args frame', async () => {
+    const chunks = await collect([
+      init,
+      {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg-1' } },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_z', name: 'Now' },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+        parent_tool_use_id: null,
+      },
+      resultSuccess,
+    ])
+
+    // Mirrors the @tanstack/ai-anthropic streaming path: no input_json_delta
+    // means no ARGS frame: START then END(input={}), never a synthesized one.
+    const toolTypes = chunks
+      .map((c) => c.type)
+      .filter((t) => t.startsWith('TOOL_CALL_'))
+    expect(toolTypes).toEqual([
+      'TOOL_CALL_START',
+      'TOOL_CALL_END',
+      'TOOL_CALL_RESULT',
+    ])
+    expect(chunks.find((c) => c.type === 'TOOL_CALL_END')).toMatchObject({
+      toolCallId: 'toolu_z',
+      input: {},
+    })
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2524,6 +2524,12 @@ importers:
       '@tanstack/ai-react-ui':
         specifier: workspace:*
         version: link:../../packages/ai-react-ui
+      '@tanstack/ai-sandbox':
+        specifier: workspace:*
+        version: link:../../packages/ai-sandbox
+      '@tanstack/ai-sandbox-local-process':
+        specifier: workspace:*
+        version: link:../../packages/ai-sandbox-local-process
       '@tanstack/devtools-event-bus':
         specifier: ^0.4.1
         version: 0.4.1

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -33,6 +33,8 @@
     "@tanstack/ai-openrouter": "workspace:*",
     "@tanstack/ai-react": "workspace:*",
     "@tanstack/ai-react-ui": "workspace:*",
+    "@tanstack/ai-sandbox": "workspace:*",
+    "@tanstack/ai-sandbox-local-process": "workspace:*",
     "@tanstack/devtools-event-bus": "^0.4.1",
     "@tanstack/nitro-v2-vite-plugin": "^1.154.7",
     "@tanstack/react-ai-devtools": "workspace:*",

--- a/testing/e2e/tests/claude-code.spec.ts
+++ b/testing/e2e/tests/claude-code.spec.ts
@@ -15,7 +15,20 @@
 import { expect, test } from '@playwright/test'
 import { chat } from '@tanstack/ai'
 import { claudeCodeText } from '@tanstack/ai-claude-code'
+import { defineSandbox, withSandbox } from '@tanstack/ai-sandbox'
+import { localProcessSandbox } from '@tanstack/ai-sandbox-local-process'
 import type { StreamChunk } from '@tanstack/ai'
+
+const sandbox = defineSandbox({
+  id: 'claude-code-e2e',
+  provider: localProcessSandbox(),
+  workspace: {
+    source: { type: 'none' },
+    instructions: 'Claude Code streaming smoke test workspace.',
+  },
+  lifecycle: { reuse: 'none', snapshot: 'none', destroyOnComplete: true },
+  fileEvents: false,
+})
 
 test.describe('claude-code harness (gated live smoke)', () => {
   test.skip(
@@ -34,6 +47,7 @@ test.describe('claude-code harness (gated live smoke)', () => {
         // that would prompt, and no tools are bridged.
         disallowedTools: ['Bash', 'Write', 'Edit'],
       }),
+      middleware: [withSandbox(sandbox)],
       messages: [
         {
           role: 'user',
@@ -68,5 +82,50 @@ test.describe('claude-code harness (gated live smoke)', () => {
       .map((chunk) => (chunk as { delta?: string }).delta ?? '')
       .join('')
     expect(text.toLowerCase()).toContain('pong')
+  })
+
+  test('streams tool-call argument deltas', async () => {
+    test.setTimeout(180_000)
+
+    const filePath = 'AGENTS.md'
+    const chunks: Array<StreamChunk> = []
+    const stream = chat({
+      adapter: claudeCodeText('haiku', {
+        maxTurns: 2,
+        allowedTools: ['Read'],
+        disallowedTools: ['Bash', 'Write', 'Edit'],
+      }),
+      middleware: [withSandbox(sandbox)],
+      messages: [
+        {
+          role: 'user',
+          content: `Use the Read tool exactly once to read ${filePath}.`,
+        },
+      ],
+    })
+
+    for await (const chunk of stream) chunks.push(chunk)
+
+    const start = chunks.find(
+      (chunk) =>
+        chunk.type === 'TOOL_CALL_START' && chunk.toolCallName === 'Read',
+    )
+    expect(start).toBeDefined()
+
+    const args = chunks.filter(
+      (chunk) =>
+        chunk.type === 'TOOL_CALL_ARGS' &&
+        chunk.toolCallId === start?.toolCallId,
+    )
+    expect(args.length).toBeGreaterThan(0)
+    expect(args.every((chunk) => !('args' in chunk))).toBe(true)
+    expect(args.map((chunk) => chunk.delta).join('')).toContain(filePath)
+
+    const endIndex = chunks.findIndex(
+      (chunk) =>
+        chunk.type === 'TOOL_CALL_END' &&
+        chunk.toolCallId === start?.toolCallId,
+    )
+    expect(endIndex).toBeGreaterThan(chunks.indexOf(args[0]))
   })
 })


### PR DESCRIPTION
## What

Stream Claude Code tool-call arguments from the SDK's partial message events:

- `content_block_start` with `tool_use` emits `TOOL_CALL_START`
- each `input_json_delta.partial_json` emits one `TOOL_CALL_ARGS` delta
- `content_block_stop` emits `TOOL_CALL_END`

The translator correlates tool blocks by SDK event index and deduplicates the later complete assistant message. With `streamPartials: false`, the existing whole-tool-call behavior remains unchanged.

This enables structured output routed through a tool call to render incrementally instead of appearing only when the complete message arrives.

## Why

Claude Code's final `structured_output` is not streamed. The Agent SDK's recommended streaming path is to consume partial `tool_use` events and forward each `input_json_delta` as it arrives.

## Test plan

- Added translator coverage for exact argument deltas, deduplication, interleaved tool blocks, malformed JSON, unsupported blocks, zero-argument tools, and interrupted streams.
- Added subprocess-boundary coverage for exact delta forwarding.
- Passed the gated live Claude smoke test for streamed tool-call arguments.
- `pnpm test:pr`

Closes #901.
