### PR TITLE
fix(ai): reject non-streaming chat on run errors

### DIFF
--- a/.changeset/calm-lions-throw.md
+++ b/.changeset/calm-lions-throw.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai': patch
+---
+
+Reject non-streaming text calls when their event stream ends with a `RUN_ERROR`.

--- a/packages/ai/src/activities/chat/stream/processor.ts
+++ b/packages/ai/src/activities/chat/stream/processor.ts
@@ -22,8 +22,9 @@ import {
   generateMessageId,
   uiMessageToModelMessages,
 } from '../messages.js'
-import { normalizeToolResult } from '../../../utilities/tool-result'
+import { runErrorEventToError } from '../../../utilities/errors'
 import { isProviderExecutedToolCall } from '../../../utilities/provider-executed'
+import { normalizeToolResult } from '../../../utilities/tool-result'
 import { defaultJSONParser } from './json-parser'
 import {
   appendStructuredOutputDelta,
@@ -1501,15 +1502,7 @@ export class StreamProcessor {
     // the surfaced Error so consumers can recover the upstream detail that the
     // RUN_ERROR's `message` alone discards. Both are optional and added only
     // when present, keeping the Error backward compatible.
-    const error = new Error(errorMessage)
-    const code = chunk.code ?? chunk.error?.code
-    if (code !== undefined) {
-      Object.assign(error, { code })
-    }
-    if (chunk.rawEvent !== undefined) {
-      Object.assign(error, { rawEvent: chunk.rawEvent })
-    }
-    this.events.onError?.(error)
+    this.events.onError?.(runErrorEventToError(chunk))
   }
 
   /**

--- a/packages/ai/src/activities/chat/stream/processor.ts
+++ b/packages/ai/src/activities/chat/stream/processor.ts
@@ -22,8 +22,9 @@ import {
   generateMessageId,
   uiMessageToModelMessages,
 } from '../messages.js'
-import { normalizeToolResult } from '../../../utilities/tool-result'
+import { runErrorEventToError } from '../../../utilities/errors'
 import { isProviderExecutedToolCall } from '../../../utilities/provider-executed'
+import { normalizeToolResult } from '../../../utilities/tool-result'
 import { defaultJSONParser } from './json-parser'
 import {
   appendStructuredOutputDelta,
@@ -1681,15 +1682,7 @@ export class StreamProcessor {
     // the surfaced Error so consumers can recover the upstream detail that the
     // RUN_ERROR's `message` alone discards. Both are optional and added only
     // when present, keeping the Error backward compatible.
-    const error = new Error(errorMessage)
-    const code = chunk.code ?? chunk.error?.code
-    if (code !== undefined) {
-      Object.assign(error, { code })
-    }
-    if (chunk.rawEvent !== undefined) {
-      Object.assign(error, { rawEvent: chunk.rawEvent })
-    }
-    this.events.onError?.(error)
+    this.events.onError?.(runErrorEventToError(chunk))
   }
 
   /**

--- a/packages/ai/src/stream-to-response.ts
+++ b/packages/ai/src/stream-to-response.ts
@@ -1,4 +1,5 @@
 import { toRunErrorPayload } from './activities/error-payload'
+import { runErrorEventToError } from './utilities/errors'
 import type { StreamChunk } from './types'
 
 /**
@@ -27,6 +28,10 @@ export async function streamToText(
   let accumulatedContent = ''
 
   for await (const chunk of stream) {
+    if (chunk.type === 'RUN_ERROR') {
+      throw runErrorEventToError(chunk)
+    }
+
     if (chunk.type === 'TEXT_MESSAGE_CONTENT' && chunk.delta) {
       accumulatedContent += chunk.delta
     }

--- a/packages/ai/src/stream-to-response.ts
+++ b/packages/ai/src/stream-to-response.ts
@@ -9,6 +9,7 @@ import { notifyRunDisconnected } from './delivery-disconnect'
 import { resolveResumeRunId } from './stream-durability'
 import { EventType } from './types'
 import { resolveDebugOption } from './logger/resolve'
+import { runErrorEventToError } from './utilities/errors'
 import type { LockStore } from './activities/chat/middleware/locks'
 import type {
   RunRecord,
@@ -46,6 +47,10 @@ export async function streamToText(
   let accumulatedContent = ''
 
   for await (const chunk of stream) {
+    if (chunk.type === 'RUN_ERROR') {
+      throw runErrorEventToError(chunk)
+    }
+
     if (chunk.type === 'TEXT_MESSAGE_CONTENT' && chunk.delta) {
       accumulatedContent += chunk.delta
     }

--- a/packages/ai/src/utilities/errors.ts
+++ b/packages/ai/src/utilities/errors.ts
@@ -1,3 +1,5 @@
+import type { StreamChunk } from '../types'
+
 /**
  * Best-effort extraction of a human-readable message from an unknown thrown
  * value, returning `undefined` when none can be found.
@@ -26,4 +28,25 @@ export function errorTypeName(err: unknown): string {
     if (typeof n === 'string') return n
   }
   return 'Error'
+}
+
+/**
+ * Convert an AG-UI RUN_ERROR event to the Error shape exposed to consumers.
+ * Preserves the provider code and sanitized raw event when available, while
+ * accepting the deprecated nested error payload for backward compatibility.
+ */
+export function runErrorEventToError(
+  chunk: Extract<StreamChunk, { type: 'RUN_ERROR' }>,
+): Error {
+  const error = new Error(
+    chunk.message || chunk.error?.message || 'An error occurred',
+  )
+  const code = chunk.code ?? chunk.error?.code
+  if (code !== undefined) {
+    Object.assign(error, { code })
+  }
+  if (chunk.rawEvent !== undefined) {
+    Object.assign(error, { rawEvent: chunk.rawEvent })
+  }
+  return error
 }

--- a/packages/ai/tests/stream-to-response.test.ts
+++ b/packages/ai/tests/stream-to-response.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
+  streamToText,
   toServerSentEventsStream,
   toServerSentEventsResponse,
 } from '../src/stream-to-response'
@@ -33,6 +34,36 @@ async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
 
   return result
 }
+
+describe('streamToText', () => {
+  it('rejects on RUN_ERROR instead of returning accumulated text', async () => {
+    const rawEvent = {
+      provider_name: 'test-provider',
+      raw: { reason: 'upstream overloaded' },
+    }
+    const stream = createMockStream([
+      {
+        type: 'TEXT_MESSAGE_CONTENT',
+        messageId: 'msg-1',
+        timestamp: Date.now(),
+        delta: 'partial text',
+      },
+      {
+        type: 'RUN_ERROR',
+        timestamp: Date.now(),
+        message: 'Provider request failed',
+        code: 'rate_limit_exceeded',
+        rawEvent,
+      },
+    ])
+
+    await expect(streamToText(stream)).rejects.toMatchObject({
+      message: 'Provider request failed',
+      code: 'rate_limit_exceeded',
+      rawEvent,
+    })
+  })
+})
 
 describe('toServerSentEventsStream', () => {
   it('should convert chunks to SSE format', async () => {

--- a/testing/e2e/src/routeTree.gen.ts
+++ b/testing/e2e/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as ApiOpenrouterWebToolsWireRouteImport } from './routes/api.open
 import { Route as ApiOpenrouterCostRouteImport } from './routes/api.openrouter-cost'
 import { Route as ApiOpenaiUsageDetailsRouteImport } from './routes/api.openai-usage-details'
 import { Route as ApiOpenaiShellSkillsWireRouteImport } from './routes/api.openai-shell-skills-wire'
+import { Route as ApiNonStreamingRunErrorRouteImport } from './routes/api.non-streaming-run-error'
 import { Route as ApiMultimodalToolResultWireRouteImport } from './routes/api.multimodal-tool-result-wire'
 import { Route as ApiMiddlewareTestRouteImport } from './routes/api.middleware-test'
 import { Route as ApiMcpTestRouteImport } from './routes/api.mcp-test'
@@ -181,6 +182,11 @@ const ApiOpenaiShellSkillsWireRoute =
     path: '/api/openai-shell-skills-wire',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiNonStreamingRunErrorRoute = ApiNonStreamingRunErrorRouteImport.update({
+  id: '/api/non-streaming-run-error',
+  path: '/api/non-streaming-run-error',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiMultimodalToolResultWireRoute =
   ApiMultimodalToolResultWireRouteImport.update({
     id: '/api/multimodal-tool-result-wire',
@@ -335,6 +341,7 @@ export interface FileRoutesByFullPath {
   '/api/mcp-test': typeof ApiMcpTestRoute
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
   '/api/multimodal-tool-result-wire': typeof ApiMultimodalToolResultWireRoute
+  '/api/non-streaming-run-error': typeof ApiNonStreamingRunErrorRoute
   '/api/openai-shell-skills-wire': typeof ApiOpenaiShellSkillsWireRoute
   '/api/openai-usage-details': typeof ApiOpenaiUsageDetailsRoute
   '/api/openrouter-cost': typeof ApiOpenrouterCostRoute
@@ -385,6 +392,7 @@ export interface FileRoutesByTo {
   '/api/mcp-test': typeof ApiMcpTestRoute
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
   '/api/multimodal-tool-result-wire': typeof ApiMultimodalToolResultWireRoute
+  '/api/non-streaming-run-error': typeof ApiNonStreamingRunErrorRoute
   '/api/openai-shell-skills-wire': typeof ApiOpenaiShellSkillsWireRoute
   '/api/openai-usage-details': typeof ApiOpenaiUsageDetailsRoute
   '/api/openrouter-cost': typeof ApiOpenrouterCostRoute
@@ -436,6 +444,7 @@ export interface FileRoutesById {
   '/api/mcp-test': typeof ApiMcpTestRoute
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
   '/api/multimodal-tool-result-wire': typeof ApiMultimodalToolResultWireRoute
+  '/api/non-streaming-run-error': typeof ApiNonStreamingRunErrorRoute
   '/api/openai-shell-skills-wire': typeof ApiOpenaiShellSkillsWireRoute
   '/api/openai-usage-details': typeof ApiOpenaiUsageDetailsRoute
   '/api/openrouter-cost': typeof ApiOpenrouterCostRoute
@@ -488,6 +497,7 @@ export interface FileRouteTypes {
     | '/api/mcp-test'
     | '/api/middleware-test'
     | '/api/multimodal-tool-result-wire'
+    | '/api/non-streaming-run-error'
     | '/api/openai-shell-skills-wire'
     | '/api/openai-usage-details'
     | '/api/openrouter-cost'
@@ -538,6 +548,7 @@ export interface FileRouteTypes {
     | '/api/mcp-test'
     | '/api/middleware-test'
     | '/api/multimodal-tool-result-wire'
+    | '/api/non-streaming-run-error'
     | '/api/openai-shell-skills-wire'
     | '/api/openai-usage-details'
     | '/api/openrouter-cost'
@@ -588,6 +599,7 @@ export interface FileRouteTypes {
     | '/api/mcp-test'
     | '/api/middleware-test'
     | '/api/multimodal-tool-result-wire'
+    | '/api/non-streaming-run-error'
     | '/api/openai-shell-skills-wire'
     | '/api/openai-usage-details'
     | '/api/openrouter-cost'
@@ -639,6 +651,7 @@ export interface RootRouteChildren {
   ApiMcpTestRoute: typeof ApiMcpTestRoute
   ApiMiddlewareTestRoute: typeof ApiMiddlewareTestRoute
   ApiMultimodalToolResultWireRoute: typeof ApiMultimodalToolResultWireRoute
+  ApiNonStreamingRunErrorRoute: typeof ApiNonStreamingRunErrorRoute
   ApiOpenaiShellSkillsWireRoute: typeof ApiOpenaiShellSkillsWireRoute
   ApiOpenaiUsageDetailsRoute: typeof ApiOpenaiUsageDetailsRoute
   ApiOpenrouterCostRoute: typeof ApiOpenrouterCostRoute
@@ -822,6 +835,13 @@ declare module '@tanstack/react-router' {
       path: '/api/openai-shell-skills-wire'
       fullPath: '/api/openai-shell-skills-wire'
       preLoaderRoute: typeof ApiOpenaiShellSkillsWireRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/non-streaming-run-error': {
+      id: '/api/non-streaming-run-error'
+      path: '/api/non-streaming-run-error'
+      fullPath: '/api/non-streaming-run-error'
+      preLoaderRoute: typeof ApiNonStreamingRunErrorRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/multimodal-tool-result-wire': {
@@ -1084,6 +1104,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiMcpTestRoute: ApiMcpTestRoute,
   ApiMiddlewareTestRoute: ApiMiddlewareTestRoute,
   ApiMultimodalToolResultWireRoute: ApiMultimodalToolResultWireRoute,
+  ApiNonStreamingRunErrorRoute: ApiNonStreamingRunErrorRoute,
   ApiOpenaiShellSkillsWireRoute: ApiOpenaiShellSkillsWireRoute,
   ApiOpenaiUsageDetailsRoute: ApiOpenaiUsageDetailsRoute,
   ApiOpenrouterCostRoute: ApiOpenrouterCostRoute,

--- a/testing/e2e/src/routeTree.gen.ts
+++ b/testing/e2e/src/routeTree.gen.ts
@@ -49,6 +49,7 @@ import { Route as ApiOpenrouterCostRouteImport } from './routes/api.openrouter-c
 import { Route as ApiOpenaiUsageDetailsRouteImport } from './routes/api.openai-usage-details'
 import { Route as ApiOpenaiShellSkillsWireRouteImport } from './routes/api.openai-shell-skills-wire'
 import { Route as ApiOpenaiCompletedResponseTextRouteImport } from './routes/api.openai-completed-response-text'
+import { Route as ApiNonStreamingRunErrorRouteImport } from './routes/api.non-streaming-run-error'
 import { Route as ApiMultimodalToolResultWireRouteImport } from './routes/api.multimodal-tool-result-wire'
 import { Route as ApiMiddlewareTestRouteImport } from './routes/api.middleware-test'
 import { Route as ApiMessageIdsRouteImport } from './routes/api.message-ids'
@@ -298,6 +299,11 @@ const ApiOpenaiCompletedResponseTextRoute =
     path: '/api/openai-completed-response-text',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiNonStreamingRunErrorRoute = ApiNonStreamingRunErrorRouteImport.update({
+  id: '/api/non-streaming-run-error',
+  path: '/api/non-streaming-run-error',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiMultimodalToolResultWireRoute =
   ApiMultimodalToolResultWireRouteImport.update({
     id: '/api/multimodal-tool-result-wire',
@@ -548,6 +554,7 @@ export interface FileRoutesByFullPath {
   '/api/message-ids': typeof ApiMessageIdsRoute
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
   '/api/multimodal-tool-result-wire': typeof ApiMultimodalToolResultWireRoute
+  '/api/non-streaming-run-error': typeof ApiNonStreamingRunErrorRoute
   '/api/openai-completed-response-text': typeof ApiOpenaiCompletedResponseTextRoute
   '/api/openai-shell-skills-wire': typeof ApiOpenaiShellSkillsWireRoute
   '/api/openai-usage-details': typeof ApiOpenaiUsageDetailsRoute
@@ -628,6 +635,7 @@ export interface FileRoutesByTo {
   '/api/message-ids': typeof ApiMessageIdsRoute
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
   '/api/multimodal-tool-result-wire': typeof ApiMultimodalToolResultWireRoute
+  '/api/non-streaming-run-error': typeof ApiNonStreamingRunErrorRoute
   '/api/openai-completed-response-text': typeof ApiOpenaiCompletedResponseTextRoute
   '/api/openai-shell-skills-wire': typeof ApiOpenaiShellSkillsWireRoute
   '/api/openai-usage-details': typeof ApiOpenaiUsageDetailsRoute
@@ -709,6 +717,7 @@ export interface FileRoutesById {
   '/api/message-ids': typeof ApiMessageIdsRoute
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
   '/api/multimodal-tool-result-wire': typeof ApiMultimodalToolResultWireRoute
+  '/api/non-streaming-run-error': typeof ApiNonStreamingRunErrorRoute
   '/api/openai-completed-response-text': typeof ApiOpenaiCompletedResponseTextRoute
   '/api/openai-shell-skills-wire': typeof ApiOpenaiShellSkillsWireRoute
   '/api/openai-usage-details': typeof ApiOpenaiUsageDetailsRoute
@@ -791,6 +800,7 @@ export interface FileRouteTypes {
     | '/api/message-ids'
     | '/api/middleware-test'
     | '/api/multimodal-tool-result-wire'
+    | '/api/non-streaming-run-error'
     | '/api/openai-completed-response-text'
     | '/api/openai-shell-skills-wire'
     | '/api/openai-usage-details'
@@ -871,6 +881,7 @@ export interface FileRouteTypes {
     | '/api/message-ids'
     | '/api/middleware-test'
     | '/api/multimodal-tool-result-wire'
+    | '/api/non-streaming-run-error'
     | '/api/openai-completed-response-text'
     | '/api/openai-shell-skills-wire'
     | '/api/openai-usage-details'
@@ -951,6 +962,7 @@ export interface FileRouteTypes {
     | '/api/message-ids'
     | '/api/middleware-test'
     | '/api/multimodal-tool-result-wire'
+    | '/api/non-streaming-run-error'
     | '/api/openai-completed-response-text'
     | '/api/openai-shell-skills-wire'
     | '/api/openai-usage-details'
@@ -1032,6 +1044,7 @@ export interface RootRouteChildren {
   ApiMessageIdsRoute: typeof ApiMessageIdsRoute
   ApiMiddlewareTestRoute: typeof ApiMiddlewareTestRoute
   ApiMultimodalToolResultWireRoute: typeof ApiMultimodalToolResultWireRoute
+  ApiNonStreamingRunErrorRoute: typeof ApiNonStreamingRunErrorRoute
   ApiOpenaiCompletedResponseTextRoute: typeof ApiOpenaiCompletedResponseTextRoute
   ApiOpenaiShellSkillsWireRoute: typeof ApiOpenaiShellSkillsWireRoute
   ApiOpenaiUsageDetailsRoute: typeof ApiOpenaiUsageDetailsRoute
@@ -1335,6 +1348,13 @@ declare module '@tanstack/react-router' {
       path: '/api/openai-completed-response-text'
       fullPath: '/api/openai-completed-response-text'
       preLoaderRoute: typeof ApiOpenaiCompletedResponseTextRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/non-streaming-run-error': {
+      id: '/api/non-streaming-run-error'
+      path: '/api/non-streaming-run-error'
+      fullPath: '/api/non-streaming-run-error'
+      preLoaderRoute: typeof ApiNonStreamingRunErrorRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/multimodal-tool-result-wire': {
@@ -1717,6 +1737,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiMessageIdsRoute: ApiMessageIdsRoute,
   ApiMiddlewareTestRoute: ApiMiddlewareTestRoute,
   ApiMultimodalToolResultWireRoute: ApiMultimodalToolResultWireRoute,
+  ApiNonStreamingRunErrorRoute: ApiNonStreamingRunErrorRoute,
   ApiOpenaiCompletedResponseTextRoute: ApiOpenaiCompletedResponseTextRoute,
   ApiOpenaiShellSkillsWireRoute: ApiOpenaiShellSkillsWireRoute,
   ApiOpenaiUsageDetailsRoute: ApiOpenaiUsageDetailsRoute,

--- a/testing/e2e/src/routes/api.non-streaming-run-error.ts
+++ b/testing/e2e/src/routes/api.non-streaming-run-error.ts
@@ -1,0 +1,54 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { chat } from '@tanstack/ai'
+import { createOpenaiChat } from '@tanstack/ai-openai'
+
+const DUMMY_KEY = 'sk-e2e-test-dummy-key'
+const ERROR_MESSAGE = 'Synthetic upstream failure'
+
+export const Route = createFileRoute('/api/non-streaming-run-error')({
+  server: {
+    handlers: {
+      POST: async () => {
+        const adapter = createOpenaiChat('gpt-5.2', DUMMY_KEY, {
+          fetch: async () =>
+            Response.json(
+              {
+                error: {
+                  message: ERROR_MESSAGE,
+                  type: 'rate_limit_error',
+                  code: 'rate_limit_exceeded',
+                },
+              },
+              { status: 429 },
+            ),
+        })
+
+        try {
+          const text = await chat({
+            adapter,
+            messages: [
+              {
+                role: 'user',
+                content: '[non-streaming-error] trigger the synthetic failure',
+              },
+            ],
+            stream: false,
+          })
+
+          return Response.json({ rejected: false, text })
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          const code =
+            error !== null &&
+            typeof error === 'object' &&
+            'code' in error &&
+            typeof error.code === 'string'
+              ? error.code
+              : null
+
+          return Response.json({ rejected: true, message, code })
+        }
+      },
+    },
+  },
+})

--- a/testing/e2e/tests/non-streaming-run-error.spec.ts
+++ b/testing/e2e/tests/non-streaming-run-error.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from './fixtures'
+
+test('non-streaming chat rejects when the provider stream emits RUN_ERROR', async ({
+  request,
+}) => {
+  const response = await request.post('/api/non-streaming-run-error')
+
+  expect(response.ok()).toBe(true)
+  await expect(response.json()).resolves.toMatchObject({
+    rejected: true,
+    message: expect.stringContaining('Synthetic upstream failure'),
+    code: 'rate_limit_exceeded',
+  })
+})


### PR DESCRIPTION
`chat({ stream: false })` used to return partial text after a provider `RUN_ERROR`. It now rejects with the same error as the streaming path.

## 🎯 Changes

- `streamToText` throws when the event stream emits `RUN_ERROR`.
- `StreamProcessor` and `streamToText` share `runErrorEventToError`, so the consumer `Error` keeps `code` and `rawEvent`.
- A unit test and a mocked OpenAI E2E route cover the rejection.
- Rebased onto `main` after #937. The only conflict was generated `testing/e2e/src/routeTree.gen.ts`. Both E2E routes stay.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.
- [ ] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

This is user-facing behavior, but there is no existing docs page for the non-streaming error path. The changeset is the user-visible note. I did not add a new docs page in this conflict rebase.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

**Commands run**

1. `pnpm --filter @tanstack/ai exec vitest run tests/stream-to-response.test.ts` — 30 passed
2. `pnpm --filter @tanstack/ai test:types` — passed after a workspace build
3. `pnpm --filter @tanstack/ai test:oxlint` — 0 errors
4. Skipped `pnpm test:pr` and the E2E spec in this pass (conflict was generated route tree only)

**Manual test**

1. Call `chat({ stream: false })` against a provider that returns HTTP 429.
2. Confirm the promise rejects. Old behavior: empty or partial string.
3. Confirm `error.message` and `error.code` match the provider.

**How this PR makes testing easy**

- `packages/ai/tests/stream-to-response.test.ts` rejects on `RUN_ERROR`
- `testing/e2e/tests/non-streaming-run-error.spec.ts` hits a mocked 429

## Risk / rollback

Low. Revert the PR. Streaming `onError` behavior does not change.

## Public API change

**Before**

```ts
const text = await chat({ adapter, messages, stream: false })
// text can be "" or partial after a provider RUN_ERROR
```

**After**

```ts
const text = await chat({ adapter, messages, stream: false })
// throws Error with message, code, and rawEvent from RUN_ERROR
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Non-streaming chat requests now reject when a provider reports a run error instead of returning incomplete text.
  * Error responses preserve the provider’s message, error code, and underlying event details.
  * Added a fallback message when run-error details are unavailable.

* **Tests**
  * Added coverage for non-streaming provider errors, including rate-limit failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->