### PR TITLE
fix(ai-gemini): resolve GeminiClientConfig from concrete module in adapter types

### DIFF
--- a/.changeset/gemini-client-config-dts-import.md
+++ b/.changeset/gemini-client-config-dts-import.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-gemini': patch
+---
+
+fix(ai-gemini): fix `GeminiClientConfig` type import in the published adapter declarations. The emitted `.d.ts` files imported `GeminiClientConfig` from a non-existent `'../utils.js'` (the barrel builds to `utils/index.js`), so under `skipLibCheck` it silently resolved to `any` in consumers — masking client-config type-checking for every adapter and producing a spurious "`httpOptions` does not exist" error on `createGeminiVideo`. Adapters now import the type from the concrete `'../utils/client'` module so the declarations resolve to the real type.

--- a/packages/ai-gemini/src/adapters/audio.ts
+++ b/packages/ai-gemini/src/adapters/audio.ts
@@ -11,7 +11,7 @@ import type {
   AudioGenerationResult,
 } from '@tanstack/ai'
 import type { GoogleGenAI } from '@google/genai'
-import type { GeminiClientConfig } from '../utils'
+import type { GeminiClientConfig } from '../utils/client'
 
 /**
  * Provider options for Gemini Lyria music generation.

--- a/packages/ai-gemini/src/adapters/image.ts
+++ b/packages/ai-gemini/src/adapters/image.ts
@@ -37,7 +37,7 @@ import type {
   GoogleGenAI,
   Part,
 } from '@google/genai'
-import type { GeminiClientConfig } from '../utils'
+import type { GeminiClientConfig } from '../utils/client'
 
 /**
  * Configuration for Gemini image adapter

--- a/packages/ai-gemini/src/adapters/summarize.ts
+++ b/packages/ai-gemini/src/adapters/summarize.ts
@@ -3,7 +3,7 @@ import { getGeminiApiKeyFromEnv } from '../utils'
 import { GeminiTextAdapter } from './text'
 import type { InferTextProviderOptions } from '@tanstack/ai/adapters'
 import type { GEMINI_MODELS } from '../model-meta'
-import type { GeminiClientConfig } from '../utils'
+import type { GeminiClientConfig } from '../utils/client'
 
 /**
  * Configuration for Gemini summarize adapter

--- a/packages/ai-gemini/src/adapters/text.ts
+++ b/packages/ai-gemini/src/adapters/text.ts
@@ -41,7 +41,7 @@ import type {
   GeminiMessageMetadataByModality,
   GeminiToolCallMetadata,
 } from '../message-types'
-import type { GeminiClientConfig } from '../utils'
+import type { GeminiClientConfig } from '../utils/client'
 
 /**
  * Configuration for Gemini text adapter

--- a/packages/ai-gemini/src/adapters/tts.ts
+++ b/packages/ai-gemini/src/adapters/tts.ts
@@ -9,7 +9,7 @@ import { buildGeminiUsage } from '../usage'
 import type { GEMINI_TTS_MODELS, GeminiTTSVoice } from '../model-meta'
 import type { TTSOptions, TTSResult } from '@tanstack/ai'
 import type { GoogleGenAI, SpeechConfig } from '@google/genai'
-import type { GeminiClientConfig } from '../utils'
+import type { GeminiClientConfig } from '../utils/client'
 
 /**
  * Configuration for a single speaker in a multi-speaker dialogue.

--- a/packages/ai-gemini/src/adapters/video.ts
+++ b/packages/ai-gemini/src/adapters/video.ts
@@ -31,7 +31,7 @@ import type {
   GeminiVideoProviderOptions,
   GeminiVideoSize,
 } from '../video/video-provider-options'
-import type { GeminiClientConfig } from '../utils'
+import type { GeminiClientConfig } from '../utils/client'
 
 /**
  * Configuration for Gemini video adapter.


### PR DESCRIPTION
## Problem

The built `.d.ts` files for the Gemini adapters import `GeminiClientConfig` from `'../utils.js'`, but the `utils` barrel builds to `utils/index.js` — no `utils.js` file exists. Under a consumer's `skipLibCheck` this import silently resolves `GeminiClientConfig` to `any`, which:

- disables client-config type-checking for **every** Gemini adapter (the inherited `GoogleGenAIOptions` fields — `httpOptions`, `apiVersion`, `vertexai`, … — vanish from the public types), and
- for the one config with an own member (`GeminiVideoConfig.allowUrlFetch`), the collapsed `Omit` becomes a non-empty weak type, surfacing a **spurious** `` `httpOptions` does not exist `` excess-property error at call sites.

This is what caused `@tanstack/ai-e2e:test:types` to fail after #820 enabled type-checking of `testing/**`.

## Fix

Import the client utilities from the concrete `'../utils/client'` module (matching the `ai-openai` convention) so the emitted declarations point at a file that actually exists and resolve to the real type. Gemini config options are fully typed for consumers again.

## Verification

- `nx run-many --targets=test:types,test:eslint,test:lib,test:build,build --projects=@tanstack/ai-gemini` — all green
- Confirmed the emitted `.d.ts` now imports `'../utils/client.js'` and that `httpOptions` (and the other `GoogleGenAIOptions` fields) are genuine, type-checked keys on the Gemini configs.

Once merged, the `test/gemini-tts-e2e` branch (#—, harshlocham's Gemini TTS matrix PR) will be rebased to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected type resolution for Gemini adapter configurations, improving TypeScript accuracy for consumers.
  * Prevented missing-type and `any` fallback issues that could affect editor feedback and type-checking.
  * Fixed a declaration issue that could cause incorrect errors when using video generation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->