### PR TITLE
fix(ai): stop text events from corrupting tool-call input

### DIFF
--- a/.changeset/fix-interleaved-text-tool-call-input.md
+++ b/.changeset/fix-interleaved-text-tool-call-input.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai': patch
+---
+
+Fix tool-call `input` corruption when a `TEXT_MESSAGE_CONTENT` event arrives between `TOOL_CALL_ARGS` events. Text events no longer force-complete in-flight tool calls, and `input` is only set when a strict `JSON.parse` of the accumulated arguments succeeds.

--- a/packages/ai/docs/chat-architecture.md
+++ b/packages/ai/docs/chat-architecture.md
@@ -165,7 +165,7 @@ The model returns text AND one tool call. This is the most common source of bugs
    The processor creates internal state (`InternalToolCallState`) in the `toolCalls` Map on `TOOL_CALL_START`. If `TOOL_CALL_ARGS` arrives for an unknown `toolCallId`, the args are **silently dropped** (the `existingToolCall` lookup fails).
 
 2. **`TOOL_CALL_END` MUST come after all `TOOL_CALL_ARGS` for that `toolCallId`.**
-   `TOOL_CALL_END` transitions the tool call to `input-complete` state and does a final JSON parse of accumulated arguments. Any `TOOL_CALL_ARGS` after `TOOL_CALL_END` for the same ID will still be processed (appending to arguments), but the state has already been set to `input-complete`.
+   `TOOL_CALL_END` transitions the tool call to `input-complete` state and does a final JSON parse of accumulated arguments. The part's `input` is set only when that parse is a strict `JSON.parse` success, or when `TOOL_CALL_END.input` supplies it. Incomplete or invalid arguments leave `input` unset; the raw `arguments` string is the fallback. Any `TOOL_CALL_ARGS` after `TOOL_CALL_END` for the same ID will still be processed (appending to arguments), but the state has already been set to `input-complete`. When text deltas arrive between `TOOL_CALL_ARGS` deltas, completion still waits for `TOOL_CALL_END` or the `RUN_FINISHED` / `finalizeStream` safety net.
 
 3. **`RUN_FINISHED` with `finishReason: "tool_calls"` MUST come last.**
    The TextEngine uses this to decide whether to enter the tool execution phase. The StreamProcessor uses it as a signal to force-complete any tool calls still not in `input-complete` state (safety net).

--- a/packages/ai/src/activities/chat/stream/processor.ts
+++ b/packages/ai/src/activities/chat/stream/processor.ts
@@ -820,6 +820,15 @@ export class StreamProcessor {
         // Update activeMessageIds
         this.activeMessageIds.delete(pendingId)
         this.activeMessageIds.add(messageId)
+
+        // TOOL_CALL_ARGS/END route through toolCallToMessage. Keep those
+        // entries on the remapped id so later args still accumulate
+        // (interleaved text can arrive as a full START/CONTENT/END block).
+        for (const [toolCallId, mappedMessageId] of this.toolCallToMessage) {
+          if (mappedMessageId === pendingId) {
+            this.toolCallToMessage.set(toolCallId, messageId)
+          }
+        }
       }
 
       // Ensure state exists

--- a/packages/ai/src/activities/chat/stream/processor.ts
+++ b/packages/ai/src/activities/chat/stream/processor.ts
@@ -887,9 +887,6 @@ export class StreamProcessor {
     if (state.currentSegmentText !== state.lastEmittedText) {
       this.emitTextUpdateForMessage(messageId)
     }
-
-    // Complete all tool calls for this message
-    this.completeAllToolCallsForMessage(messageId)
   }
 
   /**
@@ -1139,9 +1136,6 @@ export class StreamProcessor {
     chunk: Extract<StreamChunk, { type: 'TEXT_MESSAGE_CONTENT' }>,
   ): void {
     const { messageId, state } = this.ensureAssistantMessage(chunk.messageId)
-
-    // Content arriving means all current tool calls for this message are complete
-    this.completeAllToolCallsForMessage(messageId)
 
     if (this.structuredMessageIds.has(messageId)) {
       // `chunk.delta` is incremental; `chunk.content` is sometimes cumulative
@@ -2080,8 +2074,17 @@ export class StreamProcessor {
     // counts as a completed tool call in getCompletedToolCalls()/getState().
     toolCall.state = 'input-complete'
 
-    // Try final parse
-    toolCall.parsedArguments = this.jsonParser.parse(toolCall.arguments)
+    // Only surface `input` from a strict parse. The streaming partial-JSON
+    // parser closes unterminated strings, so truncated arguments would become
+    // a plausible but wrong object (GitHub issue #1017). If parse fails,
+    // `input` stays unset and consumers use the raw `arguments` string.
+    let strictParseSucceeded = false
+    try {
+      toolCall.parsedArguments = JSON.parse(toolCall.arguments)
+      strictParseSucceeded = true
+    } catch {
+      toolCall.parsedArguments = undefined
+    }
 
     // Don't downgrade the rendered part of a call that already reached the
     // terminal 'error' state (e.g. an output-error TOOL_CALL_RESULT arrived
@@ -2109,9 +2112,7 @@ export class StreamProcessor {
       name: toolCall.name,
       arguments: toolCall.arguments,
       state: 'input-complete',
-      ...(toolCall.parsedArguments !== undefined && {
-        input: toolCall.parsedArguments,
-      }),
+      ...(strictParseSucceeded && { input: toolCall.parsedArguments }),
       ...(toolCall.metadata !== undefined && { metadata: toolCall.metadata }),
     })
     this.emitMessagesChange()

--- a/packages/ai/tests/stream-processor.test.ts
+++ b/packages/ai/tests/stream-processor.test.ts
@@ -689,6 +689,86 @@ describe('StreamProcessor', () => {
   // Text-tool interleaving
   // ==========================================================================
   describe('text-tool interleaving', () => {
+    // GitHub issue #1017: TEXT_MESSAGE_CONTENT between two TOOL_CALL_ARGS
+    // deltas used to force-complete the call from a lenient partial-JSON
+    // parse of truncated arguments. TOOL_CALL_END then no-oped because the
+    // call was already input-complete, so `input` stayed silently wrong
+    // while `arguments` held the full JSON.
+    describe('text interleaved between tool-call args (#1017)', () => {
+      const ARGS_HEAD = '{"templateIds":["mock-gsk-e'
+      const ARGS_TAIL = 'fimosfermin"]}'
+      const FULL_ARGS = ARGS_HEAD + ARGS_TAIL
+      const FULL_INPUT = { templateIds: ['mock-gsk-efimosfermin'] }
+      const CORRUPTED_INPUT = { templateIds: ['mock-gsk-e'] }
+
+      const toolCallPart = (processor: StreamProcessor) =>
+        processor
+          .getMessages()
+          .flatMap((m) => m.parts)
+          .find((p): p is ToolCallPart => p.type === 'tool-call')
+
+      it('does not publish a truncated partial-JSON parse as input after interleaved text', () => {
+        const processor = new StreamProcessor()
+        processor.prepareAssistantMessage()
+
+        processor.processChunk(ev.runStarted())
+        processor.processChunk(ev.toolStart('tc-1', 'offerTemplates'))
+        processor.processChunk(ev.toolArgs('tc-1', ARGS_HEAD))
+        processor.processChunk(ev.textContent('Let me look those up. '))
+        processor.processChunk(ev.toolArgs('tc-1', ARGS_TAIL))
+        processor.processChunk(ev.toolEnd('tc-1', 'offerTemplates'))
+        processor.processChunk(ev.runFinished('stop'))
+        processor.finalizeStream()
+
+        const part = toolCallPart(processor)
+        expect(part?.state).toBe('input-complete')
+        expect(part?.arguments).toBe(FULL_ARGS)
+        expect(part?.input).not.toEqual(CORRUPTED_INPUT)
+        expect(part?.input).toEqual(FULL_INPUT)
+      })
+
+      it('never surfaces a lenient parse of truncated args as input', () => {
+        const processor = new StreamProcessor()
+        processor.prepareAssistantMessage()
+
+        processor.processChunk(ev.runStarted())
+        processor.processChunk(ev.toolStart('tc-1', 'offerTemplates'))
+        processor.processChunk(ev.toolArgs('tc-1', ARGS_HEAD))
+        processor.processChunk(ev.textContent('Let me look those up. '))
+
+        const during = toolCallPart(processor)
+        expect(during?.input).not.toEqual(CORRUPTED_INPUT)
+        expect(during?.input).toBeUndefined()
+
+        processor.processChunk(ev.toolEnd('tc-1', 'offerTemplates'))
+        processor.processChunk(ev.runFinished('stop'))
+        processor.finalizeStream()
+
+        const part = toolCallPart(processor)
+        expect(part?.state).toBe('input-complete')
+        expect(part?.arguments).toBe(ARGS_HEAD)
+        expect(part?.input).toBeUndefined()
+      })
+
+      it('RUN_FINISHED safety net completes full args when TOOL_CALL_END is missing', () => {
+        const processor = new StreamProcessor()
+        processor.prepareAssistantMessage()
+
+        processor.processChunk(ev.runStarted())
+        processor.processChunk(ev.toolStart('tc-1', 'offerTemplates'))
+        processor.processChunk(ev.toolArgs('tc-1', ARGS_HEAD))
+        processor.processChunk(ev.textContent('Let me look those up. '))
+        processor.processChunk(ev.toolArgs('tc-1', ARGS_TAIL))
+        processor.processChunk(ev.runFinished('stop'))
+        processor.finalizeStream()
+
+        const part = toolCallPart(processor)
+        expect(part?.state).toBe('input-complete')
+        expect(part?.arguments).toBe(FULL_ARGS)
+        expect(part?.input).toEqual(FULL_INPUT)
+      })
+    })
+
     it('should reset segment text accumulation on TEXT_MESSAGE_START (existing test preserved)', () => {
       const processor = new StreamProcessor()
       processor.prepareAssistantMessage()

--- a/packages/ai/tests/stream-processor.test.ts
+++ b/packages/ai/tests/stream-processor.test.ts
@@ -701,24 +701,40 @@ describe('StreamProcessor', () => {
       const FULL_INPUT = { templateIds: ['mock-gsk-efimosfermin'] }
       const CORRUPTED_INPUT = { templateIds: ['mock-gsk-e'] }
 
-      const toolCallPart = (processor: StreamProcessor) =>
+      const feed = (...chunks: Array<StreamChunk>) => {
+        const processor = new StreamProcessor()
+        processor.prepareAssistantMessage()
+        for (const chunk of chunks) processor.processChunk(chunk)
+        return processor
+      }
+
+      const settle = (processor: StreamProcessor) => {
+        processor.processChunk(ev.runFinished('stop'))
+        processor.finalizeStream()
+        return processor
+      }
+
+      const toolCallParts = (processor: StreamProcessor) =>
         processor
           .getMessages()
           .flatMap((m) => m.parts)
-          .find((p): p is ToolCallPart => p.type === 'tool-call')
+          .filter((p): p is ToolCallPart => p.type === 'tool-call')
+
+      const toolCallPart = (processor: StreamProcessor, id?: string) => {
+        const parts = toolCallParts(processor)
+        return id === undefined ? parts[0] : parts.find((p) => p.id === id)
+      }
 
       it('does not publish a truncated partial-JSON parse as input after interleaved text', () => {
-        const processor = new StreamProcessor()
-        processor.prepareAssistantMessage()
-
-        processor.processChunk(ev.runStarted())
-        processor.processChunk(ev.toolStart('tc-1', 'offerTemplates'))
-        processor.processChunk(ev.toolArgs('tc-1', ARGS_HEAD))
-        processor.processChunk(ev.textContent('Let me look those up. '))
-        processor.processChunk(ev.toolArgs('tc-1', ARGS_TAIL))
-        processor.processChunk(ev.toolEnd('tc-1', 'offerTemplates'))
-        processor.processChunk(ev.runFinished('stop'))
-        processor.finalizeStream()
+        const processor = feed(
+          ev.runStarted(),
+          ev.toolStart('tc-1', 'offerTemplates'),
+          ev.toolArgs('tc-1', ARGS_HEAD),
+          ev.textContent('Let me look those up. '),
+          ev.toolArgs('tc-1', ARGS_TAIL),
+          ev.toolEnd('tc-1', 'offerTemplates'),
+        )
+        settle(processor)
 
         const part = toolCallPart(processor)
         expect(part?.state).toBe('input-complete')
@@ -728,21 +744,19 @@ describe('StreamProcessor', () => {
       })
 
       it('never surfaces a lenient parse of truncated args as input', () => {
-        const processor = new StreamProcessor()
-        processor.prepareAssistantMessage()
-
-        processor.processChunk(ev.runStarted())
-        processor.processChunk(ev.toolStart('tc-1', 'offerTemplates'))
-        processor.processChunk(ev.toolArgs('tc-1', ARGS_HEAD))
-        processor.processChunk(ev.textContent('Let me look those up. '))
+        const processor = feed(
+          ev.runStarted(),
+          ev.toolStart('tc-1', 'offerTemplates'),
+          ev.toolArgs('tc-1', ARGS_HEAD),
+          ev.textContent('Let me look those up. '),
+        )
 
         const during = toolCallPart(processor)
         expect(during?.input).not.toEqual(CORRUPTED_INPUT)
         expect(during?.input).toBeUndefined()
 
         processor.processChunk(ev.toolEnd('tc-1', 'offerTemplates'))
-        processor.processChunk(ev.runFinished('stop'))
-        processor.finalizeStream()
+        settle(processor)
 
         const part = toolCallPart(processor)
         expect(part?.state).toBe('input-complete')
@@ -750,17 +764,94 @@ describe('StreamProcessor', () => {
         expect(part?.input).toBeUndefined()
       })
 
-      it('RUN_FINISHED safety net completes full args when TOOL_CALL_END is missing', () => {
-        const processor = new StreamProcessor()
-        processor.prepareAssistantMessage()
+      it('leaves the call streaming through interleaved text so TOOL_CALL_END can still run', () => {
+        const processor = feed(
+          ev.runStarted(),
+          ev.toolStart('tc-1', 'offerTemplates'),
+          ev.toolArgs('tc-1', ARGS_HEAD),
+          ev.textContent('Let me look those up. '),
+        )
 
-        processor.processChunk(ev.runStarted())
-        processor.processChunk(ev.toolStart('tc-1', 'offerTemplates'))
-        processor.processChunk(ev.toolArgs('tc-1', ARGS_HEAD))
-        processor.processChunk(ev.textContent('Let me look those up. '))
-        processor.processChunk(ev.toolArgs('tc-1', ARGS_TAIL))
-        processor.processChunk(ev.runFinished('stop'))
-        processor.finalizeStream()
+        expect(processor.getState().toolCalls.get('tc-1')?.state).toBe(
+          'input-streaming',
+        )
+        expect(toolCallPart(processor)?.state).toBe('input-streaming')
+        expect(toolCallPart(processor)?.input).toBeUndefined()
+      })
+
+      it('RUN_FINISHED safety net completes full args when TOOL_CALL_END is missing', () => {
+        const processor = feed(
+          ev.runStarted(),
+          ev.toolStart('tc-1', 'offerTemplates'),
+          ev.toolArgs('tc-1', ARGS_HEAD),
+          ev.textContent('Let me look those up. '),
+          ev.toolArgs('tc-1', ARGS_TAIL),
+        )
+        settle(processor)
+
+        const part = toolCallPart(processor)
+        expect(part?.state).toBe('input-complete')
+        expect(part?.arguments).toBe(FULL_ARGS)
+        expect(part?.input).toEqual(FULL_INPUT)
+      })
+
+      it('uses TOOL_CALL_END.input as canonical after interleaved text', () => {
+        const processor = feed(
+          ev.runStarted(),
+          ev.toolStart('tc-1', 'offerTemplates'),
+          ev.toolArgs('tc-1', ARGS_HEAD),
+          ev.textContent('Let me look those up. '),
+          ev.toolArgs('tc-1', ARGS_TAIL),
+          ev.toolEnd('tc-1', 'offerTemplates', { input: FULL_INPUT }),
+        )
+        settle(processor)
+
+        const part = toolCallPart(processor)
+        expect(part?.state).toBe('input-complete')
+        expect(part?.input).toEqual(FULL_INPUT)
+        expect(
+          processor.getState().toolCalls.get('tc-1')?.parsedArguments,
+        ).toEqual(FULL_INPUT)
+      })
+
+      it('repairs multiple parallel tool calls with interleaved text', () => {
+        const processor = feed(
+          ev.runStarted(),
+          ev.toolStart('tc-1', 'offerTemplates'),
+          ev.toolArgs('tc-1', ARGS_HEAD),
+          ev.toolStart('tc-2', 'getWeather'),
+          ev.toolArgs('tc-2', '{"city":"New '),
+          ev.textContent('Working on it. '),
+          ev.toolArgs('tc-1', ARGS_TAIL),
+          ev.toolArgs('tc-2', 'York"}'),
+          ev.toolEnd('tc-1', 'offerTemplates'),
+          ev.toolEnd('tc-2', 'getWeather'),
+        )
+        settle(processor)
+
+        const first = toolCallPart(processor, 'tc-1')
+        expect(first?.state).toBe('input-complete')
+        expect(first?.arguments).toBe(FULL_ARGS)
+        expect(first?.input).toEqual(FULL_INPUT)
+
+        const second = toolCallPart(processor, 'tc-2')
+        expect(second?.state).toBe('input-complete')
+        expect(second?.arguments).toBe('{"city":"New York"}')
+        expect(second?.input).toEqual({ city: 'New York' })
+      })
+
+      it('still completes after a full text block between arg deltas', () => {
+        const processor = feed(
+          ev.runStarted(),
+          ev.toolStart('tc-1', 'offerTemplates'),
+          ev.toolArgs('tc-1', ARGS_HEAD),
+          ev.textStart(),
+          ev.textContent('Let me look those up. '),
+          ev.textEnd(),
+          ev.toolArgs('tc-1', ARGS_TAIL),
+          ev.toolEnd('tc-1', 'offerTemplates'),
+        )
+        settle(processor)
 
         const part = toolCallPart(processor)
         expect(part?.state).toBe('input-complete')

--- a/testing/e2e/src/lib/tools-test-tools.ts
+++ b/testing/e2e/src/lib/tools-test-tools.ts
@@ -278,6 +278,11 @@ export const SCENARIO_LIST = [
     label: 'Triple Client Sequence',
     category: 'race',
   },
+  {
+    id: 'interleaved-args',
+    label: 'Text Interleaved in Tool Args (Regression #1017)',
+    category: 'race',
+  },
 ]
 
 /**
@@ -347,6 +352,9 @@ export function getToolsForScenario(scenario: string) {
         clientToolDefinitions.show_notification,
         clientToolDefinitions.display_chart,
       ]
+
+    case 'interleaved-args':
+      return [serverTools.get_weather]
 
     case 'lazy-tool-discovery':
       return [serverTools.get_weather, searchInventory]

--- a/testing/e2e/src/routes/api.tools-test.ts
+++ b/testing/e2e/src/routes/api.tools-test.ts
@@ -179,6 +179,127 @@ function createProviderFreeAdapter(scenario: string): AnyTextAdapter {
   }
 }
 
+/**
+ * Regression adapter for issue #1017.
+ *
+ * Emits a TEXT_MESSAGE_CONTENT delta between two TOOL_CALL_ARGS deltas.
+ * Pre-fix, the interleaved text force-completed the tool call with a
+ * lenient partial-JSON parse of the truncated arguments
+ * (`{"city":"New Yo"}`) and the later TOOL_CALL_END was skipped.
+ */
+function createInterleavedArgsAdapter(): AnyTextAdapter {
+  return {
+    kind: 'text',
+    name: 'interleaved-args-test',
+    model: 'interleaved-args-test',
+    '~types': {
+      providerOptions: {},
+      inputModalities: ['text'],
+      messageMetadataByModality: {},
+      toolCapabilities: [],
+      toolCallMetadata: undefined,
+      systemPromptMetadata: undefined,
+    },
+    async *chatStream(options): AsyncGenerator<StreamChunk> {
+      const model = 'interleaved-args-test'
+      const runId = options.runId ?? 'interleaved-args-run'
+      const threadId = options.threadId ?? 'interleaved-args-thread'
+      const messageId = `${runId}-message`
+      const toolCallId = 'interleaved-args-tool-call'
+      const hasToolResult = options.messages.some(
+        (message) => message.role === 'tool',
+      )
+
+      yield {
+        type: EventType.RUN_STARTED,
+        runId,
+        threadId,
+        model,
+        timestamp: Date.now(),
+      }
+
+      if (hasToolResult) {
+        yield {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId,
+          role: 'assistant',
+          model,
+          timestamp: Date.now(),
+        }
+        yield {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId,
+          delta: 'It is 72F in New York City.',
+          model,
+          timestamp: Date.now(),
+        }
+        yield {
+          type: EventType.TEXT_MESSAGE_END,
+          messageId,
+          model,
+          timestamp: Date.now(),
+        }
+        yield {
+          type: EventType.RUN_FINISHED,
+          runId,
+          threadId,
+          model,
+          finishReason: 'stop',
+          timestamp: Date.now(),
+        }
+        return
+      }
+
+      yield {
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'get_weather',
+        toolName: 'get_weather',
+        model,
+        timestamp: Date.now(),
+      }
+      yield {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{"city":"New Yo',
+        model,
+        timestamp: Date.now(),
+      }
+      yield {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId,
+        delta: 'Let me check the weather. ',
+        model,
+        timestamp: Date.now(),
+      }
+      yield {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: 'rk City"}',
+        model,
+        timestamp: Date.now(),
+      }
+      yield {
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+        toolCallName: 'get_weather',
+        toolName: 'get_weather',
+        model,
+        timestamp: Date.now(),
+      }
+      yield {
+        type: EventType.RUN_FINISHED,
+        runId,
+        threadId,
+        model,
+        finishReason: 'tool_calls',
+        timestamp: Date.now(),
+      }
+    },
+    structuredOutput: async () => ({ data: {}, rawText: '{}' }),
+  }
+}
+
 export const Route = createFileRoute('/api/tools-test')({
   server: {
     handlers: {
@@ -237,14 +358,19 @@ export const Route = createFileRoute('/api/tools-test')({
             return toServerSentEventsResponse(errorStream, { abortController })
           }
 
-          const adapterOptions = providerFreeScenarios.has(scenario)
-            ? { adapter: createProviderFreeAdapter(scenario) }
-            : createTextAdapter(
-                'openai',
-                scenario === 'client-tool-reasoning' ? 'gpt-5.2' : undefined,
-                aimockPort,
-                testId,
-              )
+          const adapterOptions =
+            scenario === 'interleaved-args'
+              ? { adapter: createInterleavedArgsAdapter() }
+              : providerFreeScenarios.has(scenario)
+                ? { adapter: createProviderFreeAdapter(scenario) }
+                : createTextAdapter(
+                    'openai',
+                    scenario === 'client-tool-reasoning'
+                      ? 'gpt-5.2'
+                      : undefined,
+                    aimockPort,
+                    testId,
+                  )
 
           const tools = getToolsForScenario(scenario)
           const runtimeContext: TestRuntimeContext =

--- a/testing/e2e/tests/tools-test/interleaved-args.spec.ts
+++ b/testing/e2e/tests/tools-test/interleaved-args.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '../fixtures'
+import {
+  getMessages,
+  runTest,
+  selectScenario,
+  waitForTestComplete,
+} from './helpers'
+
+/**
+ * Regression tests for issue #1017.
+ *
+ * The `interleaved-args` scenario streams a TEXT_MESSAGE_CONTENT delta
+ * between two TOOL_CALL_ARGS deltas (`{"city":"New Yo` + `rk City"}`).
+ * Pre-fix, the interleaved text force-completed the tool call and
+ * populated `input` from a lenient partial-JSON parse of the truncated
+ * arguments (`{"city":"New Yo"}`).
+ */
+test.describe('Interleaved Text/Args (tools-test page)', () => {
+  test('tool-call input matches the full arguments despite interleaved text', async ({
+    page,
+    testId,
+    aimockPort,
+  }) => {
+    await selectScenario(page, 'interleaved-args', testId, aimockPort)
+    await runTest(page)
+    await waitForTestComplete(page)
+
+    const messages = await getMessages(page)
+    const toolCallParts = messages
+      .flatMap((msg) => msg.parts || [])
+      .filter((part) => part.type === 'tool-call')
+
+    expect(toolCallParts).toHaveLength(1)
+    const part = toolCallParts[0]
+    expect(part.name).toBe('get_weather')
+    expect(part.state).toBe('complete')
+    expect(part.arguments).toBe('{"city":"New York City"}')
+    expect(part.input).toEqual({ city: 'New York City' })
+  })
+})


### PR DESCRIPTION
A `TEXT_MESSAGE_CONTENT` event between two `TOOL_CALL_ARGS` deltas permanently corrupted tool-call `input`. The processor guessed that text meant args were done, filled `input` from a lenient partial-JSON parse of the truncated string, then skipped the later `TOOL_CALL_END`. `arguments` held the full JSON. `input` held a truncated fake object. `state` said `input-complete`.

This PR stops that guess. Text events no longer complete tool calls. `completeToolCall` sets `input` only when `JSON.parse` of the accumulated arguments succeeds. Incomplete JSON leaves `input` unset. The raw `arguments` string is the fallback.

## Changes

- Remove `completeAllToolCallsForMessage` from `TEXT_MESSAGE_CONTENT` and `TEXT_MESSAGE_END`.
- Use strict `JSON.parse` when completing a tool call.
- Add unit tests for the issue #1017 sequence.
- Add an e2e `interleaved-args` scenario that streams text between arg deltas.

The earlier `inferredComplete` state machine is gone. Completing on text was the bug. `TOOL_CALL_END` and `RUN_FINISHED` already cover completion.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.
- [x] Docs: I updated `packages/ai/docs/chat-architecture.md` for this change. No public `docs/` page covers this processor contract.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

Commands run:

1. `pnpm exec vitest run` in `packages/ai`: 1589 passed.
2. `pnpm exec oxlint src --type-aware` in `packages/ai`: 0 errors.
3. `pnpm exec tsc --noEmit` in `packages/ai`: passed.
4. E2E `interleaved-args.spec.ts` did not run locally. This worktree has no built workspace packages for the Playwright app. CI will run it.

Manual test:

1. Stream `TOOL_CALL_ARGS` with truncated JSON, then one `TEXT_MESSAGE_CONTENT`, then the rest of the args, then `TOOL_CALL_END`.
2. Confirm `part.input` equals the full object, not a truncated parse.
3. Confirm a stream that ends with truncated args leaves `input` unset.

How this PR makes testing easy: three unit tests in `stream-processor.test.ts` plus `testing/e2e/tests/tools-test/interleaved-args.spec.ts`.

## Linked issues

Fixes #1017

## Risk / rollback

Low. Tool completion now waits for `TOOL_CALL_END` or `RUN_FINISHED`, which the adapter contract already requires. Revert the PR if a client depended on `input-complete` at the first text delta.

## Public API change

Callers still read `ToolCallPart.input`. The value is now the strict parse of complete arguments, or unset. No new exports.
