### PR TITLE
fix(ai-openrouter): preserve disabled reasoning requests

### DIFF
--- a/.changeset/openrouter-disable-reasoning.md
+++ b/.changeset/openrouter-disable-reasoning.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-openrouter': patch
+---
+
+Preserve `reasoning: { enabled: false }` by normalizing it to the
+SDK-supported `reasoning: { effort: 'none' }`, and omit empty reasoning
+objects before request serialization.

--- a/packages/ai-openrouter/src/adapters/text.ts
+++ b/packages/ai-openrouter/src/adapters/text.ts
@@ -42,6 +42,7 @@ import type {
 import type {
   ExternalTextProviderOptions,
   OpenRouterSystemPromptMetadata,
+  ReasoningOptions,
 } from '../text/text-provider-options'
 import type {
   OpenRouterImageMetadata,
@@ -67,6 +68,22 @@ type ResolveToolCapabilities<TModel extends string> =
   TModel extends keyof OpenRouterChatModelToolCapabilitiesByName
     ? NonNullable<OpenRouterChatModelToolCapabilitiesByName[TModel]>
     : readonly []
+
+function normalizeReasoningOptions(
+  reasoning: ReasoningOptions | undefined,
+): ChatRequest['reasoning'] | undefined {
+  if (!reasoning) return undefined
+
+  const { enabled, ...sdkReasoning } = reasoning
+  const normalized =
+    enabled === false
+      ? { ...sdkReasoning, effort: 'none' as const }
+      : sdkReasoning
+
+  return Object.values(normalized).some((value) => value !== undefined)
+    ? normalized
+    : undefined
+}
 
 /**
  * OpenRouter Text (Chat) Adapter — standalone implementation that talks to
@@ -1177,8 +1194,10 @@ export class OpenRouterTextAdapter<
     // `variant` is OpenRouter metadata used only to build the `:variant` model
     // suffix — it must NOT be spread into the request body. Destructure it out
     // so the remaining sampling/provider options flow through `...restModelOptions`.
-    const { variant, ...restModelOptions } = options.modelOptions ?? {}
+    const { variant, reasoning, ...restModelOptions } = (options.modelOptions ??
+      {}) as ExternalTextProviderOptions
     const variantSuffix = variant ? `:${variant}` : ''
+    const normalizedReasoning = normalizeReasoningOptions(reasoning)
 
     const messages: Array<ChatMessages> = []
     const systemPrompts =
@@ -1241,6 +1260,7 @@ export class OpenRouterTextAdapter<
     // SDK validates `chatRequest.metadata` as `Record<string, string>` (#735).
     const request: Omit<ChatRequest, 'stream'> = {
       ...restModelOptions,
+      ...(normalizedReasoning && { reasoning: normalizedReasoning }),
       model: options.model + variantSuffix,
       messages,
       ...(tools && tools.length > 0 && { tools }),

--- a/packages/ai-openrouter/src/text/text-provider-options.ts
+++ b/packages/ai-openrouter/src/text/text-provider-options.ts
@@ -26,7 +26,16 @@ export type PluginAutoRouter = Extract<Plugin, { id: 'auto-router' }>
 
 export type PdfParserOptions = NonNullable<PluginFileParser['pdf']>
 
-export type ReasoningOptions = NonNullable<ChatRequest['reasoning']>
+export type ReasoningOptions = NonNullable<ChatRequest['reasoning']> & {
+  /**
+   * Disable reasoning for this request.
+   *
+   * OpenRouter documents `enabled: false`, but the SDK's chat request schema
+   * currently strips that field. The adapter normalizes this explicit opt-out
+   * to `effort: 'none'`, which the SDK preserves on the wire.
+   */
+  enabled?: false
+}
 
 export type StreamOptions = NonNullable<ChatRequest['streamOptions']>
 
@@ -84,10 +93,11 @@ export type OpenRouterBaseOptions = Pick<
   | 'topLogprobs'
   | 'seed'
   | 'responseFormat'
-  | 'reasoning'
   | 'toolChoice'
   | 'parallelToolCalls'
->
+> & {
+  reasoning?: ReasoningOptions
+}
 
 export type ExternalTextProviderOptions = OpenRouterCommonOptions &
   OpenRouterBaseOptions

--- a/packages/ai-openrouter/tests/openrouter-adapter.test.ts
+++ b/packages/ai-openrouter/tests/openrouter-adapter.test.ts
@@ -1769,6 +1769,54 @@ describe('OpenRouter modelOptions pass-through', () => {
     expect(params.maxCompletionTokens).toBe(64)
   })
 
+  it('normalizes reasoning enabled false to effort none on the wire (#1006)', async () => {
+    setupMockSdkClient(minimalStreamChunks)
+    const adapter = createAdapter()
+
+    const modelOptions: OpenRouterTextModelOptions = {
+      reasoning: { enabled: false },
+    }
+
+    for await (const _ of chat({
+      adapter,
+      messages: [{ role: 'user', content: 'test' }],
+      modelOptions,
+    })) {
+      // consume
+    }
+
+    const [rawParams] = mockSend.mock.calls[0]!
+    const params = rawParams.chatRequest
+    expect(params.reasoning).toEqual({ effort: 'none' })
+
+    const serialized = ChatRequest$outboundSchema.parse(params)
+    expect(serialized.reasoning).toEqual({ effort: 'none' })
+  })
+
+  it('omits an empty reasoning object from the SDK request (#1006)', async () => {
+    setupMockSdkClient(minimalStreamChunks)
+    const adapter = createAdapter()
+
+    const modelOptions: OpenRouterTextModelOptions = {
+      reasoning: {},
+    }
+
+    for await (const _ of chat({
+      adapter,
+      messages: [{ role: 'user', content: 'test' }],
+      modelOptions,
+    })) {
+      // consume
+    }
+
+    const [rawParams] = mockSend.mock.calls[0]!
+    const params = rawParams.chatRequest
+    expect(params).not.toHaveProperty('reasoning')
+
+    const serialized = ChatRequest$outboundSchema.parse(params)
+    expect(serialized).not.toHaveProperty('reasoning')
+  })
+
   it('uses variant only for the model suffix and never sends it in the request body', async () => {
     setupMockSdkClient(minimalStreamChunks)
     const adapter = createAdapter()

--- a/testing/e2e/fixtures/reasoning/openrouter-disable.json
+++ b/testing/e2e/fixtures/reasoning/openrouter-disable.json
@@ -1,0 +1,10 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "[reasoning-wire] disable reasoning" },
+      "response": {
+        "content": "Reasoning disabled."
+      }
+    }
+  ]
+}

--- a/testing/e2e/fixtures/reasoning/openrouter-disable.json
+++ b/testing/e2e/fixtures/reasoning/openrouter-disable.json
@@ -5,6 +5,12 @@
       "response": {
         "content": "Reasoning disabled."
       }
+    },
+    {
+      "match": { "userMessage": "[reasoning-wire] empty reasoning" },
+      "response": {
+        "content": "Reasoning omitted."
+      }
     }
   ]
 }

--- a/testing/e2e/src/routeTree.gen.ts
+++ b/testing/e2e/src/routeTree.gen.ts
@@ -44,6 +44,7 @@ import { Route as ApiOtelUsageRouteImport } from './routes/api.otel-usage'
 import { Route as ApiOtelTranscriptionRouteImport } from './routes/api.otel-transcription'
 import { Route as ApiOtelMediaRouteImport } from './routes/api.otel-media'
 import { Route as ApiOpenrouterWebToolsWireRouteImport } from './routes/api.openrouter-web-tools-wire'
+import { Route as ApiOpenrouterReasoningWireRouteImport } from './routes/api.openrouter-reasoning-wire'
 import { Route as ApiOpenrouterJsonObjectWireRouteImport } from './routes/api.openrouter-json-object-wire'
 import { Route as ApiOpenrouterCostRouteImport } from './routes/api.openrouter-cost'
 import { Route as ApiOpenaiUsageDetailsRouteImport } from './routes/api.openai-usage-details'
@@ -267,6 +268,12 @@ const ApiOpenrouterWebToolsWireRoute =
   ApiOpenrouterWebToolsWireRouteImport.update({
     id: '/api/openrouter-web-tools-wire',
     path: '/api/openrouter-web-tools-wire',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiOpenrouterReasoningWireRoute =
+  ApiOpenrouterReasoningWireRouteImport.update({
+    id: '/api/openrouter-reasoning-wire',
+    path: '/api/openrouter-reasoning-wire',
     getParentRoute: () => rootRouteImport,
   } as any)
 const ApiOpenrouterJsonObjectWireRoute =
@@ -545,6 +552,7 @@ export interface FileRoutesByFullPath {
   '/api/openai-usage-details': typeof ApiOpenaiUsageDetailsRoute
   '/api/openrouter-cost': typeof ApiOpenrouterCostRoute
   '/api/openrouter-json-object-wire': typeof ApiOpenrouterJsonObjectWireRoute
+  '/api/openrouter-reasoning-wire': typeof ApiOpenrouterReasoningWireRoute
   '/api/openrouter-web-tools-wire': typeof ApiOpenrouterWebToolsWireRoute
   '/api/otel-media': typeof ApiOtelMediaRoute
   '/api/otel-transcription': typeof ApiOtelTranscriptionRoute
@@ -624,6 +632,7 @@ export interface FileRoutesByTo {
   '/api/openai-usage-details': typeof ApiOpenaiUsageDetailsRoute
   '/api/openrouter-cost': typeof ApiOpenrouterCostRoute
   '/api/openrouter-json-object-wire': typeof ApiOpenrouterJsonObjectWireRoute
+  '/api/openrouter-reasoning-wire': typeof ApiOpenrouterReasoningWireRoute
   '/api/openrouter-web-tools-wire': typeof ApiOpenrouterWebToolsWireRoute
   '/api/otel-media': typeof ApiOtelMediaRoute
   '/api/otel-transcription': typeof ApiOtelTranscriptionRoute
@@ -704,6 +713,7 @@ export interface FileRoutesById {
   '/api/openai-usage-details': typeof ApiOpenaiUsageDetailsRoute
   '/api/openrouter-cost': typeof ApiOpenrouterCostRoute
   '/api/openrouter-json-object-wire': typeof ApiOpenrouterJsonObjectWireRoute
+  '/api/openrouter-reasoning-wire': typeof ApiOpenrouterReasoningWireRoute
   '/api/openrouter-web-tools-wire': typeof ApiOpenrouterWebToolsWireRoute
   '/api/otel-media': typeof ApiOtelMediaRoute
   '/api/otel-transcription': typeof ApiOtelTranscriptionRoute
@@ -785,6 +795,7 @@ export interface FileRouteTypes {
     | '/api/openai-usage-details'
     | '/api/openrouter-cost'
     | '/api/openrouter-json-object-wire'
+    | '/api/openrouter-reasoning-wire'
     | '/api/openrouter-web-tools-wire'
     | '/api/otel-media'
     | '/api/otel-transcription'
@@ -864,6 +875,7 @@ export interface FileRouteTypes {
     | '/api/openai-usage-details'
     | '/api/openrouter-cost'
     | '/api/openrouter-json-object-wire'
+    | '/api/openrouter-reasoning-wire'
     | '/api/openrouter-web-tools-wire'
     | '/api/otel-media'
     | '/api/otel-transcription'
@@ -943,6 +955,7 @@ export interface FileRouteTypes {
     | '/api/openai-usage-details'
     | '/api/openrouter-cost'
     | '/api/openrouter-json-object-wire'
+    | '/api/openrouter-reasoning-wire'
     | '/api/openrouter-web-tools-wire'
     | '/api/otel-media'
     | '/api/otel-transcription'
@@ -1023,6 +1036,7 @@ export interface RootRouteChildren {
   ApiOpenaiUsageDetailsRoute: typeof ApiOpenaiUsageDetailsRoute
   ApiOpenrouterCostRoute: typeof ApiOpenrouterCostRoute
   ApiOpenrouterJsonObjectWireRoute: typeof ApiOpenrouterJsonObjectWireRoute
+  ApiOpenrouterReasoningWireRoute: typeof ApiOpenrouterReasoningWireRoute
   ApiOpenrouterWebToolsWireRoute: typeof ApiOpenrouterWebToolsWireRoute
   ApiOtelMediaRoute: typeof ApiOtelMediaRoute
   ApiOtelTranscriptionRoute: typeof ApiOtelTranscriptionRoute
@@ -1286,6 +1300,13 @@ declare module '@tanstack/react-router' {
       path: '/api/openrouter-web-tools-wire'
       fullPath: '/api/openrouter-web-tools-wire'
       preLoaderRoute: typeof ApiOpenrouterWebToolsWireRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/openrouter-reasoning-wire': {
+      id: '/api/openrouter-reasoning-wire'
+      path: '/api/openrouter-reasoning-wire'
+      fullPath: '/api/openrouter-reasoning-wire'
+      preLoaderRoute: typeof ApiOpenrouterReasoningWireRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/openrouter-json-object-wire': {
@@ -1700,6 +1721,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiOpenaiUsageDetailsRoute: ApiOpenaiUsageDetailsRoute,
   ApiOpenrouterCostRoute: ApiOpenrouterCostRoute,
   ApiOpenrouterJsonObjectWireRoute: ApiOpenrouterJsonObjectWireRoute,
+  ApiOpenrouterReasoningWireRoute: ApiOpenrouterReasoningWireRoute,
   ApiOpenrouterWebToolsWireRoute: ApiOpenrouterWebToolsWireRoute,
   ApiOtelMediaRoute: ApiOtelMediaRoute,
   ApiOtelTranscriptionRoute: ApiOtelTranscriptionRoute,

--- a/testing/e2e/src/routes/api.openrouter-reasoning-wire.ts
+++ b/testing/e2e/src/routes/api.openrouter-reasoning-wire.ts
@@ -1,0 +1,62 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { chat, createChatOptions } from '@tanstack/ai'
+import { createOpenRouterText } from '@tanstack/ai-openrouter'
+import { HTTPClient } from '@openrouter/sdk'
+
+const LLMOCK_DEFAULT_BASE = process.env.LLMOCK_URL || 'http://127.0.0.1:4010'
+const DUMMY_KEY = 'sk-e2e-test-dummy-key'
+
+/**
+ * Drives the real OpenRouter SDK request path with its documented
+ * `reasoning.enabled` opt-out. The companion spec inspects aimock's request
+ * journal to verify the adapter normalizes it before the SDK serializes the
+ * request body.
+ */
+export const Route = createFileRoute('/api/openrouter-reasoning-wire')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const url = new URL(request.url)
+        const testId = url.searchParams.get('testId') ?? undefined
+
+        const httpClient = new HTTPClient()
+        if (testId) {
+          httpClient.addHook('beforeRequest', (req) => {
+            const next = new Request(req)
+            next.headers.set('X-Test-Id', testId)
+            return next
+          })
+        }
+
+        const adapter = createOpenRouterText('openai/gpt-5', DUMMY_KEY, {
+          serverURL: `${LLMOCK_DEFAULT_BASE}/v1`,
+          httpClient,
+        })
+
+        try {
+          for await (const _ of chat({
+            ...createChatOptions({ adapter }),
+            messages: [
+              {
+                role: 'user',
+                content: '[reasoning-wire] disable reasoning',
+              },
+            ],
+            modelOptions: {
+              reasoning: { enabled: false },
+            },
+          })) {
+            // Drain the stream.
+          }
+        } catch (error) {
+          return Response.json({
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+
+        return Response.json({ ok: true })
+      },
+    },
+  },
+})

--- a/testing/e2e/src/routes/api.openrouter-reasoning-wire.ts
+++ b/testing/e2e/src/routes/api.openrouter-reasoning-wire.ts
@@ -8,9 +8,9 @@ const DUMMY_KEY = 'sk-e2e-test-dummy-key'
 
 /**
  * Drives the real OpenRouter SDK request path with its documented
- * `reasoning.enabled` opt-out. The companion spec inspects aimock's request
- * journal to verify the adapter normalizes it before the SDK serializes the
- * request body.
+ * `reasoning.enabled` opt-out or an empty reasoning object. The companion
+ * spec inspects aimock's request journal to verify the adapter normalizes or
+ * omits the option before the SDK serializes the request body.
  */
 export const Route = createFileRoute('/api/openrouter-reasoning-wire')({
   server: {
@@ -18,6 +18,8 @@ export const Route = createFileRoute('/api/openrouter-reasoning-wire')({
       POST: async ({ request }) => {
         const url = new URL(request.url)
         const testId = url.searchParams.get('testId') ?? undefined
+        const scenario =
+          url.searchParams.get('scenario') === 'empty' ? 'empty' : 'disabled'
 
         const httpClient = new HTTPClient()
         if (testId) {
@@ -39,12 +41,16 @@ export const Route = createFileRoute('/api/openrouter-reasoning-wire')({
             messages: [
               {
                 role: 'user',
-                content: '[reasoning-wire] disable reasoning',
+                content:
+                  scenario === 'empty'
+                    ? '[reasoning-wire] empty reasoning'
+                    : '[reasoning-wire] disable reasoning',
               },
             ],
-            modelOptions: {
-              reasoning: { enabled: false },
-            },
+            modelOptions:
+              scenario === 'empty'
+                ? { reasoning: {} }
+                : { reasoning: { enabled: false } },
           })) {
             // Drain the stream.
           }

--- a/testing/e2e/tests/openrouter-reasoning-wire.spec.ts
+++ b/testing/e2e/tests/openrouter-reasoning-wire.spec.ts
@@ -8,25 +8,31 @@ type JournalEntry = {
 }
 
 test.describe('openrouter — reasoning wire format', () => {
-  test('reasoning enabled false reaches the wire as effort none (#1006)', async ({
-    request,
-    aimockPort,
-    testId,
-  }) => {
-    const response = await request.post(
-      `/api/openrouter-reasoning-wire?testId=${encodeURIComponent(testId)}`,
-    )
-    expect(response.ok()).toBe(true)
-    expect(((await response.json()) as { ok: boolean }).ok).toBe(true)
+  for (const scenario of ['disabled', 'empty'] as const) {
+    test(`${scenario} reasoning is normalized on the wire (#1006)`, async ({
+      request,
+      aimockPort,
+      testId,
+    }) => {
+      const response = await request.post(
+        `/api/openrouter-reasoning-wire?testId=${encodeURIComponent(testId)}&scenario=${scenario}`,
+      )
+      expect(response.ok()).toBe(true)
+      expect(((await response.json()) as { ok: boolean }).ok).toBe(true)
 
-    const journalResponse = await request.get(
-      `http://127.0.0.1:${aimockPort}/v1/_requests`,
-    )
-    const entries = (await journalResponse.json()) as Array<JournalEntry>
-    const captured = entries.find(
-      (entry) => entry.headers?.['x-test-id'] === testId,
-    )
+      const journalResponse = await request.get(
+        `http://127.0.0.1:${aimockPort}/v1/_requests`,
+      )
+      const entries = (await journalResponse.json()) as Array<JournalEntry>
+      const captured = entries.find(
+        (entry) => entry.headers?.['x-test-id'] === testId,
+      )
 
-    expect(captured?.body?.reasoning).toEqual({ effort: 'none' })
-  })
+      if (scenario === 'disabled') {
+        expect(captured?.body?.reasoning).toEqual({ effort: 'none' })
+      } else {
+        expect(captured?.body).not.toHaveProperty('reasoning')
+      }
+    })
+  }
 })

--- a/testing/e2e/tests/openrouter-reasoning-wire.spec.ts
+++ b/testing/e2e/tests/openrouter-reasoning-wire.spec.ts
@@ -27,6 +27,8 @@ test.describe('openrouter — reasoning wire format', () => {
       const captured = entries.find(
         (entry) => entry.headers?.['x-test-id'] === testId,
       )
+      expect(captured).toBeDefined()
+      expect(captured?.body).toEqual(expect.any(Object))
 
       if (scenario === 'disabled') {
         expect(captured?.body?.reasoning).toEqual({ effort: 'none' })

--- a/testing/e2e/tests/openrouter-reasoning-wire.spec.ts
+++ b/testing/e2e/tests/openrouter-reasoning-wire.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from './fixtures'
+
+type JournalEntry = {
+  headers?: Record<string, string>
+  body: {
+    reasoning?: Record<string, unknown>
+  } | null
+}
+
+test.describe('openrouter — reasoning wire format', () => {
+  test('reasoning enabled false reaches the wire as effort none (#1006)', async ({
+    request,
+    aimockPort,
+    testId,
+  }) => {
+    const response = await request.post(
+      `/api/openrouter-reasoning-wire?testId=${encodeURIComponent(testId)}`,
+    )
+    expect(response.ok()).toBe(true)
+    expect(((await response.json()) as { ok: boolean }).ok).toBe(true)
+
+    const journalResponse = await request.get(
+      `http://127.0.0.1:${aimockPort}/v1/_requests`,
+    )
+    const entries = (await journalResponse.json()) as Array<JournalEntry>
+    const captured = entries.find(
+      (entry) => entry.headers?.['x-test-id'] === testId,
+    )
+
+    expect(captured?.body?.reasoning).toEqual({ effort: 'none' })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes #1006.

- Preserve explicit `reasoning: { enabled: false }` requests by normalizing them to the SDK-supported `reasoning: { effort: 'none' }`.
- Omit empty reasoning objects instead of sending `reasoning: {}`.
- Add unit coverage and a real SDK-to-HTTP wire regression test.
- Add a patch changeset for `@tanstack/ai-openrouter`.

### Root cause

The adapter accepted OpenRouter's `reasoning.enabled` option and passed it to `@openrouter/sdk@0.13.20`. The generated SDK serializer does not include the `enabled` field, so `{ enabled: false }` became an empty `reasoning: {}` object on the wire. OpenRouter then applied its default reasoning behavior, effectively re-enabling what the caller explicitly disabled.

The fix removes the unsupported field before serialization, maps explicit `false` to `effort: 'none'`, and omits the object when no supported fields remain. The SDK version stays unchanged.

### Validation

- OpenRouter adapter tests: 146 passed
- `pnpm test:pr`
- Package type checks, build, and oxlint
- E2E package type check
- Full E2E suite: 393 passed, 1 skipped; 3 flaky cases passed on retry
- New wire regression verifies the serialized request contains `reasoning: { effort: 'none' }`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## AI assistance disclosure

This contribution was developed with AI assistance. I reviewed the implementation, tests, and validation results and take responsibility for the submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenRouter reasoning opt-out is now honored reliably by converting `reasoning: { enabled: false }` to the SDK-supported wire format (`reasoning: { effort: 'none' }`).
  * Empty reasoning options (`reasoning: {}`) are no longer included in outbound request payloads.
* **Tests**
  * Added unit and end-to-end regression coverage for both “disabled” and “empty” reasoning wire-format scenarios, with updated fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->