### PR TITLE
fix(ai-persistence): make RunStore.findActiveRun required

### DIFF
--- a/.changeset/define-store-helpers.md
+++ b/.changeset/define-store-helpers.md
@@ -22,7 +22,7 @@ import {
 const persistence = defineAIPersistence({
   stores: {
     messages: defineMessageStore({ loadThread, saveThread }),
-    runs: defineRunStore({ createOrResume, update, get }),
+    runs: defineRunStore({ createOrResume, update, get, findActiveRun }),
   },
 })
 

--- a/.changeset/run-store-find-active-run-required.md
+++ b/.changeset/run-store-find-active-run-required.md
@@ -1,0 +1,22 @@
+---
+'@tanstack/ai-persistence': minor
+---
+
+`RunStore.findActiveRun` is now **required**. It was optional and
+feature-detected (`store.findActiveRun?.(threadId)`), which meant an adapter that
+had not implemented it was indistinguishable from one reporting "nothing is
+running": `reconstructChat` returned `activeRun: null`, and a client reloading
+mid-generation silently never reconnected to the run still producing. That is a
+production failure the type system was in a position to catch.
+
+Adapters that already implement `findActiveRun` need no change. Adapters that do
+not will now get a compile error; implement it as "most recent `'running'` run
+for the thread, `null` if none" — in SQL,
+`WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`.
+A backend that genuinely has no run lifecycle should declare
+`ChatTranscriptStores` and omit `runs` entirely rather than stub the method.
+
+The store-contract evolution policy changes to match: new store methods are
+added as required, and capability tiers are expressed at the store level, not by
+optional methods. The conformance testkit no longer skips its `findActiveRun`
+assertions when the method is absent.

--- a/docs/config.json
+++ b/docs/config.json
@@ -266,7 +266,7 @@
           "label": "Build Your Own Adapter",
           "to": "persistence/build-your-own-adapter",
           "addedAt": "2026-07-24",
-          "updatedAt": "2026-07-27"
+          "updatedAt": "2026-07-28"
         },
         {
           "label": "Migrations",

--- a/docs/persistence/build-your-own-adapter.md
+++ b/docs/persistence/build-your-own-adapter.md
@@ -241,9 +241,9 @@ function createRunStore(db: DatabaseSync) {
     },
     // The most recent still-running run for a thread. `reconstructChat` calls
     // this so a hydrating client (a reload, another device, or switching back to
-    // a generating thread) learns there is a live run and tails it. Skip it and
-    // the thread always looks idle on hydrate: the transcript restores, but a
-    // reply that was mid-stream never resumes.
+    // a generating thread) learns there is a live run and tails it. Stub it to
+    // null and the thread always looks idle on hydrate: the transcript restores,
+    // but a reply that was mid-stream never resumes.
     async findActiveRun(threadId) {
       const row = active.get(threadId)
       return row ? mapRun(row) : null
@@ -639,20 +639,26 @@ interface RunStore {
   ): Promise<void>
   get(runId: string): Promise<RunRecord | null>
   // The most recent 'running' run for a thread (greatest `startedAt` wins), or
-  // null when the thread is idle. Optional on the contract, but implement it:
-  // `reconstructChat` feature-detects it to report `activeRun`, which is how a
-  // hydrating client tails a run that is still generating.
-  findActiveRun?(threadId: string): Promise<RunRecord | null>
+  // null when the thread is idle. `reconstructChat` calls it to report
+  // `activeRun`, which is how a hydrating client tails a run that is still
+  // generating.
+  findActiveRun(threadId: string): Promise<RunRecord | null>
 }
 ```
 
 Implement `createOrResume` idempotently: a second call for an existing `runId`
 returns the stored record unchanged, which is what makes resuming a run safe.
 `update` against an unknown `runId` is a no-op. Retries may repeat the same run
-id. Implement `findActiveRun` too unless you never tail in-flight runs on
-reload: without it, `reconstructChat` always reports `activeRun: null`, so a
-client that reloads (or switches back to) a still-generating thread restores the
-transcript but never resumes the live reply.
+id. `findActiveRun` must do real work: stub it to `null` and `reconstructChat`
+always reports `activeRun: null`, so a client that reloads (or switches back to)
+a still-generating thread restores the transcript but never resumes the live
+reply — and nothing detects it, because `null` is also the right answer for an
+idle thread.
+
+Every method on a store you provide is required. A backend that genuinely has no
+run lifecycle should declare `ChatTranscriptStores` and omit `runs` entirely
+rather than supply a `RunStore` with a stubbed method: an absent store is caught
+by the type system, an incomplete one fails silently at runtime.
 
 ### InterruptStore
 

--- a/examples/ts-react-chat/src/lib/persistent-chat-store.ts
+++ b/examples/ts-react-chat/src/lib/persistent-chat-store.ts
@@ -19,5 +19,6 @@ let instance: ReturnType<typeof sqlitePersistence> | undefined
 export function persistentChatPersistence() {
   return (instance ??= sqlitePersistence({
     url: './.data/persistent-chat.db',
+    migrate: true,
   }))
 }

--- a/packages/ai-persistence/skills/ai-persistence/stores/SKILL.md
+++ b/packages/ai-persistence/skills/ai-persistence/stores/SKILL.md
@@ -99,7 +99,7 @@ interface RunStore {
     >,
   ): Promise<void>
   get(runId: string): Promise<RunRecord | null>
-  findActiveRun?(threadId: string): Promise<RunRecord | null> // optional
+  findActiveRun(threadId: string): Promise<RunRecord | null>
 }
 ```
 
@@ -107,8 +107,13 @@ interface RunStore {
   fields). Idempotent retries / resume depend on this.
 - **`update`**: missing `runId` is a **no-op** (do not throw, do not insert).
 - **`findActiveRun`**: latest `'running'` for `threadId` (max `startedAt`);
-  enables reconnect without a client-held run id. Optional — the middleware
-  feature-detects it.
+  this is what `reconstructChat` uses to reconnect a reloading client without a
+  client-held run id. Stub it out and reconnect silently stops working — `null`
+  is also the correct answer for an idle thread, so nothing can detect the
+  difference.
+
+Every method is **required**. Capability tiers live at the store level (omit
+`runs` and declare `ChatTranscriptStores`), never at the method level.
 
 ### `InterruptStore`
 

--- a/packages/ai-persistence/src/reconstruct.ts
+++ b/packages/ai-persistence/src/reconstruct.ts
@@ -120,7 +120,7 @@ export async function reconstructChat(
   // completes between the two reads would return a stale streaming snapshot with
   // `activeRun: null`, leaving the client stuck on the partial (no run to tail).
   const active = threadId
-    ? await persistence.stores.runs?.findActiveRun?.(threadId)
+    ? await persistence.stores.runs?.findActiveRun(threadId)
     : null
   const stored = threadId ? await messageStore.loadThread(threadId) : []
   // Pending interrupts for the thread, so a reload re-prompts the approval from

--- a/packages/ai-persistence/src/testkit/conformance.ts
+++ b/packages/ai-persistence/src/testkit/conformance.ts
@@ -203,13 +203,14 @@ export function runPersistenceConformance(
         expect(await store.get('run-absent')).toBeNull()
       })
 
-      // `findActiveRun` is optional on the RunStore contract; backends that have
-      // not implemented it are skipped, but any backend that has must satisfy
-      // these invariants (most-recent-running wins, thread-scoped, null when idle).
+      // `findActiveRun` is REQUIRED on the RunStore contract — every backend that
+      // provides a `runs` store must satisfy these invariants (most-recent-running
+      // wins, thread-scoped, null when idle). Reconnect is built on it, and a
+      // backend that always answers `null` disables reconnect indistinguishably
+      // from one that is merely idle, so this must never degrade to a skip.
       it('findActiveRun returns the most recent running run for a thread', async () => {
         const store = resolveStore('runs')
         if (!store) return
-        if (!store.findActiveRun) return
 
         const thread = 'thread-active'
         expect(await store.findActiveRun(thread)).toBeNull()

--- a/packages/ai-persistence/src/types.ts
+++ b/packages/ai-persistence/src/types.ts
@@ -14,12 +14,19 @@ export type { Scope }
 // ----------------
 // These store interfaces are the compatibility surface between the core
 // middleware and every backend — the in-memory reference store and every
-// adapter an application writes against its own database. To avoid breaking
-// existing adapters:
+// adapter an application writes against its own database.
 //
-//   - New store methods are added as OPTIONAL (`method?: (...) => ...`). The
-//     middleware feature-detects them (`store.method?.(...)`) and degrades
-//     gracefully when a backend has not implemented them yet.
+//   - Store METHODS are REQUIRED. A new method is a breaking contract change:
+//     every adapter gets a compile error and implements it. Do NOT add methods
+//     as optional-and-feature-detected (`store.method?.(...)`) — an adapter
+//     that has not implemented one is then indistinguishable from one whose
+//     answer is legitimately empty, so the feature silently does nothing in
+//     production instead of failing at build time. `findActiveRun` was optional
+//     for exactly one release cycle and cost us precisely that: reconnect
+//     degraded to "no active run" on every backend that had not caught up.
+//   - Capability tiers belong at the STORE level, not the method level. A
+//     backend that only stores a transcript declares `ChatTranscriptStores`
+//     (no `runs`); it does not declare a half-implemented `RunStore`.
 //   - Never tighten an existing method's required arguments or widen its
 //     required return shape in a breaking way.
 //
@@ -128,16 +135,18 @@ export interface RunStore {
   /**
    * The most recent `'running'` run for `threadId`, or `null` if none is active.
    *
-   * OPTIONAL — callers feature-detect it (`store.findActiveRun?.(threadId)`) and
-   * degrade to "no active run" when a backend has not implemented it.
-   *
    * This resolves "does this thread have a live run to attach to?" from the
    * STABLE thread id, which is the durable basis for reconnecting a client (a
    * reload, or the same thread opened on another device) — independent of the
    * ephemeral run id, which a single turn may mint several of. When more than
    * one run is `'running'`, the one with the greatest `startedAt` wins.
+   *
+   * REQUIRED: `reconstructChat` calls this to build the `activeRun` cursor a
+   * reloading client tails. A backend that returns `null` unconditionally does
+   * not "degrade" — it turns reconnect off, and does so silently, because
+   * `null` is also the correct answer when nothing is running.
    */
-  findActiveRun?: (threadId: string) => Promise<RunRecord | null>
+  findActiveRun: (threadId: string) => Promise<RunRecord | null>
 }
 
 /** Lifecycle status of a human-in-the-loop interrupt. */
@@ -253,12 +262,16 @@ export interface MetadataStore {
 // const persistence = defineAIPersistence({
 //   stores: {
 //     messages: defineMessageStore({ loadThread, saveThread }),
-//     runs: defineRunStore({ createOrResume, update, get }),
+//     runs: defineRunStore({ createOrResume, update, get, findActiveRun }),
 //   },
 // })
 // persistence.stores.runs        // RunStore (defined)
 // persistence.stores.interrupts  // compile error — not provided
 // ```
+//
+// Presence is per STORE, not per method: every method of a store you define is
+// required (see the evolution policy above). Omitting one is a compile error,
+// not a partial store.
 
 /** Type a {@link MessageStore} implementation inline. */
 export function defineMessageStore(store: MessageStore): MessageStore {

--- a/packages/ai-persistence/tests/persistence-fixtures.ts
+++ b/packages/ai-persistence/tests/persistence-fixtures.ts
@@ -39,6 +39,12 @@ export function createRunStore(): RunStore {
       return Promise.resolve()
     },
     get: (runId) => Promise.resolve(runs.get(runId) ?? null),
+    findActiveRun: (threadId) => {
+      const active = [...runs.values()]
+        .filter((run) => run.threadId === threadId && run.status === 'running')
+        .sort((a, b) => b.startedAt - a.startedAt)
+      return Promise.resolve(active[0] ?? null)
+    },
   }
 }
 


### PR DESCRIPTION
## 🎯 Changes

`findActiveRun` was optional on the `RunStore` contract and feature-detected at the call site (`store.findActiveRun?.(threadId)`). That made a backend which hadn't implemented it indistinguishable from one whose thread is genuinely idle — both answer `null` — so reconnect silently turned off in production instead of failing at build time. A client reloading (or switching back to) a still-generating thread restored the transcript but never resumed the live reply, with nothing to detect it.

- Make `findActiveRun` **required** on `RunStore`; drop the optional call in `reconstructChat`.
- Record the evolution policy in `types.ts`: store methods are required, and capability tiers belong at the **store** level (omit `runs`, declare `ChatTranscriptStores`) — never at the method level. An absent store is caught by the type system; an incomplete one fails silently at runtime.
- Drop the conformance skip so every backend providing `runs` must satisfy the invariants (most-recent-running wins, thread-scoped, null when idle); implement `findActiveRun` in the test fixture store.
- Update the adapter guide, the `ai-persistence` stores skill, and the `defineRunStore` changeset accordingly.
- Enable `migrate: true` in the ts-react-chat persistent store example.

**Breaking for adapter authors:** any external `RunStore` implementation without `findActiveRun` now gets a compile error — which is the point.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Active-run detection is now required for persistence adapters, enabling reconnection to in-progress replies without a client-held run ID.
  * SQLite persistence examples now enable automatic schema migration on first database open.

* **Bug Fixes**
  * Active runs are consistently identified by selecting the most recently started running reply.
  * Invalid adapters now fail clearly instead of silently appearing idle.

* **Documentation**
  * Updated adapter guidance, examples, and contract documentation to reflect required active-run support and handling for backends without run lifecycle tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->