### PR TITLE
docs: pin section landing pages to the Guides tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,12 @@ OPENAI_API_KEY=sk-... pnpm --filter @tanstack/ai-e2e record
     links, code-fence languages, formatting, factual fixes — must **not**
     touch `addedAt` or `updatedAt`. Only genuinely new or changed content
     moves these dates.
+- **Docs nav: use `"tab"` for reserved words.** The site sorts sidebar entries
+  into tabs by keyword-matching `"<sectionLabel> <pageLabel> <to>"` — `overview`,
+  `introduction`, `installation`, `quick start`, `tutorial`, `example`,
+  `community` — which yanks a page out of its own section. Don't rename around
+  it; set `"tab"` on the section or entry in `docs/config.json`
+  (`home | get-started | tutorial | guides | api | examples`).
 
 ## Key Dependencies
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -181,6 +181,7 @@
     },
     {
       "label": "Interrupts",
+      "tab": "guides",
       "children": [
         {
           "label": "Overview",
@@ -216,6 +217,7 @@
     },
     {
       "label": "Resumable Streams",
+      "tab": "guides",
       "children": [
         {
           "label": "Overview",
@@ -237,6 +239,7 @@
     },
     {
       "label": "Persistence",
+      "tab": "guides",
       "children": [
         {
           "label": "Overview",
@@ -294,6 +297,7 @@
     },
     {
       "label": "Structured Outputs",
+      "tab": "guides",
       "children": [
         {
           "label": "Overview",
@@ -441,6 +445,7 @@
     },
     {
       "label": "Sandboxes",
+      "tab": "guides",
       "children": [
         {
           "label": "Overview",
@@ -512,6 +517,7 @@
     },
     {
       "label": "Memory",
+      "tab": "guides",
       "children": [
         {
           "label": "Overview",
@@ -777,6 +783,7 @@
     },
     {
       "label": "Community Adapters",
+      "tab": "guides",
       "children": [
         {
           "label": "Community Adapters Guide",


### PR DESCRIPTION
## 🎯 Changes

Closes #1025.

The docs site sorts each sidebar entry into a tab with a keyword heuristic — `getFallbackDocsNavTabId` in tanstack.com's `src/utils/docsNavTabs.ts` — matching against `"<sectionLabel> <pageLabel> <to>"`. A page label of exactly `Overview` routes to **Get Started**, as does a path containing `quick-start`; anything matching `community` routes to **Home**. That pulled seven sections' landing pages out of their own sections and disconnected them from the surrounding content.

`getDocsNavTabId` resolves `child.tab ?? group.tab ?? heuristic`, so an explicit `tab` on the section overrides the keyword match. Seven lines in `docs/config.json`:

```json
{
  "label": "Interrupts",
  "tab": "guides",
  "children": [ ... ]
}
```

Applied to **Interrupts**, **Resumable Streams**, **Persistence**, **Structured Outputs**, **Sandboxes**, **Memory**, and **Community Adapters**. No page renamed, no URL changed, no cross-link touched.

Simulating the site's tab logic against the new config: Get Started is left with exactly the 9 pages that belong to it, Home is correctly empty of adapter docs (the site injects its own Home group for Blog/Contributors/NPM Stats), and the affected sections render without stutter:

```
Interrupts              Persistence             Sandboxes
  Overview                Overview                Overview
  Tool Approval           Chat Persistence        Quick Start
  Multiple Interrupts     Client Persistence      Providers
  Generic Interrupts      Controls                Harnesses
  Migration               Build Your Own Adapter  ...
```

`CLAUDE.md` gains a short rule so the next docs change reaches for `tab` instead of renaming around the reserved words.

### Note for a maintainer

`tab` is a first-class field in tanstack.com's runtime config parser (`src/utils/config.ts`: `tab: tabSchema`, values `home | get-started | tutorial | guides | api | examples`). But the **published JSON schema is stale** — `tanstack-docs-config.schema.json` has `additionalProperties: false` and no `tab` property, so editors flag these lines. No TanStack repo uses `tab` yet; this is the first. A one-line upstream PR adding `tab` to that schema clears the warning.

<details>
<summary>Why not rename the pages, as the issue originally proposed?</summary>

Renaming works, and the first push of this branch did exactly that. It cost 58 files: 7 page renames, 7 `redirectFrom` entries, ~40 cross-link rewrites across `docs/`, 17 README copies, and 6 agent `SKILL.md` files. It also introduced a new problem — naming a section's landing page after its own section renders as a stutter in the sidebar (`Interrupts > Interrupts`, `Persistence > Persistence`), which the repo already had in three places.

`tab` produces an identical tab distribution for 7 lines and keeps `Overview` as the label, which was never the actual problem.

</details>

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

Ran individually, all green: `test:docs`, `test:kiira` (852 snippets), `test:sherif`, `test:knip`, `test:oxlint`, `test:types`, `test:lib`, `build`, `test:build`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

Docs config + `CLAUDE.md` only. No source touched, no behavior change, so no E2E test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated navigation configuration for several guides to ensure they appear in the intended sidebar tab.
  * Added guidance for configuring tab assignments and avoiding reserved navigation keywords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->