### PR TITLE
feat: honor outputSchema in CLI harness adapters (codex, claude-code, opencode)

### DIFF
--- a/.changeset/harness-structured-output.md
+++ b/.changeset/harness-structured-output.md
@@ -1,0 +1,8 @@
+---
+'@tanstack/ai-codex': minor
+'@tanstack/ai-claude-code': minor
+'@tanstack/ai-opencode': minor
+'@tanstack/ai-grok-build': patch
+---
+
+feat: honor `outputSchema` in the CLI harness adapters that support it natively. `chat({ outputSchema })` now works with the Codex (`codex exec --output-schema`), Claude Code (`claude -p --json-schema`), and OpenCode (`json_schema` output format) harnesses — the schema-constrained answer is produced within the single harness run and harvested by the engine (via `supportsCombinedToolsAndSchema`), with no separate finalization round-trip. The Codex harness throws when `tools` and `outputSchema` are combined, because Codex silently drops the schema when MCP/tools are active (openai/codex#15451). The Grok Build harness now rejects `outputSchema` with an accurate message (the grok CLI has no schema mechanism).

--- a/docs/adapters/claude-code.md
+++ b/docs/adapters/claude-code.md
@@ -170,7 +170,25 @@ const stream = chat({
 
 ## Structured Output
 
-`structuredOutput()` uses the harness's native JSON-schema output format in a one-shot run (single turn, no tools). It works for finalization after a chat, but a plain provider adapter (e.g. `@tanstack/ai-anthropic`) is the better choice when structured extraction is the primary job — it's faster and doesn't spawn a subprocess.
+Pass `outputSchema` to `chat()` and the harness constrains its final answer to your schema in the **same** run — the adapter forwards the JSON Schema to `claude -p --json-schema`, and the schema-conforming result (returned in Claude Code's `structured_output`) is harvested by the engine. This works alongside the harness's own tools.
+
+```typescript
+import { chat } from "@tanstack/ai";
+import { claudeCodeText } from "@tanstack/ai-claude-code";
+import { z } from "zod";
+
+const result = await chat({
+  adapter: claudeCodeText("claude-sonnet-4-6"),
+  messages: [{ role: "user", content: "Audit deps and list the outdated ones." }],
+  outputSchema: z.object({
+    outdated: z.array(z.object({ name: z.string(), latest: z.string() })),
+  }),
+});
+
+result.outdated; // { name: string; latest: string }[] — typed and validated
+```
+
+For plain structured extraction that isn't a coding task, a provider adapter (e.g. `@tanstack/ai-anthropic`) is faster and doesn't spawn a subprocess.
 
 ## Limitations
 

--- a/docs/adapters/claude-code.md
+++ b/docs/adapters/claude-code.md
@@ -178,7 +178,7 @@ import { claudeCodeText } from "@tanstack/ai-claude-code";
 import { z } from "zod";
 
 const result = await chat({
-  adapter: claudeCodeText("claude-sonnet-4-6"),
+  adapter: claudeCodeText("claude-opus-4-8"),
   messages: [{ role: "user", content: "Audit deps and list the outdated ones." }],
   outputSchema: z.object({
     outdated: z.array(z.object({ name: z.string(), latest: z.string() })),

--- a/docs/adapters/codex.md
+++ b/docs/adapters/codex.md
@@ -170,7 +170,26 @@ const stream = chat({
 
 ## Structured Output
 
-`structuredOutput()` uses Codex's native `outputSchema` support in a fresh, read-only, one-shot thread whose final message is a JSON string conforming to your schema. It works for finalization after a chat, but a plain provider adapter (e.g. `@tanstack/ai-openai`) is the better choice when structured extraction is the primary job — it's faster and doesn't spawn a subprocess.
+Pass `outputSchema` to `chat()` and the harness constrains its final answer to your schema in the **same** run — the adapter forwards the JSON Schema to `codex exec --output-schema`, and the engine harvests the schema-conforming final message. No second call, no separate thread.
+
+```typescript
+import { chat } from "@tanstack/ai";
+import { codexText } from "@tanstack/ai-codex";
+import { z } from "zod";
+
+const result = await chat({
+  adapter: codexText("gpt-5.1-codex", { sandboxMode: "workspace-write" }),
+  messages: [{ role: "user", content: "Summarize the failing tests." }],
+  outputSchema: z.object({
+    failing: z.array(z.string()),
+    summary: z.string(),
+  }),
+});
+
+result.failing; // string[] — typed and validated
+```
+
+> **Cannot be combined with `tools`.** Codex silently drops the output schema whenever MCP servers / tools are active ([openai/codex#15451](https://github.com/openai/codex/issues/15451)), so the adapter throws if you pass both `tools` and `outputSchema`. Remove one. For plain structured extraction that isn't a coding task, a provider adapter (e.g. `@tanstack/ai-openai`) is faster and doesn't spawn a subprocess.
 
 ## Limitations
 

--- a/docs/adapters/opencode.md
+++ b/docs/adapters/opencode.md
@@ -175,7 +175,25 @@ const stream = chat({
 
 ## Structured Output
 
-`structuredOutput()` is best-effort: OpenCode's prompt API has no native JSON-schema channel, so the schema is embedded as a prompt instruction in a fresh, one-shot session and the final text is parsed (markdown fences are stripped when present). It works for finalization after a chat, but a plain provider adapter (e.g. `@tanstack/ai-openai`) is the better choice when structured extraction is the primary job — it's faster, deterministic, and doesn't spawn a harness.
+Pass `outputSchema` to `chat()` and the harness constrains its final answer to your schema in the **same** run — the adapter sends OpenCode's `json_schema` output format on the session prompt, and the schema-conforming result (returned on the message's `structured` field) is harvested by the engine. This works alongside the harness's own tools.
+
+```typescript
+import { chat } from "@tanstack/ai";
+import { opencodeText } from "@tanstack/ai-opencode";
+import { z } from "zod";
+
+const result = await chat({
+  adapter: opencodeText("anthropic/claude-sonnet-4-5"),
+  messages: [{ role: "user", content: "List the TODO comments in src/." }],
+  outputSchema: z.object({
+    todos: z.array(z.object({ file: z.string(), text: z.string() })),
+  }),
+});
+
+result.todos; // { file: string; text: string }[] — typed and validated
+```
+
+Requires an `@opencode-ai/sdk` new enough to expose the `json_schema` output format (v1.17+). For plain structured extraction that isn't a coding task, a provider adapter (e.g. `@tanstack/ai-openai`) is faster and doesn't spawn a harness.
 
 ## Limitations
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -197,7 +197,7 @@
           "label": "Overview",
           "to": "structured-outputs/overview",
           "addedAt": "2026-05-19",
-          "updatedAt": "2026-06-10"
+          "updatedAt": "2026-07-15"
         },
         {
           "label": "One-Shot Extraction",
@@ -592,19 +592,19 @@
           "label": "Claude Code",
           "to": "adapters/claude-code",
           "addedAt": "2026-06-12",
-          "updatedAt": "2026-06-30"
+          "updatedAt": "2026-07-15"
         },
         {
           "label": "Codex",
           "to": "adapters/codex",
           "addedAt": "2026-06-12",
-          "updatedAt": "2026-06-30"
+          "updatedAt": "2026-07-15"
         },
         {
           "label": "OpenCode",
           "to": "adapters/opencode",
           "addedAt": "2026-06-12",
-          "updatedAt": "2026-06-30"
+          "updatedAt": "2026-07-15"
         },
         {
           "label": "Grok Build",

--- a/docs/structured-outputs/overview.md
+++ b/docs/structured-outputs/overview.md
@@ -57,8 +57,11 @@ Every adapter handles structured output through its provider's native API:
 | Google Gemini | `responseSchema` |
 | Ollama | JSON mode with schema |
 | OpenRouter / Grok / Groq | `response_format` with `json_schema` |
+| Claude Code / Codex / OpenCode (CLI harnesses) | Native CLI schema flag, harvested from the single harness run |
 
 The provider-specific details are handled for you — the same `chat({ outputSchema })` call works across all of them.
+
+The CLI harness adapters constrain their final answer to the schema **within the same harness run** (Claude Code via `--json-schema`, Codex via `--output-schema`, OpenCode via its `json_schema` output format) — no extra round-trip. Two caveats: the Codex harness cannot combine `tools` with `outputSchema` (it silently drops the schema when tools/MCP are active, so the adapter throws), and the Grok Build and ACP-based harnesses expose no schema mechanism at all, so they reject `outputSchema`. See each [adapter page](../adapters/codex.md) for details.
 
 ### Anthropic schema complexity limits
 

--- a/packages/ai-claude-code/src/adapters/text.ts
+++ b/packages/ai-claude-code/src/adapters/text.ts
@@ -170,6 +170,14 @@ export class ClaudeCodeTextAdapter<
     if (config.streamPartials !== false) args.push('--include-partial-messages')
     if (resume !== undefined) args.push('--resume', q(resume))
 
+    // Structured output: constrain the final answer to the JSON Schema. Claude
+    // Code takes the schema inline; the schema-conformant result comes back in
+    // the final `result` message's `structured_output` field (which the
+    // stream-json result event carries), harvested by the engine.
+    if (options.outputSchema !== undefined) {
+      args.push('--json-schema', q(JSON.stringify(options.outputSchema)))
+    }
+
     // Precedence: per-call modelOptions > adapter config > policy > sandbox default.
     const permissionMode =
       modelOptions?.permissionMode ??
@@ -437,6 +445,9 @@ export class ClaudeCodeTextAdapter<
           ...(options.parentRunId !== undefined && {
             parentRunId: options.parentRunId,
           }),
+          ...(options.outputSchema !== undefined && {
+            structuredOutput: true,
+          }),
           genId: () => this.generateId(),
           onSdkMessage: (message) =>
             logger.provider(`provider=claude-code type=${message.type}`, {
@@ -506,13 +517,29 @@ export class ClaudeCodeTextAdapter<
     }
   }
 
+  /**
+   * Claude Code constrains its final answer to a JSON Schema via `claude -p
+   * --json-schema` in the single harness run; the schema-conformant JSON comes
+   * back in the result message's `structured_output` field. `outputSchema` is
+   * wired straight into `chatStream` and the engine harvests it — no separate
+   * finalization round-trip.
+   */
+  supportsCombinedToolsAndSchema(): boolean {
+    return true
+  }
+
+  /**
+   * Unreachable via `chat()` — `supportsCombinedToolsAndSchema()` routes every
+   * structured-output request through `chatStream`. Kept as a safety net for
+   * any direct caller of the non-combined path.
+   */
   structuredOutput(
     _options: StructuredOutputOptions<ClaudeCodeTextProviderOptions>,
   ): Promise<StructuredOutputResult<unknown>> {
     return Promise.reject(
       new Error(
-        'Structured output is not yet supported by the in-sandbox Claude Code adapter. ' +
-          'Use a model adapter (e.g. anthropic) for structured output, or omit outputSchema.',
+        'Claude Code structured output runs through chatStream (combined tools+schema mode); ' +
+          'structuredOutput() should not be called directly.',
       ),
     )
   }

--- a/packages/ai-claude-code/src/stream/translate.ts
+++ b/packages/ai-claude-code/src/stream/translate.ts
@@ -34,6 +34,16 @@ export interface TranslateContext {
   onSessionId?: (sessionId: string) => void
   /** Called for each raw SDK message, for logging. */
   onSdkMessage?: (message: AgentSdkMessage) => void
+  /**
+   * Structured-output mode (`chat({ outputSchema })`). When set, Claude Code
+   * was run with `--json-schema`, so the schema-constrained answer arrives in
+   * the final `result` message's `structured_output` field — NOT as assistant
+   * text. The engine harvests the structured result by `JSON.parse`-ing the
+   * run's accumulated text, so we suppress all assistant/partial text (which
+   * would be natural-language prose) and instead emit exactly ONE terminal
+   * text message = `JSON.stringify(structured_output)`.
+   */
+  structuredOutput?: boolean
 }
 
 /**
@@ -224,6 +234,10 @@ export async function* translateSdkStream(
     for (const block of message.message.content) {
       if (block.type === 'text') {
         if (alreadyStreamed) continue
+        // Structured mode: assistant text is natural-language prose; the JSON
+        // answer comes from the result's `structured_output`. Suppress prose so
+        // the harvested text is exactly the structured JSON.
+        if (ctx.structuredOutput === true) continue
         const messageId = message.message.id ?? genId()
         const text = (block as { text: string }).text
         yield {
@@ -319,6 +333,38 @@ export async function* translateSdkStream(
     yield* closePartialReasoning()
     yield* synthesizeUnresolvedResults()
 
+    // Structured mode: emit the schema-constrained JSON as the single terminal
+    // text message so the engine can harvest it (prose was suppressed above).
+    if (
+      ctx.structuredOutput === true &&
+      message.subtype === 'success' &&
+      message.structured_output !== undefined
+    ) {
+      const messageId = genId()
+      const text = JSON.stringify(message.structured_output)
+      yield {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId,
+        model,
+        timestamp: now(),
+        role: 'assistant',
+      }
+      yield {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId,
+        model,
+        timestamp: now(),
+        delta: text,
+        content: text,
+      }
+      yield {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId,
+        model,
+        timestamp: now(),
+      }
+    }
+
     const usage = buildUsage(message.usage, message.total_cost_usd)
     if (message.subtype === 'success') {
       yield {
@@ -365,6 +411,11 @@ export async function* translateSdkStream(
       streamedMessageIds.add(partialMessageId)
     } else if (event.type === 'content_block_start') {
       partialBlockType = event.content_block.type
+      // Structured mode: suppress streamed prose text (see handleAssistant).
+      // Reasoning still streams; the JSON answer is emitted from the result.
+      if (partialBlockType === 'text' && ctx.structuredOutput === true) {
+        return
+      }
       if (partialBlockType === 'text') {
         partialTextMessageId = partialMessageId ?? genId()
         partialTextContent = ''

--- a/packages/ai-claude-code/tests/text-adapter.test.ts
+++ b/packages/ai-claude-code/tests/text-adapter.test.ts
@@ -41,6 +41,21 @@ const FAKE_CLAUDE = [
   `})`,
 ].join('\n')
 
+// Structured-output stand-in: records argv (so a test can assert --json-schema)
+// and emits prose PLUS a result carrying `structured_output`, as `claude -p
+// --json-schema --output-format stream-json` would.
+const FAKE_CLAUDE_STRUCTURED = [
+  `import { writeFileSync } from 'node:fs'`,
+  `writeFileSync('claude-argv.txt', process.argv.join(' '))`,
+  `process.stdin.on('data', () => {})`,
+  `process.stdin.on('end', () => {`,
+  `  const w = (o) => process.stdout.write(JSON.stringify(o) + '\\n')`,
+  `  w({ type: 'system', subtype: 'init', session_id: 'sess-abc', model: 'haiku', tools: [] })`,
+  `  w({ type: 'assistant', message: { id: 'msg-1', content: [{ type: 'text', text: 'Let me think...' }] }, parent_tool_use_id: null })`,
+  `  w({ type: 'result', subtype: 'success', result: 'ok', structured_output: { answer: 'pong' }, usage: { input_tokens: 1, output_tokens: 1 } })`,
+  `})`,
+].join('\n')
+
 const noopLogger = {
   request: () => {},
   provider: () => {},
@@ -113,6 +128,45 @@ describe('claude-code in-sandbox adapter', () => {
 
     expect(chunks.some((c) => c.type === 'RUN_FINISHED')).toBe(true)
 
+    await sbx.destroy()
+  })
+
+  it('passes --json-schema and harvests structured_output as the answer', async () => {
+    const sbx = await provider.create({})
+    await sbx.fs.write('/workspace/fake-claude.mjs', FAKE_CLAUDE_STRUCTURED)
+
+    const adapter = claudeCodeText('haiku', {
+      claudeExecutable: 'node fake-claude.mjs',
+      streamPartials: false,
+      emitDiff: false,
+    })
+    const schema = {
+      type: 'object',
+      properties: { answer: { type: 'string' } },
+      required: ['answer'],
+      additionalProperties: false,
+    }
+    const chunks = await collect(
+      adapter.chatStream({
+        model: 'haiku',
+        messages: [{ role: 'user', content: 'say pong' }],
+        logger: noopLogger,
+        capabilities: capabilityContextWith(sbx),
+        outputSchema: schema,
+      }),
+    )
+
+    const argv = await sbx.fs.read('/workspace/claude-argv.txt')
+    expect(argv).toContain('--json-schema')
+
+    // Prose ("Let me think...") is suppressed; only the structured JSON is
+    // harvestable text.
+    const text = chunks
+      .filter((c) => c.type === 'TEXT_MESSAGE_CONTENT')
+      .map((c) => (c as { delta?: string }).delta ?? '')
+      .join('')
+    expect(text).toBe('{"answer":"pong"}')
+    expect(JSON.parse(text)).toEqual({ answer: 'pong' })
     await sbx.destroy()
   })
 

--- a/packages/ai-claude-code/tests/translate.test.ts
+++ b/packages/ai-claude-code/tests/translate.test.ts
@@ -66,7 +66,49 @@ const resultSuccess: AgentSdkMessage = {
   total_cost_usd: 0.12,
 }
 
+async function collectStructured(
+  messages: Array<AgentSdkMessage>,
+): Promise<Array<StreamChunk>> {
+  const chunks: Array<StreamChunk> = []
+  for await (const chunk of translateSdkStream(fromArray(messages), {
+    ...makeContext(),
+    structuredOutput: true,
+  })) {
+    chunks.push(chunk)
+  }
+  return chunks
+}
+
 describe('translateSdkStream', () => {
+  it('structured mode suppresses prose and emits structured_output as terminal text', async () => {
+    const chunks = await collectStructured([
+      init,
+      // Natural-language prose the model emits during the run — must be dropped.
+      assistantText('Let me work on that...'),
+      {
+        type: 'result',
+        subtype: 'success',
+        result: 'done',
+        structured_output: { answer: 'pong' },
+        usage,
+        total_cost_usd: 0.01,
+      },
+    ])
+
+    // Exactly one text burst, carrying the structured JSON (not the prose).
+    const textContents = chunks.filter((c) => c.type === 'TEXT_MESSAGE_CONTENT')
+    expect(textContents).toHaveLength(1)
+    expect(textContents[0]).toMatchObject({ content: '{"answer":"pong"}' })
+    expect(
+      JSON.parse((textContents[0] as { content: string }).content),
+    ).toEqual({ answer: 'pong' })
+    // Emitted before the terminal RUN_FINISHED so it's harvestable.
+    const endIdx = chunks.findIndex((c) => c.type === 'TEXT_MESSAGE_END')
+    const finishedIdx = chunks.findIndex((c) => c.type === 'RUN_FINISHED')
+    expect(endIdx).toBeGreaterThanOrEqual(0)
+    expect(endIdx).toBeLessThan(finishedIdx)
+  })
+
   it('translates a simple text turn into RUN_STARTED → CUSTOM → TEXT_* → RUN_FINISHED(stop)', async () => {
     const chunks = await collect([init, assistantText('Hello!'), resultSuccess])
 

--- a/packages/ai-codex/src/adapters/text.ts
+++ b/packages/ai-codex/src/adapters/text.ts
@@ -125,11 +125,20 @@ export class CodexTextAdapter<
     resume: string | undefined,
     bridge: HostToolBridge | undefined,
     policyFlags: CodexPolicyFlags,
+    outputSchemaFile: string | undefined,
   ): string {
     const config = this.adapterConfig
     const modelOptions = options.modelOptions
     const exe = config.codexExecutable ?? 'codex'
     const args: Array<string> = ['exec', '--experimental-json']
+
+    // Structured output: constrain the final message to the JSON Schema. Codex
+    // reads the schema from a file path (which must be relative to the process
+    // cwd — the handle already runs codex in the real workdir; an absolute
+    // VIRTUAL `/workspace/...` path wouldn't exist on the real filesystem).
+    if (outputSchemaFile !== undefined) {
+      args.push('--output-schema', q(outputSchemaFile))
+    }
 
     // Precedence: per-call modelOptions > adapter config > sandbox policy > default.
     const sandboxMode =
@@ -215,6 +224,23 @@ export class CodexTextAdapter<
       runId,
     })
     try {
+      // Codex silently drops `--output-schema` (and `response_format`) whenever
+      // MCP servers / tools are active — the run falls back to unconstrained
+      // text (openai/codex #15451). This harness only spins up an MCP bridge
+      // when chat() passes tools, so that is the exact trigger. Fail fast rather
+      // than silently returning text that won't parse against the schema.
+      if (
+        options.outputSchema !== undefined &&
+        options.tools !== undefined &&
+        options.tools.length > 0
+      ) {
+        throw new Error(
+          'The Codex harness cannot combine tools with outputSchema: Codex ignores ' +
+            'the output schema whenever tools/MCP servers are active (openai/codex #15451), ' +
+            'so the result would not conform. Remove the tools or the outputSchema.',
+        )
+      }
+
       const sandbox = this.sandboxFrom(options)
       cleanupSandbox = sandbox
       const cwd = this.workdir(options)
@@ -254,6 +280,19 @@ export class CodexTextAdapter<
           ? `${systemPrompts.join('\n\n')}\n\n${prompt}`
           : prompt
 
+      // Write the JSON Schema to a file codex reads via `--output-schema`. Use a
+      // bare filename (relative to the process cwd) for the same reason as the
+      // prompt file — the virtual `/workspace` path may not exist on the real fs.
+      let outputSchemaFile: string | undefined
+      if (options.outputSchema !== undefined) {
+        outputSchemaFile = `.tanstack-output-schema-${runId}.json`
+        await sandbox.fs.write(
+          `${cwd}/${outputSchemaFile}`,
+          JSON.stringify(options.outputSchema),
+        )
+        tempFiles.push(`${cwd}/${outputSchemaFile}`)
+      }
+
       const policy = options.capabilities
         ? getSandboxPolicy(options.capabilities, { optional: true })
         : undefined
@@ -262,6 +301,7 @@ export class CodexTextAdapter<
         resume,
         bridge,
         mapPolicyToCodexFlags(policy),
+        outputSchemaFile,
       )
 
       logger.request(
@@ -311,6 +351,9 @@ export class CodexTextAdapter<
           ...(options.parentRunId !== undefined && {
             parentRunId: options.parentRunId,
           }),
+          ...(options.outputSchema !== undefined && {
+            structuredOutput: true,
+          }),
           genId: () => this.generateId(),
           onThreadEvent: (event) =>
             logger.provider(`provider=codex type=${event.type}`, {
@@ -353,13 +396,29 @@ export class CodexTextAdapter<
     }
   }
 
+  /**
+   * Codex constrains its final answer to a JSON Schema via `codex exec
+   * --output-schema` in the single harness run, so `outputSchema` is wired
+   * straight into `chatStream` and the engine harvests the schema-constrained
+   * JSON from the run's final message — no separate finalization round-trip.
+   * (Combining with tools is rejected in `chatStream`; see #15451.)
+   */
+  supportsCombinedToolsAndSchema(): boolean {
+    return true
+  }
+
+  /**
+   * Unreachable via `chat()` — `supportsCombinedToolsAndSchema()` routes every
+   * structured-output request through `chatStream`. Kept as a safety net for
+   * any direct caller of the non-combined path.
+   */
   structuredOutput(
     _options: StructuredOutputOptions<CodexTextProviderOptions>,
   ): Promise<StructuredOutputResult<unknown>> {
     return Promise.reject(
       new Error(
-        'Structured output is not yet supported by the in-sandbox Codex adapter. ' +
-          'Use a model adapter for structured output, or omit outputSchema.',
+        'Codex structured output runs through chatStream (combined tools+schema mode); ' +
+          'structuredOutput() should not be called directly.',
       ),
     )
   }

--- a/packages/ai-codex/src/stream/translate.ts
+++ b/packages/ai-codex/src/stream/translate.ts
@@ -18,6 +18,16 @@ export interface TranslateContext {
   onSessionId?: (sessionId: string) => void
   /** Called for each raw SDK thread event, for logging. */
   onThreadEvent?: (event: CodexThreadEvent) => void
+  /**
+   * Structured-output mode (`chat({ outputSchema })`). When set, Codex was run
+   * with `--output-schema`, so every `agent_message` is schema-constrained
+   * JSON — including intermediate progress messages (openai/codex #19816). The
+   * engine harvests the structured result by `JSON.parse`-ing the run's
+   * accumulated text, so we must emit exactly ONE terminal text message = the
+   * final agent message and drop the earlier ones (concatenating multiple JSON
+   * objects would fail to parse). The last `agent_message` is the final answer.
+   */
+  structuredOutput?: boolean
 }
 
 /**
@@ -175,6 +185,11 @@ export async function* translateThreadEvents(
   const unresolvedToolCalls = new Set<string>()
   /** Item ids that already emitted TOOL_CALL_START/ARGS/END. */
   const openedToolItems = new Set<string>()
+  /**
+   * In structured-output mode, the latest `agent_message` seen — buffered and
+   * flushed as the single terminal text message at `turn.completed`.
+   */
+  let bufferedAgentMessage: { id: string; text: string } | undefined
 
   function* startRun(): Generator<StreamChunk> {
     if (runStarted) return
@@ -237,30 +252,42 @@ export async function* translateThreadEvents(
     unresolvedToolCalls.add(item.id)
   }
 
+  function* emitAgentText(
+    messageId: string,
+    text: string,
+  ): Generator<StreamChunk> {
+    yield {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId,
+      model,
+      timestamp: now(),
+      role: 'assistant',
+    }
+    yield {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId,
+      model,
+      timestamp: now(),
+      delta: text,
+      content: text,
+    }
+    yield {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId,
+      model,
+      timestamp: now(),
+    }
+  }
+
   function* handleItemCompleted(item: CodexThreadItem): Generator<StreamChunk> {
     if (item.type === 'agent_message') {
-      const messageId = item.id
-      yield {
-        type: EventType.TEXT_MESSAGE_START,
-        messageId,
-        model,
-        timestamp: now(),
-        role: 'assistant',
+      // Structured-output mode: defer emission and keep only the latest message
+      // so the harvested text is exactly the final schema-constrained JSON.
+      if (ctx.structuredOutput === true) {
+        bufferedAgentMessage = { id: item.id, text: item.text }
+        return
       }
-      yield {
-        type: EventType.TEXT_MESSAGE_CONTENT,
-        messageId,
-        model,
-        timestamp: now(),
-        delta: item.text,
-        content: item.text,
-      }
-      yield {
-        type: EventType.TEXT_MESSAGE_END,
-        messageId,
-        model,
-        timestamp: now(),
-      }
+      yield* emitAgentText(item.id, item.text)
     } else if (item.type === 'reasoning') {
       const reasoningId = item.id
       yield {
@@ -341,6 +368,13 @@ export async function* translateThreadEvents(
       } else if (event.type === 'item.completed') {
         yield* handleItemCompleted(event.item)
       } else if (event.type === 'turn.completed') {
+        if (bufferedAgentMessage !== undefined) {
+          yield* emitAgentText(
+            bufferedAgentMessage.id,
+            bufferedAgentMessage.text,
+          )
+          bufferedAgentMessage = undefined
+        }
         yield* synthesizeUnresolvedResults()
         const usage = buildUsage(event.usage)
         yield {

--- a/packages/ai-codex/tests/text-adapter.test.ts
+++ b/packages/ai-codex/tests/text-adapter.test.ts
@@ -44,6 +44,29 @@ const FAKE_CODEX = [
   `})`,
 ].join('\n')
 
+// Structured-output stand-in: records argv, reads the file passed via
+// --output-schema (proving the adapter wrote it at the exact relative path
+// codex is told to read) and echoes its contents to codex-schema.txt, then
+// emits an intermediate (progress) agent_message AND a final one — both
+// schema-shaped JSON, mirroring codex #19816. Only the final should survive
+// into the harvested text.
+const FAKE_CODEX_STRUCTURED = [
+  `import { writeFileSync, readFileSync } from 'node:fs'`,
+  `const argv = process.argv`,
+  `writeFileSync('codex-argv.txt', argv.join(' '))`,
+  `const si = argv.indexOf('--output-schema')`,
+  `if (si !== -1) writeFileSync('codex-schema.txt', readFileSync(argv[si + 1], 'utf8'))`,
+  `process.stdin.on('data', () => {})`,
+  `process.stdin.on('end', () => {`,
+  `  const w = (o) => process.stdout.write(JSON.stringify(o) + '\\n')`,
+  `  w({ type: 'thread.started', thread_id: 'th-1' })`,
+  `  w({ type: 'turn.started' })`,
+  `  w({ type: 'item.completed', item: { id: 'i1', type: 'agent_message', text: '{"answer":"working"}' } })`,
+  `  w({ type: 'item.completed', item: { id: 'i2', type: 'agent_message', text: '{"answer":"pong"}' } })`,
+  `  w({ type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1 } })`,
+  `})`,
+].join('\n')
+
 const noopLogger = {
   request: () => {},
   provider: () => {},
@@ -140,6 +163,78 @@ describe('codex in-sandbox adapter', () => {
       'mcp_servers.tanstack.http_headers={ "Authorization" = "Bearer secret-token-xyz" }',
     )
     expect(argv).not.toContain('bearer_token')
+    await sbx.destroy()
+  })
+
+  it('passes --output-schema and harvests only the final agent_message', async () => {
+    const sbx = await provider.create({})
+    await sbx.fs.write('/workspace/fake-codex.mjs', FAKE_CODEX_STRUCTURED)
+
+    const adapter = codexText('gpt-5.5-codex', {
+      codexExecutable: 'node fake-codex.mjs',
+    })
+
+    const schema = {
+      type: 'object',
+      properties: { answer: { type: 'string' } },
+      required: ['answer'],
+      additionalProperties: false,
+    }
+    const chunks = await collect(
+      adapter.chatStream({
+        model: 'gpt-5.5-codex',
+        messages: [{ role: 'user', content: 'say pong' }],
+        logger: noopLogger,
+        capabilities: capabilityContextWith(sbx),
+        outputSchema: schema,
+      }),
+    )
+
+    // The schema file was written and referenced via --output-schema.
+    const argv = await sbx.fs.read('/workspace/codex-argv.txt')
+    expect(argv).toContain('--output-schema')
+    const schemaFileArg = argv
+      .split(' ')
+      .find((a) => a.endsWith('.json') && a.includes('output-schema'))
+    expect(schemaFileArg).toBeDefined()
+
+    // The fake read the file at the path codex was given — proves the adapter
+    // wrote the schema to the exact relative path, resolvable from codex's cwd.
+    const writtenSchema = await sbx.fs.read('/workspace/codex-schema.txt')
+    expect(JSON.parse(writtenSchema)).toEqual(schema)
+
+    // Only the FINAL agent_message becomes text, so the harvested content is
+    // valid single JSON (the intermediate progress message is dropped).
+    const text = chunks
+      .filter((c) => c.type === 'TEXT_MESSAGE_CONTENT')
+      .map((c) => (c as { delta?: string }).delta ?? '')
+      .join('')
+    expect(text).toBe('{"answer":"pong"}')
+    expect(JSON.parse(text)).toEqual({ answer: 'pong' })
+    await sbx.destroy()
+  })
+
+  it('rejects combining tools with outputSchema (codex #15451)', async () => {
+    const sbx = await provider.create({})
+    await sbx.fs.write('/workspace/fake-codex.mjs', FAKE_CODEX)
+
+    const adapter = codexText('gpt-5.5-codex', {
+      codexExecutable: 'node fake-codex.mjs',
+    })
+    const chunks = await collect(
+      adapter.chatStream({
+        model: 'gpt-5.5-codex',
+        messages: [{ role: 'user', content: 'hi' }],
+        logger: noopLogger,
+        capabilities: capabilityContextWith(sbx),
+        outputSchema: { type: 'object' },
+        tools: [{ name: 'demo' } as unknown as AnyTool],
+      }),
+    )
+    const err = chunks.find((c) => c.type === 'RUN_ERROR')
+    expect((err as { message?: string }).message).toMatch(
+      /cannot combine tools with outputSchema/i,
+    )
     await sbx.destroy()
   })
 

--- a/packages/ai-codex/tests/translate.test.ts
+++ b/packages/ai-codex/tests/translate.test.ts
@@ -107,6 +107,38 @@ describe('translateThreadEvents', () => {
     expect(raw).toEqual(['thread.started', 'turn.completed'])
   })
 
+  it('structured mode emits only the final agent_message as terminal text', async () => {
+    const chunks = await collect(
+      [
+        started,
+        { type: 'turn.started' },
+        {
+          type: 'item.completed',
+          item: {
+            id: 'i1',
+            type: 'agent_message',
+            text: '{"answer":"working"}',
+          },
+        },
+        {
+          type: 'item.completed',
+          item: { id: 'i2', type: 'agent_message', text: '{"answer":"pong"}' },
+        },
+        completedTurn,
+      ],
+      makeCtx({ structuredOutput: true }),
+    )
+
+    // Exactly one text burst, carrying the final message, emitted just before
+    // RUN_FINISHED — so the harvested text is single valid JSON.
+    const textContents = chunks.filter((c) => c.type === 'TEXT_MESSAGE_CONTENT')
+    expect(textContents).toHaveLength(1)
+    expect(textContents[0]).toMatchObject({ content: '{"answer":"pong"}' })
+    const textEndIdx = chunks.findIndex((c) => c.type === 'TEXT_MESSAGE_END')
+    const finishedIdx = chunks.findIndex((c) => c.type === 'RUN_FINISHED')
+    expect(textEndIdx).toBeLessThan(finishedIdx)
+  })
+
   it('starts the run without a session event on resumed threads', async () => {
     const chunks = await collect([
       { type: 'turn.started' },

--- a/packages/ai-grok-build/src/adapters/text.ts
+++ b/packages/ai-grok-build/src/adapters/text.ts
@@ -559,7 +559,8 @@ export class GrokBuildTextAdapter<
   ): Promise<StructuredOutputResult<unknown>> {
     return Promise.reject(
       new Error(
-        'Structured output is not yet supported by the in-sandbox Grok Build adapter. ' +
+        'Structured output is not supported by the Grok Build harness adapter: the ' +
+          'grok CLI exposes no output-schema mechanism (only --output-format). ' +
           'Use a model adapter (e.g. grok) for structured output, or omit outputSchema.',
       ),
     )

--- a/packages/ai-opencode/src/adapters/text.ts
+++ b/packages/ai-opencode/src/adapters/text.ts
@@ -280,7 +280,11 @@ export class OpencodeTextAdapter<
       )
 
       session
-        .prompt(promptText)
+        .prompt(promptText, {
+          ...(options.outputSchema !== undefined && {
+            outputSchema: options.outputSchema,
+          }),
+        })
         .then(({ message }) => {
           queue.push({ kind: 'done', message })
           queue.end()
@@ -294,6 +298,9 @@ export class OpencodeTextAdapter<
           threadId,
           ...(options.parentRunId !== undefined && {
             parentRunId: options.parentRunId,
+          }),
+          ...(options.outputSchema !== undefined && {
+            structuredOutput: true,
           }),
           genId: () => this.generateId(),
           bridgedToolNames,
@@ -338,13 +345,29 @@ export class OpencodeTextAdapter<
     }
   }
 
+  /**
+   * OpenCode constrains its final answer to a JSON Schema via the session
+   * prompt's `json_schema` output format in the single harness run; the
+   * schema-conformant result comes back on `message.structured`. `outputSchema`
+   * is wired straight into `chatStream` and the engine harvests it — no
+   * separate finalization round-trip.
+   */
+  supportsCombinedToolsAndSchema(): boolean {
+    return true
+  }
+
+  /**
+   * Unreachable via `chat()` — `supportsCombinedToolsAndSchema()` routes every
+   * structured-output request through `chatStream`. Kept as a safety net for
+   * any direct caller of the non-combined path.
+   */
   structuredOutput(
     _options: StructuredOutputOptions<OpencodeTextProviderOptions>,
   ): Promise<StructuredOutputResult<unknown>> {
     return Promise.reject(
       new Error(
-        'Structured output is not yet supported by the in-sandbox OpenCode adapter. ' +
-          'Use a model adapter for structured output, or omit outputSchema.',
+        'OpenCode structured output runs through chatStream (combined tools+schema mode); ' +
+          'structuredOutput() should not be called directly.',
       ),
     )
   }

--- a/packages/ai-opencode/src/process/server.ts
+++ b/packages/ai-opencode/src/process/server.ts
@@ -18,9 +18,14 @@ export interface OpencodeSessionHandle {
    * Run one prompt turn. Resolves with the final assistant message (finish
    * reason, token usage, error) and its concatenated text once the harness
    * goes idle. Streaming deltas arrive via `onEvent` while this is pending.
+   *
+   * Pass `outputSchema` (a JSON Schema) to constrain the answer via OpenCode's
+   * `json_schema` output format; the schema-conformant result then arrives on
+   * `message.structured`.
    */
   prompt: (
     text: string,
+    opts?: { outputSchema?: unknown },
   ) => Promise<{ message: OpencodeAssistantMessage; text: string }>
   /** Ask the harness to abort the in-flight prompt turn. */
   abort: () => Promise<void>
@@ -222,13 +227,19 @@ export async function startOpencodeSession(
     return {
       sessionId: resolvedSessionId,
       resumed,
-      prompt: async (text: string) => {
+      prompt: async (text: string, opts?: { outputSchema?: unknown }) => {
         const result = await client.session.prompt({
           path: { id: resolvedSessionId },
           query: dirQuery,
           body: {
             model: { providerID: options.providerID, modelID: options.modelID },
             parts: [{ type: 'text', text }],
+            ...(opts?.outputSchema !== undefined && {
+              format: {
+                type: 'json_schema',
+                schema: opts.outputSchema as Record<string, unknown>,
+              },
+            }),
           },
           throwOnError: true,
         })

--- a/packages/ai-opencode/src/stream/sdk-types.ts
+++ b/packages/ai-opencode/src/stream/sdk-types.ts
@@ -32,6 +32,12 @@ export interface OpencodeAssistantMessage {
   error?: OpencodeMessageError
   tokens?: OpencodeTokens
   cost?: number
+  /**
+   * Schema-constrained result when the turn was prompted with a `json_schema`
+   * output format (`chat({ outputSchema })`). Mirrors the SDK's
+   * `AssistantMessage.structured`.
+   */
+  structured?: unknown
 }
 
 export type OpencodeToolState =

--- a/packages/ai-opencode/src/stream/translate.ts
+++ b/packages/ai-opencode/src/stream/translate.ts
@@ -30,6 +30,15 @@ export interface TranslateContext {
   bridgedToolNames?: ReadonlySet<string>
   /** Called for each raw stream event, for logging. */
   onStreamEvent?: (event: OpencodeStreamEvent) => void
+  /**
+   * Structured-output mode (`chat({ outputSchema })`). When set, the turn was
+   * prompted with a `json_schema` output format, so the schema-constrained
+   * answer arrives on the final message's `structured` field — NOT as
+   * streamed text. The engine harvests the structured result by
+   * `JSON.parse`-ing the run's accumulated text, so we suppress streamed prose
+   * and instead emit exactly ONE terminal text message = the structured JSON.
+   */
+  structuredOutput?: boolean
 }
 
 /**
@@ -334,6 +343,10 @@ export async function* translateOpencodeStream(
     if (event.type === 'message.part.updated') {
       const { part, delta } = event.properties
       if (isTextPart(part)) {
+        // Structured mode: streamed text is natural-language prose; the JSON
+        // answer comes from the final message's `structured` field. Suppress
+        // prose so the harvested text is exactly the structured JSON.
+        if (ctx.structuredOutput === true) return
         yield* handleTextPart(part, delta)
       } else if (isReasoningPart(part)) {
         yield* handleReasoningPart(part, delta)
@@ -371,6 +384,34 @@ export async function* translateOpencodeStream(
         error,
       }
       return
+    }
+
+    // Structured mode: emit the schema-constrained JSON as the single terminal
+    // text message so the engine can harvest it (prose was suppressed above).
+    if (ctx.structuredOutput === true && message.structured !== undefined) {
+      const messageId = genId()
+      const text = JSON.stringify(message.structured)
+      yield {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId,
+        model,
+        timestamp: now(),
+        role: 'assistant',
+      }
+      yield {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId,
+        model,
+        timestamp: now(),
+        delta: text,
+        content: text,
+      }
+      yield {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId,
+        model,
+        timestamp: now(),
+      }
     }
 
     const usage = buildUsage(message.tokens)

--- a/packages/ai-opencode/tests/translate.test.ts
+++ b/packages/ai-opencode/tests/translate.test.ts
@@ -69,6 +69,29 @@ function textPart(
 }
 
 describe('translateOpencodeStream', () => {
+  it('structured mode suppresses prose and emits message.structured as terminal text', async () => {
+    const chunks = await collect(
+      [
+        session,
+        // Prose streamed during the turn — must be dropped.
+        textPart('part-1', 'Let me work on that...', 'Let me work on that...'),
+        done({ structured: { answer: 'pong' } }),
+      ],
+      makeCtx({ structuredOutput: true }),
+    )
+
+    const textContents = chunks.filter((c) => c.type === 'TEXT_MESSAGE_CONTENT')
+    expect(textContents).toHaveLength(1)
+    expect(textContents[0]).toMatchObject({ content: '{"answer":"pong"}' })
+    expect(
+      JSON.parse((textContents[0] as { content: string }).content),
+    ).toEqual({ answer: 'pong' })
+    const endIdx = chunks.findIndex((c) => c.type === 'TEXT_MESSAGE_END')
+    const finishedIdx = chunks.findIndex((c) => c.type === 'RUN_FINISHED')
+    expect(endIdx).toBeGreaterThanOrEqual(0)
+    expect(endIdx).toBeLessThan(finishedIdx)
+  })
+
   it('translates a simple text turn', async () => {
     const chunks = await collect([
       session,

--- a/packages/ai/skills/ai-core/adapter-configuration/SKILL.md
+++ b/packages/ai/skills/ai-core/adapter-configuration/SKILL.md
@@ -324,19 +324,33 @@ runs.
 
 Current per-adapter status (#605):
 
-| Adapter                                      | Returns                                                                                           |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `openaiText` / `openaiChatCompletions`       | `true` (all supported models)                                                                     |
-| `anthropicText`                              | `true` for Claude 4.5+ (gated by `ANTHROPIC_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise |
-| `geminiText`                                 | `true` for Gemini 3.x (gated by `GEMINI_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise     |
-| `grokText`                                   | `true` for Grok 4 family (gated by `GROK_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise    |
-| `groqText`                                   | `false` (Groq API rejects schema + tools + stream)                                                |
-| `openRouterText` / `openRouterResponsesText` | `false` (per-call resolution is a follow-up)                                                      |
-| `ollamaText`                                 | `false` (constrained-decoding vs tool-call grammar conflict)                                      |
+| Adapter                                           | Returns                                                                                           |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `openaiText` / `openaiChatCompletions`            | `true` (all supported models)                                                                     |
+| `anthropicText`                                   | `true` for Claude 4.5+ (gated by `ANTHROPIC_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise |
+| `geminiText`                                      | `true` for Gemini 3.x (gated by `GEMINI_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise     |
+| `grokText`                                        | `true` for Grok 4 family (gated by `GROK_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise    |
+| `groqText`                                        | `false` (Groq API rejects schema + tools + stream)                                                |
+| `openRouterText` / `openRouterResponsesText`      | `false` (per-call resolution is a follow-up)                                                      |
+| `ollamaText`                                      | `false` (constrained-decoding vs tool-call grammar conflict)                                      |
+| `codexText` / `claudeCodeText` / `opencodeText`   | `true` — CLI harnesses constrain the answer within the single harness run (see note below)        |
+| `grokBuildText` / ACP harnesses (`compatibleAcp`) | not declared — the underlying CLI/protocol has no schema mechanism; `structuredOutput` rejects    |
 
 Subclasses can override to narrow the capability. When extending an
 adapter for a custom model that doesn't support the combination, return
 `false` explicitly.
+
+> **Harness adapters and structured output.** For CLI harnesses,
+> `supportsCombinedToolsAndSchema()` returning `true` is what makes
+> `chat({ outputSchema })` work at all: the schema is forwarded to the CLI's
+> native flag (`codex exec --output-schema`, `claude -p --json-schema`,
+> OpenCode's `json_schema` output format) and the schema-constrained final
+> answer is harvested from the one harness run. The harness translate layer
+> emits exactly one terminal text message = the structured JSON (suppressing
+> intermediate prose) so the engine's `JSON.parse` harvest is clean. The Codex
+> harness additionally **throws** when `tools` and `outputSchema` are combined
+> — Codex silently drops the schema when MCP/tools are active
+> (openai/codex#15451).
 
 ### 6. OpenAI-Compatible Providers
 

--- a/packages/ai/skills/ai-core/structured-outputs/SKILL.md
+++ b/packages/ai/skills/ai-core/structured-outputs/SKILL.md
@@ -504,6 +504,22 @@ For schema-aware middleware (e.g., transforming the JSON Schema before the
 provider call, stripping system prompts), use the dedicated
 `onStructuredOutputConfig` hook. See [middleware skill](../middleware/SKILL.md).
 
+## CLI harness adapters
+
+The CLI harness adapters support `chat({ outputSchema })` natively, constrained
+within the single harness run (no separate finalization call):
+
+- `codexText` — via `codex exec --output-schema`. **Cannot** be combined with
+  `tools`: Codex silently drops the schema when MCP/tools are active
+  (openai/codex#15451), so the adapter throws if you pass both.
+- `claudeCodeText` — via `claude -p --json-schema`; result harvested from
+  Claude Code's `structured_output`. Works alongside the harness's own tools.
+- `opencodeText` — via OpenCode's `json_schema` output format; result harvested
+  from the message's `structured` field. Requires `@opencode-ai/sdk` v1.17+.
+
+The Grok Build and ACP-based harnesses expose no schema mechanism, so they
+reject `outputSchema` — use a model adapter for structured extraction there.
+
 ## Cross-References
 
 - See also: **ai-core/chat-experience/SKILL.md** — Base `useChat` surface; the structured-output additions documented here layer on top.

--- a/testing/e2e/tests/claude-code.spec.ts
+++ b/testing/e2e/tests/claude-code.spec.ts
@@ -13,6 +13,7 @@
  * (A local `claude login` works in place of ANTHROPIC_API_KEY.)
  */
 import { expect, test } from '@playwright/test'
+import { z } from 'zod'
 import { chat } from '@tanstack/ai'
 import { claudeCodeText } from '@tanstack/ai-claude-code'
 import type { StreamChunk } from '@tanstack/ai'
@@ -68,5 +69,32 @@ test.describe('claude-code harness (gated live smoke)', () => {
       .map((chunk) => (chunk as { delta?: string }).delta ?? '')
       .join('')
     expect(text.toLowerCase()).toContain('pong')
+  })
+
+  test('produces schema-constrained structured output', async () => {
+    test.setTimeout(180_000)
+
+    const result = await chat({
+      adapter: claudeCodeText('haiku', {
+        maxTurns: 2,
+        disallowedTools: ['Bash', 'Write', 'Edit'],
+      }),
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Return the capital of France and its population (approximate).',
+        },
+      ],
+      outputSchema: z.object({
+        capital: z.string(),
+        population: z.number(),
+      }),
+    })
+
+    // `chat({ outputSchema })` (non-stream) resolves to the validated object
+    // directly (Promise<T>) — no cast, no `.object` wrapper.
+    expect(result.capital.toLowerCase()).toContain('paris')
+    expect(typeof result.population).toBe('number')
   })
 })


### PR DESCRIPTION
## 🎯 Changes

`chat({ outputSchema })` now works with the **Codex**, **Claude Code**, and **OpenCode** harness adapters, whose underlying CLIs natively constrain the final answer to a JSON Schema. Previously all harness adapters hard-rejected structured output at runtime (the API type-checked but threw).

Each adapter declares `supportsCombinedToolsAndSchema() => true` and forwards the JSON Schema to the CLI's native mechanism **within the single harness run**, so the engine harvests the schema-constrained answer with no separate finalization round-trip:

| Adapter | Mechanism | Result source |
|---|---|---|
| `@tanstack/ai-codex` | `codex exec --output-schema <file>` | final `agent_message` (buffered → flushed once) |
| `@tanstack/ai-claude-code` | `claude -p --json-schema '<inline>'` | `result.structured_output` |
| `@tanstack/ai-opencode` | session `json_schema` output format | `message.structured` |

**Key invariant:** when `outputSchema` is set, each translate layer emits exactly one terminal `TEXT_MESSAGE` = the schema-constrained JSON and suppresses all intermediate assistant prose, so the engine's `JSON.parse(accumulatedContent)` harvest stays clean. Reasoning/tool events are unaffected.

**Guards / not supported:**
- The **Codex** harness throws when `tools` and `outputSchema` are combined — Codex silently drops the schema whenever MCP/tools are active ([openai/codex#15451](https://github.com/openai/codex/issues/15451)), which would otherwise return unvalidated text.
- **Grok Build** now rejects `outputSchema` with an accurate message (the grok CLI exposes no schema mechanism); **ACP** already rejected it.

No core-engine or public-API changes — this rides the existing combined-tools-and-schema harvest path.

### Tests & docs
- Unit tests per adapter: translate-layer prose suppression + single-terminal-JSON, command/SDK wiring via fake CLIs in real local-process sandboxes, the Codex tools+schema guard, and a test proving the Codex schema file is written at the exact relative path the CLI reads.
- Gated Claude Code live-smoke (`CLAUDE_CODE_E2E=1`) extended with a structured-output case.
- Updated the codex/claude-code/opencode adapter docs, the structured-outputs overview, and the `adapter-configuration` / `structured-outputs` agent skills. Changeset added.

> **Note for reviewers:** the exact runtime surfacing of Claude Code's `structured_output` (with `--output-format stream-json`) and OpenCode's `message.structured` could only be verified against the SDK type declarations locally (both fields are pre-declared in their SDKs) — the gated live smoke exercises Claude Code against the real CLI.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally (`test:lib`, `test:types`, `test:eslint`, `test:kiira`, `test:docs`, `test:sherif`, `test:knip` — all green; harness E2E is gated live-smoke by design).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset (minor for the three adapters, patch for grok-build).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code, Codex, and OpenCode adapters now support schema-constrained structured output via `chat({ outputSchema })` in a single harness run.
  * Codex throws when `outputSchema` is combined with `tools`; Grok Build continues to reject `outputSchema` with a clearer error.

* **Documentation**
  * Updated “Structured Output” docs and provider/harness support guidance, including examples and adapter-specific limitations.

* **Tests**
  * Added/expanded e2e and unit coverage to verify schema-constrained results and structured-stream behavior across these adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->