### PR TITLE
feat: add Run Cloud sandbox provider

### DIFF
--- a/.changeset/bright-sandboxes-run.md
+++ b/.changeset/bright-sandboxes-run.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-sandbox-run-cloud': minor
+---
+
+Add a Run Cloud sandbox provider with Firecracker microVM isolation, native
+filesystem I/O, streamed commands, background processes, public port tunnels,
+resume-by-id, and restorable snapshots.

--- a/docs/sandbox/providers.md
+++ b/docs/sandbox/providers.md
@@ -2,7 +2,7 @@
 title: Providers
 id: providers
 order: 3
-description: "Pick and configure where a TanStack AI sandbox runs — local process, Docker, Daytona, or Vercel — and understand the capabilities each one exposes."
+description: "Pick and configure where a TanStack AI sandbox runs — local process, Docker, or a managed cloud provider — and understand the capabilities each one exposes."
 ---
 
 A provider owns the isolation primitive: where the harness actually runs. Every
@@ -25,6 +25,7 @@ same.
 | Daytona | `@tanstack/ai-sandbox-daytona` | cloud sandbox | Managed [Daytona](https://www.daytona.io/) sandboxes; port preview links, resume-by-id. Needs `DAYTONA_API_KEY`. |
 | Vercel | `@tanstack/ai-sandbox-vercel` | microVM | Managed [Vercel Sandbox](https://vercel.com/docs/sandbox) microVMs; exposed-port domains, resume-by-id (persistent). Needs `VERCEL_TOKEN` + team/project. |
 | Sprites | `@tanstack/ai-sandbox-sprites` | stateful sandbox | Managed [Sprites](https://sprites.dev) (Fly.io) sandboxes; durable filesystem, in-place checkpoints, single proxied public-URL port, resume-by-id. Needs `SPRITES_API_KEY`. |
+| Run Cloud | `@tanstack/ai-sandbox-run-cloud` | microVM | Managed [Run Cloud](https://run.cloud) Firecracker microVMs; native files, port tunnels, snapshots, and resume-by-id. Needs `RUN_CLOUD_API_KEY`. |
 
 Each provider is its own package, and the constructor is the only thing that
 differs between them:
@@ -34,17 +35,19 @@ import { localProcessSandbox } from '@tanstack/ai-sandbox-local-process'
 import { dockerSandbox } from '@tanstack/ai-sandbox-docker'
 import { daytonaSandbox } from '@tanstack/ai-sandbox-daytona'
 import { vercelSandbox } from '@tanstack/ai-sandbox-vercel'
+import { runCloudSandbox } from '@tanstack/ai-sandbox-run-cloud'
 
 const dev = localProcessSandbox() // runs on your host
 const isolated = dockerSandbox({ image: 'node:22' }) // runs in a container
 const daytona = daytonaSandbox({ apiKey: process.env.DAYTONA_API_KEY }) // managed cloud sandbox
 const vercel = vercelSandbox({ runtime: 'node24' }) // managed Vercel microVM
+const runCloud = runCloudSandbox() // managed Firecracker microVM
 ```
 
-> Cloud providers (Daytona, Vercel) run as remote VMs. When you drive them from
-> your laptop, [tools](./tools) bridged from `chat()` can't dial your machine's
-> `localhost` — you need the bridge tunnel. See the [tools guide](./tools) for the
-> ngrok subpath, and the [Cloudflare guide](./cloudflare) for the edge-native
+> Managed cloud providers run as remote VMs. When you drive them from your
+> laptop, [tools](./tools) bridged from `chat()` can't dial your machine's
+> `localhost` — you need the bridge tunnel. See the [tools guide](./tools) for
+> the ngrok subpath, and the [Cloudflare guide](./cloudflare) for the edge-native
 > co-located model.
 
 ## Local process
@@ -164,6 +167,29 @@ const sprites = spritesSandbox({ apiKey: process.env.SPRITES_API_KEY })
   switches the URL to `public` auth and returns it; other ports are not exposed.
 - **Bridge:** like Daytona/Vercel, a remote VM — bridged tools need the tunnel in
   local dev (see [tools](./tools)).
+
+## Run Cloud
+
+```ts
+import { runCloudSandbox } from '@tanstack/ai-sandbox-run-cloud'
+
+const runCloud = runCloudSandbox({
+  cpu: 2,
+  memory: 4096,
+  idlePauseSeconds: 300,
+})
+```
+
+- **Isolation:** a managed Firecracker microVM with native command streaming and
+  binary-safe filesystem operations.
+- **Auth / env:** needs `RUN_CLOUD_API_KEY`. Harness credentials are injected as
+  workspace secrets.
+- **Snapshot / resume:** supports point-in-time snapshots, restoring a new
+  sandbox from a snapshot, and reconnecting by sandbox id.
+- **Ports:** `ports.connect(port)` opens a short-lived public tunnel for that
+  guest port.
+- **Bridge:** Run Cloud is remote, so bridged tools need the tunnel in local dev
+  (see [tools](./tools)).
 
 ## Capabilities
 

--- a/packages/ai-sandbox-run-cloud/package.json
+++ b/packages/ai-sandbox-run-cloud/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@tanstack/ai-sandbox-run-cloud",
+  "version": "0.1.0",
+  "description": "Run Cloud sandbox provider for TanStack AI — run harness adapters inside isolated Firecracker microVMs.",
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TanStack/ai.git",
+    "directory": "packages/ai-sandbox-run-cloud"
+  },
+  "keywords": [
+    "ai",
+    "tanstack",
+    "sandbox",
+    "run-cloud",
+    "microvm",
+    "firecracker",
+    "harness",
+    "agent",
+    "isolation"
+  ],
+  "type": "module",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "clean": "premove ./build ./dist",
+    "lint:fix": "oxlint src --type-aware --fix",
+    "test:build": "publint --strict",
+    "test:oxlint": "oxlint src --type-aware",
+    "test:lib": "vitest",
+    "test:lib:dev": "pnpm test:lib --watch",
+    "test:types": "tsc"
+  },
+  "dependencies": {
+    "@run-cloud/sdk": "^0.8.0"
+  },
+  "peerDependencies": {
+    "@tanstack/ai-sandbox": "workspace:^"
+  },
+  "devDependencies": {
+    "@tanstack/ai-sandbox": "workspace:*",
+    "@vitest/coverage-v8": "4.0.14"
+  }
+}

--- a/packages/ai-sandbox-run-cloud/src/handle.ts
+++ b/packages/ai-sandbox-run-cloud/src/handle.ts
@@ -1,0 +1,279 @@
+import {
+  UnsupportedCapabilityError,
+  createExecBackedGit,
+} from '@tanstack/ai-sandbox'
+import type { Client } from '@run-cloud/sdk'
+import type {
+  ExecResult,
+  ProcessOptions,
+  SandboxCapabilities,
+  SandboxChannel,
+  SandboxHandle,
+  SnapshotRef,
+  SpawnHandle,
+} from '@tanstack/ai-sandbox'
+
+export const RUN_CLOUD_CAPS: SandboxCapabilities = {
+  fs: true,
+  exec: true,
+  env: true,
+  ports: true,
+  backgroundProcesses: true,
+  writableStdin: false,
+  snapshots: true,
+  networkPolicy: false,
+  durableFilesystem: true,
+  fork: false,
+}
+
+class AsyncChunkQueue implements AsyncIterable<string> {
+  private readonly chunks: Array<string> = []
+  private readonly waiters: Array<(result: IteratorResult<string>) => void> = []
+  private ended = false
+
+  push(chunk: string): void {
+    if (chunk === '') return
+    const waiter = this.waiters.shift()
+    if (waiter) waiter({ value: chunk, done: false })
+    else this.chunks.push(chunk)
+  }
+
+  end(): void {
+    this.ended = true
+    let waiter = this.waiters.shift()
+    while (waiter) {
+      waiter({ value: undefined, done: true })
+      waiter = this.waiters.shift()
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<string> {
+    return {
+      next: () => {
+        const chunk = this.chunks.shift()
+        if (chunk !== undefined) {
+          return Promise.resolve({ value: chunk, done: false })
+        }
+        if (this.ended) {
+          return Promise.resolve({ value: undefined, done: true })
+        }
+        return new Promise((resolve) => this.waiters.push(resolve))
+      },
+    }
+  }
+}
+
+export interface RunCloudHandleDeps {
+  client: Client
+  sandboxId: string
+  workdir: string
+  tunnelTtlSeconds?: number
+  env?: Record<string, string>
+}
+
+export class RunCloudHandle implements SandboxHandle {
+  readonly id: string
+  readonly provider = 'run-cloud'
+  readonly workspaceRoot: string
+  readonly capabilities = RUN_CLOUD_CAPS
+  readonly fs: SandboxHandle['fs']
+  readonly git: SandboxHandle['git']
+  readonly process: SandboxHandle['process']
+  readonly ports: SandboxHandle['ports']
+  readonly env: SandboxHandle['env']
+
+  private readonly client: Client
+  private readonly workdir: string
+  private readonly tunnelTtlSeconds?: number
+  private readonly envVars: Record<string, string>
+
+  constructor(deps: RunCloudHandleDeps) {
+    this.client = deps.client
+    this.id = deps.sandboxId
+    this.workdir = deps.workdir
+    this.workspaceRoot = deps.workdir
+    this.tunnelTtlSeconds = deps.tunnelTtlSeconds
+    this.envVars = { ...deps.env }
+
+    this.process = {
+      exec: (command, options) => this.exec(command, options),
+      spawn: (command, options) => this.spawn(command, options),
+    }
+
+    this.fs = {
+      read: async (path) =>
+        new TextDecoder().decode(
+          await this.client.sandboxes.readFile(this.id, this.abs(path)),
+        ),
+      readBytes: (path) =>
+        this.client.sandboxes.readFile(this.id, this.abs(path)),
+      write: (path, data) =>
+        this.client.sandboxes.writeFile(
+          this.id,
+          this.abs(path),
+          typeof data === 'string' ? new TextEncoder().encode(data) : data,
+        ),
+      list: async (path) => {
+        const result = await this.exec(`ls -1Ap ${quote(this.abs(path))}`)
+        if (result.exitCode !== 0)
+          throw new Error(`list failed: ${errorText(result)}`)
+        const base = path.replace(/\/$/, '')
+        return result.stdout
+          .split('\n')
+          .filter(Boolean)
+          .map((entry) => {
+            const isDirectory = entry.endsWith('/')
+            const name = isDirectory ? entry.slice(0, -1) : entry
+            return {
+              name,
+              path: `${base}/${name}`,
+              type: isDirectory ? ('dir' as const) : ('file' as const),
+            }
+          })
+      },
+      mkdir: async (path) => {
+        const result = await this.exec(`mkdir -p ${quote(this.abs(path))}`)
+        if (result.exitCode !== 0)
+          throw new Error(`mkdir failed: ${errorText(result)}`)
+      },
+      remove: async (path) => {
+        const result = await this.exec(`rm -rf ${quote(this.abs(path))}`)
+        if (result.exitCode !== 0)
+          throw new Error(`remove failed: ${errorText(result)}`)
+      },
+      rename: async (from, to) => {
+        const result = await this.exec(
+          `mv ${quote(this.abs(from))} ${quote(this.abs(to))}`,
+        )
+        if (result.exitCode !== 0)
+          throw new Error(`rename failed: ${errorText(result)}`)
+      },
+      exists: async (path) =>
+        (await this.exec(`test -e ${quote(this.abs(path))}`)).exitCode === 0,
+    }
+
+    this.git = createExecBackedGit(this.process, this.workdir)
+    this.ports = { connect: (port) => this.connectPort(port) }
+    this.env = {
+      set: (values) => {
+        Object.assign(this.envVars, values)
+        return Promise.resolve()
+      },
+    }
+  }
+
+  private abs(path: string): string {
+    if (this.workdir === '/workspace') return path
+    if (path === '/workspace') return this.workdir
+    if (path.startsWith('/workspace/'))
+      return `${this.workdir}/${path.slice('/workspace/'.length)}`
+    return path
+  }
+
+  private mergedEnv(extra?: Record<string, string>): Record<string, string> {
+    return { ...this.envVars, ...extra }
+  }
+
+  private async exec(
+    command: string,
+    options?: ProcessOptions,
+  ): Promise<ExecResult> {
+    const result = await this.client.sandboxes.exec(this.id, command, {
+      cwd: options?.cwd ? this.abs(options.cwd) : this.workdir,
+      env: this.mergedEnv(options?.env),
+      ...(options?.signal ? { signal: options.signal } : {}),
+    })
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    }
+  }
+
+  private spawn(
+    command: string,
+    options?: ProcessOptions,
+  ): Promise<SpawnHandle> {
+    const controller = new AbortController()
+    const abort = (): void => controller.abort()
+    if (options?.signal?.aborted) controller.abort()
+    else options?.signal?.addEventListener('abort', abort, { once: true })
+
+    const stdout = new AsyncChunkQueue()
+    const stderr = new AsyncChunkQueue()
+    const stdoutDecoder = new TextDecoder()
+    const stderrDecoder = new TextDecoder()
+    const process = this.client.sandboxes
+      .exec(this.id, command, {
+        cwd: options?.cwd ? this.abs(options.cwd) : this.workdir,
+        env: this.mergedEnv(options?.env),
+        signal: controller.signal,
+        onStdout: (chunk) =>
+          stdout.push(stdoutDecoder.decode(chunk, { stream: true })),
+        onStderr: (chunk) =>
+          stderr.push(stderrDecoder.decode(chunk, { stream: true })),
+      })
+      .finally(() => {
+        options?.signal?.removeEventListener('abort', abort)
+        stdout.push(stdoutDecoder.decode())
+        stderr.push(stderrDecoder.decode())
+        stdout.end()
+        stderr.end()
+      })
+
+    return Promise.resolve({
+      pid: -1,
+      stdout,
+      stderr,
+      stdin: {
+        write: () =>
+          Promise.reject(
+            new Error(
+              'run-cloud: background process stdin is not writable (see capabilities.writableStdin)',
+            ),
+          ),
+        end: () => Promise.resolve(),
+      },
+      wait: async () => (await process).exitCode,
+      kill: () => {
+        controller.abort()
+        return Promise.resolve()
+      },
+    })
+  }
+
+  private async connectPort(port: number): Promise<SandboxChannel> {
+    const tunnel = await this.client.sandboxes.openTunnel(this.id, port, {
+      ...(this.tunnelTtlSeconds === undefined
+        ? {}
+        : { ttlSeconds: this.tunnelTtlSeconds }),
+    })
+    return { url: tunnel.url }
+  }
+
+  async snapshot(label?: string): Promise<SnapshotRef> {
+    const snapshot = await this.client.sandboxes.snapshot(this.id, {
+      ...(label === undefined ? {} : { label }),
+    })
+    return {
+      id: snapshot.id,
+      ...(label === undefined ? {} : { label }),
+    }
+  }
+
+  fork = (): Promise<SandboxHandle> => {
+    throw new UnsupportedCapabilityError('run-cloud', 'fork')
+  }
+
+  destroy(): Promise<void> {
+    return this.client.sandboxes.destroy(this.id)
+  }
+}
+
+function quote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function errorText(result: { stdout: string; stderr: string }): string {
+  return result.stderr.trim() || result.stdout.trim() || '(no output)'
+}

--- a/packages/ai-sandbox-run-cloud/src/index.ts
+++ b/packages/ai-sandbox-run-cloud/src/index.ts
@@ -1,0 +1,4 @@
+export { runCloudSandbox } from './provider'
+export type { RunCloudSandboxConfig } from './provider'
+export { RunCloudHandle, RUN_CLOUD_CAPS } from './handle'
+export type { RunCloudHandleDeps } from './handle'

--- a/packages/ai-sandbox-run-cloud/src/provider.ts
+++ b/packages/ai-sandbox-run-cloud/src/provider.ts
@@ -1,0 +1,175 @@
+import { Client } from '@run-cloud/sdk'
+import { RUN_CLOUD_CAPS, RunCloudHandle } from './handle'
+import type { CreateSandboxOptions, Sandbox } from '@run-cloud/sdk'
+import type {
+  SandboxCapabilities,
+  SandboxCreateInput,
+  SandboxDestroyInput,
+  SandboxHandle,
+  SandboxProvider,
+  SandboxRestoreInput,
+  SandboxResumeInput,
+} from '@tanstack/ai-sandbox'
+
+export interface RunCloudSandboxConfig {
+  /** Run Cloud API key. Falls back to `RUN_CLOUD_API_KEY`. */
+  apiKey?: string
+  /** API origin override. Falls back to `RUN_CLOUD_API_URL`. */
+  apiUrl?: string
+  /** OCI image. Defaults to `runcloud/agent-base`. */
+  image?: string
+  /** Reserved CPU cores. Defaults to 2. */
+  cpu?: number
+  /** Memory in MiB. Defaults to 4096. */
+  memory?: number
+  /** Writable disk quota in GiB. Defaults to 20. */
+  disk?: number
+  /** Automatically pause after this many idle seconds. Defaults to 300. */
+  idlePauseSeconds?: number
+  /** Sandbox lifetime in seconds. Defaults to 3600; use 0 to disable. */
+  timeoutSeconds?: number
+  /** Region for newly created or restored sandboxes. */
+  region?: string
+  /** Workspace directory inside the microVM. Defaults to `/workspace`. */
+  workdir?: string
+  /** Lifetime of URLs returned by `ports.connect`, in seconds. */
+  tunnelTtlSeconds?: number
+}
+
+const DEFAULTS = {
+  image: 'runcloud/agent-base',
+  cpu: 2,
+  memory: 4096,
+  disk: 20,
+  idlePauseSeconds: 300,
+  timeoutSeconds: 3600,
+  workdir: '/workspace',
+} as const
+
+class RunCloudProvider implements SandboxProvider {
+  readonly name = 'run-cloud'
+  private readonly client: Client
+
+  constructor(private readonly config: RunCloudSandboxConfig) {
+    this.client = new Client({
+      ...(config.apiKey === undefined ? {} : { apiKey: config.apiKey }),
+      ...(config.apiUrl === undefined ? {} : { apiUrl: config.apiUrl }),
+    })
+  }
+
+  capabilities(): SandboxCapabilities {
+    return RUN_CLOUD_CAPS
+  }
+
+  private get workdir(): string {
+    return this.config.workdir ?? DEFAULTS.workdir
+  }
+
+  private createOptions(input: SandboxCreateInput): CreateSandboxOptions {
+    return {
+      image: this.config.image ?? DEFAULTS.image,
+      cpu: this.config.cpu ?? DEFAULTS.cpu,
+      memory: this.config.memory ?? DEFAULTS.memory,
+      disk: this.config.disk ?? DEFAULTS.disk,
+      idlePauseSeconds:
+        this.config.idlePauseSeconds ?? DEFAULTS.idlePauseSeconds,
+      timeoutSeconds: this.config.timeoutSeconds ?? DEFAULTS.timeoutSeconds,
+      ...(this.config.region === undefined
+        ? {}
+        : { region: this.config.region }),
+      ...(input.id === undefined
+        ? {}
+        : { name: input.id, idempotencyKey: input.id }),
+    }
+  }
+
+  private handle(
+    sandbox: Pick<Sandbox, 'id'>,
+    env?: Record<string, string>,
+  ): RunCloudHandle {
+    return new RunCloudHandle({
+      client: this.client,
+      sandboxId: sandbox.id,
+      workdir: this.workdir,
+      ...(this.config.tunnelTtlSeconds === undefined
+        ? {}
+        : { tunnelTtlSeconds: this.config.tunnelTtlSeconds }),
+      ...(env === undefined ? {} : { env }),
+    })
+  }
+
+  private async prepare(
+    sandbox: Pick<Sandbox, 'id'>,
+    input: Pick<SandboxCreateInput, 'env' | 'signal'>,
+  ): Promise<RunCloudHandle> {
+    const result = await this.client.sandboxes.exec(
+      sandbox.id,
+      ['mkdir', '-p', this.workdir],
+      {
+        cwd: '/',
+        ...(input.signal ? { signal: input.signal } : {}),
+      },
+    )
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Run Cloud: failed to create workspace directory "${this.workdir}": ${result.stderr || result.stdout}`,
+      )
+    }
+    return this.handle(sandbox, input.env)
+  }
+
+  async create(input: SandboxCreateInput): Promise<SandboxHandle> {
+    const sandbox = await this.client.sandboxes.create(
+      this.createOptions(input),
+    )
+    return this.prepare(sandbox, input)
+  }
+
+  async resume(input: SandboxResumeInput): Promise<SandboxHandle | null> {
+    try {
+      let sandbox = await this.client.sandboxes.get(input.id)
+      if (['destroyed', 'destroying', 'interrupted'].includes(sandbox.state))
+        return null
+      if (['paused', 'stopped'].includes(sandbox.state)) {
+        sandbox = await this.client.request<Sandbox>(
+          'POST',
+          `/run-cloud/sandboxes/${encodeURIComponent(input.id)}/resume`,
+          {},
+        )
+      }
+      return this.handle(sandbox)
+    } catch {
+      return null
+    }
+  }
+
+  async restoreSnapshot(input: SandboxRestoreInput): Promise<SandboxHandle> {
+    const sandbox = await this.client.snapshots.restore(input.snapshotId, {
+      cpu: this.config.cpu ?? DEFAULTS.cpu,
+      memory: this.config.memory ?? DEFAULTS.memory,
+      disk: this.config.disk ?? DEFAULTS.disk,
+      ...(this.config.region === undefined
+        ? {}
+        : { region: this.config.region }),
+    })
+    return this.prepare(sandbox, input)
+  }
+
+  async destroy(input: SandboxDestroyInput): Promise<void> {
+    try {
+      await this.client.sandboxes.destroy(input.id)
+    } catch {
+      // Already destroyed or gone.
+    }
+  }
+}
+
+/**
+ * Run Cloud provider — runs harness adapters in isolated Firecracker microVMs.
+ * Requires `config.apiKey` or `RUN_CLOUD_API_KEY`.
+ */
+export function runCloudSandbox(
+  config: RunCloudSandboxConfig = {},
+): SandboxProvider {
+  return new RunCloudProvider(config)
+}

--- a/packages/ai-sandbox-run-cloud/tests/handle.test.ts
+++ b/packages/ai-sandbox-run-cloud/tests/handle.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RunCloudHandle } from '../src/handle'
+import type { Client } from '@run-cloud/sdk'
+
+function fakeClient() {
+  const files = new Map<string, Uint8Array>()
+  return {
+    files,
+    sandboxes: {
+      exec: vi.fn(
+        async (
+          _id: string,
+          command: string | Array<string>,
+          options: {
+            onStdout?: (chunk: Uint8Array) => void
+            onStderr?: (chunk: Uint8Array) => void
+          } = {},
+        ) => {
+          if (typeof command === 'string' && command.includes('stream')) {
+            const output = new TextEncoder().encode('out 💻')
+            options.onStdout?.(output.slice(0, output.length - 2))
+            options.onStdout?.(output.slice(output.length - 2))
+            options.onStderr?.(new TextEncoder().encode('err'))
+          }
+          return {
+            stdout: 'stdout',
+            stderr: 'stderr',
+            exitCode: 0,
+            exit_code: 0,
+          }
+        },
+      ),
+      readFile: vi.fn(async (_id: string, path: string) => files.get(path)!),
+      writeFile: vi.fn(async (_id: string, path: string, data: Uint8Array) => {
+        files.set(path, data)
+      }),
+      openTunnel: vi.fn(async () => ({ url: 'https://preview.run.cloud' })),
+      snapshot: vi.fn(async () => ({ id: 'snap-1', state: 'ready' })),
+      destroy: vi.fn(async () => {}),
+    },
+  }
+}
+
+describe('RunCloudHandle', () => {
+  it('runs commands with mapped cwd and merged env', async () => {
+    const client = fakeClient()
+    const handle = new RunCloudHandle({
+      client: client as unknown as Client,
+      sandboxId: 'sbx-1',
+      workdir: '/work',
+      env: { BASE: 'one' },
+    })
+
+    await handle.env.set({ SHARED: 'two' })
+    const result = await handle.process.exec('pwd', {
+      cwd: '/workspace/src',
+      env: { TASK: 'three' },
+    })
+
+    expect(result).toEqual({
+      stdout: 'stdout',
+      stderr: 'stderr',
+      exitCode: 0,
+    })
+    expect(client.sandboxes.exec).toHaveBeenCalledWith('sbx-1', 'pwd', {
+      cwd: '/work/src',
+      env: { BASE: 'one', SHARED: 'two', TASK: 'three' },
+    })
+  })
+
+  it('round-trips text and bytes through the native filesystem API', async () => {
+    const client = fakeClient()
+    const handle = new RunCloudHandle({
+      client: client as unknown as Client,
+      sandboxId: 'sbx-1',
+      workdir: '/work',
+    })
+
+    await handle.fs.write('/workspace/note.txt', 'hello')
+    expect(await handle.fs.read('/workspace/note.txt')).toBe('hello')
+
+    const bytes = new Uint8Array([0, 1, 2, 250])
+    await handle.fs.write('/workspace/data.bin', bytes)
+    expect(
+      Array.from(await handle.fs.readBytes('/workspace/data.bin')),
+    ).toEqual([0, 1, 2, 250])
+  })
+
+  it('streams spawned process output and exposes snapshots and tunnels', async () => {
+    const client = fakeClient()
+    const handle = new RunCloudHandle({
+      client: client as unknown as Client,
+      sandboxId: 'sbx-1',
+      workdir: '/workspace',
+      tunnelTtlSeconds: 900,
+    })
+
+    const child = await handle.process.spawn('stream')
+    let stdout = ''
+    let stderr = ''
+    for await (const chunk of child.stdout) stdout += chunk
+    for await (const chunk of child.stderr) stderr += chunk
+
+    expect(stdout).toBe('out 💻')
+    expect(stderr).toBe('err')
+    expect(await child.wait()).toBe(0)
+    expect(await handle.ports.connect(3000)).toEqual({
+      url: 'https://preview.run.cloud',
+    })
+    expect(client.sandboxes.openTunnel).toHaveBeenCalledWith('sbx-1', 3000, {
+      ttlSeconds: 900,
+    })
+    expect(await handle.snapshot('ready')).toEqual({
+      id: 'snap-1',
+      label: 'ready',
+    })
+  })
+
+  it('propagates an already-aborted signal to a spawned process', async () => {
+    const client = fakeClient()
+    const handle = new RunCloudHandle({
+      client: client as unknown as Client,
+      sandboxId: 'sbx-1',
+      workdir: '/workspace',
+    })
+    const controller = new AbortController()
+    controller.abort()
+
+    const child = await handle.process.spawn('sleep 10', {
+      signal: controller.signal,
+    })
+    await child.wait()
+
+    const options = client.sandboxes.exec.mock.calls[0]?.[2] as
+      | { signal?: AbortSignal }
+      | undefined
+    expect(options?.signal?.aborted).toBe(true)
+  })
+})

--- a/packages/ai-sandbox-run-cloud/tests/run-cloud.test.ts
+++ b/packages/ai-sandbox-run-cloud/tests/run-cloud.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { runCloudSandbox } from '../src'
+import type { SandboxHandle } from '@tanstack/ai-sandbox'
+
+const apiKey = process.env.RUN_CLOUD_API_KEY
+
+describe.skipIf(!apiKey)(
+  'Run Cloud provider (gated on RUN_CLOUD_API_KEY)',
+  () => {
+    it('creates a microVM, runs exec, round-trips files, snapshots, and destroys', async () => {
+      const provider = runCloudSandbox({ apiKey, timeoutSeconds: 900 })
+      let sandbox: SandboxHandle | undefined
+      try {
+        sandbox = await provider.create({})
+
+        const echo = await sandbox.process.exec('echo hello-run-cloud')
+        expect(echo.stdout.trim()).toBe('hello-run-cloud')
+        expect(echo.exitCode).toBe(0)
+
+        await sandbox.fs.write('/workspace/note.txt', 'inside the microVM')
+        expect(await sandbox.fs.read('/workspace/note.txt')).toBe(
+          'inside the microVM',
+        )
+        expect((await sandbox.snapshot?.('tanstack-ai-test'))?.id).toBeTruthy()
+      } finally {
+        await sandbox?.destroy()
+      }
+    }, 180_000)
+  },
+)

--- a/packages/ai-sandbox-run-cloud/tsconfig.json
+++ b/packages/ai-sandbox-run-cloud/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ai-sandbox-run-cloud/vite.config.ts
+++ b/packages/ai-sandbox-run-cloud/vite.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import { tanstackViteConfig } from '@tanstack/vite-config'
+import packageJson from './package.json'
+
+const config = defineConfig({
+  test: {
+    name: packageJson.name,
+    dir: './',
+    watch: false,
+
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        'tests/',
+        '**/*.test.ts',
+        '**/*.config.ts',
+        '**/types.ts',
+      ],
+      include: ['src/**/*.ts'],
+    },
+  },
+})
+
+export default mergeConfig(
+  config,
+  tanstackViteConfig({
+    entry: ['./src/index.ts'],
+    srcDir: './src',
+    cjs: false,
+  }),
+)

--- a/packages/ai-sandbox/README.md
+++ b/packages/ai-sandbox/README.md
@@ -53,6 +53,7 @@ Pick a **provider** package for where the sandbox runs:
 | `@tanstack/ai-sandbox-vercel`        | Vercel Sandbox                         |
 | `@tanstack/ai-sandbox-daytona`       | Daytona dev environments               |
 | `@tanstack/ai-sandbox-sprites`       | Sprites stateful sandboxes             |
+| `@tanstack/ai-sandbox-run-cloud`     | Run Cloud Firecracker microVMs         |
 
 **Harness adapters** are separate packages. The default path is **Grok Build** (`@tanstack/ai-grok-build`); others include `@tanstack/ai-claude-code`, `@tanstack/ai-codex`, and `@tanstack/ai-opencode`. All require `withSandbox(...)` middleware — `chat()` fails fast without it.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2273,6 +2273,19 @@ importers:
         specifier: 4.0.14
         version: 4.0.14(supports-color@7.2.0)(vitest@4.1.10)
 
+  packages/ai-sandbox-run-cloud:
+    dependencies:
+      '@run-cloud/sdk':
+        specifier: ^0.8.0
+        version: 0.8.0
+    devDependencies:
+      '@tanstack/ai-sandbox':
+        specifier: workspace:*
+        version: link:../ai-sandbox
+      '@vitest/coverage-v8':
+        specifier: 4.0.14
+        version: 4.0.14(supports-color@7.2.0)(vitest@4.1.10)
+
   packages/ai-sandbox-sprites:
     devDependencies:
       '@tanstack/ai-sandbox':
@@ -8251,6 +8264,10 @@ packages:
     resolution: {integrity: sha512-TW5f2b5d8Y1DwilaxaXhPkYI1a+i1Am2+eDEf6Tu/QrPxt6kdh/4HT6y460MmzE1im71rudvEs5zLLFr7qBAtQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  '@run-cloud/sdk@0.8.0':
+    resolution: {integrity: sha512-GewA2LqlMGLX50yWRkA/cOE5JGuqf3H9n8cC5aY72Hkr2ndtuGltM/tI4qg47ZpdhOgbLKqIxWZ5mphxd0r/6A==}
+    engines: {node: '>=20'}
 
   '@rushstack/node-core-library@5.7.0':
     resolution: {integrity: sha512-Ff9Cz/YlWu9ce4dmqNBZpA45AEya04XaBFIjV7xTVeEf+y/kTjEasmozqFELXlNG4ROdevss75JrrZ5WgufDkQ==}
@@ -22275,6 +22292,13 @@ snapshots:
       '@types/estree': 1.0.9
     optionalDependencies:
       fsevents: 2.3.3
+
+  '@run-cloud/sdk@0.8.0':
+    dependencies:
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@rushstack/node-core-library@5.7.0(@types/node@24.10.3)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,8 @@ minimumReleaseAgeExclude:
   # Build-time devDep; 0.6.0 is the release carrying the dts-5/Vite-8 fix
   # (TanStack/config#403) this toolchain migration depends on.
   - '@tanstack/vite-config@0.6.0'
+  # Provider SDK; 0.8.0 adds the tunnel and snapshot APIs used by ai-sandbox-run-cloud.
+  - '@run-cloud/sdk@0.8.0'
 
 trustPolicyExclude:
   - 'chokidar@4.0.3' # existing transitive from sass/nitro; latest v4 with v5 available


### PR DESCRIPTION
## Changes

- add `@tanstack/ai-sandbox-run-cloud`
- implement native file I/O, exec and streamed processes, env injection, public port tunnels, durable resume, and restorable snapshots
- add unit coverage plus a `RUN_CLOUD_API_KEY`-gated live integration test
- document setup and capabilities alongside the existing sandbox providers
- add a release changeset

## Why

TanStack AI's sandbox contract makes provider choice independent from the agent harness. This package adds Run Cloud as a managed Firecracker microVM option using the published TypeScript SDK.

## Impact

This is a new opt-in package. Existing provider behavior and defaults are unchanged.

## Validation

- `pnpm --filter @tanstack/ai-sandbox-run-cloud test:lib`
- `pnpm --filter @tanstack/ai-sandbox-run-cloud test:types`
- `pnpm --filter @tanstack/ai-sandbox-run-cloud build`
- `pnpm --filter @tanstack/ai-sandbox-run-cloud test:build`
- `pnpm --filter @tanstack/ai-sandbox-run-cloud test:oxlint`
