### PR TITLE
fix(ci): scan-dangling-dts skips cleanly when no packages were built

### DIFF
--- a/scripts/scan-dangling-dts.mjs
+++ b/scripts/scan-dangling-dts.mjs
@@ -77,10 +77,14 @@ const dists = packageNames
   .filter((dir) => existsSync(dir))
 
 if (dists.length === 0) {
-  console.error(
-    'scan-dangling-dts: no packages/*/dist directories found. Build packages first (e.g. pnpm build:all).',
+  // No built declarations to scan. This is the normal state when `nx affected`
+  // built nothing — e.g. a docs / skill / CI-only PR that touches no package.
+  // There are no `.d.ts` files, so nothing could have regressed; skip cleanly.
+  // (Running standalone? Build first — `pnpm build:all` — then re-run.)
+  console.log(
+    'scan-dangling-dts: no packages/*/dist directories found — nothing to scan (no packages built). Skipping.',
   )
-  process.exit(1)
+  process.exit(0)
 }
 
 /** @type {string[]} */


### PR DESCRIPTION
## 🎯 Changes

Fixes a false CI failure that turns **every docs / skill / CI-only PR red**.

`test:pr` runs `pnpm test:react-native && nx affected --targets=…,build && pnpm test:dts`. When a PR touches no buildable package, `nx affected …build` builds nothing, so there are **zero `packages/*/dist` directories**. The dangling-`.d.ts` guardrail added in #924 treated that as a hard failure:

```
scan-dangling-dts: no packages/*/dist directories found. Build packages first (e.g. pnpm build:all).
Error: Process completed with exit code 1.
```

But "nothing was built" is the correct, expected state for an unaffected PR — there are no declaration files, so nothing could have regressed. This makes `scan-dangling-dts.mjs` treat the no-dist case as a **clean skip (exit 0)** instead of a failure.

When packages **are** built (any PR that affects a package), the scan runs and catches dangling-import regressions exactly as before — unchanged.

Verified: with `packages/*/dist` absent the script prints `… nothing to scan … Skipping.` and exits 0; with dist present it scans as before.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally (exercised both the no-dist skip and the normal scan path).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation scans to complete successfully when no package build output is present.
  * Preserved existing detection of unresolved declaration-file imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->