### PR TITLE
feat(ai-client): accept a per-call body via SendMessageOptions

### DIFF
--- a/.changeset/spotty-donuts-repeat.md
+++ b/.changeset/spotty-donuts-repeat.md
@@ -6,4 +6,4 @@ Add `body` to `SendMessageOptions`: a per-call body shallow-merged into the requ
 
 `ChatClient.sendMessage` already accepted a per-call body as its positional second argument, but the framework hooks (`useChat`, `injectChat`, `createChat`, …) expose `sendMessage(content, options)` and forwarded `undefined` for it — leaving no race-free way to send per-message data (e.g. attachment ids) through a hook. Updating a reactive chat-level `body`/`forwardedProps` option right before sending is racy because reactive option changes can flush after the send.
 
-`sendMessage(content, { body: { ... } })` now works through every framework hook and on `ChatClient` directly. The positional argument wins if both are provided. Queued sends preserve their per-call `body` exactly like the positional form.
+`sendMessage(content, { body: { ... } })` now works through every framework hook. On `ChatClient` directly, pass it as the third argument — `sendMessage(content, undefined, { body: { ... } })` — or keep using the positional second argument, which wins if both are provided. Queued sends preserve their per-call `body` exactly like the positional form.

--- a/.changeset/spotty-donuts-repeat.md
+++ b/.changeset/spotty-donuts-repeat.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/ai-client': minor
+---
+
+Add `body` to `SendMessageOptions`: a per-call body shallow-merged into the request's `forwardedProps` with the highest priority.
+
+`ChatClient.sendMessage` already accepted a per-call body as its positional second argument, but the framework hooks (`useChat`, `injectChat`, `createChat`, …) expose `sendMessage(content, options)` and forwarded `undefined` for it — leaving no race-free way to send per-message data (e.g. attachment ids) through a hook. Updating a reactive chat-level `body`/`forwardedProps` option right before sending is racy because reactive option changes can flush after the send.
+
+`sendMessage(content, { body: { ... } })` now works through every framework hook and on `ChatClient` directly. The positional argument wins if both are provided. Queued sends preserve their per-call `body` exactly like the positional form.

--- a/docs/chat/connection-adapters.md
+++ b/docs/chat/connection-adapters.md
@@ -81,6 +81,24 @@ const { messages } = useChat({
 
 > **Tip:** `body` and `forwardedProps` populate the same wire field. Use `body` for static defaults, the `forwardedProps` constructor option (or per-`sendMessage` `data`) for dynamic values. Runtime values always win.
 
+**Per-call body.** For data that belongs to one specific message (attachment ids, a one-off flag), pass `body` in `sendMessage`'s options — it is shallow-merged into `forwardedProps` with the highest priority, for that request only:
+
+```typescript
+import { useChat, fetchServerSentEvents } from "@tanstack/ai-react";
+
+const { sendMessage } = useChat({
+  connection: fetchServerSentEvents("/api/chat"),
+  body: { provider: "openai" },
+});
+
+// forwardedProps for this request: { provider: "openai", attachmentIds: [...] }
+await sendMessage("Summarize the attached files", {
+  body: { attachmentIds: ["att_1", "att_2"] },
+});
+```
+
+This is race-free where updating a reactive chat-level `body`/`forwardedProps` option right before sending is not (reactive option changes can flush after the send). On `ChatClient` directly, the positional `body` argument does the same thing and wins if both are provided.
+
 ### Resumable SSE
 
 `fetchServerSentEvents` watches SSE `id:` values. If a connection drops after

--- a/packages/ai-angular/tests/inject-chat.test.ts
+++ b/packages/ai-angular/tests/inject-chat.test.ts
@@ -124,6 +124,29 @@ describe('injectChat — streaming', () => {
     expect(result.isLoading()).toBe(false)
   })
 
+  it('merges sendMessage options.body into the request', async () => {
+    let capturedData: Record<string, any> | undefined
+    const adapter = createMockConnectionAdapter({
+      chunks: createTextChunks('Hello there'),
+      onConnect: (_messages, data) => {
+        capturedData = data
+      },
+    })
+    const { result, flush } = renderInjectChat({
+      connection: adapter,
+      body: { provider: 'openai' },
+    })
+
+    // injectChat has no positional body arg — options.body is the per-call
+    // channel, merged over the chat-level `body` option.
+    await result.sendMessage('Hi', { body: { attachmentIds: ['a1', 'a2'] } })
+    await tick()
+    flush()
+
+    expect(capturedData?.['provider']).toBe('openai')
+    expect(capturedData?.['attachmentIds']).toEqual(['a1', 'a2'])
+  })
+
   it('initializes with provided messages', () => {
     const adapter = createMockConnectionAdapter()
     const initialMessages = [

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -1858,7 +1858,9 @@ export class ChatClient<
    * @param body - Optional body parameters to merge with the client's base body for this request.
    *               Uses shallow merge with per-message body taking priority.
    * @param sendOptions - Per-call overrides, e.g. `{ whenBusy: 'interrupt' }` to
-   *                      override the configured queue policy for this one send.
+   *                      override the configured queue policy for this one send,
+   *                      or `{ body }` as an alternative to the positional `body`
+   *                      argument (the positional argument wins if both are set).
    *
    * @example
    * ```ts
@@ -1868,8 +1870,12 @@ export class ChatClient<
    * // Text message with custom body params
    * await client.sendMessage('Hello!', { temperature: 0.7 })
    *
-   * // Per-call whenBusy override (body must still be the 2nd arg on ChatClient)
+   * // Per-call whenBusy override
    * await client.sendMessage('Urgent', undefined, { whenBusy: 'interrupt' })
+   *
+   * // Per-call body via options — same effect as the positional arg. This is
+   * // the shape the framework hooks (`useChat`, `injectChat`, …) forward.
+   * await client.sendMessage('Hello!', undefined, { body: { temperature: 0.7 } })
    *
    * // Multimodal message with image
    * await client.sendMessage({
@@ -1908,13 +1914,17 @@ export class ChatClient<
       )
     }
 
+    // Positional `body` wins over `sendOptions.body` — the positional arg
+    // predates the option and existing callers may pass both.
+    const resolvedBody = body ?? sendOptions?.body
+
     if (this.isSendBusy()) {
       const { action, id } = this.decideWhenBusy(content, sendOptions)
       if (action === 'drop') {
         return
       }
       if (action === 'queue') {
-        this.enqueueMessage(content, body, id)
+        this.enqueueMessage(content, resolvedBody, id)
         return
       }
       // 'interrupt': abort the current stream, then send now.
@@ -1931,7 +1941,7 @@ export class ChatClient<
     }
 
     try {
-      await this.deliverMessage(content, body)
+      await this.deliverMessage(content, resolvedBody)
     } finally {
       this.sendInFlight = false
     }

--- a/packages/ai-client/src/types.ts
+++ b/packages/ai-client/src/types.ts
@@ -479,6 +479,20 @@ export type QueueOption = WhenBusy | QueueConfig | QueueStrategy
 export interface SendMessageOptions {
   /** Overrides the configured `whenBusy` for this one send. */
   whenBusy?: WhenBusy
+  /**
+   * Body parameters merged into this request's wire `forwardedProps`
+   * (shallow merge, highest priority — wins over the chat-level `body` and
+   * `forwardedProps` options on key collisions).
+   *
+   * Equivalent to the positional `body` argument of `ChatClient.sendMessage`;
+   * if both are provided, the positional argument wins. The framework hooks
+   * (`useChat`, `injectChat`, …) expose `sendMessage(content, options)`
+   * without the positional argument, so this option is the way to pass a
+   * per-call body through them — chat-level `forwardedProps` set via
+   * reactive options can flush asynchronously, which makes "set option,
+   * then send" racy for data that belongs to one specific message.
+   */
+  body?: Record<string, any>
 }
 
 /**

--- a/packages/ai-client/tests/chat-client-queue.test.ts
+++ b/packages/ai-client/tests/chat-client-queue.test.ts
@@ -685,6 +685,42 @@ describe('ChatClient queue policy branches', () => {
     expect(seenBodies.map((b) => b?.tag)).toEqual(['seed', 'y'])
   })
 
+  it('preserves sendOptions.body for queued sends', async () => {
+    const seenBodies: Array<Record<string, unknown> | undefined> = []
+    const deferred = createDeferred<void>()
+    let call = 0
+    const connection: ConnectConnectionAdapter = {
+      async *connect(_messages, data) {
+        call += 1
+        seenBodies.push(
+          data && typeof data === 'object'
+            ? (data as Record<string, unknown>)
+            : undefined,
+        )
+        if (call === 1) {
+          await deferred.promise
+        }
+        yield* createTextChunks('done', `msg-${call}`)
+      },
+    }
+
+    // Hook-style calls: body rides in sendOptions, positional arg unused.
+    const client = new ChatClient({ connection })
+    const firstSend = client.sendMessage('first', undefined, {
+      body: { tag: 'seed' },
+    })
+    await vi.waitFor(() => {
+      expect(client.getIsLoading()).toBe(true)
+    })
+    await client.sendMessage('a', undefined, { body: { tag: 'a' } })
+    deferred.resolve()
+    await firstSend
+    await vi.waitFor(() => {
+      expect(client.getQueue()).toEqual([])
+    })
+    expect(seenBodies.map((b) => b?.tag)).toEqual(['seed', 'a'])
+  })
+
   it('batch drain does not strand messages enqueued during the batch stream', async () => {
     const deferred1 = createDeferred<void>()
     const deferred2 = createDeferred<void>()

--- a/packages/ai-client/tests/chat-client.test.ts
+++ b/packages/ai-client/tests/chat-client.test.ts
@@ -3342,6 +3342,55 @@ describe('ChatClient', () => {
       expect(capturedData?.['maxTokens']).toBe(100) // From per-message body
     })
 
+    it('should merge sendOptions.body into the request (hook-style per-call body)', async () => {
+      const chunks = createTextChunks('Response')
+      let capturedData: Record<string, any> | undefined
+      const adapter = createMockConnectionAdapter({
+        chunks,
+        onConnect: (_messages, data) => {
+          capturedData = data
+        },
+      })
+
+      const client = new ChatClient({
+        connection: adapter,
+        body: { model: 'gpt-5.5', temperature: 0.7 },
+      })
+
+      // The framework hooks call sendMessage(content, undefined, sendOptions),
+      // so `sendOptions.body` is their only per-call body channel.
+      await client.sendMessage('Hello', undefined, {
+        body: { model: 'gpt-6', maxTokens: 100 },
+      })
+
+      expect(capturedData?.['model']).toBe('gpt-6') // From sendOptions.body
+      expect(capturedData?.['temperature']).toBe(0.7) // From base body
+      expect(capturedData?.['maxTokens']).toBe(100) // From sendOptions.body
+    })
+
+    it('positional body wins over sendOptions.body', async () => {
+      const chunks = createTextChunks('Response')
+      let capturedData: Record<string, any> | undefined
+      const adapter = createMockConnectionAdapter({
+        chunks,
+        onConnect: (_messages, data) => {
+          capturedData = data
+        },
+      })
+
+      const client = new ChatClient({ connection: adapter })
+
+      await client.sendMessage(
+        'Hello',
+        { tag: 'positional' },
+        { body: { tag: 'options', extra: true } },
+      )
+
+      // The positional arg replaces (not merges with) sendOptions.body.
+      expect(capturedData?.['tag']).toBe('positional')
+      expect(capturedData?.['extra']).toBeUndefined()
+    })
+
     it('should accept forwardedProps option and merge into request body', async () => {
       const chunks = createTextChunks('Response')
       let capturedData: Record<string, any> | undefined

--- a/packages/ai-preact/src/use-mcp-app-bridge.ts
+++ b/packages/ai-preact/src/use-mcp-app-bridge.ts
@@ -19,7 +19,7 @@ export type UseMcpAppBridgeOptions = CreateMcpAppBridgeOptions
  * const bridge = useMcpAppBridge({
  *   threadId,
  *   callEndpoint: '/api/mcp-apps-call',
- *   chat: { sendMessage: async (content) => void sendMessage(content) },
+ *   chat: { sendMessage: (content, body) => sendMessage(content, { body }) },
  *   onLink: (url) => window.open(url, '_blank', 'noopener,noreferrer'),
  * })
  * // pass `bridge` to <MCPAppResource bridge={bridge} … />

--- a/packages/ai-react/src/types.ts
+++ b/packages/ai-react/src/types.ts
@@ -168,7 +168,9 @@ interface BaseUseChatReturn<
    * Can be a simple string or multimodal content with images, audio, etc.
    * By default, sends while busy are queued until the run settles successfully
    * (`queue: 'drop'` restores the old drop-while-busy behavior).
-   * Pass `{ whenBusy }` to override the policy for a single send.
+   * Pass `{ whenBusy }` to override the policy for a single send, or
+   * `{ body }` to merge per-call body params into this request's
+   * `forwardedProps`.
    */
   sendMessage: (
     content: string | MultimodalContent,

--- a/packages/ai-react/src/use-mcp-app-bridge.ts
+++ b/packages/ai-react/src/use-mcp-app-bridge.ts
@@ -19,7 +19,7 @@ export type UseMcpAppBridgeOptions = CreateMcpAppBridgeOptions
  * const bridge = useMcpAppBridge({
  *   threadId,
  *   callEndpoint: '/api/mcp-apps-call',
- *   chat: { sendMessage: async (content) => void sendMessage(content) },
+ *   chat: { sendMessage: (content, body) => sendMessage(content, { body }) },
  *   onLink: (url) => window.open(url, '_blank', 'noopener,noreferrer'),
  * })
  * // pass `bridge` to <MCPAppResource bridge={bridge} … />

--- a/packages/ai-react/tests/use-chat.test.ts
+++ b/packages/ai-react/tests/use-chat.test.ts
@@ -411,6 +411,35 @@ describe('useChat', () => {
       expect(typeof messageId).toBe('string')
     })
 
+    it('should merge sendMessage options.body into the request', async () => {
+      const chunks = createTextChunks('Response')
+      let capturedData: Record<string, any> | undefined
+      const adapter = createMockConnectionAdapter({
+        chunks,
+        onConnect: (_messages, data) => {
+          capturedData = data
+        },
+      })
+
+      const { result } = renderUseChat({
+        connection: adapter,
+        body: { provider: 'openai' },
+      })
+
+      // The hook has no positional body arg — options.body is the per-call
+      // channel, merged over the chat-level `body` option.
+      await result.current.sendMessage('Test', {
+        body: { attachmentIds: ['a1', 'a2'] },
+      })
+
+      await waitFor(() => {
+        expect(result.current.messages.length).toBeGreaterThan(0)
+      })
+
+      expect(capturedData?.['provider']).toBe('openai')
+      expect(capturedData?.['attachmentIds']).toEqual(['a1', 'a2'])
+    })
+
     it('should generate id if not provided', async () => {
       const chunks = createTextChunks('Response')
       const adapter = createMockConnectionAdapter({ chunks })

--- a/packages/ai-solid/src/types.ts
+++ b/packages/ai-solid/src/types.ts
@@ -165,7 +165,9 @@ interface BaseUseChatReturn<
    * Can be a simple string or multimodal content with images, audio, etc.
    * By default, sends while busy are queued until the run settles successfully
    * (`queue: 'drop'` restores the old drop-while-busy behavior).
-   * Pass `{ whenBusy }` to override the policy for a single send.
+   * Pass `{ whenBusy }` to override the policy for a single send, or
+   * `{ body }` to merge per-call body params into this request's
+   * `forwardedProps`.
    */
   sendMessage: (
     content: string | MultimodalContent,

--- a/testing/e2e/fixtures/chat/basic.json
+++ b/testing/e2e/fixtures/chat/basic.json
@@ -5,6 +5,12 @@
       "response": {
         "content": "I'd recommend the Fender Stratocaster for its versatile tone and comfortable playability. At $1,299, it's great for beginners and pros alike, covering everything from blues to rock."
       }
+    },
+    {
+      "match": { "userMessage": "[per-call-body] send with per-call body" },
+      "response": {
+        "content": "Acknowledged the per-call body send."
+      }
     }
   ]
 }

--- a/testing/e2e/src/routes/$provider/$feature.tsx
+++ b/testing/e2e/src/routes/$provider/$feature.tsx
@@ -455,6 +455,14 @@ function ChatFeature({
         queue={queue}
         cancelQueued={cancelQueued}
         onSendMessage={(text) => {
+          // Exercises the hook-level per-call body channel
+          // (`SendMessageOptions.body`): the marker must reach the wire under
+          // `forwardedProps`, merged with (not replacing) the chat-level
+          // `body` keys. Asserted by per-call-body.spec.ts.
+          if (text.startsWith('[per-call-body]')) {
+            sendMessage(text, { body: { perCallBodyMarker: testId } })
+            return
+          }
           sendMessage(text)
         }}
         onSendMessageWithImage={

--- a/testing/e2e/tests/per-call-body.spec.ts
+++ b/testing/e2e/tests/per-call-body.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from './fixtures'
+import {
+  featureUrl,
+  getLastAssistantMessage,
+  sendMessage,
+  waitForResponse,
+} from './helpers'
+
+// Fixture: fixtures/chat/basic.json ("[per-call-body] send with per-call body").
+//
+// Coverage for the per-call `body` on `SendMessageOptions`: the framework
+// hooks expose `sendMessage(content, options)` with no positional body arg,
+// so `options.body` is their only per-message body channel. The chat page
+// sends the `[per-call-body]` prompt via
+// `sendMessage(text, { body: { perCallBodyMarker: testId } })`.
+//
+// The load-bearing assertion is on the page → /api/chat POST body:
+// `forwardedProps` must contain the per-call marker MERGED with the
+// chat-level `body` keys (provider/feature/testId/…) — a regression that
+// dropped `options.body` (the pre-feature behavior: the hooks forwarded
+// `undefined`) fails the marker assertion; one that *replaced* the body
+// instead of merging fails the provider/feature assertions.
+test.describe('per-call sendMessage body', () => {
+  test('options.body reaches the wire under forwardedProps, merged with chat-level body', async ({
+    page,
+    testId,
+    aimockPort,
+  }) => {
+    const chatRequestBodies: Array<Record<string, unknown>> = []
+    page.on('request', (req) => {
+      if (req.method() !== 'POST') return
+      if (!req.url().endsWith('/api/chat')) return
+      const raw = req.postData()
+      if (!raw) return
+      try {
+        chatRequestBodies.push(JSON.parse(raw) as Record<string, unknown>)
+      } catch {
+        // Non-JSON bodies are unrelated to the chat round-trip.
+      }
+    })
+
+    await page.goto(featureUrl('openai', 'chat', testId, aimockPort))
+
+    await sendMessage(page, '[per-call-body] send with per-call body')
+    await waitForResponse(page)
+    const response = await getLastAssistantMessage(page)
+    expect(response).toContain('Acknowledged the per-call body send.')
+
+    expect(chatRequestBodies).toHaveLength(1)
+    const fp = chatRequestBodies[0]?.forwardedProps as
+      | Record<string, unknown>
+      | undefined
+    expect(fp).toBeDefined()
+    // The per-call body landed on the wire…
+    expect(fp!.perCallBodyMarker).toBe(testId)
+    // …merged with — not replacing — the chat-level `body` keys.
+    expect(fp!.provider).toBe('openai')
+    expect(fp!.feature).toBe('chat')
+    expect(fp!.testId).toBe(testId)
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

`ChatClient.sendMessage(content, body?, sendOptions?)` accepts a per-call `body` merged into the request's `forwardedProps` at the highest priority — but every framework hook (`useChat`, `injectChat`, `createChat`, …) exposes `sendMessage(content, options)` and hardcodes `undefined` for the positional argument (e.g. `ai-angular/src/inject-chat.ts`, `ai-react/src/use-chat.ts`), and none of them expose the underlying `ChatClient`.

That leaves no race-free way to send per-message data through a hook. The workaround — updating a reactive chat-level `body`/`forwardedProps` option right before sending — is racy: reactive option changes sync to the client asynchronously (e.g. via an Angular `effect`), so "set option, then send" can flush after the request is built. Real-world case: attaching upload ids to the specific message that references them.

**The fix:** `SendMessageOptions` gains an optional `body`. `ChatClient.sendMessage` resolves `body ?? sendOptions.body` (the positional argument wins — it predates the option and existing callers may pass both), so **every framework wrapper inherits the capability with zero wrapper code changes** — they already forward `sendOptions`. Queued sends preserve the per-call body exactly like the positional form (same `enqueueMessage`/`deliverMessage` path).

```ts
// Now works through every hook:
await sendMessage("Summarize the attached files", {
  body: { attachmentIds: ["att_1", "att_2"] },
});
```

Also included:
- Docs: "Per-call body" section in `docs/chat/connection-adapters.md`; updated `sendMessage` JSDoc (the "(body must still be the 2nd arg on ChatClient)" note is no longer true) and the `useMcpAppBridge` example, which can now forward the bridge's `body` instead of dropping it.
- Non-breaking: purely additive; no existing signature or behavior changes.

## Test plan

- **Unit — `ai-client`** (`chat-client.test.ts`, `chat-client-queue.test.ts`): `sendOptions.body` merges over chat-level `body`; positional `body` wins over (replaces, not merges with) `sendOptions.body`; queued sends drain with their own per-call `sendOptions.body`.
- **Unit — wrappers** (`ai-react/tests/use-chat.test.ts`, `ai-angular/tests/inject-chat.test.ts`): hook-level `sendMessage(content, { body })` reaches the connection adapter's `data`, merged with the chat-level `body` option.
- **E2E** (`testing/e2e/tests/per-call-body.spec.ts` + fixture + a `[per-call-body]` branch in the chat page): drives the browser UI and asserts the `/api/chat` POST body carries the per-call marker under `forwardedProps`, merged with — not replacing — the chat-level keys. A regression that drops `options.body` fails the marker assertion; one that replaces the merge fails the provider/feature assertions.
- Verified locally: `pnpm run test:pr` (sherif, knip, docs links, kiira doc-snippet typecheck, oxlint, unit, types, build — all green) and the e2e subset `per-call-body` + `chat.spec.ts` + `queue.spec.ts` (27 passed).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (`@tanstack/ai-client` minor).
- [ ] This change is docs/CI/dev-only (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for supplying request body data per message when sending chat messages.
  * Per-message values merge with chat-level settings and take precedence.
  * Per-call body data works with framework hooks, direct chat clients, streaming, and queued messages.
  * Direct chat clients may continue using the positional body argument.

* **Bug Fixes**
  * Improved streaming behavior when the page is hidden.

* **Documentation**
  * Updated guidance and examples for per-message request bodies.

* **Tests**
  * Added coverage for merging, precedence, streaming, queued messages, and end-to-end request forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->