### PR TITLE
chore(nx): disable nx analytics to stop the interactive prompt

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -4,6 +4,7 @@
   "nxCloudId": "6928ccd60a2e27ab22f38ad0",
   "useDaemonProcess": true,
   "useInferencePlugins": false,
+  "analytics": false,
   "parallel": 15,
   "tui": {
     "enabled": false


### PR DESCRIPTION
## Summary

Nx asks about sharing usage analytics on every interactive run. This sets `"analytics": false` in `nx.json` so nobody gets prompted and no usage data is sent.

In Nx 23.1, `ensureAnalyticsPreferenceSet` (`nx/src/utils/analytics-prompt.ts`) prompts until `nx.json` has a boolean `analytics` key, then writes the answer back. Committing `false` opts the whole workspace out up front. It's a documented root-level property in `nx-schema.json`.

Closes #1009

## Verification

- `nx.json` parses; `npx nx show projects` runs clean with no prompt
- `pnpm format` leaves the added line unchanged

No changeset, docs, or E2E coverage applies — this is repo tooling config with no published-package or runtime behavior surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy**
  * Disabled Nx analytics collection for the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->