### PR TITLE
fix(ai-orchestration): observe agentStream output before draining

### DIFF
--- a/packages/ai-orchestration/src/execute-agent.ts
+++ b/packages/ai-orchestration/src/execute-agent.ts
@@ -33,8 +33,14 @@ export async function executeAgent<TInput, TOutput>(args: {
     })
 
     if (isAgentStreamResult<TOutput>(result)) {
+      // `output` is already in flight, so observe it before draining can throw.
+      // Otherwise a failing stream leaves it rejected and unhandled, which
+      // terminates the worker under Node's default unhandled-rejection policy.
+      const output = Promise.resolve(result.output)
+      output.catch(() => undefined)
+
       await drainAgentStream(definition.name, result.stream, args.emit)
-      return validateOutput(definition, await result.output)
+      return validateOutput(definition, await output)
     }
 
     if (isAsyncIterable<StreamChunk>(result)) {

--- a/packages/ai-orchestration/tests/orchestration.test.ts
+++ b/packages/ai-orchestration/tests/orchestration.test.ts
@@ -8,7 +8,9 @@ import { z } from 'zod'
 import { EventType } from '@tanstack/ai'
 import {
   AgentApprovalUnsupportedError,
+  AgentStreamError,
   agentMiddleware,
+  agentStream,
   createAIEventPublisher,
   defineAgent,
   toAIStream,
@@ -215,6 +217,44 @@ describe('Workflow-backed agent orchestration', () => {
     expect(events.some((event) => event.type === 'RUN_FINISHED')).toBe(false)
   })
 
+  it('fails the step without an unhandled rejection when an agentStream errors', async () => {
+    const unhandled: Array<unknown> = []
+    const onUnhandled = (reason: unknown) => unhandled.push(reason)
+    process.on('unhandledRejection', onUnhandled)
+
+    const broken = defineAgent({
+      name: 'broken',
+      run: () =>
+        agentStream(
+          errorStream('model exploded'),
+          Promise.reject(new Error('output never settles')),
+        ),
+    })
+    const workflow = createWorkflow({ id: 'broken' })
+      .middleware([agentMiddleware()])
+      .handler((ctx) => ctx.ai.agent('broken', broken, undefined))
+
+    const events = await collect(
+      runWorkflow({
+        workflow,
+        runStore: inMemoryRunStore(),
+        input: {},
+      }),
+    )
+    // Let a rejection scheduled during the run reach the process handler.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    process.off('unhandledRejection', onUnhandled)
+
+    expect(unhandled).toEqual([])
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'STEP_FAILED',
+        error: expect.objectContaining({ name: AgentStreamError.name }),
+      }),
+    )
+    expect(events.some((event) => event.type === 'RUN_FINISHED')).toBe(false)
+  })
+
   it('adapts the Workflow publish hook without changing execution IDs', async () => {
     const published: Array<{ runId: string; chunk: StreamChunk }> = []
     const publisher = createAIEventPublisher({
@@ -276,6 +316,14 @@ async function* streamText(text: string): AsyncIterable<StreamChunk> {
     type: EventType.RUN_FINISHED,
     runId: 'inner-run',
     threadId: 'inner-thread',
+    timestamp: Date.now(),
+  }
+}
+
+async function* errorStream(message: string): AsyncIterable<StreamChunk> {
+  yield {
+    type: EventType.RUN_ERROR,
+    message,
     timestamp: Date.now(),
   }
 }


### PR DESCRIPTION
## 🎯 Changes

Targets #979's branch, not `main`.

`executeAgent` awaited `drainAgentStream()` before `result.output`. When the stream fails, drain throws and the already-in-flight `output` promise is never observed — leaving a rejected promise unhandled. Under Node's default `--unhandled-rejections=throw` that terminates the worker, so an ordinary model error took down the process *in addition to* correctly failing the step.

Reproduced against the real `workflow-core` runtime before fixing:

```
unhandled rejections: 1 [ 'Error: output never observed' ]
events: [ 'RUN_STARTED', 'STEP_STARTED', 'STEP_FAILED', 'RUN_ERRORED' ]
```

The fix attaches a no-op catch to `output` as soon as the result is recognized, then awaits it after draining. Behaviour on the success path is unchanged.

Also adds the first test coverage for `agentStream()` — it was exported from `index.ts` but had no unit or E2E exercise, which is why this path went unnoticed. The test asserts both halves: the step fails with `AgentStreamError`, and no unhandled rejection escapes. Verified it fails without the source change.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change is docs/CI/dev-only (no release).

`@tanstack/ai-orchestration` is still unreleased (`0.0.0`) and #979 already carries a `minor` changeset introducing the package. This fixes code from that same unreleased changeset, so a second changeset would only add noise. Happy to add one if you'd rather it be itemised.