### PR TITLE
feat: add LLM Gateway provider adapter

### DIFF
--- a/.changeset/llmgateway-adapter.md
+++ b/.changeset/llmgateway-adapter.md
@@ -1,5 +1,6 @@
 ---
 '@tanstack/ai-llmgateway': minor
+'@tanstack/ai': patch
 ---
 
 New provider adapter: `@tanstack/ai-llmgateway` connects TanStack AI to
@@ -12,8 +13,13 @@ across many providers.
   deltas (`reasoning_content`) surfaced as AG-UI `REASONING_*` events
 - `llmGatewaySummarize` / `createLLMGatewaySummarize` — summarization via
   the shared `ChatStreamSummarizeAdapter`
-- Curated model metadata (context windows, pricing, modalities) for
-  flagship models, with any other model id from llmgateway.io/models
-  accepted and typed against the generic provider options
+- `LLMGATEWAY_CHAT_MODELS` — a curated list of flagship model ids, with
+  per-model input modalities and tool capabilities resolved at the type
+  level, and any other model id from llmgateway.io/models accepted and
+  typed against the generic provider options
 - `provider/model` ids pin routing to a specific provider; bare ids let
   the gateway choose
+
+`@tanstack/ai` registers `llmgateway` in the summarize wrapper's
+provider-native token-key map, so `summarize({ maxLength })` reaches the
+gateway as `max_tokens` instead of being dropped with a warning.

--- a/.changeset/llmgateway-adapter.md
+++ b/.changeset/llmgateway-adapter.md
@@ -1,0 +1,19 @@
+---
+'@tanstack/ai-llmgateway': minor
+---
+
+New provider adapter: `@tanstack/ai-llmgateway` connects TanStack AI to
+[LLM Gateway](https://llmgateway.io), an open-source, self-hostable AI
+gateway that routes one OpenAI-compatible endpoint to hundreds of models
+across many providers.
+
+- `llmGatewayText` / `createLLMGatewayText` — streaming chat with tool
+  calling, structured outputs, multimodal (image) input, and reasoning
+  deltas (`reasoning_content`) surfaced as AG-UI `REASONING_*` events
+- `llmGatewaySummarize` / `createLLMGatewaySummarize` — summarization via
+  the shared `ChatStreamSummarizeAdapter`
+- Curated model metadata (context windows, pricing, modalities) for
+  flagship models, with any other model id from llmgateway.io/models
+  accepted and typed against the generic provider options
+- `provider/model` ids pin routing to a specific provider; bare ids let
+  the gateway choose

--- a/docs/adapters/llmgateway.md
+++ b/docs/adapters/llmgateway.md
@@ -1,0 +1,163 @@
+---
+title: LLM Gateway
+id: llmgateway-adapter
+description: "Route chat, tool calling, and structured outputs to hundreds of LLMs from OpenAI, Anthropic, Google, Moonshot, DeepSeek, and more through LLM Gateway's single OpenAI-compatible endpoint in TanStack AI."
+keywords:
+  - tanstack ai
+  - llm gateway
+  - llmgateway
+  - multi-provider
+  - unified api
+  - model router
+  - self-hosted
+  - adapter
+---
+
+[LLM Gateway](https://llmgateway.io) is an open-source AI gateway that routes one OpenAI-compatible endpoint to hundreds of models across many providers — with automatic provider selection, fallback, usage analytics, and cost tracking. Use the hosted gateway at `api.llmgateway.io` or point the adapter at your own self-hosted deployment.
+
+## Installation
+
+```bash
+npm install @tanstack/ai-llmgateway
+```
+
+## Basic Usage
+
+```typescript
+import { chat } from "@tanstack/ai";
+import { llmGatewayText } from "@tanstack/ai-llmgateway";
+
+const stream = chat({
+  adapter: llmGatewayText("gpt-5.6-terra"),
+  messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+`llmGatewayText` reads your API key from the `LLM_GATEWAY_API_KEY` environment variable. Use `createLLMGatewayText` to pass it explicitly.
+
+## Configuration
+
+```typescript
+import { createLLMGatewayText } from "@tanstack/ai-llmgateway";
+
+const adapter = createLLMGatewayText(
+  "gpt-5.6-terra",
+  process.env.LLM_GATEWAY_API_KEY!,
+  {
+    baseURL: "https://api.llmgateway.io/v1", // Optional — set for self-hosted deployments
+  },
+);
+```
+
+LLM Gateway is open source and self-hostable; point `baseURL` at your own deployment to keep the same adapter surface.
+
+## Available Models
+
+Any model listed at [llmgateway.io/models](https://llmgateway.io/models) works — pass its id as the model name. A bare model id lets the gateway route to the best available provider; prefix it with `provider/` to pin routing to a specific provider:
+
+```text
+model: "gpt-5.6-terra"          // gateway picks the provider
+model: "claude-sonnet-5"        // gateway picks the provider
+model: "moonshot/kimi-k3"       // always routed to Moonshot
+model: "fireworks/kimi-k3"      // always routed to Fireworks
+```
+
+A curated set of flagship models (see `LLMGATEWAY_CHAT_MODELS`) additionally carries per-model type metadata — input modalities and provider options — with editor autocomplete. Uncurated ids still work and fall back to text-only input with the generic options.
+
+## Example: Chat Completion
+
+```typescript
+import { chat, toServerSentEventsResponse } from "@tanstack/ai";
+import { llmGatewayText } from "@tanstack/ai-llmgateway";
+
+export async function POST(request: Request) {
+  const { messages } = await request.json();
+
+  const stream = chat({
+    adapter: llmGatewayText("gpt-5.6-terra"),
+    messages,
+  });
+
+  return toServerSentEventsResponse(stream);
+}
+```
+
+## Example: With Tools
+
+```typescript
+import { chat, toServerSentEventsResponse, toolDefinition } from "@tanstack/ai";
+import { llmGatewayText } from "@tanstack/ai-llmgateway";
+import { z } from "zod";
+
+const getWeatherDef = toolDefinition({
+  name: "get_weather",
+  description: "Get the current weather",
+  inputSchema: z.object({
+    location: z.string(),
+  }),
+});
+
+const getWeather = getWeatherDef.server(async ({ location }) => {
+  return { temperature: 72, conditions: "sunny" };
+});
+
+export async function POST(request: Request) {
+  const { messages } = await request.json();
+
+  const stream = chat({
+    adapter: llmGatewayText("gpt-5.6-terra"),
+    messages,
+    tools: [getWeather],
+  });
+
+  return toServerSentEventsResponse(stream);
+}
+```
+
+## Model Options
+
+The gateway accepts the standard Chat Completions parameters and forwards them to the routed provider (parameters a provider doesn't support are stripped server-side). Sampling parameters live in `modelOptions`:
+
+```typescript
+import { chat } from "@tanstack/ai";
+import { llmGatewayText } from "@tanstack/ai-llmgateway";
+
+const stream = chat({
+  adapter: llmGatewayText("kimi-k3"),
+  messages: [{ role: "user", content: "Hello!" }],
+  modelOptions: {
+    temperature: 0.7,
+    max_completion_tokens: 4096,
+    reasoning_effort: "high",
+  },
+});
+```
+
+`reasoning_effort` accepts the extended scale `none` / `minimal` / `low` / `medium` / `high` / `xhigh` / `max` in addition to OpenAI's standard tiers — which tiers a model honors depends on the model and provider it is routed to (see the model's page on [llmgateway.io/models](https://llmgateway.io/models)).
+
+Reasoning models stream their thinking as `reasoning_content` deltas, which the adapter surfaces as AG-UI `REASONING_*` events.
+
+## Summarization
+
+```typescript
+import { summarize } from "@tanstack/ai";
+import { llmGatewaySummarize } from "@tanstack/ai-llmgateway";
+
+const result = await summarize({
+  adapter: llmGatewaySummarize("gpt-5.4-mini"),
+  text: "Long article text...",
+  stream: false,
+});
+
+console.log(result.summary);
+```
+
+## Environment Variables
+
+Set your API key in environment variables:
+
+```bash
+LLM_GATEWAY_API_KEY=llmgtwy_your-api-key
+```
+
+Get an API key from the [LLM Gateway dashboard](https://llmgateway.io).

--- a/docs/config.json
+++ b/docs/config.json
@@ -13,7 +13,7 @@
           "label": "Overview",
           "to": "getting-started/overview",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-31"
+          "updatedAt": "2026-08-07"
         },
         {
           "label": "Quick Start: React",

--- a/docs/config.json
+++ b/docs/config.json
@@ -961,6 +961,11 @@
           "updatedAt": "2026-08-13"
         },
         {
+          "label": "LLM Gateway",
+          "to": "adapters/llmgateway",
+          "addedAt": "2026-07-29"
+        },
+        {
           "label": "Claude Code",
           "to": "adapters/claude-code",
           "addedAt": "2026-06-12",

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -115,6 +115,7 @@ With the help of adapters, TanStack AI can connect to various LLM providers. Ava
 - **@tanstack/ai-bedrock** - Amazon Bedrock (Claude, Nova, Llama, and more via AWS)
 - **@tanstack/ai-byteplus** - BytePlus (Seed chat, Seedance video, Seedream image, Seed Speech)
 - **@tanstack/ai-fal** - fal (image & video generation)
+- **@tanstack/ai-llmgateway** - LLM Gateway (hundreds of models via one OpenAI-compatible endpoint, self-hostable)
 
 ## Next Steps
 

--- a/docs/structured-outputs/streaming.md
+++ b/docs/structured-outputs/streaming.md
@@ -185,6 +185,7 @@ Streaming structured output works with **every adapter**, but only some support 
 | `@tanstack/ai-groq` | Native single-request stream (Chat Completions, `response_format: json_schema`) |
 | `@tanstack/ai-bedrock` | Native stream through Converse or an OpenAI-compatible API |
 | `@tanstack/ai-byteplus` | Native single-request stream on supported models; unsupported models emit `RUN_ERROR` |
+| `@tanstack/ai-llmgateway` | Native single-request stream (Chat Completions, `response_format: json_schema`) |
 | Other adapters (anthropic, gemini, ollama, …) | Fallback: runs non-streaming `structuredOutput` and emits the final object as one `structured-output.complete` event |
 
 The fallback path keeps the consumer code identical across providers — you always read the final object off `structured-output.complete` — but you won't see incremental deltas unless the adapter implements `structuredOutputStream` natively.

--- a/packages/ai-llmgateway/LICENSE
+++ b/packages/ai-llmgateway/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Tanner Linsley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/ai-llmgateway/README.md
+++ b/packages/ai-llmgateway/README.md
@@ -1,0 +1,94 @@
+# @tanstack/ai-llmgateway
+
+[LLM Gateway](https://llmgateway.io) adapter for TanStack AI — one OpenAI-compatible endpoint that routes chat, tool calling, and structured outputs to hundreds of models across many providers.
+
+## Installation
+
+```bash
+npm install @tanstack/ai-llmgateway
+# or
+pnpm add @tanstack/ai-llmgateway
+# or
+yarn add @tanstack/ai-llmgateway
+```
+
+## Setup
+
+Get your API key from the [LLM Gateway dashboard](https://llmgateway.io) and set it as an environment variable:
+
+```bash
+export LLM_GATEWAY_API_KEY="llmgtwy_..."
+```
+
+## Usage
+
+### Text/Chat Adapter
+
+```typescript
+import { llmGatewayText } from '@tanstack/ai-llmgateway'
+import { chat } from '@tanstack/ai'
+
+const stream = chat({
+  adapter: llmGatewayText('gpt-5.6-terra'),
+  messages: [
+    { role: 'user', content: 'Explain quantum computing in simple terms' },
+  ],
+})
+```
+
+### With Explicit API Key
+
+```typescript
+import { createLLMGatewayText } from '@tanstack/ai-llmgateway'
+
+const adapter = createLLMGatewayText('gpt-5.6-terra', 'llmgtwy_api_key')
+```
+
+### Self-Hosted Gateways
+
+LLM Gateway is open source and self-hostable — point `baseURL` at your own deployment:
+
+```typescript
+import { createLLMGatewayText } from '@tanstack/ai-llmgateway'
+
+const adapter = createLLMGatewayText('gpt-5.6-terra', 'llmgtwy_api_key', {
+  baseURL: 'https://gateway.example.com/v1',
+})
+```
+
+## Models
+
+Any model listed on [llmgateway.io/models](https://llmgateway.io/models) works — pass its id as the model name. A curated set of flagship models additionally carries per-model type metadata (input modalities, provider options) with autocomplete, including `gpt-5.6-terra`, `claude-sonnet-5`, `gemini-pro-latest`, `kimi-k3`, `glm-5.2`, `deepseek-v4-pro`, and more (see `LLMGATEWAY_CHAT_MODELS`).
+
+Model ids accept an optional `provider/` prefix to pin routing to a specific provider:
+
+```typescript
+llmGatewayText('kimi-k3') // gateway picks the best available provider
+llmGatewayText('moonshot/kimi-k3') // always routed to Moonshot
+```
+
+## Features
+
+- ✅ Streaming chat completions
+- ✅ Structured output (JSON Schema)
+- ✅ Function/tool calling
+- ✅ Multimodal input (text + images for vision models)
+- ✅ Reasoning output (`reasoning_content` deltas from reasoning models)
+- ✅ Summarization (`llmGatewaySummarize`)
+
+## Tree-Shakeable Adapters
+
+This package uses tree-shakeable adapters, so you only import what you need:
+
+```typescript
+// Text/chat only
+import { llmGatewayText } from '@tanstack/ai-llmgateway'
+
+// Summarization only
+import { llmGatewaySummarize } from '@tanstack/ai-llmgateway'
+```
+
+## Documentation
+
+- [TanStack AI Documentation](https://tanstack.com/ai)
+- [LLM Gateway Documentation](https://docs.llmgateway.io)

--- a/packages/ai-llmgateway/package.json
+++ b/packages/ai-llmgateway/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@tanstack/ai-llmgateway",
+  "version": "0.0.0",
+  "description": "LLM Gateway adapter for TanStack AI — one OpenAI-compatible endpoint for chat, tool calling, and structured outputs across many providers and models.",
+  "author": "Tanner Linsley",
+  "license": "MIT",
+  "homepage": "https://tanstack.com/ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TanStack/ai.git",
+    "directory": "packages/ai-llmgateway"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
+  "type": "module",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "clean": "premove ./build ./dist",
+    "lint:fix": "oxlint src --type-aware --fix",
+    "test:build": "publint --strict",
+    "test:oxlint": "oxlint src --type-aware",
+    "test:lib": "vitest run",
+    "test:lib:dev": "pnpm test:lib --watch",
+    "test:types": "tsc"
+  },
+  "keywords": [
+    "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
+    "llmgateway",
+    "llm-gateway",
+    "adapter",
+    "llm",
+    "gateway",
+    "chat",
+    "streaming",
+    "tool-calling",
+    "structured-outputs",
+    "model-router"
+  ],
+  "dependencies": {
+    "@tanstack/ai-utils": "workspace:*",
+    "@tanstack/openai-base": "workspace:*",
+    "openai": "^6.41.0"
+  },
+  "devDependencies": {
+    "@tanstack/ai": "workspace:*",
+    "@vitest/coverage-v8": "4.0.14",
+    "vite": "^8.1.4",
+    "zod": "^4.2.0"
+  },
+  "peerDependencies": {
+    "@tanstack/ai": "workspace:^",
+    "zod": "^4.0.0"
+  }
+}

--- a/packages/ai-llmgateway/package.json
+++ b/packages/ai-llmgateway/package.json
@@ -57,14 +57,14 @@
     "model-router"
   ],
   "dependencies": {
-    "@tanstack/ai-utils": "workspace:*",
-    "@tanstack/openai-base": "workspace:*",
+    "@tanstack/ai-utils": "workspace:^",
+    "@tanstack/openai-base": "workspace:^",
     "openai": "^6.41.0"
   },
   "devDependencies": {
     "@tanstack/ai": "workspace:*",
-    "@vitest/coverage-v8": "4.0.14",
-    "vite": "^8.1.4",
+    "@vitest/coverage-v8": "4.1.10",
+    "vite": "^8.2.1",
     "zod": "^4.2.0"
   },
   "peerDependencies": {

--- a/packages/ai-llmgateway/src/adapters/summarize.ts
+++ b/packages/ai-llmgateway/src/adapters/summarize.ts
@@ -1,0 +1,79 @@
+import { ChatStreamSummarizeAdapter } from '@tanstack/ai/adapters'
+import { getLLMGatewayApiKeyFromEnv } from '../utils/client'
+import { LLMGatewayTextAdapter } from './text'
+import type { InferTextProviderOptions } from '@tanstack/ai/adapters'
+import type { LLMGatewayModelId } from '../model-meta'
+import type { LLMGatewayClientConfig } from '../utils/client'
+
+/**
+ * Configuration for LLM Gateway summarize adapter
+ */
+export interface LLMGatewaySummarizeConfig extends LLMGatewayClientConfig {}
+
+/** Model type for LLM Gateway summarization */
+export type LLMGatewaySummarizeModel = LLMGatewayModelId
+
+/**
+ * Creates an LLM Gateway summarize adapter with explicit API key.
+ * Type resolution happens here at the call site.
+ *
+ * @param model - The model id (e.g., 'gpt-5.6-terra')
+ * @param apiKey - Your LLM Gateway API key
+ * @param config - Optional additional configuration
+ * @returns Configured LLM Gateway summarize adapter instance with resolved types
+ *
+ * @example
+ * ```typescript
+ * const adapter = createLLMGatewaySummarize('gpt-5.6-terra', "llmgtwy_...");
+ * ```
+ */
+export function createLLMGatewaySummarize<
+  TModel extends LLMGatewaySummarizeModel,
+>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<LLMGatewaySummarizeConfig, 'apiKey'>,
+): ChatStreamSummarizeAdapter<
+  TModel,
+  InferTextProviderOptions<LLMGatewayTextAdapter<TModel>>
+> {
+  return new ChatStreamSummarizeAdapter(
+    new LLMGatewayTextAdapter({ apiKey, ...config }, model),
+    model,
+    'llmgateway',
+  )
+}
+
+/**
+ * Creates an LLM Gateway summarize adapter with automatic API key detection
+ * from environment variables. Type resolution happens here at the call site.
+ *
+ * Looks for `LLM_GATEWAY_API_KEY` in:
+ * - `process.env` (Node.js)
+ * - `window.env` (Browser with injected env)
+ *
+ * @param model - The model id (e.g., 'gpt-5.6-terra')
+ * @param config - Optional configuration (excluding apiKey which is auto-detected)
+ * @returns Configured LLM Gateway summarize adapter instance with resolved types
+ * @throws Error if LLM_GATEWAY_API_KEY is not found in environment
+ *
+ * @example
+ * ```typescript
+ * // Automatically uses LLM_GATEWAY_API_KEY from environment
+ * const adapter = llmGatewaySummarize('gpt-5.6-terra');
+ *
+ * await summarize({
+ *   adapter,
+ *   text: "Long article text..."
+ * });
+ * ```
+ */
+export function llmGatewaySummarize<TModel extends LLMGatewaySummarizeModel>(
+  model: TModel,
+  config?: Omit<LLMGatewaySummarizeConfig, 'apiKey'>,
+): ChatStreamSummarizeAdapter<
+  TModel,
+  InferTextProviderOptions<LLMGatewayTextAdapter<TModel>>
+> {
+  return createLLMGatewaySummarize(model, getLLMGatewayApiKeyFromEnv(), config)
+}

--- a/packages/ai-llmgateway/src/adapters/text.ts
+++ b/packages/ai-llmgateway/src/adapters/text.ts
@@ -1,0 +1,119 @@
+import OpenAI from 'openai'
+import { OpenAIBaseChatCompletionsTextAdapter } from '@tanstack/openai-base'
+import {
+  getLLMGatewayApiKeyFromEnv,
+  withLLMGatewayDefaults,
+} from '../utils/client'
+import type { Modality } from '@tanstack/ai'
+import type {
+  LLMGatewayChatModelToolCapabilitiesByName,
+  LLMGatewayModelId,
+  ResolveInputModalities,
+  ResolveProviderOptions,
+} from '../model-meta'
+import type { LLMGatewayMessageMetadataByModality } from '../message-types'
+import type { LLMGatewayClientConfig } from '../utils/client'
+
+type ResolveToolCapabilities<TModel extends string> =
+  TModel extends keyof LLMGatewayChatModelToolCapabilitiesByName
+    ? NonNullable<LLMGatewayChatModelToolCapabilitiesByName[TModel]>
+    : readonly []
+
+/**
+ * Configuration for LLM Gateway text adapter
+ */
+export interface LLMGatewayTextConfig extends LLMGatewayClientConfig {}
+
+/**
+ * Re-export of the public provider options type
+ */
+export type { ExternalTextProviderOptions as LLMGatewayTextProviderOptions } from '../text/text-provider-options'
+
+/**
+ * LLM Gateway Text (Chat) Adapter
+ *
+ * Tree-shakeable adapter for LLM Gateway chat/text completion. LLM Gateway
+ * exposes one OpenAI-compatible Chat Completions endpoint that routes to
+ * hundreds of models across many providers, so the adapter drives it with
+ * the OpenAI SDK via a `baseURL` override (the same pattern as `ai-grok`
+ * and `ai-groq`).
+ *
+ * Model ids are open-ended: curated ids get per-model type metadata, and
+ * any other id from https://llmgateway.io/models works with text-only
+ * defaults. A `provider/model` id (e.g. `openai/gpt-5.5`) pins routing to
+ * that provider; a bare id lets the gateway pick.
+ */
+export class LLMGatewayTextAdapter<
+  TModel extends LLMGatewayModelId,
+  TProviderOptions extends Record<string, any> = ResolveProviderOptions<TModel>,
+  TInputModalities extends ReadonlyArray<Modality> =
+    ResolveInputModalities<TModel>,
+  TToolCapabilities extends ReadonlyArray<string> =
+    ResolveToolCapabilities<TModel>,
+> extends OpenAIBaseChatCompletionsTextAdapter<
+  TModel,
+  TProviderOptions,
+  TInputModalities,
+  LLMGatewayMessageMetadataByModality,
+  TToolCapabilities
+> {
+  override readonly kind = 'text' as const
+  override readonly name = 'llmgateway' as const
+
+  constructor(config: LLMGatewayTextConfig, model: TModel) {
+    super(model, 'llmgateway', new OpenAI(withLLMGatewayDefaults(config)))
+  }
+
+  /**
+   * Surfaces reasoning deltas during streaming. LLM Gateway normalizes
+   * upstream reasoning output to `delta.reasoning_content` on the OpenAI
+   * Chat Completions wire format (the DeepSeek-style field most
+   * OpenAI-compatible providers emit); some routed providers emit
+   * `delta.reasoning` instead, so both are read.
+   */
+  protected override extractReasoning(
+    chunk: OpenAI.Chat.Completions.ChatCompletionChunk,
+  ): { text: string } | undefined {
+    const delta = chunk.choices[0]?.delta as
+      | { reasoning?: unknown; reasoning_content?: unknown }
+      | undefined
+    const raw = delta?.reasoning_content ?? delta?.reasoning
+    if (typeof raw === 'string' && raw.length > 0) {
+      return { text: raw }
+    }
+    return undefined
+  }
+}
+
+/**
+ * Creates an LLM Gateway text adapter with explicit API key.
+ *
+ * @example
+ * ```typescript
+ * const adapter = createLLMGatewayText('gpt-5.6-terra', "llmgtwy_...");
+ * ```
+ */
+export function createLLMGatewayText<TModel extends LLMGatewayModelId>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<LLMGatewayTextConfig, 'apiKey'>,
+): LLMGatewayTextAdapter<TModel> {
+  return new LLMGatewayTextAdapter({ apiKey, ...config }, model)
+}
+
+/**
+ * Creates an LLM Gateway text adapter with API key from
+ * `LLM_GATEWAY_API_KEY`.
+ *
+ * @example
+ * ```typescript
+ * const adapter = llmGatewayText('gpt-5.6-terra');
+ * ```
+ */
+export function llmGatewayText<TModel extends LLMGatewayModelId>(
+  model: TModel,
+  config?: Omit<LLMGatewayTextConfig, 'apiKey'>,
+): LLMGatewayTextAdapter<TModel> {
+  const apiKey = getLLMGatewayApiKeyFromEnv()
+  return createLLMGatewayText(model, apiKey, config)
+}

--- a/packages/ai-llmgateway/src/index.ts
+++ b/packages/ai-llmgateway/src/index.ts
@@ -1,0 +1,52 @@
+/**
+ * @module @tanstack/ai-llmgateway
+ *
+ * LLM Gateway provider adapter for TanStack AI.
+ * Provides tree-shakeable adapters for LLM Gateway's OpenAI-compatible Chat
+ * Completions API, which routes one endpoint to hundreds of models across
+ * many providers.
+ */
+
+// Text (Chat) adapter
+export {
+  LLMGatewayTextAdapter,
+  createLLMGatewayText,
+  llmGatewayText,
+  type LLMGatewayTextConfig,
+  type LLMGatewayTextProviderOptions,
+} from './adapters/text'
+
+// Summarize - thin factory functions over @tanstack/ai's ChatStreamSummarizeAdapter
+export {
+  createLLMGatewaySummarize,
+  llmGatewaySummarize,
+  type LLMGatewaySummarizeConfig,
+  type LLMGatewaySummarizeModel,
+} from './adapters/summarize'
+
+// Types
+export type {
+  LLMGatewayChatModelProviderOptionsByName,
+  LLMGatewayChatModelToolCapabilitiesByName,
+  LLMGatewayModelInputModalitiesByName,
+  ResolveProviderOptions,
+  ResolveInputModalities,
+  LLMGatewayChatModels,
+  LLMGatewayModelId,
+} from './model-meta'
+export { LLMGATEWAY_CHAT_MODELS } from './model-meta'
+export type {
+  LLMGatewayTextMetadata,
+  LLMGatewayImageMetadata,
+  LLMGatewayAudioMetadata,
+  LLMGatewayVideoMetadata,
+  LLMGatewayDocumentMetadata,
+  LLMGatewayMessageMetadataByModality,
+} from './message-types'
+
+// Utils
+export {
+  getLLMGatewayApiKeyFromEnv,
+  withLLMGatewayDefaults,
+  type LLMGatewayClientConfig,
+} from './utils/client'

--- a/packages/ai-llmgateway/src/message-types.ts
+++ b/packages/ai-llmgateway/src/message-types.ts
@@ -1,0 +1,130 @@
+/**
+ * LLM Gateway-specific message types for the Chat Completions API.
+ *
+ * LLM Gateway's wire format is OpenAI Chat Completions — the gateway
+ * translates it to each routed provider's native format server-side. These
+ * type definitions describe that wire shape directly; the adapter drives
+ * the endpoint with the OpenAI SDK pointed at the gateway's base URL.
+ *
+ * @see https://docs.llmgateway.io
+ */
+
+export interface ChatCompletionNamedToolChoice {
+  /** Always `function` for a named tool choice. */
+  type: 'function'
+  function: {
+    /** The name of the function to call. */
+    name: string
+  }
+}
+
+/**
+ * Controls which (if any) tool is called by the model.
+ *
+ * - `none` — the model will not call any tool and instead generates a message
+ * - `auto` — the model can pick between generating a message or calling tools
+ * - `required` — the model must call one or more tools
+ * - Named tool choice — forces the model to call a specific tool
+ */
+export type ChatCompletionToolChoiceOption =
+  | 'none'
+  | 'auto'
+  | 'required'
+  | ChatCompletionNamedToolChoice
+
+export interface ResponseFormatText {
+  /** The type of response format being defined. Always `text`. */
+  type: 'text'
+}
+
+export interface ResponseFormatJsonSchemaJsonSchema {
+  /**
+   * The name of the response format. Must be a-z, A-Z, 0-9, or contain
+   * underscores and dashes, with a maximum length of 64.
+   */
+  name: string
+
+  /**
+   * A description of what the response format is for, used by the model to
+   * determine how to respond in the format.
+   */
+  description?: string
+
+  /**
+   * The schema for the response format, described as a JSON Schema object.
+   * @see https://json-schema.org/
+   */
+  schema?: { [key: string]: unknown }
+
+  /**
+   * Whether to enable strict schema adherence when generating the output. If
+   * set to true, the model will always follow the exact schema defined in the
+   * `schema` field. Only a subset of JSON Schema is supported when `strict`
+   * is `true`.
+   */
+  strict?: boolean | null
+}
+
+export interface ResponseFormatJsonSchema {
+  /** Structured Outputs configuration options, including a JSON Schema. */
+  json_schema: ResponseFormatJsonSchemaJsonSchema
+
+  /** The type of response format being defined. Always `json_schema`. */
+  type: 'json_schema'
+}
+
+export interface ResponseFormatJsonObject {
+  /** The type of response format being defined. Always `json_object`. */
+  type: 'json_object'
+}
+
+/**
+ * Metadata for LLM Gateway document content parts.
+ */
+export interface LLMGatewayDocumentMetadata {}
+
+/**
+ * Metadata for LLM Gateway text content parts.
+ * Currently no specific metadata options for text.
+ */
+export interface LLMGatewayTextMetadata {}
+
+/**
+ * Metadata for LLM Gateway image content parts.
+ * Controls how the model processes and analyzes images.
+ */
+export interface LLMGatewayImageMetadata {
+  /**
+   * Specifies the detail level of the image.
+   * - 'auto': Let the model decide based on image size and content
+   * - 'low': Use low resolution processing (faster, cheaper, less detail)
+   * - 'high': Use high resolution processing (slower, more expensive, more detail)
+   *
+   * @default 'auto'
+   */
+  detail?: 'auto' | 'low' | 'high'
+}
+
+/**
+ * Metadata for LLM Gateway audio content parts.
+ * Note: audio input support depends on the routed model.
+ */
+export interface LLMGatewayAudioMetadata {}
+
+/**
+ * Metadata for LLM Gateway video content parts.
+ * Note: video input support depends on the routed model.
+ */
+export interface LLMGatewayVideoMetadata {}
+
+/**
+ * Map of modality types to their LLM Gateway-specific metadata types.
+ * Used for type inference when constructing multimodal messages.
+ */
+export interface LLMGatewayMessageMetadataByModality {
+  text: LLMGatewayTextMetadata
+  image: LLMGatewayImageMetadata
+  audio: LLMGatewayAudioMetadata
+  video: LLMGatewayVideoMetadata
+  document: LLMGatewayDocumentMetadata
+}

--- a/packages/ai-llmgateway/src/model-meta.ts
+++ b/packages/ai-llmgateway/src/model-meta.ts
@@ -1,0 +1,516 @@
+import type { LLMGatewayTextProviderOptions } from './text/text-provider-options'
+
+/**
+ * Internal metadata structure describing an LLM Gateway model's capabilities
+ * and pricing.
+ *
+ * LLM Gateway routes hundreds of models from many providers through one
+ * OpenAI-compatible endpoint. This file curates a set of flagship models
+ * with per-model metadata for type safety; any model listed on
+ * https://llmgateway.io/models works at runtime — pass its id with a type
+ * assertion, or prefer a curated model for full type support. Prices are
+ * USD per million tokens and follow the gateway's provider-passthrough
+ * pricing (they may drift; the models page is the source of truth).
+ *
+ * Model ids accept an optional `provider/` prefix (e.g. `openai/gpt-5.5`)
+ * to pin routing to a specific provider — the unprefixed ids below let the
+ * gateway pick the best available provider.
+ */
+interface ModelMeta<TProviderOptions = unknown> {
+  name: string
+  context_window?: number
+  max_completion_tokens?: number
+  pricing: {
+    input?: { normal: number; cached?: number }
+    output?: { normal: number }
+  }
+  supports: {
+    input: Array<'text' | 'image' | 'audio'>
+    output: Array<'text'>
+    endpoints: Array<'chat'>
+    features: Array<
+      | 'streaming'
+      | 'tools'
+      | 'json_object'
+      | 'json_schema'
+      | 'reasoning'
+      | 'vision'
+    >
+    tools?: ReadonlyArray<never>
+  }
+  /**
+   * Type-level description of which provider options this model supports.
+   */
+  providerOptions?: TProviderOptions
+}
+
+const GPT_5_6_TERRA = {
+  name: 'gpt-5.6-terra',
+  context_window: 1_050_000,
+  max_completion_tokens: 128_000,
+  pricing: {
+    input: {
+      normal: 2.5,
+      cached: 0.25,
+    },
+    output: {
+      normal: 15,
+    },
+  },
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: [
+      'streaming',
+      'tools',
+      'json_object',
+      'json_schema',
+      'reasoning',
+      'vision',
+    ],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const GPT_5_5 = {
+  name: 'gpt-5.5',
+  context_window: 1_050_000,
+  max_completion_tokens: 128_000,
+  pricing: {
+    input: {
+      normal: 5,
+      cached: 0.5,
+    },
+    output: {
+      normal: 30,
+    },
+  },
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: [
+      'streaming',
+      'tools',
+      'json_object',
+      'json_schema',
+      'reasoning',
+      'vision',
+    ],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const GPT_5_4_MINI = {
+  name: 'gpt-5.4-mini',
+  context_window: 400_000,
+  max_completion_tokens: 128_000,
+  pricing: {
+    input: {
+      normal: 0.75,
+      cached: 0.075,
+    },
+    output: {
+      normal: 4.5,
+    },
+  },
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: [
+      'streaming',
+      'tools',
+      'json_object',
+      'json_schema',
+      'reasoning',
+      'vision',
+    ],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const CLAUDE_OPUS_5 = {
+  name: 'claude-opus-5',
+  context_window: 1_000_000,
+  max_completion_tokens: 128_000,
+  pricing: {
+    input: {
+      normal: 5,
+      cached: 0.5,
+    },
+    output: {
+      normal: 25,
+    },
+  },
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming', 'tools', 'reasoning', 'vision'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const CLAUDE_SONNET_5 = {
+  name: 'claude-sonnet-5',
+  context_window: 1_000_000,
+  max_completion_tokens: 128_000,
+  pricing: {
+    input: {
+      normal: 2,
+      cached: 0.2,
+    },
+    output: {
+      normal: 10,
+    },
+  },
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming', 'tools', 'reasoning', 'vision'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const CLAUDE_HAIKU_4_5 = {
+  name: 'claude-haiku-4-5',
+  context_window: 200_000,
+  max_completion_tokens: 64_000,
+  pricing: {
+    input: {
+      normal: 1,
+      cached: 0.1,
+    },
+    output: {
+      normal: 5,
+    },
+  },
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: [
+      'streaming',
+      'tools',
+      'json_object',
+      'json_schema',
+      'reasoning',
+      'vision',
+    ],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const GEMINI_PRO_LATEST = {
+  name: 'gemini-pro-latest',
+  context_window: 1_048_576,
+  max_completion_tokens: 65_536,
+  pricing: {
+    input: {
+      normal: 2,
+      cached: 0.2,
+    },
+    output: {
+      normal: 12,
+    },
+  },
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: [
+      'streaming',
+      'tools',
+      'json_object',
+      'json_schema',
+      'reasoning',
+      'vision',
+    ],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const GEMINI_3_6_FLASH = {
+  name: 'gemini-3.6-flash',
+  context_window: 1_048_576,
+  max_completion_tokens: 65_536,
+  pricing: {
+    input: {
+      normal: 1.5,
+      cached: 0.15,
+    },
+    output: {
+      normal: 7.5,
+    },
+  },
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: [
+      'streaming',
+      'tools',
+      'json_object',
+      'json_schema',
+      'reasoning',
+      'vision',
+    ],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const KIMI_K3 = {
+  name: 'kimi-k3',
+  context_window: 1_048_576,
+  max_completion_tokens: 1_048_576,
+  pricing: {
+    input: {
+      normal: 3,
+      cached: 0.3,
+    },
+    output: {
+      normal: 15,
+    },
+  },
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: [
+      'streaming',
+      'tools',
+      'json_object',
+      'json_schema',
+      'reasoning',
+      'vision',
+    ],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const GLM_5_2 = {
+  name: 'glm-5.2',
+  context_window: 1_000_000,
+  max_completion_tokens: 128_000,
+  pricing: {
+    input: {
+      normal: 1.4,
+      cached: 0.26,
+    },
+    output: {
+      normal: 4.4,
+    },
+  },
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming', 'tools', 'json_object', 'json_schema', 'reasoning'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const DEEPSEEK_V4_PRO = {
+  name: 'deepseek-v4-pro',
+  context_window: 1_050_000,
+  max_completion_tokens: 393_216,
+  pricing: {
+    input: {
+      normal: 0.435,
+    },
+    output: {
+      normal: 0.87,
+    },
+  },
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming', 'tools', 'json_object', 'json_schema', 'reasoning'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const QWEN_3_7_MAX = {
+  name: 'qwen3.7-max',
+  context_window: 1_000_000,
+  max_completion_tokens: 65_536,
+  pricing: {
+    input: {
+      normal: 2.5,
+      cached: 0.5,
+    },
+    output: {
+      normal: 7.5,
+    },
+  },
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming', 'tools', 'json_object', 'json_schema', 'reasoning'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const MINIMAX_M2_5 = {
+  name: 'minimax-m2.5',
+  context_window: 204_800,
+  max_completion_tokens: 131_100,
+  pricing: {
+    input: {
+      normal: 0.3,
+      cached: 0.03,
+    },
+    output: {
+      normal: 1.2,
+    },
+  },
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming', 'tools', 'reasoning'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+const GROK_4_5 = {
+  name: 'grok-4-5',
+  context_window: 500_000,
+  pricing: {
+    input: {
+      normal: 2,
+      cached: 0.5,
+    },
+    output: {
+      normal: 6,
+    },
+  },
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: [
+      'streaming',
+      'tools',
+      'json_object',
+      'json_schema',
+      'reasoning',
+      'vision',
+    ],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta<LLMGatewayTextProviderOptions>
+
+/**
+ * Curated LLM Gateway chat model identifiers.
+ *
+ * Any model on https://llmgateway.io/models works at runtime; these curated
+ * entries carry per-model type metadata (input modalities, provider
+ * options).
+ */
+export const LLMGATEWAY_CHAT_MODELS = [
+  GPT_5_6_TERRA.name,
+  GPT_5_5.name,
+  GPT_5_4_MINI.name,
+  CLAUDE_OPUS_5.name,
+  CLAUDE_SONNET_5.name,
+  CLAUDE_HAIKU_4_5.name,
+  GEMINI_PRO_LATEST.name,
+  GEMINI_3_6_FLASH.name,
+  KIMI_K3.name,
+  GLM_5_2.name,
+  DEEPSEEK_V4_PRO.name,
+  QWEN_3_7_MAX.name,
+  MINIMAX_M2_5.name,
+  GROK_4_5.name,
+] as const
+
+/**
+ * Union type of all curated LLM Gateway chat model names.
+ */
+export type LLMGatewayChatModels = (typeof LLMGATEWAY_CHAT_MODELS)[number]
+
+/**
+ * Model id accepted by the LLM Gateway adapters: a curated model name (with
+ * autocomplete and per-model type metadata) or any other model id from
+ * https://llmgateway.io/models, optionally prefixed with `provider/` to pin
+ * routing to a specific provider. Uncurated ids fall back to text-only
+ * input and the generic provider options.
+ */
+export type LLMGatewayModelId = LLMGatewayChatModels | (string & {})
+
+/**
+ * Type-only map from LLM Gateway chat model name to its supported input
+ * modalities.
+ */
+export type LLMGatewayModelInputModalitiesByName = {
+  [GPT_5_6_TERRA.name]: typeof GPT_5_6_TERRA.supports.input
+  [GPT_5_5.name]: typeof GPT_5_5.supports.input
+  [GPT_5_4_MINI.name]: typeof GPT_5_4_MINI.supports.input
+  [CLAUDE_OPUS_5.name]: typeof CLAUDE_OPUS_5.supports.input
+  [CLAUDE_SONNET_5.name]: typeof CLAUDE_SONNET_5.supports.input
+  [CLAUDE_HAIKU_4_5.name]: typeof CLAUDE_HAIKU_4_5.supports.input
+  [GEMINI_PRO_LATEST.name]: typeof GEMINI_PRO_LATEST.supports.input
+  [GEMINI_3_6_FLASH.name]: typeof GEMINI_3_6_FLASH.supports.input
+  [KIMI_K3.name]: typeof KIMI_K3.supports.input
+  [GLM_5_2.name]: typeof GLM_5_2.supports.input
+  [DEEPSEEK_V4_PRO.name]: typeof DEEPSEEK_V4_PRO.supports.input
+  [QWEN_3_7_MAX.name]: typeof QWEN_3_7_MAX.supports.input
+  [MINIMAX_M2_5.name]: typeof MINIMAX_M2_5.supports.input
+  [GROK_4_5.name]: typeof GROK_4_5.supports.input
+}
+
+/**
+ * Type-only map from LLM Gateway chat model name to its provider options
+ * type.
+ */
+export type LLMGatewayChatModelProviderOptionsByName = {
+  [K in (typeof LLMGATEWAY_CHAT_MODELS)[number]]: LLMGatewayTextProviderOptions
+}
+
+/**
+ * Type-only map from LLM Gateway chat model name to its supported provider
+ * tools. LLM Gateway exposes no provider-specific tool factories, so every
+ * model gets an empty tuple. This ensures that passing an Anthropic/OpenAI
+ * ProviderTool to an LLM Gateway adapter produces a compile-time type error.
+ */
+export type LLMGatewayChatModelToolCapabilitiesByName = {
+  [GPT_5_6_TERRA.name]: typeof GPT_5_6_TERRA.supports.tools
+  [GPT_5_5.name]: typeof GPT_5_5.supports.tools
+  [GPT_5_4_MINI.name]: typeof GPT_5_4_MINI.supports.tools
+  [CLAUDE_OPUS_5.name]: typeof CLAUDE_OPUS_5.supports.tools
+  [CLAUDE_SONNET_5.name]: typeof CLAUDE_SONNET_5.supports.tools
+  [CLAUDE_HAIKU_4_5.name]: typeof CLAUDE_HAIKU_4_5.supports.tools
+  [GEMINI_PRO_LATEST.name]: typeof GEMINI_PRO_LATEST.supports.tools
+  [GEMINI_3_6_FLASH.name]: typeof GEMINI_3_6_FLASH.supports.tools
+  [KIMI_K3.name]: typeof KIMI_K3.supports.tools
+  [GLM_5_2.name]: typeof GLM_5_2.supports.tools
+  [DEEPSEEK_V4_PRO.name]: typeof DEEPSEEK_V4_PRO.supports.tools
+  [QWEN_3_7_MAX.name]: typeof QWEN_3_7_MAX.supports.tools
+  [MINIMAX_M2_5.name]: typeof MINIMAX_M2_5.supports.tools
+  [GROK_4_5.name]: typeof GROK_4_5.supports.tools
+}
+
+/**
+ * Resolves the provider options type for a specific LLM Gateway model.
+ * Falls back to the generic options for uncurated model ids.
+ */
+export type ResolveProviderOptions<TModel extends string> =
+  TModel extends keyof LLMGatewayChatModelProviderOptionsByName
+    ? LLMGatewayChatModelProviderOptionsByName[TModel]
+    : LLMGatewayTextProviderOptions
+
+/**
+ * Resolve input modalities for a specific model.
+ * If the model has explicit modalities in the map, use those; otherwise use
+ * text only.
+ */
+export type ResolveInputModalities<TModel extends string> =
+  TModel extends keyof LLMGatewayModelInputModalitiesByName
+    ? LLMGatewayModelInputModalitiesByName[TModel]
+    : readonly ['text']

--- a/packages/ai-llmgateway/src/text/text-provider-options.ts
+++ b/packages/ai-llmgateway/src/text/text-provider-options.ts
@@ -1,0 +1,128 @@
+import type {
+  ChatCompletionToolChoiceOption,
+  ResponseFormatJsonObject,
+  ResponseFormatJsonSchema,
+  ResponseFormatText,
+} from '../message-types'
+
+/**
+ * LLM Gateway provider options for text/chat models.
+ *
+ * LLM Gateway exposes the OpenAI Chat Completions wire format and routes
+ * each request to the underlying provider, so these are the standard Chat
+ * Completions parameters. Parameters a routed provider doesn't support are
+ * stripped by the gateway before the request is forwarded upstream.
+ *
+ * @see https://docs.llmgateway.io
+ */
+export interface LLMGatewayTextProviderOptions {
+  /**
+   * Number between -2.0 and 2.0. Positive values penalize new tokens based on
+   * their existing frequency in the text so far, decreasing the model's
+   * likelihood to repeat the same line verbatim.
+   */
+  frequency_penalty?: number | null
+
+  /**
+   * The maximum number of tokens that can be generated in the chat
+   * completion. Deprecated by OpenAI in favor of `max_completion_tokens`,
+   * but still accepted by the gateway and translated per provider.
+   */
+  max_tokens?: number | null
+
+  /**
+   * An upper bound for the number of tokens that can be generated for a
+   * completion, including visible output tokens and reasoning tokens.
+   */
+  max_completion_tokens?: number | null
+
+  /** Whether to enable parallel function calling during tool use. */
+  parallel_tool_calls?: boolean | null
+
+  /**
+   * Number between -2.0 and 2.0. Positive values penalize new tokens based on
+   * whether they appear in the text so far, increasing the model's likelihood
+   * to talk about new topics.
+   */
+  presence_penalty?: number | null
+
+  /**
+   * Controls reasoning effort for reasoning-capable models.
+   *
+   * The gateway accepts the extended effort scale in addition to OpenAI's
+   * `low` / `medium` / `high`; which tiers a given model honors depends on
+   * the model and the provider it is routed to. See the model's page on
+   * https://llmgateway.io/models for the tiers it supports.
+   */
+  reasoning_effort?:
+    | 'none'
+    | 'minimal'
+    | 'low'
+    | 'medium'
+    | 'high'
+    | 'xhigh'
+    | 'max'
+    | null
+
+  /**
+   * An object specifying the format that the model must output.
+   *
+   * - `json_schema` — enables Structured Outputs (preferred)
+   * - `json_object` — enables the older JSON mode
+   * - `text` — plain text output (default)
+   */
+  response_format?:
+    | ResponseFormatText
+    | ResponseFormatJsonSchema
+    | ResponseFormatJsonObject
+    | null
+
+  /**
+   * If specified, the gateway forwards the seed so providers that support it
+   * can sample deterministically. Determinism is not guaranteed.
+   */
+  seed?: number | null
+
+  /**
+   * Up to 4 sequences where the API will stop generating further tokens.
+   * The returned text will not contain the stop sequence.
+   */
+  stop?: string | null | Array<string>
+
+  /**
+   * Sampling temperature between 0 and 2. Higher values like 0.8 make the
+   * output more random, while lower values like 0.2 make it more focused and
+   * deterministic. We generally recommend altering this or `top_p` but not
+   * both.
+   */
+  temperature?: number | null
+
+  /**
+   * Controls which (if any) tool is called by the model.
+   *
+   * - `none` — never call tools
+   * - `auto` — model decides (default when tools are present)
+   * - `required` — model must call tools
+   * - Named choice — forces a specific tool
+   */
+  tool_choice?: ChatCompletionToolChoiceOption | null
+
+  /**
+   * An alternative to sampling with temperature, called nucleus sampling,
+   * where the model considers the results of the tokens with top_p
+   * probability mass. So 0.1 means only the tokens comprising the top 10%
+   * probability mass are considered.
+   */
+  top_p?: number | null
+
+  /**
+   * A unique identifier representing your end-user, which can help monitor
+   * and detect abuse.
+   */
+  user?: string | null
+}
+
+/**
+ * External provider options (what users pass in)
+ */
+export type ExternalTextProviderOptions = LLMGatewayTextProviderOptions

--- a/packages/ai-llmgateway/src/utils/client.ts
+++ b/packages/ai-llmgateway/src/utils/client.ts
@@ -1,0 +1,35 @@
+import { getApiKeyFromEnv } from '@tanstack/ai-utils'
+import type { ClientOptions } from 'openai'
+
+export interface LLMGatewayClientConfig extends Omit<ClientOptions, 'apiKey'> {
+  apiKey: string
+}
+
+/**
+ * Gets the LLM Gateway API key from environment variables
+ * @throws Error if LLM_GATEWAY_API_KEY is not found
+ */
+export function getLLMGatewayApiKeyFromEnv(): string {
+  try {
+    return getApiKeyFromEnv('LLM_GATEWAY_API_KEY')
+  } catch {
+    throw new Error(
+      'LLM_GATEWAY_API_KEY is required. Please set it in your environment variables or use the factory function with an explicit API key.',
+    )
+  }
+}
+
+/**
+ * Returns an LLM Gateway client config with the gateway's OpenAI-compatible
+ * base URL applied when not already set. LLM Gateway accepts the OpenAI SDK
+ * verbatim, so the adapter drives it via the OpenAI SDK with this baseURL.
+ * Point `baseURL` at your own deployment when self-hosting.
+ */
+export function withLLMGatewayDefaults(
+  config: LLMGatewayClientConfig,
+): LLMGatewayClientConfig {
+  return {
+    ...config,
+    baseURL: config.baseURL || 'https://api.llmgateway.io/v1',
+  }
+}

--- a/packages/ai-llmgateway/src/utils/client.ts
+++ b/packages/ai-llmgateway/src/utils/client.ts
@@ -12,9 +12,10 @@ export interface LLMGatewayClientConfig extends Omit<ClientOptions, 'apiKey'> {
 export function getLLMGatewayApiKeyFromEnv(): string {
   try {
     return getApiKeyFromEnv('LLM_GATEWAY_API_KEY')
-  } catch {
+  } catch (cause) {
     throw new Error(
       'LLM_GATEWAY_API_KEY is required. Please set it in your environment variables or use the factory function with an explicit API key.',
+      { cause },
     )
   }
 }

--- a/packages/ai-llmgateway/tests/llmgateway-adapter.test.ts
+++ b/packages/ai-llmgateway/tests/llmgateway-adapter.test.ts
@@ -91,6 +91,16 @@ const createLLMGatewayText: typeof _realCreateLLMGatewayText = (
 const llmGatewayText: typeof _realLLMGatewayText = (model, config) =>
   applyPendingMock(_realLLMGatewayText(model, config))
 
+// `createLLMGatewaySummarize` builds its own `LLMGatewayTextAdapter` internally,
+// so the wrapped text factories above can't reach it. Apply the pending mock to
+// the wrapper's private `textAdapter` instead, so summarize tests can assert on
+// the request that actually goes out on the wire.
+function applyPendingMockToSummarize<T extends object>(adapter: T): T {
+  const inner = (adapter as any).textAdapter
+  if (inner) applyPendingMock(inner)
+  return adapter
+}
+
 describe('LLM Gateway adapters', () => {
   // Reset the module-level `pendingMockCreate` between tests so a previous
   // test's setupMockSdkClient call can't leak into a later test that
@@ -209,6 +219,38 @@ describe('LLM Gateway adapters', () => {
 
       expect(adapter).toBeDefined()
       expect(adapter.model).toBe('gpt-5.6-terra')
+    })
+
+    // Regression: the summarize wrapper resolves `maxLength` to a token cap via
+    // its own adapter `name`. LLM Gateway's OpenAI-compatible Chat Completions
+    // surface reads `max_tokens`, so an unregistered name would silently drop
+    // the cap and bill an unbounded completion.
+    it('forwards maxLength to the wire as max_tokens', async () => {
+      const mockCreate = setupMockSdkClient([
+        {
+          id: 'chatcmpl-summary',
+          model: 'gpt-5.6-terra',
+          choices: [
+            {
+              delta: { content: 'A short summary.' },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      ])
+      const adapter = applyPendingMockToSummarize(
+        createLLMGatewaySummarize('gpt-5.6-terra', 'test-api-key'),
+      )
+
+      await adapter.summarize({
+        model: 'gpt-5.6-terra',
+        text: 'Some long article text that needs summarizing.',
+        maxLength: 100,
+        logger: testLogger,
+      })
+
+      expect(mockCreate).toHaveBeenCalledTimes(1)
+      expect(mockCreate.mock.calls[0]?.[0]).toMatchObject({ max_tokens: 100 })
     })
   })
 })

--- a/packages/ai-llmgateway/tests/llmgateway-adapter.test.ts
+++ b/packages/ai-llmgateway/tests/llmgateway-adapter.test.ts
@@ -1,0 +1,499 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  afterEach,
+  beforeEach,
+  type Mock,
+} from 'vitest'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import {
+  createLLMGatewayText as _realCreateLLMGatewayText,
+  llmGatewayText as _realLLMGatewayText,
+} from '../src/adapters/text'
+import { createLLMGatewaySummarize } from '../src/adapters/summarize'
+import { withLLMGatewayDefaults } from '../src/utils/client'
+import type { StreamChunk } from '@tanstack/ai'
+import type { LLMGatewayTextProviderOptions } from '../src/index'
+
+// Test helper: a silent logger for test chatStream calls.
+const testLogger = resolveDebugOption(false)
+
+// Stub the OpenAI SDK so adapter construction doesn't open a real network
+// handle. The per-test mock client is injected post-construction via
+// `setupMockSdkClient` (mirrors the ai-groq pattern). We avoid relying on
+// vi.mock to intercept transitive openai imports — the built openai-base
+// dist resolves `openai` independently and is unaffected by vi.mock here.
+vi.mock('openai', () => {
+  return {
+    default: class {
+      chat = {
+        completions: {
+          create: vi.fn(),
+        },
+      }
+    },
+  }
+})
+
+// Helper to create async iterable from chunks
+function createAsyncIterable<T>(chunks: Array<T>): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0
+      return {
+        async next() {
+          if (index < chunks.length) {
+            return { value: chunks[index++]!, done: false }
+          }
+          return { value: undefined as T, done: true }
+        },
+      }
+    },
+  }
+}
+
+// Sets up a mock client on the most recently created adapter. Tests use the
+// existing call order: `setupMockSdkClient(chunks)` first, then `const
+// adapter = createLLMGatewayText(...)`. The wrapped factories below apply
+// the pending mock to the returned adapter so it intercepts subsequent
+// chatStream/structuredOutput calls.
+let pendingMockCreate: Mock<(...args: Array<unknown>) => unknown> | undefined
+
+function setupMockSdkClient(
+  streamChunks: Array<Record<string, unknown>>,
+  nonStreamResponse?: Record<string, unknown>,
+): Mock<(...args: Array<unknown>) => unknown> {
+  pendingMockCreate = vi.fn().mockImplementation((params) => {
+    if (params.stream) {
+      return Promise.resolve(createAsyncIterable(streamChunks))
+    }
+    return Promise.resolve(nonStreamResponse)
+  })
+  return pendingMockCreate
+}
+
+function applyPendingMock<T extends object>(adapter: T): T {
+  if (pendingMockCreate) {
+    ;(adapter as any).client = {
+      chat: { completions: { create: pendingMockCreate } },
+    }
+    pendingMockCreate = undefined
+  }
+  return adapter
+}
+const createLLMGatewayText: typeof _realCreateLLMGatewayText = (
+  model,
+  apiKey,
+  config,
+) => applyPendingMock(_realCreateLLMGatewayText(model, apiKey, config))
+const llmGatewayText: typeof _realLLMGatewayText = (model, config) =>
+  applyPendingMock(_realLLMGatewayText(model, config))
+
+describe('LLM Gateway adapters', () => {
+  // Reset the module-level `pendingMockCreate` between tests so a previous
+  // test's setupMockSdkClient call can't leak into a later test that
+  // instantiates the adapter without setting up a mock.
+  beforeEach(() => {
+    pendingMockCreate = undefined
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('Client config', () => {
+    it('defaults baseURL to the hosted gateway', () => {
+      const config = withLLMGatewayDefaults({ apiKey: 'llmgtwy_test' })
+      expect(config.baseURL).toBe('https://api.llmgateway.io/v1')
+    })
+
+    it('keeps an explicit baseURL for self-hosted gateways', () => {
+      const config = withLLMGatewayDefaults({
+        apiKey: 'llmgtwy_test',
+        baseURL: 'https://gateway.example.com/v1',
+      })
+      expect(config.baseURL).toBe('https://gateway.example.com/v1')
+    })
+  })
+
+  describe('Text adapter', () => {
+    it('creates a text adapter with explicit API key', () => {
+      const adapter = createLLMGatewayText('gpt-5.6-terra', 'test-api-key')
+
+      expect(adapter).toBeDefined()
+      expect(adapter.kind).toBe('text')
+      expect(adapter.name).toBe('llmgateway')
+      expect(adapter.model).toBe('gpt-5.6-terra')
+    })
+
+    it('creates a text adapter from environment variable', () => {
+      vi.stubEnv('LLM_GATEWAY_API_KEY', 'env-api-key')
+
+      const adapter = llmGatewayText('claude-sonnet-5')
+
+      expect(adapter).toBeDefined()
+      expect(adapter.kind).toBe('text')
+      expect(adapter.model).toBe('claude-sonnet-5')
+    })
+
+    it('throws if LLM_GATEWAY_API_KEY is not set when using llmGatewayText', () => {
+      vi.stubEnv('LLM_GATEWAY_API_KEY', '')
+
+      expect(() => llmGatewayText('gpt-5.6-terra')).toThrow(
+        'LLM_GATEWAY_API_KEY',
+      )
+    })
+
+    it('accepts uncurated and provider-pinned model ids', () => {
+      // The gateway routes hundreds of models; ids outside the curated list
+      // (including `provider/model` pins) must remain valid at both type
+      // level and runtime.
+      const adapter = createLLMGatewayText('moonshot/kimi-k3', 'test-api-key')
+
+      expect(adapter).toBeDefined()
+      expect(adapter.model).toBe('moonshot/kimi-k3')
+    })
+
+    it('allows custom baseURL override', () => {
+      const adapter = createLLMGatewayText('gpt-5.6-terra', 'test-api-key', {
+        baseURL: 'https://gateway.example.com/v1',
+      })
+
+      expect(adapter).toBeDefined()
+    })
+
+    it('forwards sampling options from modelOptions', async () => {
+      const streamChunks = [
+        {
+          id: 'chatcmpl-sampling',
+          model: 'gpt-5.6-terra',
+          choices: [{ delta: {}, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
+        },
+      ]
+
+      const mockCreate = setupMockSdkClient(streamChunks)
+      const adapter = createLLMGatewayText('gpt-5.6-terra', 'test-api-key')
+
+      const modelOptions: LLMGatewayTextProviderOptions = {
+        temperature: 0.5,
+        top_p: 0.8,
+        max_completion_tokens: 128,
+        reasoning_effort: 'high',
+      }
+
+      for await (const _ of adapter.chatStream({
+        model: 'gpt-5.6-terra',
+        messages: [{ role: 'user', content: 'Hello' }],
+        modelOptions,
+        logger: testLogger,
+      })) {
+        // consume stream
+      }
+
+      expect(mockCreate).toHaveBeenCalledTimes(1)
+      expect(mockCreate.mock.calls[0]?.[0]).toMatchObject({
+        temperature: 0.5,
+        top_p: 0.8,
+        max_completion_tokens: 128,
+        reasoning_effort: 'high',
+      })
+    })
+  })
+
+  describe('Summarize adapter', () => {
+    it('creates a summarize adapter wrapping the text adapter', () => {
+      const adapter = createLLMGatewaySummarize('gpt-5.6-terra', 'test-api-key')
+
+      expect(adapter).toBeDefined()
+      expect(adapter.model).toBe('gpt-5.6-terra')
+    })
+  })
+})
+
+describe('LLM Gateway AG-UI event emission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pendingMockCreate = undefined
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('emits RUN_STARTED as the first event', async () => {
+    const streamChunks = [
+      {
+        id: 'chatcmpl-123',
+        model: 'gpt-5.6-terra',
+        choices: [
+          {
+            delta: { content: 'Hello' },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-123',
+        model: 'gpt-5.6-terra',
+        choices: [
+          {
+            delta: {},
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 5,
+          completion_tokens: 1,
+          total_tokens: 6,
+        },
+      },
+    ]
+
+    setupMockSdkClient(streamChunks)
+    const adapter = createLLMGatewayText('gpt-5.6-terra', 'test-api-key')
+    const chunks: Array<StreamChunk> = []
+
+    for await (const chunk of adapter.chatStream({
+      model: 'gpt-5.6-terra',
+      messages: [{ role: 'user', content: 'Hello' }],
+      logger: testLogger,
+    })) {
+      chunks.push(chunk)
+    }
+
+    expect(chunks[0]?.type).toBe('RUN_STARTED')
+    if (chunks[0]?.type === 'RUN_STARTED') {
+      expect(chunks[0].runId).toBeDefined()
+      expect(chunks[0].model).toBe('gpt-5.6-terra')
+    }
+  })
+
+  it('emits TEXT_MESSAGE_START before TEXT_MESSAGE_CONTENT and finishes with usage', async () => {
+    const streamChunks = [
+      {
+        id: 'chatcmpl-123',
+        model: 'gpt-5.6-terra',
+        choices: [
+          {
+            delta: { content: 'Hello' },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-123',
+        model: 'gpt-5.6-terra',
+        choices: [
+          {
+            delta: {},
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 5,
+          completion_tokens: 1,
+          total_tokens: 6,
+        },
+      },
+    ]
+
+    setupMockSdkClient(streamChunks)
+    const adapter = createLLMGatewayText('gpt-5.6-terra', 'test-api-key')
+    const chunks: Array<StreamChunk> = []
+
+    for await (const chunk of adapter.chatStream({
+      model: 'gpt-5.6-terra',
+      messages: [{ role: 'user', content: 'Hello' }],
+      logger: testLogger,
+    })) {
+      chunks.push(chunk)
+    }
+
+    const textStartIndex = chunks.findIndex(
+      (c) => c.type === 'TEXT_MESSAGE_START',
+    )
+    const textContentIndex = chunks.findIndex(
+      (c) => c.type === 'TEXT_MESSAGE_CONTENT',
+    )
+
+    expect(textStartIndex).toBeGreaterThan(-1)
+    expect(textContentIndex).toBeGreaterThan(-1)
+    expect(textStartIndex).toBeLessThan(textContentIndex)
+
+    const runFinishedChunk = chunks.find((c) => c.type === 'RUN_FINISHED')
+    expect(runFinishedChunk).toBeDefined()
+    if (runFinishedChunk?.type === 'RUN_FINISHED') {
+      expect(runFinishedChunk.finishReason).toBe('stop')
+      expect(runFinishedChunk.usage).toMatchObject({
+        promptTokens: 5,
+        completionTokens: 1,
+        totalTokens: 6,
+      })
+    }
+  })
+
+  it('surfaces reasoning_content deltas as REASONING events', async () => {
+    const streamChunks = [
+      {
+        id: 'chatcmpl-reasoning',
+        model: 'kimi-k3',
+        choices: [
+          {
+            delta: { reasoning_content: 'Thinking about it...' },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-reasoning',
+        model: 'kimi-k3',
+        choices: [
+          {
+            delta: { content: 'The answer is 4.' },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-reasoning',
+        model: 'kimi-k3',
+        choices: [
+          {
+            delta: {},
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 5,
+          completion_tokens: 10,
+          total_tokens: 15,
+        },
+      },
+    ]
+
+    setupMockSdkClient(streamChunks)
+    const adapter = createLLMGatewayText('kimi-k3', 'test-api-key')
+    const chunks: Array<StreamChunk> = []
+
+    for await (const chunk of adapter.chatStream({
+      model: 'kimi-k3',
+      messages: [{ role: 'user', content: 'What is 2+2?' }],
+      logger: testLogger,
+    })) {
+      chunks.push(chunk)
+    }
+
+    const reasoningContent = chunks.find(
+      (c) => c.type === 'REASONING_MESSAGE_CONTENT',
+    )
+    expect(reasoningContent).toBeDefined()
+    if (reasoningContent?.type === 'REASONING_MESSAGE_CONTENT') {
+      expect(reasoningContent.delta).toBe('Thinking about it...')
+    }
+
+    // Reasoning must close before the visible text message starts.
+    const reasoningEndIndex = chunks.findIndex(
+      (c) => c.type === 'REASONING_MESSAGE_END',
+    )
+    const textStartIndex = chunks.findIndex(
+      (c) => c.type === 'TEXT_MESSAGE_START',
+    )
+    expect(reasoningEndIndex).toBeGreaterThan(-1)
+    expect(textStartIndex).toBeGreaterThan(reasoningEndIndex)
+  })
+
+  it('emits AG-UI tool call events', async () => {
+    const streamChunks = [
+      {
+        id: 'chatcmpl-456',
+        model: 'gpt-5.6-terra',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_abc',
+                  type: 'function',
+                  function: {
+                    name: 'lookup_weather',
+                    arguments: '{"location":',
+                  },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-456',
+        model: 'gpt-5.6-terra',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  function: { arguments: '"Paris"}' },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-456',
+        model: 'gpt-5.6-terra',
+        choices: [
+          {
+            delta: {},
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 8,
+          total_tokens: 20,
+        },
+      },
+    ]
+
+    setupMockSdkClient(streamChunks)
+    const adapter = createLLMGatewayText('gpt-5.6-terra', 'test-api-key')
+    const chunks: Array<StreamChunk> = []
+
+    for await (const chunk of adapter.chatStream({
+      model: 'gpt-5.6-terra',
+      messages: [{ role: 'user', content: 'Weather in Paris?' }],
+      logger: testLogger,
+    })) {
+      chunks.push(chunk)
+    }
+
+    const toolStart = chunks.find((c) => c.type === 'TOOL_CALL_START')
+    expect(toolStart).toBeDefined()
+    if (toolStart?.type === 'TOOL_CALL_START') {
+      expect(toolStart.toolCallName).toBe('lookup_weather')
+    }
+
+    const toolArgs = chunks
+      .filter((c) => c.type === 'TOOL_CALL_ARGS')
+      .map((c) => (c.type === 'TOOL_CALL_ARGS' ? c.delta : ''))
+      .join('')
+    expect(toolArgs).toBe('{"location":"Paris"}')
+
+    const toolEnd = chunks.find((c) => c.type === 'TOOL_CALL_END')
+    expect(toolEnd).toBeDefined()
+
+    const runFinishedChunk = chunks.find((c) => c.type === 'RUN_FINISHED')
+    expect(runFinishedChunk).toBeDefined()
+    if (runFinishedChunk?.type === 'RUN_FINISHED') {
+      expect(runFinishedChunk.finishReason).toBe('tool_calls')
+    }
+  })
+})

--- a/packages/ai-llmgateway/tsconfig.json
+++ b/packages/ai-llmgateway/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ai-llmgateway/vite.config.ts
+++ b/packages/ai-llmgateway/vite.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import { tanstackViteConfig } from '@tanstack/vite-config'
+import packageJson from './package.json'
+
+const config = defineConfig({
+  test: {
+    name: packageJson.name,
+    dir: './',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        'tests/',
+        '**/*.test.ts',
+        '**/*.config.ts',
+        '**/types.ts',
+      ],
+      include: ['src/**/*.ts'],
+    },
+  },
+})
+
+export default mergeConfig(
+  config,
+  tanstackViteConfig({
+    entry: ['./src/index.ts'],
+    srcDir: './src',
+    cjs: false,
+  }),
+)

--- a/packages/ai-llmgateway/vitest.config.ts
+++ b/packages/ai-llmgateway/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        'tests/',
+        '**/*.test.ts',
+        '**/*.config.ts',
+        '**/types.ts',
+      ],
+      include: ['src/**/*.ts'],
+    },
+  },
+})

--- a/packages/ai/src/activities/summarize/chat-stream-summarize.ts
+++ b/packages/ai/src/activities/summarize/chat-stream-summarize.ts
@@ -38,6 +38,7 @@ export interface ChatStreamCapable {
  * - Groq: `max_completion_tokens`
  * - Gemini: `maxOutputTokens`
  * - OpenRouter: `maxCompletionTokens`
+ * - LLM Gateway: `max_tokens`
  * - Ollama: nested `options.num_predict` (no entry — see `applyMaxLength`)
  */
 const MAX_TOKENS_KEY_BY_ADAPTER: Record<string, string> = {
@@ -47,6 +48,9 @@ const MAX_TOKENS_KEY_BY_ADAPTER: Record<string, string> = {
   groq: 'max_completion_tokens',
   gemini: 'maxOutputTokens',
   openrouter: 'maxCompletionTokens',
+  // LLM Gateway exposes an OpenAI-compatible Chat Completions surface whose
+  // only output cap is `max_tokens` — it does not read `max_completion_tokens`.
+  llmgateway: 'max_tokens',
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2073,7 +2073,7 @@ importers:
         version: link:../ai
       '@vitest/coverage-v8':
         specifier: 4.0.14
-        version: 4.0.14(vitest@4.1.10)
+        version: 4.0.14(supports-color@7.2.0)(vitest@4.1.10)
       vite:
         specifier: ^8.1.4
         version: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
@@ -2842,6 +2842,9 @@ importers:
       '@tanstack/ai-groq':
         specifier: workspace:*
         version: link:../../packages/ai-groq
+      '@tanstack/ai-llmgateway':
+        specifier: workspace:*
+        version: link:../../packages/ai-llmgateway
       '@tanstack/ai-mcp':
         specifier: workspace:*
         version: link:../../packages/ai-mcp
@@ -24845,14 +24848,14 @@ snapshots:
       vite: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
       vue: 3.5.25(typescript@5.9.3)
 
-  '@vitest/coverage-v8@4.0.14(vitest@4.1.10)':
+  '@vitest/coverage-v8@4.0.14(supports-color@7.2.0)(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.14
       ast-v8-to-istanbul: 0.3.12
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
+      istanbul-lib-source-maps: 5.0.6(supports-color@7.2.0)
       istanbul-reports: 3.2.0
       magicast: 0.5.2
       obug: 2.1.1
@@ -28228,7 +28231,7 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
+  istanbul-lib-source-maps@5.0.6(supports-color@7.2.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       debug: 4.4.3(supports-color@7.2.0)
@@ -33297,7 +33300,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.10.3
-      '@vitest/coverage-v8': 4.0.14(vitest@4.1.10)
+      '@vitest/coverage-v8': 4.0.14(supports-color@7.2.0)(vitest@4.1.10)
       happy-dom: 20.11.2
       jsdom: 27.4.0(postcss@8.5.26)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2056,6 +2056,31 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(vitest@4.1.10)
 
+  packages/ai-llmgateway:
+    dependencies:
+      '@tanstack/ai-utils':
+        specifier: workspace:*
+        version: link:../ai-utils
+      '@tanstack/openai-base':
+        specifier: workspace:*
+        version: link:../openai-base
+      openai:
+        specifier: ^6.41.0
+        version: 6.41.0(ws@8.21.0)(zod@4.3.6)
+    devDependencies:
+      '@tanstack/ai':
+        specifier: workspace:*
+        version: link:../ai
+      '@vitest/coverage-v8':
+        specifier: 4.0.14
+        version: 4.0.14(vitest@4.1.10)
+      vite:
+        specifier: ^8.1.4
+        version: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
+      zod:
+        specifier: ^4.2.0
+        version: 4.3.6
+
   packages/ai-mcp:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -9853,6 +9878,15 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
+  '@vitest/coverage-v8@4.0.14':
+    resolution: {integrity: sha512-EYHLqN/BY6b47qHH7gtMxAg++saoGmsjWmAq9MlXxAz4M0NcHh9iOyKhBZyU4yxZqOd8Xnqp80/5saeitz4Cng==}
+    peerDependencies:
+      '@vitest/browser': 4.0.14
+      vitest: 4.0.14
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
@@ -9876,6 +9910,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@4.0.14':
+    resolution: {integrity: sha512-SOYPgujB6TITcJxgd3wmsLl+wZv+fy3av2PpiPpsWPZ6J1ySUYfScfpIt2Yv56ShJXR2MOA6q2KjKHN4EpdyRQ==}
+
   '@vitest/pretty-format@4.1.10':
     resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
@@ -9887,6 +9924,9 @@ packages:
 
   '@vitest/spy@4.1.10':
     resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.0.14':
+    resolution: {integrity: sha512-hLqXZKAWNg8pI+SQXyXxWCTOpA3MvsqcbVeNgSi8x/CSN2wi26dSzn1wrOhmCmFjEvN9p8/kLFRHa6PI8jHazw==}
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
@@ -10176,6 +10216,9 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   ast-v8-to-istanbul@1.0.5:
     resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
@@ -12747,6 +12790,10 @@ packages:
 
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
 
   istanbul-reports@3.2.0:
@@ -22735,10 +22782,6 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.4
 
-  '@sveltejs/acorn-typescript@1.0.13(acorn@8.15.0)':
-    dependencies:
-      acorn: 8.15.0
-
   '@sveltejs/acorn-typescript@1.0.13(acorn@8.18.0)':
     dependencies:
       acorn: 8.18.0
@@ -24802,6 +24845,23 @@ snapshots:
       vite: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
       vue: 3.5.25(typescript@5.9.3)
 
+  '@vitest/coverage-v8@4.0.14(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.14
+      ast-v8-to-istanbul: 0.3.12
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(@vitest/coverage-v8@4.0.14)(happy-dom@20.11.2)(jsdom@27.4.0(postcss@8.5.26))(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -24842,6 +24902,10 @@ snapshots:
       vite: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
     optional: true
 
+  '@vitest/pretty-format@4.0.14':
+    dependencies:
+      tinyrainbow: 3.1.0
+
   '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
@@ -24859,6 +24923,11 @@ snapshots:
       pathe: 2.0.3
 
   '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.0.14':
+    dependencies:
+      '@vitest/pretty-format': 4.0.14
+      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -25206,6 +25275,12 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   ast-v8-to-istanbul@1.0.5:
     dependencies:
@@ -28152,6 +28227,14 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3(supports-color@7.2.0)
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
 
   istanbul-reports@3.2.0:
     dependencies:
@@ -32245,10 +32328,10 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.13(acorn@8.15.0)
+      '@sveltejs/acorn-typescript': 1.0.13(acorn@8.18.0)
       '@types/estree': 1.0.9
       '@types/trusted-types': 2.0.7
-      acorn: 8.15.0
+      acorn: 8.18.0
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
@@ -32336,7 +32419,7 @@ snapshots:
   terser@5.44.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -33075,7 +33158,7 @@ snapshots:
       solid-js: 1.9.10
       solid-refresh: 0.6.3(solid-js@1.9.10)
       vite: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
-      vitefu: 1.1.1(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0))
+      vitefu: 1.1.3(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -33188,6 +33271,37 @@ snapshots:
   vitefu@1.1.3(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(@vitest/coverage-v8@4.0.14)(happy-dom@20.11.2)(jsdom@27.4.0(postcss@8.5.26))(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.10.3
+      '@vitest/coverage-v8': 4.0.14(vitest@4.1.10)
+      happy-dom: 20.11.2
+      jsdom: 27.4.0(postcss@8.5.26)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(jsdom@27.4.0(postcss@8.5.19))(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2059,10 +2059,10 @@ importers:
   packages/ai-llmgateway:
     dependencies:
       '@tanstack/ai-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../ai-utils
       '@tanstack/openai-base':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../openai-base
       openai:
         specifier: ^6.41.0
@@ -2072,10 +2072,10 @@ importers:
         specifier: workspace:*
         version: link:../ai
       '@vitest/coverage-v8':
-        specifier: 4.0.14
-        version: 4.0.14(supports-color@7.2.0)(vitest@4.1.10)
+        specifier: 4.1.10
+        version: 4.1.10(vitest@4.1.10)
       vite:
-        specifier: ^8.1.4
+        specifier: ^8.2.1
         version: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
       zod:
         specifier: ^4.2.0
@@ -9881,15 +9881,6 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vitest/coverage-v8@4.0.14':
-    resolution: {integrity: sha512-EYHLqN/BY6b47qHH7gtMxAg++saoGmsjWmAq9MlXxAz4M0NcHh9iOyKhBZyU4yxZqOd8Xnqp80/5saeitz4Cng==}
-    peerDependencies:
-      '@vitest/browser': 4.0.14
-      vitest: 4.0.14
-    peerDependenciesMeta:
-      '@vitest/browser':
-        optional: true
-
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
@@ -9913,9 +9904,6 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.14':
-    resolution: {integrity: sha512-SOYPgujB6TITcJxgd3wmsLl+wZv+fy3av2PpiPpsWPZ6J1ySUYfScfpIt2Yv56ShJXR2MOA6q2KjKHN4EpdyRQ==}
-
   '@vitest/pretty-format@4.1.10':
     resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
@@ -9927,9 +9915,6 @@ packages:
 
   '@vitest/spy@4.1.10':
     resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
-
-  '@vitest/utils@4.0.14':
-    resolution: {integrity: sha512-hLqXZKAWNg8pI+SQXyXxWCTOpA3MvsqcbVeNgSi8x/CSN2wi26dSzn1wrOhmCmFjEvN9p8/kLFRHa6PI8jHazw==}
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
@@ -10219,9 +10204,6 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
-
-  ast-v8-to-istanbul@0.3.12:
-    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   ast-v8-to-istanbul@1.0.5:
     resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
@@ -12793,10 +12775,6 @@ packages:
 
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
-    engines: {node: '>=10'}
-
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
 
   istanbul-reports@3.2.0:
@@ -24848,23 +24826,6 @@ snapshots:
       vite: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
       vue: 3.5.25(typescript@5.9.3)
 
-  '@vitest/coverage-v8@4.0.14(supports-color@7.2.0)(vitest@4.1.10)':
-    dependencies:
-      '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.0.14
-      ast-v8-to-istanbul: 0.3.12
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6(supports-color@7.2.0)
-      istanbul-reports: 3.2.0
-      magicast: 0.5.2
-      obug: 2.1.1
-      std-env: 3.10.0
-      tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(@vitest/coverage-v8@4.0.14)(happy-dom@20.11.2)(jsdom@27.4.0(postcss@8.5.26))(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -24905,10 +24866,6 @@ snapshots:
       vite: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
     optional: true
 
-  '@vitest/pretty-format@4.0.14':
-    dependencies:
-      tinyrainbow: 3.1.0
-
   '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
@@ -24926,11 +24883,6 @@ snapshots:
       pathe: 2.0.3
 
   '@vitest/spy@4.1.10': {}
-
-  '@vitest/utils@4.0.14':
-    dependencies:
-      '@vitest/pretty-format': 4.0.14
-      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -25278,12 +25230,6 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
-
-  ast-v8-to-istanbul@0.3.12:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      estree-walker: 3.0.3
-      js-tokens: 10.0.0
 
   ast-v8-to-istanbul@1.0.5:
     dependencies:
@@ -28230,14 +28176,6 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
-
-  istanbul-lib-source-maps@5.0.6(supports-color@7.2.0):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@7.2.0)
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
 
   istanbul-reports@3.2.0:
     dependencies:
@@ -33274,37 +33212,6 @@ snapshots:
   vitefu@1.1.3(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
-
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(@vitest/coverage-v8@4.0.14)(happy-dom@20.11.2)(jsdom@27.4.0(postcss@8.5.26))(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 24.10.3
-      '@vitest/coverage-v8': 4.0.14(supports-color@7.2.0)(vitest@4.1.10)
-      happy-dom: 20.11.2
-      jsdom: 27.4.0(postcss@8.5.26)
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(jsdom@27.4.0(postcss@8.5.19))(vite@8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -4,7 +4,7 @@ End-to-end tests for TanStack AI using Playwright and [aimock](https://github.co
 
 **Architecture:** Playwright drives a TanStack Start app (`testing/e2e/`) which routes requests through provider adapters pointing at aimock. Fixtures define mock responses. No real API keys needed. All scenarios (including tool execution flows) use aimock fixtures. Tests run in parallel with per-test `X-Test-Id` isolation.
 
-**Providers tested:** openai, anthropic, gemini, ollama, groq, grok, openrouter, openrouter-responses, vercel-gateway, vercel-gateway-responses, bedrock, bedrock-responses, openai-compatible, mistral, byteplus, elevenlabs
+**Providers tested:** openai, anthropic, gemini, ollama, groq, grok, openrouter, openrouter-responses, vercel-gateway, vercel-gateway-responses, bedrock, bedrock-responses, openai-compatible, mistral, byteplus, elevenlabs, llmgateway
 
 > **Claude Code (`@tanstack/ai-claude-code`) is excluded from the standard matrix.** It's a harness adapter that spawns the Claude Code runtime as a subprocess, so aimock's per-test `X-Test-Id` header isolation can't be injected into its requests. It's covered by unit tests in the package plus a gated live smoke test in `tests/claude-code.spec.ts` — run it with `CLAUDE_CODE_E2E=1` and an `ANTHROPIC_API_KEY` (or a local `claude login`).
 

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -27,6 +27,7 @@
     "@tanstack/ai-gemini": "workspace:*",
     "@tanstack/ai-grok": "workspace:*",
     "@tanstack/ai-groq": "workspace:*",
+    "@tanstack/ai-llmgateway": "workspace:*",
     "@tanstack/ai-mcp": "workspace:*",
     "@tanstack/ai-memory": "workspace:*",
     "@tanstack/ai-mistral": "workspace:*",

--- a/testing/e2e/src/lib/feature-support.ts
+++ b/testing/e2e/src/lib/feature-support.ts
@@ -22,6 +22,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openai-compatible',
     'mistral',
     'byteplus',
+    'llmgateway',
   ]),
   'one-shot-text': new Set([
     'openai',
@@ -37,6 +38,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openai-compatible',
     'mistral',
     'byteplus',
+    'llmgateway',
   ]),
   // BytePlus streams its reasoning trace as `delta.reasoning_content`, which is
   // exactly the field aimock's OpenAI-compatible chunk builder emits for a
@@ -57,6 +59,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openai-compatible',
     'mistral',
     'byteplus',
+    'llmgateway',
   ]),
   'tool-calling': new Set([
     'openai',
@@ -74,6 +77,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openai-compatible',
     'mistral',
     'byteplus',
+    'llmgateway',
   ]),
   'parallel-tool-calls': new Set([
     'openai',
@@ -88,6 +92,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openai-compatible',
     'mistral',
     'byteplus',
+    'llmgateway',
   ]),
   // Gemini excluded: approval flow timing issues with Gemini's streaming format
   'tool-approval': new Set([
@@ -103,6 +108,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openai-compatible',
     'mistral',
     'byteplus',
+    'llmgateway',
   ]),
   // Ollama excluded: aimock doesn't support content+toolCalls for /api/chat format
   'text-tool-text': new Set([
@@ -118,6 +124,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openai-compatible',
     'mistral',
     'byteplus',
+    'llmgateway',
   ]),
   'structured-output': new Set([
     'openai',
@@ -133,6 +140,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openai-compatible',
     'mistral',
     'byteplus',
+    'llmgateway',
   ]),
   // Streaming structured output: only providers with native streaming JSON
   // schema support are listed here. Other providers fall back to the
@@ -148,6 +156,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'vercel-gateway',
     'openai-compatible',
     'byteplus',
+    'llmgateway',
   ]),
   // Multi-turn structured output: every turn produces its own typed
   // `structured-output` part on the assistant message, and historical
@@ -179,6 +188,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'vercel-gateway',
     'openai-compatible',
     'byteplus',
+    'llmgateway',
   ]),
   'agentic-structured': new Set([
     'openai',
@@ -194,6 +204,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openai-compatible',
     'mistral',
     'byteplus',
+    'llmgateway',
   ]),
   // Native-combined-mode adapters only. Each provider's default test model
   // (or per-feature override in `features.ts`) must opt into combined mode
@@ -221,6 +232,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'grok',
     'openrouter',
     'byteplus',
+    'llmgateway',
   ]),
   // OpenAI only: this feature exercises the Responses adapter's PDF
   // `input_file` conversion (base64 `file_data` + filename).
@@ -233,6 +245,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'grok',
     'openrouter',
     'byteplus',
+    'llmgateway',
   ]),
   // byteplus excluded: @tanstack/ai-byteplus ships no summarize adapter —
   // Ark has no summarization endpoint, and api.summarize.ts builds a
@@ -250,6 +263,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'vercel-gateway',
     'mistral',
+    'llmgateway',
   ]),
   'summarize-stream': new Set([
     'openai',
@@ -263,6 +277,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'vercel-gateway',
     'mistral',
+    'llmgateway',
   ]),
   // Embedding (Promise-based `embed()` activity, no streaming). aimock 1.34
   // natively mocks OpenAI's /v1/embeddings (JSON fixture in

--- a/testing/e2e/src/lib/feature-support.ts
+++ b/testing/e2e/src/lib/feature-support.ts
@@ -40,11 +40,19 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'byteplus',
     'llmgateway',
   ]),
-  // BytePlus streams its reasoning trace as `delta.reasoning_content`, which is
-  // exactly the field aimock's OpenAI-compatible chunk builder emits for a
-  // fixture's `reasoning` channel — so the adapter's `extractReasoning`
-  // override is exercised end-to-end against the shared fixture.
-  reasoning: new Set(['openai', 'anthropic', 'gemini', 'mistral', 'byteplus']),
+  // BytePlus and LLM Gateway both stream their reasoning trace as
+  // `delta.reasoning_content`, which is exactly the field aimock's
+  // OpenAI-compatible chunk builder emits for a fixture's `reasoning` channel —
+  // so each adapter's `extractReasoning` override is exercised end-to-end
+  // against the shared fixture.
+  reasoning: new Set([
+    'openai',
+    'anthropic',
+    'gemini',
+    'mistral',
+    'byteplus',
+    'llmgateway',
+  ]),
   'multi-turn': new Set([
     'openai',
     'anthropic',

--- a/testing/e2e/src/lib/providers.ts
+++ b/testing/e2e/src/lib/providers.ts
@@ -15,6 +15,7 @@ import {
 import { createVercelGatewayText } from '@tanstack/ai-vercel-gateway'
 import { createMistralText } from '@tanstack/ai-mistral'
 import { createBytePlusText } from '@tanstack/ai-byteplus'
+import { createLLMGatewayText } from '@tanstack/ai-llmgateway'
 import { HTTPClient } from '@openrouter/sdk'
 import type { AnyTextAdapter } from '@tanstack/ai'
 import type { BytePlusChatModel } from '@tanstack/ai-byteplus'
@@ -46,6 +47,7 @@ const defaultModels: Record<Provider, string> = {
   // it out of text features, but we still need an entry to satisfy the
   // Record<Provider, …> constraint.
   elevenlabs: '',
+  llmgateway: 'gpt-5.6-terra',
 }
 
 export function createTextAdapter(
@@ -249,6 +251,13 @@ export function createTextAdapter(
         'ElevenLabs has no text/chat adapter — use createTTSAdapter or createTranscriptionAdapter.',
       )
     },
+    llmgateway: () =>
+      createChatOptions({
+        adapter: createLLMGatewayText(model as 'gpt-5.6-terra', DUMMY_KEY, {
+          baseURL: openaiUrl,
+          defaultHeaders: testHeaders,
+        }),
+      }),
   }
 
   return factories[provider]()

--- a/testing/e2e/src/lib/types.ts
+++ b/testing/e2e/src/lib/types.ts
@@ -17,6 +17,7 @@ export type Provider =
   | 'mistral'
   | 'byteplus'
   | 'elevenlabs'
+  | 'llmgateway'
 
 export type Feature =
   | 'chat'
@@ -67,6 +68,7 @@ export const ALL_PROVIDERS: Provider[] = [
   'mistral',
   'byteplus',
   'elevenlabs',
+  'llmgateway',
 ]
 
 export const ALL_FEATURES: Feature[] = [

--- a/testing/e2e/src/routes/api.summarize.ts
+++ b/testing/e2e/src/routes/api.summarize.ts
@@ -6,6 +6,7 @@ import { createGeminiSummarize } from '@tanstack/ai-gemini'
 import { createOllamaSummarize } from '@tanstack/ai-ollama'
 import { createGroqSummarize } from '@tanstack/ai-groq'
 import { createGrokSummarize } from '@tanstack/ai-grok'
+import { createLLMGatewaySummarize } from '@tanstack/ai-llmgateway'
 import { createOpenRouterSummarize } from '@tanstack/ai-openrouter'
 import { createVercelGatewaySummarize } from '@tanstack/ai-vercel-gateway'
 import { HTTPClient } from '@openrouter/sdk'
@@ -76,6 +77,11 @@ function createSummarizeAdapter(
       }),
     grok: () =>
       createGrokSummarize('grok-build-0.1', DUMMY_KEY, {
+        baseURL: openaiUrl(aimockPort),
+        defaultHeaders: headers,
+      }),
+    llmgateway: () =>
+      createLLMGatewaySummarize('gpt-5.6-terra', DUMMY_KEY, {
         baseURL: openaiUrl(aimockPort),
         defaultHeaders: headers,
       }),

--- a/testing/e2e/tests/test-matrix.ts
+++ b/testing/e2e/tests/test-matrix.ts
@@ -30,6 +30,7 @@ export const providers: Provider[] = [
   'mistral',
   'byteplus',
   'elevenlabs',
+  'llmgateway',
 ]
 
 export { isSupported }


### PR DESCRIPTION
## 🎯 Changes

Adds **`@tanstack/ai-llmgateway`** — a first-class provider adapter for [LLM Gateway](https://llmgateway.io), an open-source, self-hostable AI gateway that routes one OpenAI-compatible endpoint to hundreds of models across many providers (with automatic provider selection, fallback, analytics, and cost tracking).

### Adapter (`packages/ai-llmgateway`)

- Built on `@tanstack/openai-base`'s `OpenAIBaseChatCompletionsTextAdapter`, driven by the OpenAI SDK with a `baseURL` override — the same pattern as `ai-grok`/`ai-groq`. Defaults to `https://api.llmgateway.io/v1`; `baseURL` points at self-hosted deployments.
- `llmGatewayText` / `createLLMGatewayText` (chat) and `llmGatewaySummarize` / `createLLMGatewaySummarize` (summarize via the shared `ChatStreamSummarizeAdapter`). API key from `LLM_GATEWAY_API_KEY` or explicit.
- **Curated model metadata** for flagship models (context windows, pricing, modalities, provider options) with one gateway-specific twist: because the gateway serves hundreds of models whose ids change frequently, the model parameter is typed `LLMGatewayChatModels | (string & {})` — curated ids keep autocomplete and per-model type resolution, while any other id from [llmgateway.io/models](https://llmgateway.io/models) (including `provider/model` pins like `moonshot/kimi-k3`) still works and resolves to the generic options. Happy to switch to the strict-union pattern used by ai-groq if you prefer.
- Reasoning models: the gateway normalizes upstream thinking output to `delta.reasoning_content`, which the adapter surfaces as AG-UI `REASONING_*` events (with a `delta.reasoning` fallback).
- No custom tool converter or schema converter — the gateway speaks the OpenAI wire format verbatim, so the base's defaults apply unchanged.

### E2E (`testing/e2e`)

Wired `llmgateway` into `feature-support.ts`, `test-matrix.ts`, the chat/summarize factories, and types — covering chat, one-shot, multi-turn, tool-calling, parallel tool calls, tool approval, text-tool-text, structured output (incl. native single-request streaming), multi-turn/agentic structured, multimodal image + structured, and summarize (stream + non-stream).

### Docs

- New `docs/adapters/llmgateway.md` + `docs/config.json` entry (after OpenAI-Compatible)
- Listed in `getting-started/overview.md` adapters and the structured-output streaming support table

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (`@tanstack/ai-llmgateway`: minor).
- [ ] This change is docs/CI/dev-only (no release).

## Test plan

- `pnpm --filter @tanstack/ai-llmgateway test:lib` — 13 unit tests (factories, env key handling, uncurated/pinned model ids, sampling-option forwarding incl. `reasoning_effort`, AG-UI event ordering, reasoning deltas, tool-call streaming) ✅
- `pnpm --filter @tanstack/ai-e2e test:e2e --grep llmgateway` — 19 Playwright specs across the wired feature matrix, all passing against aimock ✅
- `nx affected --targets=test:sherif,test:knip,test:docs,test:kiira,test:oxlint,test:lib,test:types,test:build,build` + `pnpm test:dts` — all green ✅
- Reviewer smoke: `llmGatewayText('gpt-5.6-terra')` against a real key streams text, tools, and structured output through the hosted gateway.

https://claude.ai/code/session_01PuLomtAzhhxAa692JW6eFU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LLM Gateway support for chat, tool-calling, summarization, and OpenAI-compatible routing.
  * Supports streaming, structured outputs, multimodal inputs, reasoning events, and provider-pinned model selection.
  * Added curated model metadata, self-hosted gateway configuration, and automatic API key detection.
  * Supports token limits, advanced model options, and native structured-output streaming.
* **Documentation**
  * Added installation, configuration, usage, model selection, and feature support guidance.
  * Added LLM Gateway coverage to end-to-end testing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->