### PR TITLE
fix(ai-anthropic): document metadata

### DIFF
--- a/.changeset/tidy-pdfs.md
+++ b/.changeset/tidy-pdfs.md
@@ -2,4 +2,4 @@
 '@tanstack/ai-anthropic': patch
 ---
 
-Fix document metadata serialization.
+Serialize only Anthropic-supported fields from document and image metadata; use `filename` as a fallback document title.

--- a/.changeset/tidy-pdfs.md
+++ b/.changeset/tidy-pdfs.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-anthropic': patch
+---
+
+Fix document metadata serialization.

--- a/packages/ai-anthropic/src/adapters/text.ts
+++ b/packages/ai-anthropic/src/adapters/text.ts
@@ -665,6 +665,7 @@ export class AnthropicTextAdapter<
       }
       case 'document': {
         const metadata = part.metadata as AnthropicDocumentMetadata | undefined
+        const title = metadata?.title ?? metadata?.filename
         const docSource: Base64PDFSource | URLPDFSource =
           part.source.type === 'data'
             ? {
@@ -679,7 +680,16 @@ export class AnthropicTextAdapter<
         return {
           type: 'document',
           source: docSource,
-          ...metadata,
+          ...(metadata?.cache_control !== undefined && {
+            cache_control: metadata.cache_control,
+          }),
+          ...(metadata?.citations !== undefined && {
+            citations: metadata.citations,
+          }),
+          ...(metadata?.context !== undefined && {
+            context: metadata.context,
+          }),
+          ...(title !== undefined && { title }),
         }
       }
       case 'audio':

--- a/packages/ai-anthropic/src/adapters/text.ts
+++ b/packages/ai-anthropic/src/adapters/text.ts
@@ -660,7 +660,9 @@ export class AnthropicTextAdapter<
         return {
           type: 'image',
           source: imageSource,
-          ...metadata,
+          ...(metadata?.cache_control !== undefined && {
+            cache_control: metadata.cache_control,
+          }),
         }
       }
       case 'document': {

--- a/packages/ai-anthropic/src/message-types.ts
+++ b/packages/ai-anthropic/src/message-types.ts
@@ -26,10 +26,7 @@ export type AnthropicImageMediaType =
  */
 export interface AnthropicImageMetadata {
   /**
-   * The MIME type of the image.
-   * Required when using base64 source type.
-   *
-   * @see https://docs.anthropic.com/claude/docs/vision#supported-image-types
+   * @deprecated Ignored. The media type is taken from `source.mimeType`.
    */
   mediaType?: AnthropicImageMediaType
   /**
@@ -58,10 +55,7 @@ export type AnthropicDocumentMediaType = 'application/pdf'
  */
 export interface AnthropicDocumentMetadata {
   /**
-   * The MIME type of the document.
-   * Required for document content, typically 'application/pdf'.
-   *
-   * @see https://docs.anthropic.com/claude/docs/pdf-support
+   * @deprecated Ignored. The media type is taken from `source.mimeType`.
    */
   mediaType?: AnthropicDocumentMediaType
   /**

--- a/packages/ai-anthropic/src/message-types.ts
+++ b/packages/ai-anthropic/src/message-types.ts
@@ -8,6 +8,7 @@
 
 import type {
   CacheControlEphemeral,
+  CitationsConfigParam,
   TextCitationParam,
 } from '@anthropic-ai/sdk/resources'
 
@@ -68,7 +69,14 @@ export interface AnthropicDocumentMetadata {
    */
   cache_control?: CacheControlEphemeral
 
+  citations?: CitationsConfigParam
+
   context?: string
+
+  /**
+   * The document filename. Used as the document title when `title` is absent.
+   */
+  filename?: string
 
   title?: string
 }

--- a/packages/ai-anthropic/tests/anthropic-adapter.test.ts
+++ b/packages/ai-anthropic/tests/anthropic-adapter.test.ts
@@ -134,6 +134,52 @@ describe('Anthropic adapter option mapping', () => {
     })
   })
 
+  it('prefers document title over filename and serializes only cache_control for images', async () => {
+    mocks.betaMessagesCreate.mockResolvedValueOnce(createTextStream('ok'))
+
+    const adapter = createAdapter('claude-opus-4-1')
+
+    for await (const _ of chat({
+      adapter,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'document',
+              source: {
+                type: 'data',
+                value: 'JVBERi0xLjQ=',
+                mimeType: 'application/pdf',
+              },
+              metadata: { title: 'Q3 Report', filename: 'report.pdf' },
+            },
+            {
+              type: 'image',
+              source: { type: 'url', value: 'https://example.com/a.png' },
+              metadata: {
+                mediaType: 'image/png',
+                cache_control: { type: 'ephemeral' },
+                filename: 'a.png',
+              },
+            },
+          ],
+        },
+      ],
+    })) {
+      // consume stream
+    }
+
+    const [payload] = mocks.betaMessagesCreate.mock.calls[0]!
+
+    expect(payload.messages[0].content[0].title).toBe('Q3 Report')
+    expect(payload.messages[0].content[1]).toEqual({
+      type: 'image',
+      source: { type: 'url', url: 'https://example.com/a.png' },
+      cache_control: { type: 'ephemeral' },
+    })
+  })
+
   it('passes systemPrompts as TextBlockParam[] for prompt caching support', async () => {
     const mockStream = (async function* () {
       yield {

--- a/packages/ai-anthropic/tests/anthropic-adapter.test.ts
+++ b/packages/ai-anthropic/tests/anthropic-adapter.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@tanstack/ai'
 import { AnthropicTextAdapter } from '../src/adapters/text'
 import type { AnthropicTextProviderOptions } from '../src/adapters/text'
+import type { AnthropicDocumentMetadata } from '../src/message-types'
 import { ANTHROPIC_MAX_NONSTREAMING_TOKENS } from '../src/model-meta'
 import { z } from 'zod'
 
@@ -80,6 +81,57 @@ function createTextStream(text: string) {
 describe('Anthropic adapter option mapping', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('serializes only supported document metadata', async () => {
+    mocks.betaMessagesCreate.mockResolvedValueOnce(createTextStream('ok'))
+
+    const adapter = createAdapter('claude-opus-4-1')
+    const metadata = {
+      mediaType: 'application/pdf',
+      cache_control: { type: 'ephemeral' },
+      citations: { enabled: true },
+      context: 'Quarterly report',
+      filename: 'report.pdf',
+      placeholder: 'Attachment: report.pdf',
+    } as AnthropicDocumentMetadata & { placeholder: string }
+
+    for await (const _ of chat({
+      adapter,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'document',
+              source: {
+                type: 'data',
+                value: 'JVBERi0xLjQ=',
+                mimeType: 'application/pdf',
+              },
+              metadata,
+            },
+          ],
+        },
+      ],
+    })) {
+      // consume stream
+    }
+
+    const [payload] = mocks.betaMessagesCreate.mock.calls[0]!
+
+    expect(payload.messages[0].content[0]).toEqual({
+      type: 'document',
+      source: {
+        type: 'base64',
+        data: 'JVBERi0xLjQ=',
+        media_type: 'application/pdf',
+      },
+      cache_control: { type: 'ephemeral' },
+      citations: { enabled: true },
+      context: 'Quarterly report',
+      title: 'report.pdf',
+    })
   })
 
   it('passes systemPrompts as TextBlockParam[] for prompt caching support', async () => {


### PR DESCRIPTION
## Problem

The document adapter spreads `part.metadata` into Anthropic's request. This forwards `mediaType`, which is declared by `AnthropicDocumentMetadata` but invalid on Anthropic's document block, as well as application metadata such as `filename` or `placeholder`. Anthropic rejects these as extra inputs.

## Fix

Serialize only supported document fields. Preserve `cache_control`, `citations`, `context`, and `title`, and use `filename` as a fallback title.

Includes a request-shape regression test and patch changeset.

Tests: CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document and image metadata serialization for Anthropic requests.
  * Document titles now use the specified title, or fall back to the filename.
  * Supported metadata, including caching, citations, and context, is forwarded correctly while unsupported fields are excluded.

* **Documentation**
  * Clarified filename fallback behavior and deprecated legacy MIME-type metadata fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->