### PR TITLE
feat(ai-openai): PDF document input

### DIFF
--- a/.changeset/openai-pdf-document-input.md
+++ b/.changeset/openai-pdf-document-input.md
@@ -1,0 +1,26 @@
+---
+'@tanstack/openai-base': minor
+'@tanstack/ai-openai': minor
+---
+
+feat(ai-openai): support PDF `document` content parts in the Responses adapter.
+
+`openaiText`'s Responses adapter now accepts PDF `document` content parts, for any model whose `model-meta` entry declares the `document` input modality. Base64 data sources are sent as `input_file` with a `file_data` data URL and a `filename` (from `metadata.filename`, defaulting to `document.pdf`). URL sources are sent as `input_file` with `file_url`.
+
+```ts
+const adapter = openaiText('gpt-5.5')
+
+const message = {
+  role: 'user',
+  content: [
+    { type: 'text', content: 'Summarize this document' },
+    {
+      type: 'document',
+      source: { type: 'data', value: pdfBase64, mimeType: 'application/pdf' },
+      metadata: { filename: 'report.pdf' },
+    },
+  ],
+}
+```
+
+Non-PDF MIME types are rejected before the request is sent — including pre-wrapped `data:` URLs whose media type disagrees with `mimeType` — so callers get an actionable message instead of an opaque provider `400`. `OpenAIDocumentMetadata` gains `filename` and `detail`. The Chat Completions adapter throws a document-specific error pointing here, since documents are Responses-only.

--- a/.changeset/openai-pdf-document-input.md
+++ b/.changeset/openai-pdf-document-input.md
@@ -23,4 +23,4 @@ const message = {
 }
 ```
 
-Non-PDF MIME types are rejected before the request is sent — including pre-wrapped `data:` URLs whose media type disagrees with `mimeType` — so callers get an actionable message instead of an opaque provider `400`. `OpenAIDocumentMetadata` gains `filename` and `detail`. The Chat Completions adapter throws a document-specific error pointing here, since documents are Responses-only.
+Non-PDF MIME types are rejected before the request is sent — including pre-wrapped `data:` URLs whose media type disagrees with `mimeType` — so callers get an actionable message instead of an opaque provider `400`. Inline base64 payloads are also checked for the `%PDF` magic bytes, so non-PDF data mislabeled (or sent without) a PDF `mimeType` is rejected locally. `OpenAIDocumentMetadata` gains `filename` and `detail`. The Chat Completions adapter throws a document-specific error pointing here, since documents are Responses-only.

--- a/docs/advanced/multimodal-content.md
+++ b/docs/advanced/multimodal-content.md
@@ -94,11 +94,12 @@ const response = await chat({
 
 ### OpenAI
 
-OpenAI supports images and audio in their vision and audio models:
+OpenAI supports images, audio, and PDF documents in their vision, audio, and
+document-capable models:
 
 ```typescript
 import { openaiText } from '@tanstack/ai-openai'
-import { imageBase64 } from './data'
+import { imageBase64, pdfBase64 } from './data'
 
 const adapter = openaiText('gpt-5.5')
 
@@ -116,9 +117,29 @@ const message = {
 }
 ```
 
+```typescript
+import { pdfBase64 } from './data'
+
+// PDF document via base64 data (the API requires a filename alongside
+// inline data; defaults to "document.pdf" when omitted)
+const documentMessage = {
+  role: 'user',
+  content: [
+    { type: 'text', content: 'Summarize this document' },
+    {
+      type: 'document',
+      source: { type: 'data', value: pdfBase64, mimeType: 'application/pdf' },
+      metadata: { filename: 'report.pdf' }
+    }
+  ]
+}
+```
+
 **Supported modalities by model:**
-- `gpt-5.2`, `gpt-5-mini`: text, image
+- `gpt-5.5`, `gpt-5.2`, `gpt-5-mini` (among others): text, image, PDF document
 - `gpt-4o-audio`: text, audio
+
+Check each model's `supports.input` in `@tanstack/ai-openai`'s `model-meta.ts` for the authoritative per-model list.
 
 ### Anthropic
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -702,7 +702,8 @@
         {
           "label": "Multimodal Content",
           "to": "advanced/multimodal-content",
-          "addedAt": "2026-04-15"
+          "addedAt": "2026-04-15",
+          "updatedAt": "2026-07-21"
         },
         {
           "label": "Per-Model Type Safety",

--- a/packages/ai-openai/src/message-types.ts
+++ b/packages/ai-openai/src/message-types.ts
@@ -44,9 +44,27 @@ export interface OpenAIVideoMetadata {}
 
 /**
  * Metadata for OpenAI document content parts.
- * Note: Direct document support may vary; PDFs often need to be converted to images.
+ *
+ * Documents are supported by the Responses adapter only, which sends them
+ * as `input_file`; the Chat Completions adapter rejects document parts.
+ * This adapter currently supports only `application/pdf` documents. That is
+ * enforced locally for inline (base64) data; URL-sourced documents are sent
+ * to OpenAI unvalidated, so a non-PDF URL fails server-side instead.
+ *
+ * @see https://developers.openai.com/api/docs/guides/pdf-files
  */
-export interface OpenAIDocumentMetadata {}
+export interface OpenAIDocumentMetadata {
+  /**
+   * Filename sent alongside inline (base64) PDF data.
+   * @default 'document.pdf'
+   */
+  filename?: string
+  /**
+   * Rendering quality for the file's page images. Omitted by default so the
+   * API applies its own default ('low').
+   */
+  detail?: 'low' | 'high'
+}
 
 /**
  * Metadata for OpenAI text content parts.

--- a/packages/ai-openai/src/message-types.ts
+++ b/packages/ai-openai/src/message-types.ts
@@ -47,9 +47,11 @@ export interface OpenAIVideoMetadata {}
  *
  * Documents are supported by the Responses adapter only, which sends them
  * as `input_file`; the Chat Completions adapter rejects document parts.
- * This adapter currently supports only `application/pdf` documents. That is
- * enforced locally for inline (base64) data; URL-sourced documents are sent
- * to OpenAI unvalidated, so a non-PDF URL fails server-side instead.
+ * This adapter currently supports only `application/pdf` documents. Inline
+ * (base64) data is verified locally — both the declared/embedded MIME type
+ * and the `%PDF` content header, so mislabeled non-PDF data is rejected
+ * before the request. URL-sourced documents are sent to OpenAI unvalidated,
+ * so a non-PDF URL fails server-side instead.
  *
  * @see https://developers.openai.com/api/docs/guides/pdf-files
  */
@@ -61,9 +63,12 @@ export interface OpenAIDocumentMetadata {
   filename?: string
   /**
    * Rendering quality for the file's page images. Omitted by default so the
-   * API applies its own default ('low').
+   * API applies its own default ('auto'), which resolves to 'low' or 'high'
+   * depending on the model.
+   *
+   * @see https://developers.openai.com/api/docs/guides/pdf-files
    */
-  detail?: 'low' | 'high'
+  detail?: 'auto' | 'low' | 'high'
 }
 
 /**

--- a/packages/ai-openai/src/model-meta.ts
+++ b/packages/ai-openai/src/model-meta.ts
@@ -12,7 +12,7 @@ import type { OpenAIEmbeddingProviderOptions } from './embedding/embedding-provi
 interface ModelMeta<TProviderOptions = unknown> {
   name: string
   supports: {
-    input: Array<'text' | 'image' | 'audio' | 'video'>
+    input: Array<'text' | 'image' | 'audio' | 'video' | 'document'>
     output: Array<'text' | 'image' | 'audio' | 'video'>
     endpoints: Array<
       | 'chat'
@@ -75,7 +75,7 @@ const GPT5_2 = {
   max_output_tokens: 128_000,
   knowledge_cutoff: '2025-08-31',
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'chat-completions'],
     features: [
@@ -120,7 +120,7 @@ const GPT5_2_PRO = {
   max_output_tokens: 128_000,
   knowledge_cutoff: '2025-08-31',
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'chat-completions'],
     features: ['streaming', 'function_calling'],
@@ -159,7 +159,7 @@ const GPT5_2_CHAT = {
   max_output_tokens: 16_384,
   knowledge_cutoff: '2025-08-31',
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'chat-completions'],
     features: ['streaming', 'function_calling', 'structured_outputs'],
@@ -195,7 +195,7 @@ const GPT5_1 = {
   max_output_tokens: 128_000,
   knowledge_cutoff: '2024-09-30',
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text', 'image'],
     endpoints: ['chat', 'chat-completions'],
     features: [
@@ -241,7 +241,7 @@ const GPT5_1_CODEX = {
   max_output_tokens: 128_000,
   knowledge_cutoff: '2024-09-30',
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text', 'image'],
     endpoints: ['chat'],
     features: ['streaming', 'function_calling', 'structured_outputs'],
@@ -278,7 +278,7 @@ const GPT5 = {
   max_output_tokens: 128_000,
   knowledge_cutoff: '2024-09-30',
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'chat-completions', 'batch'],
     features: [
@@ -324,7 +324,7 @@ const GPT5_MINI = {
   max_output_tokens: 128_000,
   knowledge_cutoff: '2024-05-31',
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'chat-completions', 'batch'],
     features: ['streaming', 'structured_outputs', 'function_calling'],
@@ -374,7 +374,7 @@ const GPT5_NANO = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'chat-completions', 'batch'],
     features: ['streaming', 'structured_outputs', 'function_calling'],
@@ -414,7 +414,7 @@ const GPT5_PRO = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'batch'],
     features: ['streaming', 'structured_outputs', 'function_calling'],
@@ -455,7 +455,7 @@ const GPT5_CODEX = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text', 'image'],
     endpoints: ['chat'],
     features: ['streaming', 'structured_outputs', 'function_calling'],
@@ -687,7 +687,7 @@ const O3_PRO = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'batch'],
     features: ['function_calling', 'structured_outputs'],
@@ -840,7 +840,7 @@ const O3 = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'batch', 'chat-completions'],
     features: ['function_calling', 'structured_outputs', 'streaming'],
@@ -881,7 +881,7 @@ const O4_MINI = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'batch', 'chat-completions', 'fine-tuning'],
     features: [
@@ -926,7 +926,7 @@ const GPT4_1 = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: [
       'chat',
@@ -979,7 +979,7 @@ const GPT4_1_MINI = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: [
       'chat',
@@ -1030,7 +1030,7 @@ const GPT4_1_NANO = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: [
       'chat',
@@ -1081,7 +1081,7 @@ const O1_PRO = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'batch'],
     features: ['function_calling', 'structured_outputs'],
@@ -1284,7 +1284,7 @@ const O1 = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'batch', 'chat-completions', 'assistants'],
     features: ['function_calling', 'structured_outputs', 'streaming'],
@@ -1334,7 +1334,7 @@ const GPT_4O = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: [
       'chat',
@@ -1411,7 +1411,7 @@ const GPT_4O_MINI = {
     },
   },
   supports: {
-    input: ['text', 'image'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: [
       'chat',
@@ -2233,7 +2233,7 @@ const GPT_5_5 = {
   context_window: 1_050_000,
   max_output_tokens: 128_000,
   supports: {
-    input: ['image', 'text'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'chat-completions'],
     features: [
@@ -2278,7 +2278,7 @@ const GPT_5_5_PRO = {
   context_window: 1_050_000,
   max_output_tokens: 128_000,
   supports: {
-    input: ['image', 'text'],
+    input: ['text', 'image', 'document'],
     output: ['text'],
     endpoints: ['chat', 'chat-completions'],
     features: [

--- a/packages/ai-openai/tests/model-meta.test.ts
+++ b/packages/ai-openai/tests/model-meta.test.ts
@@ -884,222 +884,222 @@ type MessageWithContent<T> = { role: 'user'; content: Array<T> }
 describe('OpenAI Model Input Modality Type Assertions', () => {
   // ===== Models with text + image input =====
 
-  describe('gpt-5.1 (text + image)', () => {
+  describe('gpt-5.1 (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['gpt-5.1']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
       >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().not.toExtend<Message>()
     })
   })
 
-  describe('gpt-5.1-codex (text + image)', () => {
+  describe('gpt-5.1-codex (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['gpt-5.1-codex']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
       >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().not.toExtend<Message>()
     })
   })
 
-  describe('gpt-5 (text + image)', () => {
+  describe('gpt-5 (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['gpt-5']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
       >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().not.toExtend<Message>()
     })
   })
 
-  describe('gpt-5-mini (text + image)', () => {
+  describe('gpt-5-mini (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['gpt-5-mini']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
       >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().not.toExtend<Message>()
     })
   })
 
-  describe('gpt-5-nano (text + image)', () => {
+  describe('gpt-5-nano (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['gpt-5-nano']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
       >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().not.toExtend<Message>()
     })
   })
 
-  describe('gpt-5-pro (text + image)', () => {
+  describe('gpt-5-pro (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['gpt-5-pro']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
       >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().not.toExtend<Message>()
     })
   })
 
-  describe('gpt-5-codex (text + image)', () => {
+  describe('gpt-5-codex (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['gpt-5-codex']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
       >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().not.toExtend<Message>()
     })
   })
 
-  describe('gpt-4.1 (text + image)', () => {
+  describe('gpt-4.1 (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['gpt-4.1']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
       >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().not.toExtend<Message>()
     })
   })
 
-  describe('gpt-4.1-mini (text + image)', () => {
+  describe('gpt-4.1-mini (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['gpt-4.1-mini']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
-      >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
       >().not.toExtend<Message>()
     })
   })
 
-  describe('gpt-4.1-nano (text + image)', () => {
+  describe('gpt-4.1-nano (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['gpt-4.1-nano']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
-      >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
       >().not.toExtend<Message>()
     })
   })
@@ -1148,46 +1148,46 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     })
   })
 
-  describe('o3 (text + image)', () => {
+  describe('o3 (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['o3']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
-      >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
       >().not.toExtend<Message>()
     })
   })
 
-  describe('o3-pro (text + image)', () => {
+  describe('o3-pro (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['o3-pro']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
-      >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
       >().not.toExtend<Message>()
     })
   })
@@ -1236,68 +1236,68 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     })
   })
 
-  describe('o4-mini (text + image)', () => {
+  describe('o4-mini (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['o4-mini']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
       >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().not.toExtend<Message>()
     })
   })
 
-  describe('o1 (text + image)', () => {
+  describe('o1 (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['o1']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
-      >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
       >().not.toExtend<Message>()
     })
   })
 
-  describe('o1-pro (text + image)', () => {
+  describe('o1-pro (text + image + document)', () => {
     type Modalities = OpenAIModelInputModalitiesByName['o1-pro']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
-    it('should allow TextPart and ImagePart', () => {
+    it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
+      expectTypeOf<
+        MessageWithContent<OpenAIDocumentPart>
+      >().toExtend<Message>()
     })
 
-    it('should NOT allow AudioPart, VideoPart, or DocumentPart', () => {
+    it('should NOT allow AudioPart or VideoPart', () => {
       expectTypeOf<
         MessageWithContent<OpenAIAudioPart>
       >().not.toExtend<Message>()
       expectTypeOf<
         MessageWithContent<OpenAIVideoPart>
-      >().not.toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
       >().not.toExtend<Message>()
     })
   })

--- a/packages/ai-openai/tests/model-meta.test.ts
+++ b/packages/ai-openai/tests/model-meta.test.ts
@@ -891,9 +891,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -913,9 +911,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -935,9 +931,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -957,9 +951,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -979,9 +971,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -1001,9 +991,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -1023,9 +1011,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -1045,9 +1031,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -1067,9 +1051,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -1089,9 +1071,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -1155,9 +1135,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -1177,9 +1155,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -1243,9 +1219,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -1265,9 +1239,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {
@@ -1287,9 +1259,7 @@ describe('OpenAI Model Input Modality Type Assertions', () => {
     it('should allow TextPart, ImagePart, and DocumentPart', () => {
       expectTypeOf<MessageWithContent<OpenAITextPart>>().toExtend<Message>()
       expectTypeOf<MessageWithContent<OpenAIImagePart>>().toExtend<Message>()
-      expectTypeOf<
-        MessageWithContent<OpenAIDocumentPart>
-      >().toExtend<Message>()
+      expectTypeOf<MessageWithContent<OpenAIDocumentPart>>().toExtend<Message>()
     })
 
     it('should NOT allow AudioPart or VideoPart', () => {

--- a/packages/openai-base/src/adapters/chat-completions-text.ts
+++ b/packages/openai-base/src/adapters/chat-completions-text.ts
@@ -1399,6 +1399,17 @@ export abstract class OpenAIBaseChatCompletionsTextAdapter<
       }
     }
 
+    if (part.type === 'document') {
+      // Documents (PDF) are implemented on the Responses adapter, which maps
+      // them to `input_file`. Model modality arrays are not endpoint-scoped,
+      // so a document part can type-check for a model this adapter serves —
+      // point callers at the supported path instead of a generic error.
+      throw new Error(
+        `${this.name} does not support document parts on the Chat Completions ` +
+          `API; use the Responses adapter, which sends them as input_file.`,
+      )
+    }
+
     // Unsupported content type — subclasses can override to handle more types
     return null
   }

--- a/packages/openai-base/src/adapters/responses-text.ts
+++ b/packages/openai-base/src/adapters/responses-text.ts
@@ -1898,7 +1898,9 @@ export abstract class OpenAIBaseResponsesTextAdapter<
         // rejected. MIME types are case-insensitive and can carry
         // ;parameters (RFC 2045), so the type is normalized before comparing.
         const documentValue = part.source.value
-        const documentMime = ((part.source.mimeType || 'application/pdf').split(';')[0] ?? '')
+        const documentMime = (
+          (part.source.mimeType || 'application/pdf').split(';')[0] ?? ''
+        )
           .trim()
           .toLowerCase()
         if (documentMime !== 'application/pdf') {

--- a/packages/openai-base/src/adapters/responses-text.ts
+++ b/packages/openai-base/src/adapters/responses-text.ts
@@ -1795,7 +1795,7 @@ export abstract class OpenAIBaseResponsesTextAdapter<
         throw new Error(
           `User message for ${this.name} has no content parts. ` +
             `Empty user messages would produce a paid request with no input; ` +
-            `provide at least one text/image/audio part or omit the message.`,
+            `provide at least one text/image/audio/document part or omit the message.`,
         )
       }
 
@@ -1811,7 +1811,7 @@ export abstract class OpenAIBaseResponsesTextAdapter<
 
   /**
    * Converts a ContentPart to Responses API input content item.
-   * Handles text, image, and audio content parts.
+   * Handles text, image, audio, and document (PDF) content parts.
    * Override this in subclasses for additional content types or provider-specific metadata.
    */
   protected convertContentPartToInput(part: ContentPart): ResponseInputContent {
@@ -1855,7 +1855,7 @@ export abstract class OpenAIBaseResponsesTextAdapter<
           }
         }
         // Wrap raw base64 in a data URL — `input_file` rejects bare base64
-        // payloads (matches the image branch above which already does this).
+        // payloads (matches the image branch above).
         // Default the MIME if missing so we never interpolate `undefined`.
         const audioValue = part.source.value
         const audioMime = part.source.mimeType || 'application/octet-stream'
@@ -1868,12 +1868,67 @@ export abstract class OpenAIBaseResponsesTextAdapter<
         }
       }
 
+      case 'document': {
+        const documentMetadata = part.metadata as
+          | { filename?: string; detail?: 'low' | 'high' }
+          | undefined
+        // `detail` is optional with no 'auto' member (unlike input_image) —
+        // spread only when provided so the API applies its own default.
+        const documentDetail =
+          documentMetadata?.detail !== undefined
+            ? { detail: documentMetadata.detail }
+            : {}
+        if (part.source.type === 'url') {
+          // The Responses API fetches the PDF itself; filename and MIME
+          // type are inferred from the response.
+          return {
+            type: 'input_file',
+            file_url: part.source.value,
+            ...documentDetail,
+          }
+        }
+        // This adapter supports only PDF documents; anything else is
+        // rejected. MIME types are case-insensitive and can carry
+        // ;parameters (RFC 2045), so the type is normalized before comparing.
+        const documentValue = part.source.value
+        const documentMime = ((part.source.mimeType || 'application/pdf').split(';')[0] ?? '')
+          .trim()
+          .toLowerCase()
+        if (documentMime !== 'application/pdf') {
+          throw new Error(
+            `${this.name} document parts only support application/pdf ` +
+              `(received ${documentMime})`,
+          )
+        }
+        // A pre-wrapped data URL carries its own media type — validate it too.
+        if (
+          documentValue.startsWith('data:') &&
+          !/^data:application\/pdf[;,]/i.test(documentValue)
+        ) {
+          throw new Error(
+            `${this.name} document parts only support application/pdf ` +
+              `(received data URL with non-PDF media type)`,
+          )
+        }
+        // Wrap raw base64 in a data URL — `input_file` rejects bare base64
+        // payloads (matches the image and audio branches above).
+        const documentFileData = documentValue.startsWith('data:')
+          ? documentValue
+          : `data:${documentMime};base64,${documentValue}`
+        return {
+          type: 'input_file',
+          // The Responses API requires a filename alongside PDF `file_data`.
+          filename: documentMetadata?.filename || 'document.pdf',
+          file_data: documentFileData,
+          ...documentDetail,
+        }
+      }
+
       case 'video':
-      case 'document':
       default:
-        // OpenAI Responses API doesn't accept native video/document parts on
-        // this path — surface as explicit unsupported error so callers see
-        // the same message regardless of which content type leaked through.
+        // OpenAI Responses API doesn't accept native video parts on this
+        // path — surface as explicit unsupported error so callers see the
+        // same message regardless of which content type leaked through.
         throw new Error(`Unsupported content part type: ${part.type}`)
     }
   }

--- a/packages/openai-base/src/adapters/responses-text.ts
+++ b/packages/openai-base/src/adapters/responses-text.ts
@@ -31,6 +31,10 @@ import type {
   TextOptions,
 } from '@tanstack/ai'
 
+// Base64 encoding of the '%PDF' file header — every PDF payload starts with
+// these bytes, so inline document data must begin with this prefix.
+const PDF_BASE64_MAGIC = 'JVBERi'
+
 /**
  * Provider-specific metadata that preserves the Responses API output item ID.
  *
@@ -1870,13 +1874,16 @@ export abstract class OpenAIBaseResponsesTextAdapter<
 
       case 'document': {
         const documentMetadata = part.metadata as
-          | { filename?: string; detail?: 'low' | 'high' }
+          | { filename?: string; detail?: 'auto' | 'low' | 'high' }
           | undefined
-        // `detail` is optional with no 'auto' member (unlike input_image) —
-        // spread only when provided so the API applies its own default.
+        // Spread `detail` only when provided so the API applies its own
+        // default ('auto'). The Responses API accepts 'auto' | 'low' | 'high',
+        // but the pinned OpenAI SDK's `ResponseInputFile.detail` type still
+        // lists only 'low' | 'high' — cast so 'auto' (a valid API value) can
+        // pass through without a type error.
         const documentDetail =
           documentMetadata?.detail !== undefined
-            ? { detail: documentMetadata.detail }
+            ? { detail: documentMetadata.detail as 'low' | 'high' }
             : {}
         if (part.source.type === 'url') {
           // The Responses API fetches the PDF itself; filename and MIME
@@ -1908,6 +1915,21 @@ export abstract class OpenAIBaseResponsesTextAdapter<
           throw new Error(
             `${this.name} document parts only support application/pdf ` +
               `(received data URL with non-PDF media type)`,
+          )
+        }
+        // Sniff the payload so a non-PDF labeled (or unlabeled) as PDF is
+        // caught locally instead of by an opaque provider 400. Only base64
+        // payloads are checked; a rare `data:` URL without `;base64` is left
+        // to the server.
+        const documentBase64 = documentValue.startsWith('data:')
+          ? /;base64,/i.test(documentValue)
+            ? documentValue.slice(documentValue.indexOf(',') + 1)
+            : ''
+          : documentValue
+        if (documentBase64 && !documentBase64.startsWith(PDF_BASE64_MAGIC)) {
+          throw new Error(
+            `${this.name} document parts only support application/pdf ` +
+              `(inline data does not start with the %PDF header)`,
           )
         }
         // Wrap raw base64 in a data URL — `input_file` rejects bare base64

--- a/packages/openai-base/tests/chat-completions-text.test.ts
+++ b/packages/openai-base/tests/chat-completions-text.test.ts
@@ -620,6 +620,44 @@ describe('OpenAIBaseChatCompletionsTextAdapter', () => {
   })
 
   describe('error handling', () => {
+    it('points document parts at the Responses adapter', async () => {
+      mockCreate = vi.fn()
+      const adapter = new TestChatCompletionsAdapter(testConfig, 'test-model')
+      const chunks: Array<StreamChunk> = []
+
+      for await (const chunk of adapter.chatStream({
+        logger: testLogger,
+        model: 'test-model',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', content: 'summarize this' },
+              {
+                type: 'document',
+                source: {
+                  type: 'data',
+                  value: 'JVBERi0xLjQK',
+                  mimeType: 'application/pdf',
+                },
+              },
+            ],
+          },
+        ],
+      })) {
+        chunks.push(chunk)
+      }
+
+      const runErrorChunk = chunks.find((c) => c.type === 'RUN_ERROR')
+      expect(runErrorChunk).toBeDefined()
+      if (runErrorChunk?.type === 'RUN_ERROR') {
+        expect(runErrorChunk.message).toMatch(/Responses adapter/)
+        expect(runErrorChunk.message).toMatch(/document/)
+      }
+      // No request should have been attempted.
+      expect(mockCreate).not.toHaveBeenCalled()
+    })
+
     it('emits RUN_ERROR on stream error', async () => {
       const streamChunks = [
         {

--- a/packages/openai-base/tests/responses-text.test.ts
+++ b/packages/openai-base/tests/responses-text.test.ts
@@ -2427,7 +2427,11 @@ describe('OpenAIBaseResponsesTextAdapter', () => {
     const minimalStreamChunks = [
       {
         type: 'response.created',
-        response: { id: 'resp-doc-1', model: 'test-model', status: 'in_progress' },
+        response: {
+          id: 'resp-doc-1',
+          model: 'test-model',
+          status: 'in_progress',
+        },
       },
       {
         type: 'response.completed',

--- a/packages/openai-base/tests/responses-text.test.ts
+++ b/packages/openai-base/tests/responses-text.test.ts
@@ -2421,6 +2421,9 @@ describe('OpenAIBaseResponsesTextAdapter', () => {
         'trailer<</Root 1 0 R>>\n%%EOF',
     ).toString('base64')
 
+    // A payload that is not a PDF (no '%PDF' header).
+    const NOT_PDF_BASE64 = Buffer.from('hello, not a pdf').toString('base64')
+
     const minimalStreamChunks = [
       {
         type: 'response.created',
@@ -2621,6 +2624,23 @@ describe('OpenAIBaseResponsesTextAdapter', () => {
       })
     })
 
+    it("passes detail: 'auto' through to the payload", async () => {
+      await runChat([
+        {
+          type: 'document',
+          source: {
+            type: 'data',
+            value: TINY_PDF_BASE64,
+            mimeType: 'application/pdf',
+          },
+          metadata: { detail: 'auto' },
+        },
+      ])
+
+      const [payload] = mockResponsesCreate.mock.calls[0]!
+      expect(payload.input[0].content[0].detail).toBe('auto')
+    })
+
     it('omits detail when metadata does not provide it', async () => {
       await runChat([
         {
@@ -2730,6 +2750,80 @@ describe('OpenAIBaseResponsesTextAdapter', () => {
           file_data: `data:application/pdf;base64,${TINY_PDF_BASE64}`,
         },
       ])
+    })
+
+    it('emits RUN_ERROR for raw base64 without a mimeType that is not a PDF', async () => {
+      const chunks = await runChat([
+        {
+          type: 'document',
+          source: { type: 'data', value: NOT_PDF_BASE64 },
+        },
+      ])
+
+      const errorChunk = chunks.find((c) => c.type === 'RUN_ERROR')
+      expect(errorChunk).toBeDefined()
+      if (errorChunk?.type === 'RUN_ERROR') {
+        expect(errorChunk.message).toMatch(/only support application\/pdf/)
+        expect(errorChunk.message).toMatch(/%PDF/)
+      }
+    })
+
+    it('accepts raw base64 PDF data without a mimeType', async () => {
+      await runChat([
+        {
+          type: 'document',
+          source: { type: 'data', value: TINY_PDF_BASE64 },
+        },
+      ])
+
+      const [payload] = mockResponsesCreate.mock.calls[0]!
+      expect(payload.input[0].content).toEqual([
+        {
+          type: 'input_file',
+          filename: 'document.pdf',
+          file_data: `data:application/pdf;base64,${TINY_PDF_BASE64}`,
+        },
+      ])
+    })
+
+    it('emits RUN_ERROR for non-PDF data mislabeled as application/pdf', async () => {
+      const chunks = await runChat([
+        {
+          type: 'document',
+          source: {
+            type: 'data',
+            value: NOT_PDF_BASE64,
+            mimeType: 'application/pdf',
+          },
+        },
+      ])
+
+      const errorChunk = chunks.find((c) => c.type === 'RUN_ERROR')
+      expect(errorChunk).toBeDefined()
+      if (errorChunk?.type === 'RUN_ERROR') {
+        expect(errorChunk.message).toMatch(/only support application\/pdf/)
+        expect(errorChunk.message).toMatch(/%PDF/)
+      }
+    })
+
+    it('emits RUN_ERROR for a PDF data URL whose payload is not a PDF', async () => {
+      const chunks = await runChat([
+        {
+          type: 'document',
+          source: {
+            type: 'data',
+            value: `data:application/pdf;base64,${NOT_PDF_BASE64}`,
+            mimeType: 'application/pdf',
+          },
+        },
+      ])
+
+      const errorChunk = chunks.find((c) => c.type === 'RUN_ERROR')
+      expect(errorChunk).toBeDefined()
+      if (errorChunk?.type === 'RUN_ERROR') {
+        expect(errorChunk.message).toMatch(/only support application\/pdf/)
+        expect(errorChunk.message).toMatch(/%PDF/)
+      }
     })
   })
 

--- a/packages/openai-base/tests/responses-text.test.ts
+++ b/packages/openai-base/tests/responses-text.test.ts
@@ -2412,6 +2412,327 @@ describe('OpenAIBaseResponsesTextAdapter', () => {
     })
   })
 
+  describe('document content parts (PDF input)', () => {
+    // A minimal one-page PDF.
+    const TINY_PDF_BASE64 = Buffer.from(
+      '%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n' +
+        '2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n' +
+        '3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]>>endobj\n' +
+        'trailer<</Root 1 0 R>>\n%%EOF',
+    ).toString('base64')
+
+    const minimalStreamChunks = [
+      {
+        type: 'response.created',
+        response: { id: 'resp-doc-1', model: 'test-model', status: 'in_progress' },
+      },
+      {
+        type: 'response.completed',
+        response: {
+          id: 'resp-doc-1',
+          model: 'test-model',
+          status: 'completed',
+          output: [],
+          usage: { input_tokens: 10, output_tokens: 1, total_tokens: 11 },
+        },
+      },
+    ]
+
+    async function runChat(content: Array<any>): Promise<Array<StreamChunk>> {
+      setupMockResponsesClient(minimalStreamChunks)
+      const adapter = new TestResponsesAdapter(testConfig, 'test-model')
+      const chunks: Array<StreamChunk> = []
+      for await (const chunk of adapter.chatStream({
+        logger: testLogger,
+        model: 'test-model',
+        messages: [{ role: 'user', content }],
+      })) {
+        chunks.push(chunk)
+      }
+      return chunks
+    }
+
+    it('converts a base64 data source to input_file with a default filename', async () => {
+      await runChat([
+        {
+          type: 'document',
+          source: {
+            type: 'data',
+            value: TINY_PDF_BASE64,
+            mimeType: 'application/pdf',
+          },
+        },
+      ])
+
+      const [payload] = mockResponsesCreate.mock.calls[0]!
+      expect(payload.input[0].content).toEqual([
+        {
+          type: 'input_file',
+          filename: 'document.pdf',
+          file_data: `data:application/pdf;base64,${TINY_PDF_BASE64}`,
+        },
+      ])
+    })
+
+    it('uses metadata.filename when provided', async () => {
+      await runChat([
+        {
+          type: 'document',
+          source: {
+            type: 'data',
+            value: TINY_PDF_BASE64,
+            mimeType: 'application/pdf',
+          },
+          metadata: { filename: 'report.pdf' },
+        },
+      ])
+
+      const [payload] = mockResponsesCreate.mock.calls[0]!
+      expect(payload.input[0].content[0].filename).toBe('report.pdf')
+    })
+
+    it('passes an existing data URL through without double-wrapping', async () => {
+      const dataUrl = `data:application/pdf;base64,${TINY_PDF_BASE64}`
+      await runChat([
+        {
+          type: 'document',
+          source: { type: 'data', value: dataUrl, mimeType: 'application/pdf' },
+        },
+      ])
+
+      const [payload] = mockResponsesCreate.mock.calls[0]!
+      expect(payload.input[0].content[0].file_data).toBe(dataUrl)
+    })
+
+    it('converts a URL source to input_file with file_url only', async () => {
+      await runChat([
+        {
+          type: 'document',
+          source: { type: 'url', value: 'https://example.com/doc.pdf' },
+        },
+      ])
+
+      const [payload] = mockResponsesCreate.mock.calls[0]!
+      const part = payload.input[0].content[0]
+      expect(part).toEqual({
+        type: 'input_file',
+        file_url: 'https://example.com/doc.pdf',
+      })
+      expect(part).not.toHaveProperty('file_data')
+      expect(part).not.toHaveProperty('filename')
+    })
+
+    it('emits RUN_ERROR for a non-PDF document MIME type', async () => {
+      const chunks = await runChat([
+        {
+          type: 'document',
+          source: {
+            type: 'data',
+            value: TINY_PDF_BASE64,
+            mimeType: 'application/msword',
+          },
+        },
+      ])
+
+      const errorChunk = chunks.find((c) => c.type === 'RUN_ERROR')
+      expect(errorChunk).toBeDefined()
+      if (errorChunk?.type === 'RUN_ERROR') {
+        expect(errorChunk.message).toMatch(/only support application\/pdf/)
+        expect(errorChunk.message).toMatch(/application\/msword/)
+      }
+    })
+
+    it('emits RUN_ERROR for a data URL with a non-PDF media type', async () => {
+      const chunks = await runChat([
+        {
+          type: 'document',
+          source: {
+            type: 'data',
+            value: `data:image/png;base64,${TINY_PDF_BASE64}`,
+            mimeType: 'application/pdf',
+          },
+        },
+      ])
+
+      const errorChunk = chunks.find((c) => c.type === 'RUN_ERROR')
+      expect(errorChunk).toBeDefined()
+      if (errorChunk?.type === 'RUN_ERROR') {
+        expect(errorChunk.message).toMatch(/only support application\/pdf/)
+        expect(errorChunk.message).toMatch(/non-PDF media type/)
+      }
+    })
+
+    it('rejects a data URL whose media type merely extends application/pdf', async () => {
+      const chunks = await runChat([
+        {
+          type: 'document',
+          source: {
+            type: 'data',
+            value: `data:application/pdf+xml;base64,${TINY_PDF_BASE64}`,
+            mimeType: 'application/pdf',
+          },
+        },
+      ])
+
+      const errorChunk = chunks.find((c) => c.type === 'RUN_ERROR')
+      expect(errorChunk).toBeDefined()
+      if (errorChunk?.type === 'RUN_ERROR') {
+        expect(errorChunk.message).toMatch(/non-PDF media type/)
+      }
+    })
+
+    it('accepts case-insensitive PDF media types (RFC 2045)', async () => {
+      const dataUrl = `data:APPLICATION/PDF;base64,${TINY_PDF_BASE64}`
+      await runChat([
+        {
+          type: 'document',
+          source: { type: 'data', value: dataUrl, mimeType: 'Application/PDF' },
+        },
+      ])
+
+      const [payload] = mockResponsesCreate.mock.calls[0]!
+      expect(payload.input[0].content[0].file_data).toBe(dataUrl)
+    })
+
+    it('passes metadata.detail through on both source shapes', async () => {
+      await runChat([
+        {
+          type: 'document',
+          source: {
+            type: 'data',
+            value: TINY_PDF_BASE64,
+            mimeType: 'application/pdf',
+          },
+          metadata: { detail: 'high' },
+        },
+        {
+          type: 'document',
+          source: { type: 'url', value: 'https://example.com/doc.pdf' },
+          metadata: { detail: 'low' },
+        },
+      ])
+
+      const [payload] = mockResponsesCreate.mock.calls[0]!
+      expect(payload.input[0].content[0].detail).toBe('high')
+      expect(payload.input[0].content[1]).toEqual({
+        type: 'input_file',
+        file_url: 'https://example.com/doc.pdf',
+        detail: 'low',
+      })
+    })
+
+    it('omits detail when metadata does not provide it', async () => {
+      await runChat([
+        {
+          type: 'document',
+          source: {
+            type: 'data',
+            value: TINY_PDF_BASE64,
+            mimeType: 'application/pdf',
+          },
+        },
+      ])
+
+      const [payload] = mockResponsesCreate.mock.calls[0]!
+      expect(payload.input[0].content[0]).not.toHaveProperty('detail')
+    })
+
+    it('still rejects video content parts', async () => {
+      const chunks = await runChat([
+        {
+          type: 'video',
+          source: { type: 'url', value: 'https://example.com/clip.mp4' },
+        },
+      ])
+
+      const errorChunk = chunks.find((c) => c.type === 'RUN_ERROR')
+      expect(errorChunk).toBeDefined()
+      if (errorChunk?.type === 'RUN_ERROR') {
+        expect(errorChunk.message).toMatch(
+          /Unsupported content part type: video/,
+        )
+      }
+    })
+
+    it('keeps text and document parts in order within one message', async () => {
+      await runChat([
+        { type: 'text', content: 'summarize this' },
+        {
+          type: 'document',
+          source: {
+            type: 'data',
+            value: TINY_PDF_BASE64,
+            mimeType: 'application/pdf',
+          },
+        },
+      ])
+
+      const [payload] = mockResponsesCreate.mock.calls[0]!
+      expect(payload.input[0].content).toEqual([
+        { type: 'input_text', text: 'summarize this' },
+        {
+          type: 'input_file',
+          filename: 'document.pdf',
+          file_data: `data:application/pdf;base64,${TINY_PDF_BASE64}`,
+        },
+      ])
+    })
+
+    it('converts a document part inside a tool result', async () => {
+      setupMockResponsesClient(minimalStreamChunks)
+      const adapter = new TestResponsesAdapter(testConfig, 'test-model')
+      const chunks: Array<StreamChunk> = []
+      for await (const chunk of adapter.chatStream({
+        logger: testLogger,
+        model: 'test-model',
+        messages: [
+          { role: 'user', content: 'fetch the doc' },
+          {
+            role: 'assistant',
+            content: '',
+            toolCalls: [
+              {
+                id: 'call_doc',
+                type: 'function',
+                function: { name: 'fetch_doc', arguments: '{}' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            toolCallId: 'call_doc',
+            content: [
+              { type: 'text', content: 'here it is' },
+              {
+                type: 'document',
+                source: {
+                  type: 'data',
+                  value: TINY_PDF_BASE64,
+                  mimeType: 'application/pdf',
+                },
+              },
+            ],
+          },
+        ],
+      })) {
+        chunks.push(chunk)
+      }
+
+      const [payload] = mockResponsesCreate.mock.calls[0]!
+      const out = payload.input.find(
+        (i: any) => i.type === 'function_call_output',
+      )
+      expect(out.output).toEqual([
+        { type: 'input_text', text: 'here it is' },
+        {
+          type: 'input_file',
+          filename: 'document.pdf',
+          file_data: `data:application/pdf;base64,${TINY_PDF_BASE64}`,
+        },
+      ])
+    })
+  })
+
   describe('subclassing', () => {
     it('allows subclassing with custom name', () => {
       class MyProviderAdapter extends OpenAIBaseResponsesTextAdapter<string> {

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -28,6 +28,7 @@ Each test iterates over supported providers using `providersFor('feature')`:
 | agentic-structured       | 7         | `tests/agentic-structured.spec.ts`       |
 | reasoning                | 3         | `tests/reasoning.spec.ts`                |
 | multimodal-image         | 5         | `tests/multimodal-image.spec.ts`         |
+| multimodal-document      | 1         | `tests/multimodal-document.spec.ts`      |
 | multimodal-structured    | 5         | `tests/multimodal-structured.spec.ts`    |
 | summarize                | 6         | `tests/summarize.spec.ts`                |
 | summarize-stream         | 6         | `tests/summarize-stream.spec.ts`         |

--- a/testing/e2e/fixtures/multimodal-document/basic.json
+++ b/testing/e2e/fixtures/multimodal-document/basic.json
@@ -1,0 +1,12 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "[mmdocument] summarize this pdf"
+      },
+      "response": {
+        "content": "The PDF contains a single blank page with no text content."
+      }
+    }
+  ]
+}

--- a/testing/e2e/src/components/ChatUI.tsx
+++ b/testing/e2e/src/components/ChatUI.tsx
@@ -18,7 +18,9 @@ interface ChatUIProps<
   messages: Array<UIMessage>
   isLoading: boolean
   onSendMessage: (text: string) => void
+  /** Sends the typed prompt plus an attached image as an image content part. */
   onSendMessageWithImage?: (text: string, file: File) => void
+  /** Sends the typed prompt plus an attached PDF as a document content part. */
   onSendMessageWithDocument?: (text: string, file: File) => void
   /**
    * Bound AG-UI interrupts from `useChat({ tools })` —
@@ -30,7 +32,9 @@ interface ChatUIProps<
     id: string
     approved: boolean
   }) => Promise<void>
+  /** Renders the image file input (multimodal image features only). */
   showImageInput?: boolean
+  /** Renders the PDF file input (multimodal-document feature only). */
   showDocumentInput?: boolean
   onStop?: () => void
   /** When the streaming structured-output CUSTOM event lands, the page

--- a/testing/e2e/src/components/ChatUI.tsx
+++ b/testing/e2e/src/components/ChatUI.tsx
@@ -19,6 +19,7 @@ interface ChatUIProps<
   isLoading: boolean
   onSendMessage: (text: string) => void
   onSendMessageWithImage?: (text: string, file: File) => void
+  onSendMessageWithDocument?: (text: string, file: File) => void
   /**
    * Bound AG-UI interrupts from `useChat({ tools })` —
    * `BoundInterrupts<TTools>` (library type, not a harness DTO).
@@ -30,6 +31,7 @@ interface ChatUIProps<
     approved: boolean
   }) => Promise<void>
   showImageInput?: boolean
+  showDocumentInput?: boolean
   onStop?: () => void
   /** When the streaming structured-output CUSTOM event lands, the page
    *  exposes the parsed object here so e2e tests can assert that the event
@@ -56,9 +58,11 @@ export function ChatUI<
   isLoading,
   onSendMessage,
   onSendMessageWithImage,
+  onSendMessageWithDocument,
   interrupts = [],
   addToolApprovalResponse,
   showImageInput,
+  showDocumentInput,
   onStop,
   structuredObject,
   contentDeltaCount,
@@ -325,6 +329,23 @@ export function ChatUI<
               const text = (inputRef.current?.value ?? input).trim()
               if (file && text && onSendMessageWithImage) {
                 onSendMessageWithImage(text, file)
+                setInput('')
+              }
+            }}
+          />
+        )}
+        {showDocumentInput && (
+          <input
+            type="file"
+            accept="application/pdf,.pdf"
+            data-testid="document-attachment-input"
+            className="text-xs text-gray-400"
+            onChange={(e) => {
+              const file = e.target.files?.[0]
+              // Same DOM-value read as the image input above.
+              const text = (inputRef.current?.value ?? input).trim()
+              if (file && text && onSendMessageWithDocument) {
+                onSendMessageWithDocument(text, file)
                 setInput('')
               }
             }}

--- a/testing/e2e/src/components/ChatUI.tsx
+++ b/testing/e2e/src/components/ChatUI.tsx
@@ -351,6 +351,7 @@ export function ChatUI<
               if (file && text && onSendMessageWithDocument) {
                 onSendMessageWithDocument(text, file)
                 setInput('')
+                e.target.value = ''
               }
             }}
           />

--- a/testing/e2e/src/lib/feature-support.ts
+++ b/testing/e2e/src/lib/feature-support.ts
@@ -222,6 +222,9 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'byteplus',
   ]),
+  // OpenAI only: this feature exercises the Responses adapter's PDF
+  // `input_file` conversion (base64 `file_data` + filename).
+  'multimodal-document': new Set(['openai']),
   // Bedrock excluded: same text-only default e2e model as multimodal-image above.
   'multimodal-structured': new Set([
     'openai',

--- a/testing/e2e/src/lib/features.ts
+++ b/testing/e2e/src/lib/features.ts
@@ -108,6 +108,10 @@ export const featureConfigs: Record<Feature, FeatureConfig> = {
     tools: [],
     modelOptions: {},
   },
+  'multimodal-document': {
+    tools: [],
+    modelOptions: {},
+  },
   'multimodal-structured': {
     tools: [],
     modelOptions: {},

--- a/testing/e2e/src/lib/types.ts
+++ b/testing/e2e/src/lib/types.ts
@@ -33,6 +33,7 @@ export type Feature =
   | 'agentic-structured'
   | 'agentic-structured-stream'
   | 'multimodal-image'
+  | 'multimodal-document'
   | 'multimodal-structured'
   | 'summarize'
   | 'summarize-stream'
@@ -83,6 +84,7 @@ export const ALL_FEATURES: Feature[] = [
   'agentic-structured',
   'agentic-structured-stream',
   'multimodal-image',
+  'multimodal-document',
   'multimodal-structured',
   'summarize',
   'summarize-stream',

--- a/testing/e2e/src/routes/$provider/$feature.tsx
+++ b/testing/e2e/src/routes/$provider/$feature.tsx
@@ -299,6 +299,7 @@ function ChatFeature({
   const needsApproval = feature === 'tool-approval'
   const showImageInput =
     feature === 'multimodal-image' || feature === 'multimodal-structured'
+  const showDocumentInput = feature === 'multimodal-document'
 
   // Stable tools tuple so `useChat` / `BoundInterrupts` keep approval typing
   // (and ChatUI can accept `interrupts` without casts).
@@ -480,9 +481,38 @@ function ChatFeature({
               }
             : undefined
         }
+        onSendMessageWithDocument={
+          showDocumentInput
+            ? (text, file) => {
+                const reader = new FileReader()
+                reader.onload = () => {
+                  const base64 = (reader.result as string).split(',')[1]
+                  sendMessage({
+                    content: [
+                      { type: 'text', content: text },
+                      {
+                        type: 'document',
+                        source: {
+                          type: 'data',
+                          value: base64,
+                          mimeType: file.type,
+                        },
+                        metadata: { filename: file.name },
+                      },
+                    ],
+                  })
+                }
+                reader.readAsDataURL(file)
+              }
+            : undefined
+        }
         interrupts={needsApproval ? interrupts : undefined}
         hasPendingInterrupt={interrupts.some((i) => i.status === 'pending')}
+        addToolApprovalResponse={
+          needsApproval ? addToolApprovalResponse : undefined
+        }
         showImageInput={showImageInput}
+        showDocumentInput={showDocumentInput}
         onStop={stop}
       />
     </>

--- a/testing/e2e/src/routes/$provider/$feature.tsx
+++ b/testing/e2e/src/routes/$provider/$feature.tsx
@@ -508,9 +508,6 @@ function ChatFeature({
         }
         interrupts={needsApproval ? interrupts : undefined}
         hasPendingInterrupt={interrupts.some((i) => i.status === 'pending')}
-        addToolApprovalResponse={
-          needsApproval ? addToolApprovalResponse : undefined
-        }
         showImageInput={showImageInput}
         showDocumentInput={showDocumentInput}
         onStop={stop}

--- a/testing/e2e/test-assets/tiny.pdf
+++ b/testing/e2e/test-assets/tiny.pdf
@@ -1,0 +1,6 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]>>endobj
+trailer<</Root 1 0 R>>
+%%EOF

--- a/testing/e2e/tests/helpers.ts
+++ b/testing/e2e/tests/helpers.ts
@@ -31,6 +31,8 @@ export async function sendMessage(page: Page, text: string) {
     })
 }
 
+/** Types a prompt and attaches an image; attaching auto-sends. Retries until
+ *  the user bubble renders — the inline comment below explains why. */
 export async function sendMessageWithImage(
   page: Page,
   text: string,
@@ -64,6 +66,9 @@ export async function sendMessageWithImage(
   }).toPass({ timeout: 15_000, intervals: [250, 500, 1000] })
 }
 
+/** Types a prompt and attaches a PDF; attaching auto-sends. Retries until the
+ *  user bubble renders (same fragile-controlled-input problem as
+ *  sendMessageWithImage — see the comment there). */
 export async function sendMessageWithDocument(
   page: Page,
   text: string,

--- a/testing/e2e/tests/helpers.ts
+++ b/testing/e2e/tests/helpers.ts
@@ -64,6 +64,27 @@ export async function sendMessageWithImage(
   }).toPass({ timeout: 15_000, intervals: [250, 500, 1000] })
 }
 
+export async function sendMessageWithDocument(
+  page: Page,
+  text: string,
+  documentPath: string,
+) {
+  const input = page.getByTestId('chat-input')
+  const fileInput = page.getByTestId('document-attachment-input')
+  const userMessages = page.getByTestId('user-message')
+
+  // Same retry-to-observable-outcome pattern as sendMessageWithImage above.
+  await expect(async () => {
+    await input.click()
+    await input.fill('')
+    await input.pressSequentially(text, { delay: 15 })
+    expect(await input.inputValue()).toBe(text)
+    await fileInput.setInputFiles([])
+    await fileInput.setInputFiles(documentPath)
+    await expect(userMessages.first()).toBeVisible({ timeout: 2_000 })
+  }).toPass({ timeout: 15_000, intervals: [250, 500, 1000] })
+}
+
 export async function waitForResponse(page: Page, timeout = 15_000) {
   try {
     await page

--- a/testing/e2e/tests/multimodal-document.spec.ts
+++ b/testing/e2e/tests/multimodal-document.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from './fixtures'
+import {
+  sendMessageWithDocument,
+  waitForResponse,
+  getLastAssistantMessage,
+  featureUrl,
+} from './helpers'
+import { providersFor } from './test-matrix'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const testDocumentPath = path.resolve(__dirname, '../test-assets/tiny.pdf')
+
+for (const provider of providersFor('multimodal-document')) {
+  test.describe(`${provider} — multimodal-document`, () => {
+    test('answers a question about an uploaded PDF', async ({
+      page,
+      testId,
+      aimockPort,
+    }) => {
+      await page.goto(
+        featureUrl(provider, 'multimodal-document', testId, aimockPort),
+      )
+
+      await sendMessageWithDocument(
+        page,
+        '[mmdocument] summarize this pdf',
+        testDocumentPath,
+      )
+      await waitForResponse(page)
+
+      const response = await getLastAssistantMessage(page)
+      expect(response).toContain('blank page')
+    })
+  })
+}


### PR DESCRIPTION
feat(ai-openai): support PDF `document` content parts in the Responses adapter

## 🎯 Changes

`openaiText`'s Responses adapter now accepts PDF `document` content parts. Any OpenAI chat model whose `model-meta` entry declares the `document` input modality can take a PDF as message content.

- Base64 (`data`) sources send `input_file` with a `file_data` data URL and a `filename` (from `metadata.filename`, defaulting to `document.pdf`).
- URL sources send `input_file` with `file_url`.
- Non-PDF MIME types are rejected before the request goes out — including pre-wrapped `data:` URLs whose media type doesn't match the declared `mimeType` — so callers get a clear error instead of an opaque provider `400`.
- `OpenAIDocumentMetadata` gains `filename` and `detail`.
- Documents are Responses-only; the Chat Completions adapter throws a document-specific error naming the Responses path.

```ts
import { openaiText } from '@tanstack/ai-openai/adapters'

const adapter = openaiText('gpt-5.5')

const message = {
  role: 'user',
  content: [
    { type: 'text', content: 'Summarize this document' },
    {
      type: 'document',
      source: { type: 'data', value: pdfBase64, mimeType: 'application/pdf' },
      metadata: { filename: 'report.pdf' },
    },
  ],
}
```

### Test plan

- **Unit:** Responses adapter mapping for base64 and URL sources, filename defaulting, and the MIME guards (non-PDF `mimeType`, mismatched `data:` URL media type); the Chat Completions document-rejection error; `model-meta` modality assertions.
- **E2E:** new `multimodal-document` feature — fixture, spec (`testing/e2e/tests/multimodal-document.spec.ts`), harness page, and a `tiny.pdf` asset (a minimal PDF), wired into `feature-support.ts` and `features.ts`.
- **Docs:** `document` example in `docs/advanced/multimodal-content.md`; the modality list points readers at `model-meta.ts`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PDF document (“document” modality) support for compatible OpenAI Responses models (base64 or URL sources), including optional `filename` and `detail`, with sensible defaults like `document.pdf`.
  * Enabled PDF attachments in the multimodal chat UI and added a new multimodal-document end-to-end test and fixture.
* **Bug Fixes**
  * Improved validation and error messaging for invalid/non-PDF inputs; document parts are now routed correctly for Responses (Chat Completions rejects them).
* **Documentation**
  * Updated OpenAI provider multimodal docs and the supported-modality list to include PDF documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->