### PR TITLE
fix(ai-gemini): dedup functionResponse by id, not name

### DIFF
--- a/.changeset/ai-gemini-parallel-function-response-dedup.md
+++ b/.changeset/ai-gemini-parallel-function-response-dedup.md
@@ -1,0 +1,20 @@
+---
+"@tanstack/ai-gemini": patch
+---
+
+Fix parallel functionResponse dedup dropping same-tool calls (#894)
+
+`GeminiTextAdapter.mergeConsecutiveSameRoleMessages` deduplicated
+`functionResponse` parts by tool **name** instead of by **id**. When Gemini
+returned two or more parallel calls to the same tool in one turn, the second
+matching response was filtered out, so the follow-up request failed with:
+
+> 400 INVALID_ARGUMENT: Please ensure that the number of function response
+> parts is equal to the number of function call parts of the function call turn.
+
+Each `functionResponse` is already built with a unique `id` (the originating
+`toolCallId`), so keying the dedup on `id` keeps parallel calls distinct
+(different ids → both kept) while still collapsing a genuine duplicate
+(same id → second one dropped). The pre-existing comment already described
+the key as "tool call ID" — this brings the implementation in line with
+that comment.

--- a/packages/ai-gemini/src/adapters/text.ts
+++ b/packages/ai-gemini/src/adapters/text.ts
@@ -818,7 +818,7 @@ export class GeminiTextAdapter<
    * user messages in multi-turn conversations.
    *
    * Also filters out empty model messages (e.g., from a previous failed request)
-   * and deduplicates functionResponse parts with the same name (tool call ID).
+   * and deduplicates functionResponse parts with the same id (tool call ID).
    */
   private mergeConsecutiveSameRoleMessages(
     messages: Array<Content>,
@@ -849,16 +849,21 @@ export class GeminiTextAdapter<
       }
     }
 
-    // Deduplicate functionResponse parts with the same name (tool call ID)
+    // Deduplicate functionResponse parts with the same id (tool call ID)
     for (const msg of merged) {
       if (!msg.parts) continue
-      const seenFunctionResponseNames = new Set<string>()
+      // Each `functionResponse` carries a unique `id` (set to the originating
+      // `toolCallId` above), so keying on `id` keeps parallel calls to the same
+      // tool distinct (different ids → both kept) while still collapsing a
+      // genuine duplicate (same id → second one dropped). Keying on `.name`
+      // would drop the second of two parallel calls to the same tool — #894.
+      const seenFunctionResponseIds = new Set<string>()
       msg.parts = msg.parts.filter((part) => {
-        if ('functionResponse' in part && part.functionResponse?.name) {
-          if (seenFunctionResponseNames.has(part.functionResponse.name)) {
+        if ('functionResponse' in part && part.functionResponse?.id) {
+          if (seenFunctionResponseIds.has(part.functionResponse.id)) {
             return false
           }
-          seenFunctionResponseNames.add(part.functionResponse.name)
+          seenFunctionResponseIds.add(part.functionResponse.id)
         }
         return true
       })

--- a/packages/ai-gemini/tests/parallel-function-response.test.ts
+++ b/packages/ai-gemini/tests/parallel-function-response.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import { GeminiTextAdapter } from '../src/adapters/text'
+import type { ModelMessage } from '@tanstack/ai'
+import type { Content } from '@google/genai'
+
+// `formatMessages` is `private` on the adapter (TS2341 blocks subclass access,
+// so the Probe pattern used in ai-bedrock/tests for `protected` hooks doesn't
+// apply here). Cast through `unknown` to a minimal shape — keeps the test
+// type-safe without widening the adapter's public API surface just to make a
+// private method testable.
+type WithFormatMessages = {
+  formatMessages: (messages: Array<ModelMessage>) => Array<Content>
+}
+
+const adapter = new GeminiTextAdapter(
+  { apiKey: 'not-used' },
+  'gemini-2.5-flash-lite',
+)
+
+const format = (messages: Array<ModelMessage>): Array<Content> =>
+  (adapter as unknown as WithFormatMessages).formatMessages(messages)
+
+function functionResponseIds(out: Array<Content>): Array<string> {
+  // `Content.parts` is `Part[] | undefined`; once narrowed past the `?? []`
+  // each `Part` is a discriminated union keyed by which optional field it
+  // carries. Filtering on `'functionResponse' in p` is enough to land us on
+  // the right arm at runtime; cast through to read the id.
+  return out
+    .flatMap((c) => c.parts ?? [])
+    .filter((p) => 'functionResponse' in p)
+    .map(
+      (p) =>
+        (p as { functionResponse?: { id?: string } }).functionResponse?.id ??
+        '',
+    )
+}
+
+describe('GeminiTextAdapter — parallel functionResponse dedup (#894)', () => {
+  it('keeps both responses when two parallel calls share a tool name but have distinct ids', () => {
+    // Repro straight from the issue: same-tool parallel calls, distinct ids.
+    // Pre-fix the dedup keyed on `.name` and dropped the second response,
+    // making the next Gemini request 400 with "function response/call part
+    // count mismatch".
+    const messages: Array<ModelMessage> = [
+      { role: 'user', content: 'log 50 USD and 30 EUR' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'lookupCurrency', arguments: '{"query":"USD"}' },
+          },
+          {
+            id: 'call_2',
+            type: 'function',
+            function: { name: 'lookupCurrency', arguments: '{"query":"EUR"}' },
+          },
+        ],
+      },
+      { role: 'tool', toolCallId: 'call_1', content: 'USD -> US Dollar' },
+      { role: 'tool', toolCallId: 'call_2', content: 'EUR -> Euro' },
+    ]
+
+    const out = format(messages)
+    const ids = functionResponseIds(out)
+
+    expect(ids).toEqual(['call_1', 'call_2'])
+  })
+
+  it('drops a genuine duplicate functionResponse (same id reappears)', () => {
+    // The dedup still has to collapse a real duplicate — e.g. a caller that
+    // re-sends the same toolCallId's result. Keying on `.id` keeps this
+    // guarantee intact while letting same-name parallel calls through.
+    const messages: Array<ModelMessage> = [
+      { role: 'user', content: 'lookup USD' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'lookupCurrency', arguments: '{"query":"USD"}' },
+          },
+        ],
+      },
+      { role: 'tool', toolCallId: 'call_1', content: 'USD -> US Dollar' },
+      // Accidental re-send of the same toolCallId.
+      { role: 'tool', toolCallId: 'call_1', content: 'USD -> US Dollar' },
+    ]
+
+    const out = format(messages)
+    const ids = functionResponseIds(out)
+
+    expect(ids).toEqual(['call_1'])
+  })
+
+  it('keeps both responses when the parallel calls use different tool names', () => {
+    // Different names AND different ids — both old and new code keep these,
+    // so this is a regression guard against an overzealous "dedup by id" fix
+    // that might accidentally drop by name as well.
+    const messages: Array<ModelMessage> = [
+      { role: 'user', content: 'lookup USD and log it' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'lookupCurrency', arguments: '{"query":"USD"}' },
+          },
+          {
+            id: 'call_2',
+            type: 'function',
+            function: { name: 'logMessage', arguments: '{"msg":"hi"}' },
+          },
+        ],
+      },
+      { role: 'tool', toolCallId: 'call_1', content: 'USD -> US Dollar' },
+      { role: 'tool', toolCallId: 'call_2', content: 'logged' },
+    ]
+
+    const out = format(messages)
+    const ids = functionResponseIds(out)
+
+    expect(ids).toEqual(['call_1', 'call_2'])
+  })
+
+  it('keeps all three responses when three parallel calls share a tool name', () => {
+    // Stress the dedup with 3 same-name parallel calls — pre-fix this would
+    // collapse to a single response, after the fix all three survive.
+    const messages: Array<ModelMessage> = [
+      { role: 'user', content: 'log USD EUR GBP' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'lookupCurrency', arguments: '{"query":"USD"}' },
+          },
+          {
+            id: 'call_2',
+            type: 'function',
+            function: { name: 'lookupCurrency', arguments: '{"query":"EUR"}' },
+          },
+          {
+            id: 'call_3',
+            type: 'function',
+            function: { name: 'lookupCurrency', arguments: '{"query":"GBP"}' },
+          },
+        ],
+      },
+      { role: 'tool', toolCallId: 'call_1', content: 'USD -> US Dollar' },
+      { role: 'tool', toolCallId: 'call_2', content: 'EUR -> Euro' },
+      { role: 'tool', toolCallId: 'call_3', content: 'GBP -> Pound Sterling' },
+    ]
+
+    const out = format(messages)
+    const ids = functionResponseIds(out)
+
+    expect(ids).toEqual(['call_1', 'call_2', 'call_3'])
+  })
+})


### PR DESCRIPTION
## Summary

`GeminiTextAdapter.mergeConsecutiveSameRoleMessages` deduplicated `functionResponse` parts by tool **name**. When Gemini returned two or more parallel calls to the **same** tool in one turn, the second matching response was filtered out, so the follow-up request 400'd:

> `INVALID_ARGUMENT: Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn.`

Fixes #894.

## Root cause

`packages/ai-gemini/src/adapters/text.ts`, `mergeConsecutiveSameRoleMessages` (~L852):

```ts
const seenFunctionResponseNames = new Set<string>()
msg.parts = msg.parts.filter((part) => {
  if ('functionResponse' in part && part.functionResponse?.name) {
    if (seenFunctionResponseNames.has(part.functionResponse.name)) {
      return false
    }
    seenFunctionResponseNames.add(part.functionResponse.name)
  }
  return true
})
```

Two parallel calls to the same tool share a `name` but have different `id`s, so the second response is dropped. The comment above the filter already called the key "tool call ID", but the implementation was actually keying on `name`.

Each `functionResponse` is built upstream with a unique `id` set to the originating `toolCallId` (L785 / L794), so the unique-per-call invariant already holds at the data layer — the dedup just wasn't using it.

## Fix

Key the dedup on `part.functionResponse.id` instead of `.name`:

- Different ids (parallel calls to the same tool) → both kept.
- Same id (genuine duplicate, e.g. a caller re-sends the same `toolCallId`'s result) → second one still dropped, dedup guarantee preserved.
- Pre-existing comment describing the key as "tool call ID" is now accurate.

## Tests

New `packages/ai-gemini/tests/parallel-function-response.test.ts` covers four cases:

| # | Scenario | Pre-fix | Post-fix |
|---|---|---|---|
| 1 | Two parallel calls, same tool name, distinct ids | ❌ drops one | ✅ keeps both |
| 2 | Genuine duplicate (same `toolCallId` re-sent) | ✅ collapses to one | ✅ collapses to one |
| 3 | Two parallel calls, different tool names | ✅ keeps both | ✅ keeps both |
| 4 | Three parallel calls, same tool name, distinct ids | ❌ collapses to one | ✅ keeps all three |

`formatMessages` is `private` on the adapter (TS2341 blocks subclass access, so the Probe pattern used in `ai-bedrock/tests` for `protected` hooks doesn't apply). The test casts through `unknown` to a minimal typed shape — keeps the assertion type-safe without widening the adapter's public API just to make a private method testable.

## Backward compatibility

`mergeConsecutiveSameRoleMessages` is a private method; the change is observable only through the wire payload sent to Gemini. The set of cases that change behavior:

- Pre-fix: parallel calls to the same tool were broken (400 from Gemini). Post-fix: they work.
- Pre-fix: a genuine duplicate `functionResponse` (same `toolCallId` re-sent) was collapsed. Post-fix: still collapsed (now keyed on `id`).

No caller's behavior regresses; only previously-broken paths become correct.

## Verification

- `pnpm --filter @tanstack/ai-gemini test:lib` — 241/241 passing (including the 4 new tests).
- `pnpm --filter @tanstack/ai-gemini test:eslint` — 0 errors (7 pre-existing warnings in unrelated files).
- `pnpm --filter @tanstack/ai-gemini test:types` — `tsc` clean.
- **Red→green verified**: temporarily reverted the dedup key back to `name`; cases 1 and 4 fail with the exact symptom from the issue (`expected ['call_1'] to deeply equal ['call_1', 'call_2']`). Restored the fix; all 4 cases pass.

## Out of scope

- The comment above the dedup filter mentions "empty model messages" being filtered in the same pass — left untouched.
- Parallel-call id generation for `functionCall` parts was added back in #199; this PR only consumes those ids in the dedup.

## Changeset

`.changeset/ai-gemini-parallel-function-response-dedup.md` — `@tanstack/ai-gemini: patch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where parallel tool/function calls could be incorrectly dropped when they shared the same tool name.
  * Deduplication now uses each call’s identifier, so distinct parallel calls are retained while true duplicates are still collapsed.
* **Tests**
  * Added new test coverage for parallel scenarios (two and three calls) and verification of proper duplicate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->