### PR TITLE
feat(ai-mistral): support document (PDF) input via document_url

### DIFF
--- a/.changeset/mistral-document-input.md
+++ b/.changeset/mistral-document-input.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-mistral': minor
+---
+
+Support document (PDF) input for Mistral vision models via `document_url`. The text adapter now maps `document` content parts to Mistral's `document_url` format (hosted URLs pass through; inline bytes are wrapped in a `data:` URL, mirroring image handling), and `document` is declared as an input modality for the vision-capable models. Previously any `document` content part threw "Supported types: text, image".

--- a/packages/ai-mistral/src/adapters/text.ts
+++ b/packages/ai-mistral/src/adapters/text.ts
@@ -1021,8 +1021,17 @@ export class MistralTextAdapter<
       }
     }
 
+    if (part.type === 'document') {
+      const documentValue = part.source.value
+      const documentUrl =
+        part.source.type === 'data' && !documentValue.startsWith('data:')
+          ? `data:${part.source.mimeType};base64,${documentValue}`
+          : documentValue
+      return { type: 'document_url', documentUrl }
+    }
+
     throw new Error(
-      `Mistral text adapter does not support content part of type '${(part as ContentPart).type}'. Supported types: text, image. Use a vision-capable model (pixtral-large-latest, pixtral-12b-2409, mistral-medium-latest, or mistral-small-latest) for images.`,
+      `Mistral text adapter does not support content part of type '${(part as ContentPart).type}'. Supported types: text, image, document. Use a vision-capable model (mistral-medium-latest or mistral-small-latest) for images and documents.`,
     )
   }
 

--- a/packages/ai-mistral/src/model-meta.ts
+++ b/packages/ai-mistral/src/model-meta.ts
@@ -19,7 +19,7 @@ interface ModelMeta<TProviderOptions = unknown> {
     output?: { normal: number }
   }
   supports: {
-    input: Array<'text' | 'image' | 'audio'>
+    input: Array<'text' | 'image' | 'audio' | 'document'>
     output: Array<'text'>
     endpoints: Array<'chat' | 'embeddings'>
 
@@ -61,7 +61,7 @@ const MISTRAL_MEDIUM_LATEST = {
     output: { normal: 2 },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat'],
     features: ['streaming', 'tools', 'json_object', 'json_schema', 'vision'],
@@ -77,7 +77,7 @@ const MISTRAL_SMALL_LATEST = {
     output: { normal: 0.3 },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat'],
     features: ['streaming', 'tools', 'json_object', 'json_schema', 'vision'],
@@ -141,7 +141,7 @@ const PIXTRAL_LARGE_LATEST = {
     output: { normal: 6 },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat'],
     features: ['streaming', 'tools', 'json_object', 'json_schema', 'vision'],
@@ -157,7 +157,7 @@ const PIXTRAL_12B_2409 = {
     output: { normal: 0.15 },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat'],
     features: ['streaming', 'tools', 'json_object', 'vision'],

--- a/packages/ai-mistral/tests/document-input.test.ts
+++ b/packages/ai-mistral/tests/document-input.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { createMistralText } from '../src/adapters/text'
+import type { DocumentPart } from '@tanstack/ai'
+
+// `convertContentPartToMistral` is private; reach it directly so the test
+// exercises the document mapping without standing up an HTTP mock. The
+// `messageToWire` step then snake-cases `documentUrl` -> `document_url`.
+const convertContentPart = (
+  adapter: ReturnType<typeof createMistralText>,
+  part: DocumentPart,
+): unknown =>
+  (
+    adapter as unknown as {
+      convertContentPartToMistral: (p: DocumentPart) => unknown
+    }
+  ).convertContentPartToMistral(part)
+
+describe('mistral document content parts', () => {
+  const adapter = createMistralText('mistral-small-latest', 'test-key')
+
+  it('maps a hosted-URL document to a document_url part', () => {
+    const part: DocumentPart = {
+      type: 'document',
+      source: { type: 'url', value: 'https://example.com/contract.pdf' },
+    }
+
+    expect(convertContentPart(adapter, part)).toEqual({
+      type: 'document_url',
+      documentUrl: 'https://example.com/contract.pdf',
+    })
+  })
+
+  it('wraps inline base64 document bytes in a data: URL', () => {
+    const part: DocumentPart = {
+      type: 'document',
+      source: {
+        type: 'data',
+        value: 'JVBERi0xLjQ=',
+        mimeType: 'application/pdf',
+      },
+    }
+
+    expect(convertContentPart(adapter, part)).toEqual({
+      type: 'document_url',
+      documentUrl: 'data:application/pdf;base64,JVBERi0xLjQ=',
+    })
+  })
+
+  it('passes through a data: URL that is already formatted', () => {
+    const part: DocumentPart = {
+      type: 'document',
+      source: {
+        type: 'data',
+        value: 'data:application/pdf;base64,JVBERi0xLjQ=',
+        mimeType: 'application/pdf',
+      },
+    }
+
+    expect(convertContentPart(adapter, part)).toEqual({
+      type: 'document_url',
+      documentUrl: 'data:application/pdf;base64,JVBERi0xLjQ=',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

The Mistral text adapter is half-wired for document (PDF) input: `messageToWire` already snake-cases a `document_url` part, but `convertContentPartToMistral` never produces one — it throws `"Supported types: text, image"` for any `document` content part — and `model-meta` declares no `document` input modality. As a result, `document` content parts can't be sent to Mistral even though the API supports them and the other provider adapters (Anthropic, Gemini, Bedrock, OpenAI) already expose PDF input.

This PR closes that gap.

## Changes

- **`adapters/text.ts`**: add a `document` branch to `convertContentPartToMistral`, mirroring the existing `image` branch — hosted URLs pass through, inline `data` bytes are wrapped in a `data:<mime>;base64,…` URL — returning `{ type: 'document_url', documentUrl }` (which `messageToWire` already maps to the wire `document_url`). Updated the fallback error message accordingly.
- **`model-meta.ts`**: add `'document'` to the `supports.input` modality union and to the vision-capable models that already declare `image`.
- **`tests/document-input.test.ts`**: unit tests for the new mapping (hosted URL, inline base64, already-formatted `data:` URL).

## Verification

Checked against Mistral's own API (not just docs):

- `GET /v1/models` reports `vision: true` for the affected models.
- `document_url` round-trips a PDF end-to-end on `mistral-small-latest` and `mistral-medium-latest`, for **both** a hosted URL and an inline base64 `data:` URL — the model returns the document's text.
- `nx build ai-mistral` (typecheck + dts) passes; new unit tests pass; `eslint` clean on the changed files.

## Notes

- `document` is added to the four models that already declare `image`, since Mistral routes both through the same vision pipeline; `mistral-small-latest` and `mistral-medium-latest` were verified live. Happy to narrow or expand the set (e.g. Mistral's API now also reports `vision: true` for `mistral-large-latest`, `magistral-*`, and `ministral-*`) if maintainers prefer.
- Scope is limited to the `document` input path; no changes to the OCR endpoint or other modalities.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for document/PDF inputs in Mistral vision-capable models.
  * Document content can now be sent as a hosted URL or inline data, matching existing media handling.

* **Bug Fixes**
  * Improved input validation so document parts are no longer rejected for supported models.
  * Updated supported input types for affected Mistral models to include documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->