### PR TITLE
feat: add @tanstack/ai-byteplus — Seed LLMs, Seedance video, Seedream image, Seed Speech TTS/ASR

### DIFF
--- a/.changeset/add-ai-byteplus.md
+++ b/.changeset/add-ai-byteplus.md
@@ -1,0 +1,13 @@
+---
+'@tanstack/ai-byteplus': minor
+---
+
+Add `@tanstack/ai-byteplus`, an adapter package for BytePlus ModelArk: Seed
+chat models, Seedance video generation, Seedream image generation, and Seed
+Speech text-to-speech and transcription.
+
+Seedance was already reachable through `@tanstack/ai-fal`, which proxies it.
+This package is the direct-to-BytePlus path — BytePlus billing and rate limits,
+the first-class Seedance request fields, and BytePlus's own model ids — so the
+overlap is deliberate. Seed Speech is a separate BytePlus product and needs its
+own API key (`BYTEPLUS_VOICE_API_KEY`), not the Ark key.

--- a/.claude/skills/gap-analysis/SKILL.md
+++ b/.claude/skills/gap-analysis/SKILL.md
@@ -86,10 +86,13 @@ markdown report under `.agent/gap-analysis/`. **Do not edit source files.**
 `bedrock` (`@tanstack/ai-bedrock`; three-API surface — Converse default
 (adapter name `bedrock-converse`), Chat Completions opt-in (`api: 'chat'`,
 adapter name `bedrock`), Responses opt-in (`api: 'responses'`, adapter name
-`bedrock-responses`)), `fal` (media-only), `elevenlabs` (TTS-only). The
+`bedrock-responses`)), `byteplus` (`@tanstack/ai-byteplus`; text, video, tts,
+transcription, image — two products/keys: ModelArk `ARK_API_KEY` for
+text/video/image, Seed Speech `BYTEPLUS_VOICE_API_KEY` for tts/transcription),
+`fal` (media-only), `elevenlabs` (TTS-only). The
 feature matrix tracks `openai`, `anthropic`, `gemini`, `ollama`, `grok`,
-`groq`, `openrouter`, `bedrock`, `bedrock-converse`, and `bedrock-responses`;
-`fal` and `elevenlabs` only appear in model/media audits.
+`groq`, `openrouter`, `bedrock`, `bedrock-converse`, `bedrock-responses`, and
+`byteplus`; `fal` and `elevenlabs` only appear in model/media audits.
 
 ## Known features (19)
 

--- a/.claude/skills/gap-analysis/references/provider-doc-urls.md
+++ b/.claude/skills/gap-analysis/references/provider-doc-urls.md
@@ -93,6 +93,31 @@ WebFetch — call `resolve-library-id` with the SDK npm name, then `query-docs`.
 - TTS API: https://elevenlabs.io/docs/api-reference/text-to-speech
 - npm SDK: https://www.npmjs.com/package/@elevenlabs/elevenlabs-js
 
+## byteplus (BytePlus ModelArk + Seed Speech)
+
+Two separate products with separate docs trees and separate API keys —
+ModelArk (chat / Seedance video / Seedream image, `ARK_API_KEY`) and
+BytePlus Voice (Seed Speech TTS + ASR, `BYTEPLUS_VOICE_API_KEY`).
+
+- ModelArk docs root: https://docs.byteplus.com/en/docs/ModelArk/ — the chat
+  completions, content-generation-tasks (Seedance) and image-generations
+  (Seedream) pages live under numeric ids that change; navigate from the root
+  or WebSearch "byteplus modelark <endpoint>" rather than deep-linking.
+- Ark data plane base URL: `https://ark.ap-southeast.bytepluses.com/api/v3`
+  (EU: `ark.eu-west.bytepluses.com`, chat + image only)
+- Seed Speech docs root: https://docs.byteplus.com/en/docs/byteplusvoice/
+- Seed Audio 1.0 TTS: https://docs.byteplus.com/en/docs/byteplusvoice/seedaudio-01
+- TTS voice roster: https://docs.byteplus.com/en/docs/byteplusvoice/voicelist
+- No first-party npm SDK is used — the chat path goes through the `openai`
+  SDK via `@tanstack/openai-base`; video/image/speech use hand-written wire
+  types. `@volcengine/ark-runtime` is deliberately **not** a dependency.
+
+> **Docs are unreliable here — probe before trusting.** BytePlus capability
+> tables have been wrong in both directions (structured-output support,
+> Seedance resolution tiers, the tool `type` value), and published model lists
+> include ids that no longer resolve. Verify any claim against a live request
+> before changing `model-meta.ts` or `feature-support.ts`.
+
 ---
 
 ## Maintenance

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Official adapters include:
 | [`@tanstack/ai-grok`](https://tanstack.com/ai/latest/docs/adapters/grok)             | xAI Grok chat, images, and realtime                                            |
 | [`@tanstack/ai-groq`](https://tanstack.com/ai/latest/docs/adapters/groq)             | Groq low-latency inference                                                     |
 | [`@tanstack/ai-elevenlabs`](https://tanstack.com/ai/latest/docs/adapters/elevenlabs) | ElevenLabs realtime voice, speech, transcription, music, and sound effects     |
+| [`@tanstack/ai-byteplus`](https://tanstack.com/ai/latest/docs/adapters/byteplus)     | BytePlus Seed chat, Seedance video, Seedream image, and Seed Speech TTS/ASR    |
 | [`@tanstack/ai-fal`](https://tanstack.com/ai/latest/docs/adapters/fal)               | fal.ai image, video, audio, speech, and transcription models                   |
 
 The adapter system is tree-shakeable by activity. Import `openaiText` for chat,

--- a/docs/adapters/byteplus.md
+++ b/docs/adapters/byteplus.md
@@ -1,0 +1,514 @@
+---
+title: BytePlus
+id: byteplus-adapter
+order: 8
+description: "Use BytePlus ModelArk with TanStack AI — Seed chat models with reasoning, Seedance video generation, Seedream image generation, and Seed Speech text-to-speech and transcription via @tanstack/ai-byteplus."
+keywords:
+  - tanstack ai
+  - byteplus
+  - modelark
+  - ark
+  - seed
+  - seedance
+  - seedream
+  - seed speech
+  - bytedance
+  - video generation
+  - image generation
+  - text to speech
+  - transcription
+  - adapter
+---
+
+The BytePlus adapter connects TanStack AI to [BytePlus](https://www.byteplus.com/), ByteDance's international model platform, across four generation kinds:
+
+- **Chat** — the Seed model family (plus GLM, DeepSeek and gpt-oss) on ModelArk's OpenAI-compatible `/chat/completions` endpoint, with reasoning on by default.
+- **Video** — Seedance, an asynchronous task API.
+- **Image** — Seedream.
+- **Speech** — Seed Speech text-to-speech and transcription, which live on a **different host with a different API key** (see [Two products, two keys](#two-products-two-keys)).
+
+## Installation
+
+```bash
+npm install @tanstack/ai-byteplus
+# or
+pnpm add @tanstack/ai-byteplus
+# or
+yarn add @tanstack/ai-byteplus
+```
+
+## Two products, two keys
+
+BytePlus splits these models across two products, and they do not share credentials:
+
+| Adapters | Product | Env var | Auth header |
+| --- | --- | --- | --- |
+| `byteplusText`, `byteplusVideo`, `byteplusImage` | ModelArk (Ark) | `ARK_API_KEY` (falls back to `BYTEPLUS_API_KEY`) | `Authorization: Bearer` |
+| `byteplusSpeech`, `byteplusTranscription` | Seed Speech | `BYTEPLUS_VOICE_API_KEY` | `X-Api-Key` |
+
+```bash
+# ModelArk: chat, Seedance video, Seedream image
+ARK_API_KEY=...
+
+# Seed Speech: TTS and transcription — a separate product key
+BYTEPLUS_VOICE_API_KEY=...
+```
+
+Passing an Ark key to the speech adapters fails with `45000010 Invalid X-Api-Key`.
+
+Ark keys are also **region-isolated**: the default base URL is the Asia-Pacific south-east endpoint (`https://ark.ap-southeast.bytepluses.com/api/v3`), and a key issued for one region will not authenticate against another. Point the adapter elsewhere with `baseURL`:
+
+```typescript
+import { createBytePlusText } from '@tanstack/ai-byteplus'
+import { arkApiKey } from './config'
+
+const adapter = createBytePlusText('dola-seed-2-1-turbo-260628', arkApiKey, {
+  baseURL: 'https://ark.eu-west.bytepluses.com/api/v3',
+})
+```
+
+Per the BytePlus docs the EU endpoint serves chat and image only — Seedance video is Asia-Pacific only.
+
+## Chat
+
+The adapter carries the model, so there is no separate `model` option.
+
+**Server** — an endpoint that streams the reply back over SSE:
+
+```typescript
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { byteplusText } from '@tanstack/ai-byteplus'
+
+export async function POST(request: Request) {
+  const { messages } = await request.json()
+
+  const stream = chat({
+    adapter: byteplusText('dola-seed-2-1-turbo-260628'),
+    messages,
+  })
+
+  return toServerSentEventsResponse(stream)
+}
+```
+
+**Client** — the same `useChat` hook as every other provider:
+
+```tsx
+import { useState } from 'react'
+import { fetchServerSentEvents, useChat } from '@tanstack/ai-react'
+
+export function Chat() {
+  const [input, setInput] = useState('')
+
+  const { messages, sendMessage, isLoading } = useChat({
+    connection: fetchServerSentEvents('/api/chat'),
+  })
+
+  return (
+    <div>
+      {messages.map((message) => (
+        <div key={message.id}>
+          <strong>{message.role}</strong>
+          {message.parts.map((part, index) =>
+            part.type === 'text' ? <p key={index}>{part.content}</p> : null,
+          )}
+        </div>
+      ))}
+
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          if (!input.trim() || isLoading) return
+          sendMessage(input)
+          setInput('')
+        }}
+      >
+        <input value={input} onChange={(e) => setInput(e.target.value)} />
+        <button type="submit" disabled={isLoading}>
+          Send
+        </button>
+      </form>
+    </div>
+  )
+}
+```
+
+### Model options
+
+Ark's chat endpoint is OpenAI-compatible, so sampling parameters keep their OpenAI snake_case names and live in `modelOptions`. `thinking`, `reasoning_effort`, `repetition_penalty` and `service_tier` are the Ark-only additions:
+
+```typescript
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { byteplusText } from '@tanstack/ai-byteplus'
+
+export async function POST(request: Request) {
+  const { messages } = await request.json()
+
+  const stream = chat({
+    adapter: byteplusText('dola-seed-2-1-turbo-260628'),
+    messages,
+    modelOptions: {
+      temperature: 0.7,
+      top_p: 0.9,
+      max_tokens: 2048,
+      thinking: { type: 'enabled' },
+      reasoning_effort: 'medium',
+    },
+  })
+
+  return toServerSentEventsResponse(stream)
+}
+```
+
+Two constraints the type system can't express, both live-verified as `400`s:
+
+- `max_tokens` and `max_completion_tokens` are mutually exclusive.
+- `reasoning_effort` cannot be combined with `thinking: { type: 'disabled' }`.
+
+`service_tier: 'flex'` routes the request to the cheaper offline batch queue with no latency guarantee.
+
+## Reasoning and `encrypted_content`
+
+Seed models reason by default. Reasoning arrives as its own stream of `reasoning_content` deltas and is surfaced as reasoning content rather than answer text, so `useChat` renders it separately from the reply. Turn it off per request:
+
+```typescript
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { byteplusText } from '@tanstack/ai-byteplus'
+
+export async function POST(request: Request) {
+  const { messages } = await request.json()
+
+  const stream = chat({
+    adapter: byteplusText('dola-seed-2-1-turbo-260628'),
+    messages,
+    modelOptions: { thinking: { type: 'disabled' } },
+  })
+
+  return toServerSentEventsResponse(stream)
+}
+```
+
+`disabled` works everywhere; `auto` is accepted only by `gpt-oss-120b-250805`. `deepseek-v3-2-251201` is the one model that defaults to reasoning *off*.
+
+The four "thinking summary" models — `dola-seed-2-1-turbo-260628`, `seed-2-0-lite-260428`, `seed-2-0-mini-260428` and `seed-2-0-pro-260328` — also emit an opaque `encrypted_content` blob alongside the reasoning trace. It is a signature over that trace, and BytePlus's docs ask for it back verbatim on the assistant message in the next turn.
+
+**The adapter round-trips it for you**, over the same seam Anthropic's thinking signatures use: the blob is captured off the stream and attached to the reasoning step as its `signature`, which lands on the thinking part of the assistant message and is echoed back on the next request. Two consequences worth knowing:
+
+- If you persist and replay conversation history yourself, keep the thinking parts' `signature` — dropping it costs you the reasoning-cache hit. It is not fatal: a live probe confirmed Ark accepts a turn whose assistant message omits `encrypted_content`.
+- A structured-output turn doesn't capture the blob, for the same reason — again a lost cache hit, not a failed request.
+
+## Structured output
+
+Ten of the eighteen chat models accept `response_format: { type: 'json_schema' }`:
+
+`dola-seed-2-1-turbo-260628`, `seed-2-0-pro-260328`, `seed-2-0-lite-260228`, `seed-2-0-mini-260215`, `seed-1-8-251228`, `seed-1-6-250915`, `seed-1-6-250615`, `seed-1-6-flash-250715`, `seed-1-6-flash-250615`, `glm-5-2-260617`.
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { byteplusText } from '@tanstack/ai-byteplus'
+import { z } from 'zod'
+
+const RecipeSchema = z.object({
+  name: z.string().meta({ description: 'Name of the dish' }),
+  minutes: z.number().meta({ description: 'Total cooking time in minutes' }),
+  ingredients: z.array(z.string()),
+})
+
+const recipe = await chat({
+  adapter: byteplusText('dola-seed-2-1-turbo-260628'),
+  messages: [{ role: 'user', content: 'Give me a recipe for carbonara' }],
+  outputSchema: RecipeSchema,
+})
+
+console.log(recipe.name, recipe.minutes)
+```
+
+On the other eight models the adapter **fails loudly** rather than degrading: `chat({ outputSchema })` throws, and the streaming form emits a `RUN_ERROR` naming the models that do work. There is no JSON-mode fallback to fall back *to* — Ark rejects `response_format: { type: 'json_object' }` on every one of them too.
+
+Two traps worth knowing, both found by probing the live API rather than reading the tables:
+
+- **The published capability tables are wrong in both directions.** `seed-2-0-lite-260428` — the obvious default model — is one of the eight that reject a JSON schema. Reach for `seed-2-0-lite-260228` or `dola-seed-2-1-turbo-260628` when you need typed output.
+- **`glm-4-7-251222` accepts a schema and then ignores it**, answering in prose with a `200`. It is deliberately excluded from the supported list, so the adapter rejects it up front instead of handing you unparseable output.
+
+`BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS` is exported if you want to gate a model picker on it.
+
+## Video generation (Seedance)
+
+> Video generation is an [experimental feature](../media/video-generation).
+
+Seedance is an asynchronous task API: `generateVideo()` opens the job and returns a `jobId`, and the video URL arrives with the terminal status.
+
+```typescript
+import { generateVideo, getVideoJobStatus } from '@tanstack/ai'
+import { byteplusVideo } from '@tanstack/ai-byteplus'
+
+const adapter = byteplusVideo('dreamina-seedance-2-0-260128')
+
+const { jobId } = await generateVideo({
+  adapter,
+  prompt: 'a guitar being played in a store',
+  size: '16:9_720p',
+  duration: 5,
+})
+
+let status = await getVideoJobStatus({ adapter, jobId })
+while (status.status === 'pending' || status.status === 'processing') {
+  await new Promise((resolve) => setTimeout(resolve, 5000))
+  status = await getVideoJobStatus({ adapter, jobId })
+}
+
+console.log(status.status === 'completed' ? status.url : status.error)
+```
+
+**Generated video URLs expire 24 hours after the task completes** (the task record itself is kept for seven days), so download anything you intend to keep — see [Keeping generated files](../persistence/keep-generated-files).
+
+`size` is a `ratio` or `ratio_resolution` template (`'16:9'`, `'16:9_720p'`). Ratios are `16:9`, `9:16`, `4:3`, `3:4`, `1:1`, `21:9` and `adaptive`.
+
+### Driving the whole lifecycle from the client
+
+**Server** — hand the polling to the core with `stream: true` and pipe the chunks out:
+
+```typescript
+import { generateVideo, toServerSentEventsResponse } from '@tanstack/ai'
+import { byteplusVideo } from '@tanstack/ai-byteplus'
+
+export async function POST(request: Request) {
+  const { prompt } = await request.json()
+
+  const stream = generateVideo({
+    adapter: byteplusVideo('dreamina-seedance-2-0-260128'),
+    prompt,
+    size: '16:9_720p',
+    duration: 5,
+    stream: true,
+    pollingInterval: 5000,
+  })
+
+  return toServerSentEventsResponse(stream)
+}
+```
+
+**Client** — `useGenerateVideo` tracks the job for you:
+
+```tsx
+import { fetchServerSentEvents, useGenerateVideo } from '@tanstack/ai-react'
+
+export function SeedanceGenerator() {
+  const { generate, result, videoStatus, isLoading, error } = useGenerateVideo({
+    connection: fetchServerSentEvents('/api/generate/video'),
+  })
+
+  return (
+    <div>
+      <button
+        onClick={() => generate({ prompt: 'a guitar being played in a store' })}
+        disabled={isLoading}
+      >
+        {isLoading ? 'Generating…' : 'Generate video'}
+      </button>
+
+      {isLoading && <p>Status: {videoStatus?.status ?? 'starting…'}</p>}
+      {error && <p>Error: {error.message}</p>}
+      {result && <video src={result.url} controls width={640} />}
+    </div>
+  )
+}
+```
+
+### Per-model options
+
+Seedance options are model-specific, and **Ark rejects an inapplicable field with a `400` rather than ignoring it** — "the specified parameter `draft` is not supported for model seedance-1-0-pro in t2v, must be empty". The applicable set:
+
+| Option | Models that accept it |
+| --- | --- |
+| `service_tier` (`'default'` \| `'flex'`) | Seedance 1.x only — the 2.0 family rejects it |
+| `camera_fixed` | Seedance 1.x only |
+| `frames` (fractional-second output, `25 + 4n` in `[29, 289]`) | `seedance-1-0-pro-250528`, `seedance-1-0-pro-fast-251015` |
+| `draft` (cheap low-fidelity preview) | `seedance-1-5-pro-251215` only |
+| `priority` (`0`–`9`) | the `dreamina-seedance-2-0-*` family only |
+| `duration: -1` (model picks the length) | Seedance 2.0 and `seedance-1-5-pro-251215` |
+| `seed`, `watermark`, `generate_audio`, `return_last_frame`, `callback_url` | every model |
+
+`watermark` defaults to `false` for video (the opposite of Seedream images). `generate_audio` is accepted everywhere but only Seedance 2.0 and 1.5-pro actually produce an audio track.
+
+Resolutions are per model too, and the shipped table comes from live probes rather than the published docs: there is **no 2K tier on any Seedance model**, `4k` exists only on `dreamina-seedance-2-0-260128`, and `seedance-1-0-pro-fast-251015` does accept `1080p` despite being documented as 480p/720p only. An unsupported combination is caught locally with a clear error before the request goes out.
+
+Reference media follows the shared [role hints](../media/video-generation#role-hints) — `start_frame`, `end_frame` and `reference`. The Seedance 2.0 family takes full multimodal references (reference images, video and audio); the 1.x models take start/end frames only, and `seedance-1-0-pro-fast-251015` takes a start frame only.
+
+### Seedance here vs. Seedance via fal
+
+Seedance is also reachable through [`@tanstack/ai-fal`](./fal), which proxies it alongside hundreds of other hosted models. This adapter talks to BytePlus directly, which means BytePlus billing and rate limits, model ids in BytePlus's own naming, and the first-class Seedance request fields above (`camera_fixed`, `draft`, `priority`, reference-media roles) rather than fal's normalized subset. Pick whichever matches the account you already have; there is no reason to install both just for Seedance.
+
+## Image generation (Seedream)
+
+```typescript
+import { generateImage } from '@tanstack/ai'
+import { byteplusImage } from '@tanstack/ai-byteplus'
+
+const result = await generateImage({
+  adapter: byteplusImage('dola-seedream-5-0-pro-260628'),
+  prompt: 'a guitar being played in a store',
+  size: '2K',
+  modelOptions: { watermark: false },
+})
+
+console.log(result.images[0]?.url)
+```
+
+`size` takes either a token (`1K`, `2K`, `4K`) or explicit pixels (`2048x2048`) — never a mix of the two. Pass image parts in the `prompt` array to edit or condition on existing images (up to 14 references, 10 on `dola-seedream-5-0-pro-260628`):
+
+```typescript
+import { generateImage } from '@tanstack/ai'
+import { byteplusImage } from '@tanstack/ai-byteplus'
+
+const result = await generateImage({
+  adapter: byteplusImage('seedream-5-0-260128'),
+  prompt: [
+    { type: 'text', content: 'Put this guitar on a concert stage' },
+    {
+      type: 'image',
+      source: { type: 'url', value: 'https://example.com/guitar.png' },
+    },
+  ],
+})
+
+console.log(result.images.length)
+```
+
+Two behaviours surprise people:
+
+- **`watermark` defaults to `true`.** BytePlus stamps "AI generated" into the bottom-right corner unless you pass `watermark: false`. The adapter never sets the field implicitly, so the provider default applies.
+- **`numberOfImages` is an upper bound, not a count.** Seedream has no `n` parameter; asking for more than one image maps onto its group-image mode (`sequential_image_generation: 'auto'` with `max_images`), where the model decides how many images the prompt actually warrants. A request for four can come back with two, and the adapter logs a warning when it does.
+
+Result URLs expire after 24 hours. Pass `response_format: 'b64_json'` in `modelOptions` to get the bytes inline instead.
+
+## Text-to-speech (Seed Speech)
+
+Seed Speech uses `BYTEPLUS_VOICE_API_KEY`, not the Ark key.
+
+```typescript
+import { generateSpeech } from '@tanstack/ai'
+import { byteplusSpeech } from '@tanstack/ai-byteplus'
+
+const result = await generateSpeech({
+  adapter: byteplusSpeech('seed-audio-1.0'),
+  text: 'welcome to the guitar store',
+  voice: 'en_female_stokie_uranus_bigtts',
+  format: 'mp3',
+})
+
+console.log(result.contentType, result.audio.length)
+```
+
+Seed Speech has **no top-level `speaker` field** — the voice travels inside a
+`references` entry, so the adapter turns `voice` into
+`references: [{ speaker: 'en_female_stokie_uranus_bigtts' }]` for you. The
+consequence: `modelOptions.references` **replaces** that entry rather than
+merging with it, so a request that passes `references` for voice cloning
+silently drops `voice`. Include a `speaker` member yourself if you still want a
+stock voice alongside your clips.
+
+The suffix on a voice id tells you which generation you are asking for:
+
+- `_uranus_bigtts` — TTS 2.0 voices, the current generation.
+- `_mars_bigtts` / `_moon_bigtts` — TTS 1.0 voices.
+- `*_emo_v2_*` — TTS 1.0 voices that additionally accept emotion tags.
+
+The full roster lives in the [BytePlus voice list](https://docs.byteplus.com/en/docs/byteplusvoice/voicelist) and changes far more often than this package ships, so any string is accepted.
+
+Output formats are `wav`, `mp3`, `pcm` and `ogg_opus`. Reach for `modelOptions` for `ogg_opus`, for an explicit `sample_rate`, for `references` (voice cloning — up to three 30-second audio clips, addressed from the text as `@Audio1`–`@Audio3`), for `watermark`, or for word-level timings:
+
+```typescript
+import { generateSpeech } from '@tanstack/ai'
+import { byteplusSpeech, type BytePlusTTSResult } from '@tanstack/ai-byteplus'
+
+const result: BytePlusTTSResult = await generateSpeech({
+  adapter: byteplusSpeech('seed-audio-1.0'),
+  text: 'welcome to the guitar store',
+  modelOptions: {
+    format: 'ogg_opus',
+    sample_rate: 48000,
+    speech_rate: 20,
+    enable_subtitle: true,
+  },
+})
+
+for (const sentence of result.subtitle?.sentences ?? []) {
+  console.log(sentence.text, sentence.start_time)
+}
+```
+
+Three things to plan around:
+
+- **Synthesis is capped at 120 seconds of output.** The cap applies to `originalDuration` (the length before `speech_rate` is applied), which is also what BytePlus bills on.
+- **Subtitle timings are milliseconds** while `duration` and `originalDuration` are seconds. The units genuinely differ.
+- The `url` on the result expires roughly two hours after generation — persist the base64 `audio`, not the link.
+
+The client half is the standard [`useGenerateSpeech` hook](../media/text-to-speech#streaming-mode-server-route--client-hook); nothing about it is BytePlus-specific.
+
+## Transcription (Seed Speech ASR)
+
+Also on the voice key. The endpoint is synchronous — audio in, transcript out, no polling:
+
+```typescript
+import { generateTranscription } from '@tanstack/ai'
+import { byteplusTranscription } from '@tanstack/ai-byteplus'
+import { audioFile } from './audio'
+
+const result = await generateTranscription({
+  adapter: byteplusTranscription('seed-asr'),
+  audio: audioFile,
+  modelOptions: { enable_punc: true, enable_speaker_info: true },
+})
+
+console.log(result.text)
+for (const segment of result.segments ?? []) {
+  console.log(segment.speaker, segment.text)
+}
+```
+
+Audio can be a `File`, base64, a data URL or a public URL, up to two hours and 100 MB. `enable_itn` renders spoken numbers and dates as digits, `enable_punc` inserts punctuation, `enable_ddc` strips fillers, and `enable_speaker_info` attaches speaker labels that surface as `segment.speaker`.
+
+## Supported models
+
+- **Chat** — `dola-seed-2-1-turbo-260628`, `seed-2-0-lite-260428`, `seed-2-0-mini-260428`, `seed-2-0-pro-260328`, `seed-2-0-lite-260228`, `seed-2-0-mini-260215`, `seed-2-0-code-preview-260328`, `seed-1-8-251228`, `seed-1-6-250915`, `seed-1-6-250615`, `seed-1-6-flash-250715`, `seed-1-6-flash-250615`, `glm-5-2-260617`, `glm-4-7-251222`, `deepseek-v4-pro-260425`, `deepseek-v4-flash-260425`, `deepseek-v3-2-251201`, `gpt-oss-120b-250805`.
+- **Video** — `dreamina-seedance-2-0-260128`, `dreamina-seedance-2-0-fast-260128`, `dreamina-seedance-2-0-mini-260615`, `seedance-1-5-pro-251215`, `seedance-1-0-pro-250528`, `seedance-1-0-pro-fast-251015`.
+- **Image** — `dola-seedream-5-0-pro-260628`, `seedream-5-0-260128`, `seedream-5-0-lite-260128`, `seedream-4-5-251128`, `seedream-4-0-250828`.
+- **Speech** — `seed-audio-1.0` (TTS) and `seed-asr` (transcription).
+
+BytePlus retires model ids aggressively and its published lists include ids that no longer resolve, so this package ships only dated ids that answered a live request. `BYTEPLUS_CHAT_MODELS`, `BYTEPLUS_VIDEO_MODELS`, `BYTEPLUS_IMAGE_MODELS`, `BYTEPLUS_TTS_MODELS` and `BYTEPLUS_TRANSCRIPTION_MODELS` are the authoritative lists and are exported for building model pickers.
+
+## API Reference
+
+Every factory has an environment-variable form and an explicit-key form.
+
+### `byteplusText(model, config?)` / `createBytePlusText(model, apiKey, config?)`
+
+Chat adapter for the Seed, GLM, DeepSeek and gpt-oss models. Reads `ARK_API_KEY` (or `BYTEPLUS_API_KEY`). `config.baseURL` overrides the region endpoint.
+
+### `byteplusVideo(model, config?)` / `createBytePlusVideo(model, apiKey, config?)`
+
+Seedance video adapter (experimental). Reads `ARK_API_KEY`.
+
+### `byteplusImage(model, config?)` / `createBytePlusImage(model, apiKey, config?)`
+
+Seedream image adapter. Reads `ARK_API_KEY`.
+
+### `byteplusSpeech(model, config?)` / `createBytePlusSpeech(model, apiKey, config?)`
+
+Seed Speech TTS adapter. Reads **`BYTEPLUS_VOICE_API_KEY`**.
+
+### `byteplusTranscription(model, config?)` / `createBytePlusTranscription(model, apiKey, config?)`
+
+Seed Speech transcription adapter. Reads **`BYTEPLUS_VOICE_API_KEY`**.
+
+## Provider Tools
+
+BytePlus does not expose provider-specific tool factories. Define your own with `toolDefinition()` from `@tanstack/ai` — Ark's tool calling is the standard OpenAI shape and works with the usual [tools flow](../tools/tools.md).
+
+## Next Steps
+
+- [Video Generation](../media/video-generation) — the full jobs/polling flow and the `useGenerateVideo` hook
+- [Image Generation](../media/image-generation) — image-conditioned generation and role hints
+- [Structured Outputs](../structured-outputs/one-shot) — schemas, validation and streaming
+- [Other Adapters](./openai) — explore other providers

--- a/docs/adapters/byteplus.md
+++ b/docs/adapters/byteplus.md
@@ -335,6 +335,27 @@ Resolutions are per model too, and the shipped table comes from live probes rath
 
 Reference media follows the shared [role hints](../media/video-generation#role-hints) — `start_frame`, `end_frame` and `reference`. The Seedance 2.0 family takes full multimodal references (reference images, video and audio); the 1.x models take start/end frames only, and `seedance-1-0-pro-fast-251015` takes a start frame only.
 
+### Seedance 2.5
+
+Seedance 2.5 was announced on 2026-07-31, initially on BytePlus's consumer surfaces. Its Ark id — `dreamina-seedance-2-5-260628` — is real and reachable, but it is **activation-gated per account**: until the model is switched on in the Ark Console, Ark answers `404 ModelNotOpen`.
+
+Because its capabilities could not be probed from a non-activated account, 2.5 is **deliberately absent from the typed model tables** above. It is still usable today — `byteplusVideo()`'s model parameter accepts any string, so an id BytePlus publishes after this release works without upgrading the package:
+
+```typescript
+import { generateVideo } from '@tanstack/ai'
+import { byteplusVideo } from '@tanstack/ai-byteplus'
+
+// Activate Seedance 2.5 in the Ark Console first, or this 404s.
+const { jobId } = await generateVideo({
+  adapter: byteplusVideo('dreamina-seedance-2-5-260628'),
+  prompt: 'a guitar being played in a store',
+  size: '16:9_720p',
+  duration: 5,
+})
+```
+
+An unknown id relaxes both halves of the adapter: `size` widens to any string, provider options are ungated, and the local runtime guards that encode per-model capabilities — resolution tiers, closing-frame and reference-media support, frame cardinality and mode exclusivity, duration snapping — stand down so Ark validates the request instead. Known ids keep their probe-verified narrowing. Typed narrowing for 2.5 follows in a package update once its capabilities can be verified.
+
 ### Seedance here vs. Seedance via fal
 
 Seedance is also reachable through [`@tanstack/ai-fal`](./fal), which proxies it alongside hundreds of other hosted models. This adapter talks to BytePlus directly, which means BytePlus billing and rate limits, model ids in BytePlus's own naming, and the first-class Seedance request fields above (`camera_fixed`, `draft`, `priority`, reference-media roles) rather than fal's normalized subset. Pick whichever matches the account you already have; there is no reason to install both just for Seedance.
@@ -472,7 +493,7 @@ Audio can be a `File`, base64, a data URL or a public URL, up to two hours and 1
 ## Supported models
 
 - **Chat** — `dola-seed-2-1-turbo-260628`, `seed-2-0-lite-260428`, `seed-2-0-mini-260428`, `seed-2-0-pro-260328`, `seed-2-0-lite-260228`, `seed-2-0-mini-260215`, `seed-2-0-code-preview-260328`, `seed-1-8-251228`, `seed-1-6-250915`, `seed-1-6-250615`, `seed-1-6-flash-250715`, `seed-1-6-flash-250615`, `glm-5-2-260617`, `glm-4-7-251222`, `deepseek-v4-pro-260425`, `deepseek-v4-flash-260425`, `deepseek-v3-2-251201`, `gpt-oss-120b-250805`.
-- **Video** — `dreamina-seedance-2-0-260128`, `dreamina-seedance-2-0-fast-260128`, `dreamina-seedance-2-0-mini-260615`, `seedance-1-5-pro-251215`, `seedance-1-0-pro-250528`, `seedance-1-0-pro-fast-251015`.
+- **Video** — `dreamina-seedance-2-0-260128`, `dreamina-seedance-2-0-fast-260128`, `dreamina-seedance-2-0-mini-260615`, `seedance-1-5-pro-251215`, `seedance-1-0-pro-250528`, `seedance-1-0-pro-fast-251015`. (Seedance 2.5, `dreamina-seedance-2-5-260628`, is untyped-but-usable pending account activation — see [Seedance 2.5](#seedance-25).)
 - **Image** — `dola-seedream-5-0-pro-260628`, `seedream-5-0-260128`, `seedream-5-0-lite-260128`, `seedream-4-5-251128`, `seedream-4-0-250828`.
 - **Speech** — `seed-audio-1.0` (TTS) and `seed-asr` (transcription).
 

--- a/docs/adapters/byteplus.md
+++ b/docs/adapters/byteplus.md
@@ -356,6 +356,8 @@ const { jobId } = await generateVideo({
 
 An unknown id relaxes both halves of the adapter: `size` widens to any string, provider options are ungated, and the local runtime guards that encode per-model capabilities — resolution tiers, closing-frame and reference-media support, frame cardinality and mode exclusivity, duration snapping — stand down so Ark validates the request instead. Known ids keep their probe-verified narrowing. Typed narrowing for 2.5 follows in a package update once its capabilities can be verified.
 
+The quickest way to try a newly-released id is the [Seedance Studio example](https://github.com/TanStack/ai/tree/main/examples/ts-react-media): its **Advanced: custom model id** field (placeholder `dreamina-seedance-2-5-260628`) takes an arbitrary id, switches the studio into unknown-model mode with every option enabled, and spells the activation caveat out in the UI — so a `ModelNotOpen` response reads as expected rather than broken.
+
 ### Seedance here vs. Seedance via fal
 
 Seedance is also reachable through [`@tanstack/ai-fal`](./fal), which proxies it alongside hundreds of other hosted models. This adapter talks to BytePlus directly, which means BytePlus billing and rate limits, model ids in BytePlus's own naming, and the first-class Seedance request fields above (`camera_fixed`, `draft`, `priority`, reference-media roles) rather than fal's normalized subset. Pick whichever matches the account you already have; there is no reason to install both just for Seedance.

--- a/docs/config.json
+++ b/docs/config.json
@@ -12,7 +12,8 @@
         {
           "label": "Overview",
           "to": "getting-started/overview",
-          "addedAt": "2026-04-15"
+          "addedAt": "2026-04-15",
+          "updatedAt": "2026-07-31"
         },
         {
           "label": "Quick Start: React",
@@ -393,13 +394,14 @@
         {
           "label": "Text-to-Speech",
           "to": "media/text-to-speech",
-          "addedAt": "2026-04-15"
+          "addedAt": "2026-04-15",
+          "updatedAt": "2026-07-31"
         },
         {
           "label": "Transcription",
           "to": "media/transcription",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-30"
+          "updatedAt": "2026-07-31"
         },
         {
           "label": "Audio Recording",
@@ -417,13 +419,13 @@
           "label": "Image Generation",
           "to": "media/image-generation",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-30"
+          "updatedAt": "2026-07-31"
         },
         {
           "label": "Video Generation",
           "to": "media/video-generation",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-30"
+          "updatedAt": "2026-07-31"
         },
         {
           "label": "Generation Hooks",
@@ -802,6 +804,11 @@
           "label": "Amazon Bedrock",
           "to": "adapters/bedrock",
           "addedAt": "2026-06-25"
+        },
+        {
+          "label": "BytePlus",
+          "to": "adapters/byteplus",
+          "addedAt": "2026-07-31"
         }
       ]
     },

--- a/docs/config.json
+++ b/docs/config.json
@@ -425,7 +425,7 @@
           "label": "Video Generation",
           "to": "media/video-generation",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-31"
+          "updatedAt": "2026-08-02"
         },
         {
           "label": "Generation Hooks",

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -113,6 +113,7 @@ With the help of adapters, TanStack AI can connect to various LLM providers. Ava
 - **@tanstack/ai-groq** - Groq
 - **@tanstack/ai-grok** - xAI Grok
 - **@tanstack/ai-bedrock** - Amazon Bedrock (Claude, Nova, Llama, and more via AWS)
+- **@tanstack/ai-byteplus** - BytePlus (Seed chat, Seedance video, Seedream image, Seed Speech)
 - **@tanstack/ai-fal** - fal (image & video generation)
 
 ## Next Steps

--- a/docs/media/image-generation.md
+++ b/docs/media/image-generation.md
@@ -2,7 +2,7 @@
 title: Image Generation
 id: image-generation
 order: 5
-description: "Generate images with OpenAI DALL-E, Gemini NanoBanana and Imagen, and fal.ai models via TanStack AI's unified generateImage() API."
+description: "Generate images with OpenAI DALL-E, Gemini NanoBanana and Imagen, BytePlus Seedream, and fal.ai models via TanStack AI's unified generateImage() API."
 keywords:
   - tanstack ai
   - image generation
@@ -24,6 +24,7 @@ Image generation is handled by image adapters that follow the same tree-shakeabl
 
 - **OpenAI**: DALL-E 2, DALL-E 3, GPT-Image-1, GPT-Image-1-Mini, and GPT-Image-2 models
 - **Gemini**: Gemini native image models (NanoBanana) and Imagen 3/4 models
+- **BytePlus**: Seedream 5.0, 4.5, and 4.0 models
 - **fal.ai**: 600+ models including Nano Banana Pro, FLUX, and more
 
 ## Basic Usage
@@ -66,6 +67,31 @@ const result2 = await generateImage({
 
 console.log(result.images[0]?.b64Json) // Base64 encoded image
 ```
+
+### BytePlus Image Generation
+
+Seedream sizes take either a token (`1K`, `2K`, `4K`) or explicit pixels (`2048x2048`) — never a mix of the two.
+
+```typescript
+import { generateImage } from '@tanstack/ai'
+import { byteplusImage } from '@tanstack/ai-byteplus'
+
+const result = await generateImage({
+  adapter: byteplusImage('dola-seedream-5-0-pro-260628'),
+  prompt: 'A futuristic cityscape at night',
+  size: '2K',
+  modelOptions: { watermark: false },
+})
+
+console.log(result.images[0]?.url)
+```
+
+Two Seedream behaviours differ from the other providers:
+
+- **`watermark` defaults to `true`** — BytePlus stamps "AI generated" into the corner unless you turn it off.
+- **`numberOfImages` is an upper bound, not a count.** Seedream has no `n` parameter, so more than one image maps onto its group-image mode and the model decides how many the prompt warrants. A request for four can return two.
+
+Image URLs expire after 24 hours; pass `response_format: 'b64_json'` in `modelOptions` for inline bytes. See the [BytePlus adapter](../adapters/byteplus#image-generation-seedream) for details.
 
 ## Options
 
@@ -328,6 +354,7 @@ await generateImage({
 | **fal.ai**   | Field names resolve per endpoint from a map generated from the fal SDK's endpoint types (e.g. nano-banana edit gets `image_urls`, Fooocus masks get `mask_image_url`). Defaults for unknown endpoints: 1 input → `image_url`; multiple → `image_urls`; `role: 'mask'` → `mask_url`; `role: 'control'` → `control_image_url`; `role: 'reference'` / `'character'` → `reference_image_urls`. Override with `modelOptions` for endpoint-specific fields. |
 | **Grok**     | grok-imagine models → xAI's `/v1/images/edits` (up to 3 source images, addressed by xAI in request order; prompt sent verbatim). `role: 'mask'` / `'control'` throw (no Imagine API equivalent). `grok-2-image-1212` throws (text-to-image only). |
 | **OpenRouter** | Prompt parts map 1:1 onto multimodal `image_url` / `text` content parts, preserving interleaved order, and are forwarded to the underlying image model.                                                                                    |
+| **BytePlus** | Seedream models → every input image is a plain reference on the `image` field (up to 14, or 10 on `dola-seedream-5-0-pro-260628`). There is no mask, control or frame channel, so any role other than `'reference'` / `'character'` throws rather than being silently flattened. |
 | **Anthropic** | n/a — no image generation API.                                                                                                                                                                          |
 
 Adapters that don't support image-conditioned generation throw a clear
@@ -707,6 +734,7 @@ The image adapters use the same environment variables as the text adapters:
 
 - **OpenAI**: `OPENAI_API_KEY`
 - **Gemini** (including NanoBanana): `GOOGLE_API_KEY` or `GEMINI_API_KEY`
+- **BytePlus** (Seedream): `ARK_API_KEY` or `BYTEPLUS_API_KEY`
 
 ## Explicit API Keys
 

--- a/docs/media/text-to-speech.md
+++ b/docs/media/text-to-speech.md
@@ -2,7 +2,7 @@
 title: Text-to-Speech
 id: text-to-speech
 order: 3
-description: "Convert text to spoken audio with OpenAI TTS and Gemini voice models via TanStack AI's generateSpeech() API."
+description: "Convert text to spoken audio with OpenAI TTS, Gemini voice models, and BytePlus Seed Speech via TanStack AI's generateSpeech() API."
 keywords:
   - tanstack ai
   - text-to-speech
@@ -23,6 +23,7 @@ Text-to-speech (TTS) is handled by TTS adapters that follow the same tree-shakea
 
 - **OpenAI**: TTS-1, TTS-1-HD, and audio-capable GPT-4o models
 - **Gemini**: Gemini 2.5 Flash TTS (experimental)
+- **BytePlus**: Seed Speech (`seed-audio-1.0`)
 - **fal.ai**: Kokoro, ElevenLabs, MiniMax, Chatterbox, Dia, Orpheus, F5-TTS, VibeVoice, and more
 
 ## Basic Usage
@@ -108,6 +109,28 @@ const result = await generateSpeech({
   },
 })
 ```
+
+### BytePlus Seed Speech
+
+Seed Speech is a **separate BytePlus product from ModelArk**, so it uses its own key (`BYTEPLUS_VOICE_API_KEY`) rather than the `ARK_API_KEY` the chat, image and video adapters read. Voice ids go on the wire as Seed Speech's `speaker`:
+
+```typescript
+import { generateSpeech } from '@tanstack/ai'
+import { byteplusSpeech } from '@tanstack/ai-byteplus'
+
+const result = await generateSpeech({
+  adapter: byteplusSpeech('seed-audio-1.0'),
+  text: 'Welcome to TanStack AI!',
+  voice: 'en_female_stokie_uranus_bigtts',
+  format: 'mp3',
+})
+
+console.log(result.contentType) // "audio/mpeg"
+```
+
+Formats are `wav`, `mp3`, `pcm` and `ogg_opus`, and synthesis is **capped at 120 seconds of output**. Set `modelOptions.enable_subtitle` for sentence- and word-level timings — note those timings are in milliseconds while `duration` is in seconds.
+
+Seed Speech has no top-level `speaker` field: the adapter sends `voice` as `references: [{ speaker }]`. Because `modelOptions.references` **replaces** that array rather than merging into it, passing `references` for voice cloning silently drops `voice` — include a `speaker` member yourself if you still want a stock voice. See the [BytePlus adapter](../adapters/byteplus#text-to-speech-seed-speech) for the voice-id naming conventions.
 
 ## Options
 
@@ -508,6 +531,7 @@ The TTS adapters use the same environment variables as other adapters:
 
 - **OpenAI**: `OPENAI_API_KEY`
 - **Gemini**: `GOOGLE_API_KEY` or `GEMINI_API_KEY`
+- **BytePlus**: `BYTEPLUS_VOICE_API_KEY` (Seed Speech is a different product from ModelArk — the `ARK_API_KEY` used by the chat/image/video adapters is not accepted here)
 
 ## Explicit API Keys
 

--- a/docs/media/transcription.md
+++ b/docs/media/transcription.md
@@ -2,7 +2,7 @@
 title: Transcription
 id: transcription
 order: 4
-description: "Transcribe audio to text with OpenAI Whisper and GPT-4o transcription models (including speaker diarization), Groq Whisper, and fal.ai STT models via TanStack AI's generateTranscription() API."
+description: "Transcribe audio to text with OpenAI Whisper and GPT-4o transcription models (including speaker diarization), Groq Whisper, BytePlus Seed Speech, and fal.ai STT models via TanStack AI's generateTranscription() API."
 keywords:
   - tanstack ai
   - transcription
@@ -26,6 +26,7 @@ Audio transcription is handled by transcription adapters that follow the same tr
 Currently supported:
 - **OpenAI**: Whisper-1, GPT-4o-transcribe, GPT-4o-mini-transcribe, GPT-4o-transcribe-diarize
 - **Groq**: whisper-large-v3-turbo, whisper-large-v3
+- **BytePlus**: Seed Speech ASR (`seed-asr`)
 - **fal.ai**: Whisper, Wizper, speech-to-text turbo, ElevenLabs speech-to-text
 
 ## Basic Usage
@@ -107,6 +108,31 @@ for (const segment of result.segments ?? []) {
 ```
 
 > **Note:** Groq supports `responseFormat` values `json`, `text`, and `verbose_json` (default). `srt` and `vtt` are not supported — passing them throws. Provider-specific `modelOptions` are `temperature` and `timestamp_granularities` (`['word']`, `['segment']`, or both).
+
+### BytePlus Transcription
+
+BytePlus Seed Speech ASR is synchronous — audio in, transcript out, no polling. It belongs to the Seed Speech product, so it reads `BYTEPLUS_VOICE_API_KEY` rather than the `ARK_API_KEY` used by the BytePlus chat, image and video adapters. Audio can be a `File`, base64, a data URL or a public URL, up to two hours and 100 MB.
+
+```typescript
+import { generateTranscription } from '@tanstack/ai'
+import { byteplusTranscription } from '@tanstack/ai-byteplus'
+
+const result = await generateTranscription({
+  adapter: byteplusTranscription('seed-asr'),
+  audio: 'https://example.com/recording.mp3',
+  language: 'en',
+  modelOptions: { enable_punc: true, enable_speaker_info: true },
+})
+
+console.log(result.text)
+
+// Speaker labels land on the segment when enable_speaker_info is set
+for (const segment of result.segments ?? []) {
+  console.log(`[${segment.speaker ?? 'unknown'}] ${segment.text}`)
+}
+```
+
+> **Note:** Provider-specific `modelOptions` are `enable_itn` (spoken numbers and dates as digits), `enable_punc` (punctuation), `enable_ddc` (drop fillers and stutters), `enable_speaker_info` (speaker labels) and `show_utterances` (per-utterance breakdown, on by default).
 
 ### fal.ai Transcription
 
@@ -614,6 +640,7 @@ try {
 The transcription adapter uses:
 
 - `OPENAI_API_KEY`: Your OpenAI API key
+- `BYTEPLUS_VOICE_API_KEY`: Your BytePlus Seed Speech key (not the ModelArk key)
 
 ## Explicit API Keys
 

--- a/docs/media/video-generation.md
+++ b/docs/media/video-generation.md
@@ -749,7 +749,20 @@ const { jobId } = await generateVideo({
 
 Options are **model-specific and validated server-side**: Ark rejects an inapplicable field with a `400` instead of ignoring it. `service_tier` and `camera_fixed` are Seedance 1.x only, `frames` works on the 1.0-pro models, `draft` on 1.5-pro, `priority` on the 2.0 family, and `duration: -1` (let the model choose) on 2.0 and 1.5-pro. Durations are 4–15s on the 2.0 family, 4–12s on 1.5-pro and 2–12s on the 1.0-pro models.
 
-**Seedance video URLs expire 24 hours after the task completes** (the task record is kept for seven days), so persist the bytes rather than the link. See the [BytePlus adapter](../adapters/byteplus#video-generation-seedance) for the full option table, and note that Seedance is also reachable indirectly through the [fal adapter](../adapters/fal) — this is the direct-to-BytePlus path.
+**Seedance video URLs expire 24 hours after the task completes** (the task record is kept for seven days), so persist the bytes rather than the link. See the [BytePlus adapter](../adapters/byteplus#video-generation-seedance) for the full option table.
+
+#### Porting a Seedance call between providers
+
+Seedance is reachable through more than one adapter — this package is the direct-to-BytePlus path, and the [fal adapter](../adapters/fal) proxies the same models. The `metadata.role` vocabulary is identical across them (see the role table above), but **`size` is not**, because each provider sizes its endpoints differently:
+
+| Adapter                | `size` shape                             | Example        |
+| ---------------------- | ---------------------------------------- | -------------- |
+| `@tanstack/ai-byteplus` | `ratio` or `ratio_resolution` (required ratio) | `'16:9_720p'`, `'16:9'` |
+| `@tanstack/ai-fal`      | `ratio_resolution`, `ratio`, **or** a bare resolution | `'16:9_720p'`, `'16:9'`, `'720p'` |
+
+A bare `size: '720p'` is valid on fal and throws on BytePlus, which follows the [Grok Imagine](#grok-xai-imagine-model-options) template and always wants the ratio. Pass the ratio explicitly (`'16:9_720p'`) and the same string works on both.
+
+The mode also moves: fal encodes it in the endpoint id (`fal-ai/bytedance/seedance/v1/pro/image-to-video` vs `.../reference-to-video`), while BytePlus takes one model id and infers the mode from the prompt parts you attach. Neither is configurable — it follows each provider's own API.
 
 ## Response Types
 

--- a/docs/media/video-generation.md
+++ b/docs/media/video-generation.md
@@ -2,7 +2,7 @@
 title: Video Generation
 id: video-generation
 order: 6
-description: "Generate video from text prompts with OpenAI Sora, Google Veo, Gemini Omni Flash, xAI Grok Imagine, or fal.ai using TanStack AI's experimental generateVideo() jobs/polling API."
+description: "Generate video from text prompts with OpenAI Sora, Google Veo, Gemini Omni Flash, xAI Grok Imagine, BytePlus Seedance, or fal.ai using TanStack AI's experimental generateVideo() jobs/polling API."
 keywords:
   - tanstack ai
   - video generation
@@ -12,6 +12,8 @@ keywords:
   - interactions api
   - gemini
   - grok imagine
+  - seedance
+  - byteplus
   - fal
   - generateVideo
   - jobs api
@@ -44,6 +46,7 @@ Currently supported:
 - **OpenAI**: Sora-2 and Sora-2-Pro models (when available)
 - **Google Gemini**: Veo 3.1 models (via the long-running operations API), and Gemini Omni Flash (via the Interactions API)
 - **Grok (xAI)**: grok-imagine-video (text-to-video + image-to-video) and grok-imagine-video-1.5 (image-to-video only) models
+- **BytePlus**: Seedance 2.0, 1.5-pro and 1.0-pro models (text-to-video, first/last frame, and multimodal references on 2.0)
 - **fal.ai**: MiniMax, Luma, Kling, Hunyuan, and other hosted video models
 
 > **Video runs take minutes — don't lose them to a reload.** This is the
@@ -444,9 +447,9 @@ adapter uses to route the input to the provider-specific field:
 
 | Role            | Maps to                                                       |
 | --------------- | ------------------------------------------------------------- |
-| `'start_frame'` | fal `start_image_url`, Veo input `image` (positional default for the first input) |
-| `'end_frame'`   | fal `end_image_url`, Veo `lastFrame`                          |
-| `'reference'`   | fal `reference_image_urls`, Veo `referenceImages`             |
+| `'start_frame'` | fal `start_image_url`, Veo input `image` (positional default for the first input), Seedance `first_frame` |
+| `'end_frame'`   | fal `end_image_url`, Veo `lastFrame`, Seedance `last_frame`   |
+| `'reference'`   | fal `reference_image_urls`, Veo `referenceImages`, Seedance `reference_image` |
 | `'character'`   | Same as `'reference'` — character consistency images                    |
 
 ```typescript
@@ -475,6 +478,7 @@ await generateVideo({
 | **OpenAI**   | Sora-2 / Sora-2-Pro → the image part goes to `input_reference`; flattened text is the prompt. Single image only — throws if more than one. |
 | **fal.ai**   | Field names resolve per endpoint from a map generated from the fal SDK's endpoint types — e.g. `role: 'start_frame'` lands on `image_url` for Kling/Veo image-to-video, `first_frame_url` for first-last-frame endpoints, and `start_image_url` otherwise. Defaults: single input → `image_url` (start frame); `role: 'end_frame'` → `end_image_url`; `role: 'reference'` / `'character'` → `reference_image_urls`. Override per-endpoint via `modelOptions` — the media-conditioning fields are typed optional there (even when the endpoint requires them) since they usually arrive as prompt parts. |
 | **Gemini**   | Veo → the first un-roled / `'start_frame'` image becomes the input image; `'end_frame'` → `lastFrame`; `'reference'` / `'character'` → `referenceImages` (asset references, Veo 3.1). Throws on multiple starting images. |
+| **BytePlus** | Seedance → a single un-roled or `'start_frame'` image becomes `first_frame`; `'end_frame'` → `last_frame` (needs a first frame alongside it, and is rejected by `seedance-1-0-pro-fast-251015`); `'reference'` / `'character'` → `reference_image`, video parts → `reference_video`, audio parts → `reference_audio` (Seedance 2.0 family only). Frame roles and reference roles are mutually exclusive modes — mixing them throws. |
 
 Adapters whose underlying API can't accept image inputs throw a clear
 runtime error so calls fail fast.
@@ -722,6 +726,31 @@ adapter.snapDuration(99) // 15
 
 Generated clips include an audio track. When the job completes, the adapter reports `usage.unitsBilled` (billed seconds of video) and `usage.cost` (exact USD cost as returned by the API) on the result.
 
+### BytePlus (Seedance) Model Options
+
+Seedance is aspect-ratio sized like Grok Imagine — `size` takes a `ratio` or `ratio_resolution` template. Ratios are `16:9`, `9:16`, `4:3`, `3:4`, `1:1`, `21:9` and `adaptive`; resolutions are `480p`, `720p`, `1080p` and (on `dreamina-seedance-2-0-260128` only) `4k`. There is no 2K tier on any Seedance model:
+
+```typescript
+import { generateVideo } from '@tanstack/ai'
+import { byteplusVideo } from '@tanstack/ai-byteplus'
+
+const { jobId } = await generateVideo({
+  adapter: byteplusVideo('dreamina-seedance-2-0-260128'),
+  prompt: 'A beautiful sunset over the ocean',
+  size: '16:9_720p',
+  duration: 5,
+  modelOptions: {
+    seed: 42,
+    generate_audio: true,
+    priority: 5, // Seedance 2.0 family only — queue priority, 0-9
+  },
+})
+```
+
+Options are **model-specific and validated server-side**: Ark rejects an inapplicable field with a `400` instead of ignoring it. `service_tier` and `camera_fixed` are Seedance 1.x only, `frames` works on the 1.0-pro models, `draft` on 1.5-pro, `priority` on the 2.0 family, and `duration: -1` (let the model choose) on 2.0 and 1.5-pro. Durations are 4–15s on the 2.0 family, 4–12s on 1.5-pro and 2–12s on the 1.0-pro models.
+
+**Seedance video URLs expire 24 hours after the task completes** (the task record is kept for seven days), so persist the bytes rather than the link. See the [BytePlus adapter](../adapters/byteplus#video-generation-seedance) for the full option table, and note that Seedance is also reachable indirectly through the [fal adapter](../adapters/fal) — this is the direct-to-BytePlus path.
+
 ## Response Types
 
 > **Note:** The interfaces below are the underlying adapter-level types. The `getVideoJobStatus()` helper returns a single merged object, `{ status, progress?, url?, error?, usage? }` — it does not return `jobId` or `expiresAt`.
@@ -832,6 +861,7 @@ for their provider:
 
 - `OPENAI_API_KEY`: Your OpenAI API key (Sora)
 - `GOOGLE_API_KEY` or `GEMINI_API_KEY`: Your Google API key (Veo)
+- `ARK_API_KEY` (or `BYTEPLUS_API_KEY`): Your BytePlus ModelArk key (Seedance)
 
 ## Explicit API Keys
 

--- a/examples/ts-react-chat/.env.example
+++ b/examples/ts-react-chat/.env.example
@@ -42,6 +42,20 @@ ELEVENLABS_API_KEY=
 # Create an agent at: https://elevenlabs.io/app/conversational-ai
 ELEVENLABS_AGENT_ID=
 
+# BytePlus needs TWO different keys from TWO different products — one is not a
+# fallback for the other.
+#
+# BytePlus ModelArk key (chat, images, video). Falls back to BYTEPLUS_API_KEY.
+# Ark keys are region-isolated: a key issued for one region won't work against
+# another region's host.
+# Get yours at: https://docs.byteplus.com/en/docs/ModelArk/
+ARK_API_KEY=
+
+# BytePlus Voice key (Seed Speech TTS + ASR) — a separate product from ModelArk
+# with its own key; the Ark key will not authenticate against it.
+# Get yours at: https://docs.byteplus.com/en/docs/byteplusvoice/
+BYTEPLUS_VOICE_API_KEY=
+
 # ── Sandbox triage demo (/sandboxes) ────────────────────────────────────────
 
 # GitHub token — raises API rate limits for the triage tools (issue comments,

--- a/examples/ts-react-chat/package.json
+++ b/examples/ts-react-chat/package.json
@@ -21,6 +21,7 @@
     "@tanstack/ai": "workspace:*",
     "@tanstack/ai-anthropic": "workspace:*",
     "@tanstack/ai-bedrock": "workspace:*",
+    "@tanstack/ai-byteplus": "workspace:*",
     "@tanstack/ai-claude-code": "workspace:*",
     "@tanstack/ai-client": "workspace:*",
     "@tanstack/ai-code-mode": "workspace:*",

--- a/examples/ts-react-chat/src/lib/audio-providers.ts
+++ b/examples/ts-react-chat/src/lib/audio-providers.ts
@@ -14,6 +14,7 @@ export type SpeechProviderId =
   | 'fal'
   | 'grok'
   | 'elevenlabs'
+  | 'byteplus'
 
 export interface SpeechProviderConfig {
   id: SpeechProviderId
@@ -87,6 +88,19 @@ export const SPEECH_PROVIDERS: ReadonlyArray<SpeechProviderConfig> = [
     ],
     placeholder: 'Enter text to synthesize with ElevenLabs…',
   },
+  {
+    id: 'byteplus',
+    label: 'BytePlus Seed Speech',
+    model: 'seed-audio-1.0',
+    // Voice ids ("speakers") encode language, gender, character and TTS
+    // generation. The full roster lives at
+    // https://docs.byteplus.com/en/docs/byteplusvoice/voicelist; this is the
+    // adapter's default. Output formats: wav | mp3 | pcm | ogg_opus.
+    voices: [
+      { id: 'en_female_stokie_uranus_bigtts', label: 'Stokie (EN female)' },
+    ],
+    placeholder: 'Enter text for BytePlus Seed Speech…',
+  },
 ]
 
 export type TranscriptionProviderId =
@@ -95,6 +109,7 @@ export type TranscriptionProviderId =
   | 'fal'
   | 'grok'
   | 'elevenlabs'
+  | 'byteplus'
 
 export interface TranscriptionProviderConfig {
   id: TranscriptionProviderId
@@ -146,6 +161,13 @@ export const TRANSCRIPTION_PROVIDERS: ReadonlyArray<TranscriptionProviderConfig>
       model: 'scribe_v1',
       description:
         'ElevenLabs Scribe with diarization, keyterm biasing, and PII redaction.',
+    },
+    {
+      id: 'byteplus',
+      label: 'BytePlus Seed ASR',
+      model: 'seed-asr',
+      description:
+        'BytePlus Seed Speech ASR with utterance and word-level timestamps.',
     },
   ]
 

--- a/examples/ts-react-chat/src/lib/model-selection.ts
+++ b/examples/ts-react-chat/src/lib/model-selection.ts
@@ -8,6 +8,7 @@ export type Provider =
   | 'groq'
   | 'openrouter'
   | 'bedrock'
+  | 'byteplus'
 
 export interface ModelOption {
   provider: Provider
@@ -217,6 +218,52 @@ export const MODEL_OPTIONS: Array<ModelOption> = [
     model: 'openai.gpt-oss-120b-1:0',
     label: 'Bedrock - GPT-OSS 120B (Converse)',
   },
+
+  // BytePlus ModelArk (ARK_API_KEY) — Seed models plus third-party models
+  // (GLM, DeepSeek, gpt-oss) served from the same Ark endpoint.
+  {
+    provider: 'byteplus',
+    model: 'dola-seed-2-1-turbo-260628',
+    label: 'BytePlus - Seed 2.1 Turbo',
+  },
+  {
+    provider: 'byteplus',
+    model: 'seed-2-0-pro-260328',
+    label: 'BytePlus - Seed 2.0 Pro',
+  },
+  {
+    provider: 'byteplus',
+    model: 'seed-2-0-lite-260428',
+    label: 'BytePlus - Seed 2.0 Lite',
+  },
+  {
+    provider: 'byteplus',
+    model: 'seed-2-0-mini-260428',
+    label: 'BytePlus - Seed 2.0 Mini',
+  },
+  {
+    provider: 'byteplus',
+    model: 'seed-2-0-code-preview-260328',
+    label: 'BytePlus - Seed 2.0 Code Preview',
+  },
+  {
+    provider: 'byteplus',
+    model: 'seed-1-6-flash-250715',
+    label: 'BytePlus - Seed 1.6 Flash',
+  },
+  {
+    provider: 'byteplus',
+    model: 'glm-5-2-260617',
+    label: 'BytePlus - GLM 5.2',
+  },
+  {
+    provider: 'byteplus',
+    model: 'deepseek-v4-pro-260425',
+    label: 'BytePlus - DeepSeek V4 Pro',
+  },
+  // gpt-oss-120b-250805 is deliberately absent: this route always merges the
+  // server tool set into the request, and that model's tool support is
+  // undeclared in model-meta and unverified against the live API.
 ]
 
 export const DEFAULT_MODEL_OPTION = MODEL_OPTIONS[0]

--- a/examples/ts-react-chat/src/lib/server-audio-adapters.ts
+++ b/examples/ts-react-chat/src/lib/server-audio-adapters.ts
@@ -14,6 +14,7 @@ import {
   elevenlabsTranscription,
 } from '@tanstack/ai-elevenlabs'
 import { grokSpeech, grokTranscription } from '@tanstack/ai-grok'
+import { byteplusSpeech, byteplusTranscription } from '@tanstack/ai-byteplus'
 import type {
   AnyAudioAdapter,
   AnyTranscriptionAdapter,
@@ -55,6 +56,10 @@ export function buildSpeechAdapter(provider: SpeechProviderId): AnyTTSAdapter {
       return grokSpeech(config.model as 'grok-tts')
     case 'elevenlabs':
       return elevenlabsSpeech(config.model as 'eleven_multilingual_v2')
+    case 'byteplus':
+      // Seed Speech TTS authenticates with BYTEPLUS_VOICE_API_KEY — a
+      // different product (and key) from the ARK_API_KEY used for chat.
+      return byteplusSpeech(config.model as 'seed-audio-1.0')
   }
 }
 
@@ -73,6 +78,9 @@ export function buildTranscriptionAdapter(
       return grokTranscription(config.model as 'grok-stt')
     case 'elevenlabs':
       return elevenlabsTranscription(config.model as 'scribe_v1')
+    case 'byteplus':
+      // Seed Speech ASR shares the BYTEPLUS_VOICE_API_KEY key with TTS.
+      return byteplusTranscription(config.model as 'seed-asr')
   }
 }
 

--- a/examples/ts-react-chat/src/lib/server-fns.ts
+++ b/examples/ts-react-chat/src/lib/server-fns.ts
@@ -80,11 +80,11 @@ function rethrowAudioAdapterError(err: unknown): never {
 }
 
 const SPEECH_PROVIDER_SCHEMA = z
-  .enum(['openai', 'gemini', 'fal', 'grok', 'elevenlabs'])
+  .enum(['openai', 'gemini', 'fal', 'grok', 'elevenlabs', 'byteplus'])
   .optional()
 
 const TRANSCRIPTION_PROVIDER_SCHEMA = z
-  .enum(['openai', 'openai-diarize', 'fal', 'grok', 'elevenlabs'])
+  .enum(['openai', 'openai-diarize', 'fal', 'grok', 'elevenlabs', 'byteplus'])
   .optional()
 
 const TRANSCRIPTION_RESPONSE_FORMAT_SCHEMA = z

--- a/examples/ts-react-chat/src/routes/api.generate.speech.ts
+++ b/examples/ts-react-chat/src/routes/api.generate.speech.ts
@@ -22,7 +22,7 @@ import {
 } from '../lib/generation-server-store'
 
 const SPEECH_PROVIDER_SCHEMA = z
-  .enum(['openai', 'gemini', 'fal', 'grok', 'elevenlabs'])
+  .enum(['openai', 'gemini', 'fal', 'grok', 'elevenlabs', 'byteplus'])
   .optional()
 
 const SPEECH_BODY_SCHEMA = z.object({

--- a/examples/ts-react-chat/src/routes/api.tanchat.ts
+++ b/examples/ts-react-chat/src/routes/api.tanchat.ts
@@ -16,6 +16,7 @@ import { openRouterText } from '@tanstack/ai-openrouter'
 import { grokText } from '@tanstack/ai-grok'
 import { groqText } from '@tanstack/ai-groq'
 import { bedrockText } from '@tanstack/ai-bedrock'
+import { byteplusText } from '@tanstack/ai-byteplus'
 import type { AnyTextAdapter, ChatMiddleware } from '@tanstack/ai'
 import {
   addToCartToolDef,
@@ -42,6 +43,7 @@ type Provider =
   | 'groq'
   | 'openrouter'
   | 'bedrock'
+  | 'byteplus'
 
 const SYSTEM_PROMPT = `You are a helpful assistant for a guitar store.
 
@@ -321,6 +323,15 @@ export const Route = createFileRoute('/api/tanchat')({
                     auth: 'sigv4' as const,
                   }),
                 },
+              ),
+            }),
+          byteplus: () =>
+            createChatOptions({
+              // BytePlus ModelArk (ARK_API_KEY, falling back to
+              // BYTEPLUS_API_KEY). Keys are region-isolated — an EU key will
+              // not work against the Asia-Pacific host.
+              adapter: byteplusText(
+                (model || 'seed-2-0-lite-260428') as 'seed-2-0-lite-260428',
               ),
             }),
           ollama: () =>

--- a/examples/ts-react-chat/src/routes/api.transcribe.ts
+++ b/examples/ts-react-chat/src/routes/api.transcribe.ts
@@ -22,7 +22,7 @@ import {
 } from '../lib/generation-server-store'
 
 const TRANSCRIPTION_PROVIDER_SCHEMA = z
-  .enum(['openai', 'openai-diarize', 'fal', 'grok', 'elevenlabs'])
+  .enum(['openai', 'openai-diarize', 'fal', 'grok', 'elevenlabs', 'byteplus'])
   .optional()
 
 const TRANSCRIPTION_RESPONSE_FORMAT_SCHEMA = z

--- a/examples/ts-react-media/.env.example
+++ b/examples/ts-react-media/.env.example
@@ -9,3 +9,8 @@ GOOGLE_API_KEY=
 # Get an xAI API key at https://console.x.ai — used by the "xAI Direct"
 # Grok Imagine video models (the other Grok Imagine entries go through fal).
 XAI_API_KEY=
+
+# Get a BytePlus ModelArk key at https://console.byteplus.com/ark — used by
+# Seedream image generation and the Seedance Studio page. Ark keys are
+# region-isolated and Seedance is only served from the Asia-Pacific endpoint.
+ARK_API_KEY=

--- a/examples/ts-react-media/package.json
+++ b/examples/ts-react-media/package.json
@@ -16,6 +16,7 @@
     "@tanstack/ai-fal": "workspace:*",
     "@tanstack/ai-gemini": "workspace:*",
     "@tanstack/ai-grok": "workspace:*",
+    "@tanstack/ai-react": "workspace:*",
     "@tanstack/react-router": "^1.158.4",
     "@tanstack/react-start": "^1.159.0",
     "@tanstack/router-plugin": "^1.158.4",

--- a/examples/ts-react-media/package.json
+++ b/examples/ts-react-media/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/ai": "workspace:*",
+    "@tanstack/ai-byteplus": "workspace:*",
     "@tanstack/ai-fal": "workspace:*",
     "@tanstack/ai-gemini": "workspace:*",
     "@tanstack/ai-grok": "workspace:*",

--- a/examples/ts-react-media/src/components/Header.tsx
+++ b/examples/ts-react-media/src/components/Header.tsx
@@ -1,5 +1,9 @@
 import { Link } from '@tanstack/react-router'
 
+const navLinkClass =
+  'px-3 py-1.5 rounded-lg text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white transition-colors'
+const navLinkActiveClass = 'bg-gray-700 text-white'
+
 export default function Header() {
   return (
     <header className="p-4 flex items-center bg-gray-800 text-white shadow-lg">
@@ -12,6 +16,23 @@ export default function Header() {
       <span className="ml-4 text-sm text-gray-400">
         Image & Video Generation
       </span>
+      <nav className="ml-auto flex items-center gap-1">
+        <Link
+          to="/"
+          className={navLinkClass}
+          activeProps={{ className: `${navLinkClass} ${navLinkActiveClass}` }}
+          activeOptions={{ exact: true }}
+        >
+          Generators
+        </Link>
+        <Link
+          to="/seedance"
+          className={navLinkClass}
+          activeProps={{ className: `${navLinkClass} ${navLinkActiveClass}` }}
+        >
+          Seedance Studio
+        </Link>
+      </nav>
     </header>
   )
 }

--- a/examples/ts-react-media/src/components/ImageGenerator.tsx
+++ b/examples/ts-react-media/src/components/ImageGenerator.tsx
@@ -28,6 +28,7 @@ function getImageSrc(image: { url?: string; b64Json?: string }): string {
 const falModels = IMAGE_MODELS.filter((m) => m.provider === 'fal')
 const geminiModels = IMAGE_MODELS.filter((m) => m.provider === 'gemini')
 const xaiModels = IMAGE_MODELS.filter((m) => m.provider === 'xai')
+const byteplusModels = IMAGE_MODELS.filter((m) => m.provider === 'byteplus')
 
 export default function ImageGenerator({
   onImageGenerated,
@@ -164,6 +165,13 @@ export default function ImageGenerator({
             </optgroup>
             <optgroup label="xAI (direct)">
               {xaiModels.map((model) => (
+                <option key={model.id} value={model.id}>
+                  {model.name}
+                </option>
+              ))}
+            </optgroup>
+            <optgroup label="BytePlus (direct)">
+              {byteplusModels.map((model) => (
                 <option key={model.id} value={model.id}>
                   {model.name}
                 </option>

--- a/examples/ts-react-media/src/components/ImageGenerator.tsx
+++ b/examples/ts-react-media/src/components/ImageGenerator.tsx
@@ -1,11 +1,12 @@
-import { useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ImageIcon, Loader2, Plus, Shuffle, X } from 'lucide-react'
-import type { ImageGenerationResult } from '@tanstack/ai'
+import { useGenerateImage } from '@tanstack/ai-react'
 import type { MediaPrompt } from '@tanstack/ai/client'
 
 import { generateImageFn } from '@/lib/server-functions'
 import { getRandomImagePrompt } from '@/lib/prompts'
 import { IMAGE_MODELS } from '@/lib/models'
+import type { ImageModel } from '@/lib/models'
 import { readMediaFile, toImagePart } from '@/lib/media'
 import type { AttachedMedia } from '@/lib/media'
 
@@ -13,11 +14,8 @@ interface ImageGeneratorProps {
   onImageGenerated?: (imageUrl: string) => void
 }
 
-type ModelResult = {
-  status: 'loading' | 'success' | 'error'
-  result?: ImageGenerationResult
-  error?: string
-}
+/** How the parent asks one card to run: the built prompt, nothing else. */
+type ImageRunner = (prompt: MediaPrompt) => void
 
 function getImageSrc(image: { url?: string; b64Json?: string }): string {
   if (image.url) return image.url
@@ -35,12 +33,24 @@ export default function ImageGenerator({
 }: ImageGeneratorProps) {
   const [prompt, setPrompt] = useState('')
   const [selectedModel, setSelectedModel] = useState<string>('all')
-  const [isLoading, setIsLoading] = useState(false)
-  const [results, setResults] = useState<Record<string, ModelResult>>({})
   const [images, setImages] = useState<Array<AttachedMedia>>([])
+  /** Whether anything has been generated for the current model selection. */
+  const [submitted, setSubmitted] = useState(false)
+  const [running, setRunning] = useState<Record<string, boolean>>({})
   const fileInputRef = useRef<HTMLInputElement>(null)
+  // Generation is started from the click, not from an effect on the cards:
+  // a hook only exists inside a mounted component, so the cards mount with
+  // the picker and hand the parent a way to run them.
+  const runnersRef = useRef(new Map<string, ImageRunner>())
 
   const currentModel = IMAGE_MODELS.find((m) => m.id === selectedModel)
+  const activeModels =
+    selectedModel === 'all'
+      ? IMAGE_MODELS
+      : IMAGE_MODELS.filter((model) => model.id === selectedModel)
+  // Each card owns its own generation, so the form's busy state is the union
+  // of what the cards report.
+  const isLoading = Object.values(running).some(Boolean)
 
   // When images are attached, send an ordered parts array (text first, then one
   // image part per attachment). Otherwise send the plain string. Only image-capable
@@ -49,7 +59,7 @@ export default function ImageGenerator({
     if (images.length === 0) return prompt
     return [
       { type: 'text', content: prompt },
-      ...images.map((image) => toImagePart(image)),
+      ...images.map((image) => toImagePart(image, { role: 'reference' })),
     ]
   }
 
@@ -65,73 +75,26 @@ export default function ImageGenerator({
     setImages((prev) => prev.filter((image) => image.id !== id))
   }
 
-  const handleGenerate = async () => {
+  const handleRunningChange = useCallback((modelId: string, value: boolean) => {
+    setRunning((prev) =>
+      prev[modelId] === value ? prev : { ...prev, [modelId]: value },
+    )
+  }, [])
+
+  const registerRunner = useCallback(
+    (modelId: string, run: ImageRunner | null) => {
+      if (run) runnersRef.current.set(modelId, run)
+      else runnersRef.current.delete(modelId)
+    },
+    [],
+  )
+
+  const handleGenerate = () => {
     if (!prompt.trim()) return
-    const builtPrompt = buildPrompt()
-
-    setIsLoading(true)
-    setResults({})
-
-    if (selectedModel === 'all') {
-      // Initialize all models as loading
-      const initialResults: Record<string, ModelResult> = {}
-      for (const model of IMAGE_MODELS) {
-        initialResults[model.id] = { status: 'loading' }
-      }
-      setResults(initialResults)
-
-      // Fire all requests in parallel
-      const promises = IMAGE_MODELS.map(async (model) => {
-        try {
-          const response = await generateImageFn({
-            data: { prompt: builtPrompt, model: model.id },
-          })
-          setResults((prev) => ({
-            ...prev,
-            [model.id]: { status: 'success', result: response },
-          }))
-          const image = response.images[0]
-          if (image) {
-            onImageGenerated?.(getImageSrc(image))
-          }
-        } catch (err) {
-          setResults((prev) => ({
-            ...prev,
-            [model.id]: {
-              status: 'error',
-              error:
-                err instanceof Error ? err.message : 'Failed to generate image',
-            },
-          }))
-        }
-      })
-
-      await Promise.allSettled(promises)
-      setIsLoading(false)
-    } else {
-      // Single model generation
-      setResults({ [selectedModel]: { status: 'loading' } })
-
-      try {
-        const response = await generateImageFn({
-          data: { prompt: builtPrompt, model: selectedModel },
-        })
-        setResults({ [selectedModel]: { status: 'success', result: response } })
-        const image = response.images[0]
-        if (image) {
-          onImageGenerated?.(getImageSrc(image))
-        }
-      } catch (err) {
-        setResults({
-          [selectedModel]: {
-            status: 'error',
-            error:
-              err instanceof Error ? err.message : 'Failed to generate image',
-          },
-        })
-      } finally {
-        setIsLoading(false)
-      }
+    const built = buildPrompt()
+    setSubmitted(true)
+    for (const model of activeModels) {
+      runnersRef.current.get(model.id)?.(built)
     }
   }
 
@@ -144,7 +107,12 @@ export default function ImageGenerator({
           </label>
           <select
             value={selectedModel}
-            onChange={(e) => setSelectedModel(e.target.value)}
+            onChange={(e) => {
+              setSelectedModel(e.target.value)
+              // The results below belong to the models that produced them.
+              setSubmitted(false)
+              setRunning({})
+            }}
             disabled={isLoading}
             className="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:opacity-50"
           >
@@ -213,8 +181,8 @@ export default function ImageGenerator({
               Reference Images
             </label>
             <span className="text-xs text-gray-500">
-              Supported by Gemini multimodal models only
-              (gemini-3.1-flash-image-preview, gemini-3-pro-image-preview)
+              Sent as image prompt parts with role &quot;reference&quot; —
+              accepted by the Gemini multimodal models, xAI Imagine and Seedream
             </span>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -276,57 +244,125 @@ export default function ImageGenerator({
         </button>
       </div>
 
-      {Object.keys(results).length > 0 && (
-        <div className="space-y-6">
+      <div className="space-y-6">
+        {submitted && (
           <h3 className="text-lg font-medium text-white">
-            {selectedModel === 'all' ? 'Generated Images' : 'Generated Image'}
+            {activeModels.length > 1 ? 'Generated Images' : 'Generated Image'}
           </h3>
-          {Object.entries(results).map(([modelId, modelResult]) => {
-            const model = IMAGE_MODELS.find((m) => m.id === modelId)
-            return (
-              <div key={modelId} className="space-y-2">
-                {selectedModel === 'all' && (
-                  <h4 className="text-sm font-medium text-gray-300">
-                    {model?.name ?? modelId}
-                  </h4>
-                )}
-                {modelResult.status === 'loading' && (
-                  <div className="flex items-center gap-2 p-4 bg-gray-800 rounded-lg border border-gray-700">
-                    <Loader2 className="w-5 h-5 animate-spin text-purple-400" />
-                    <span className="text-gray-400">Generating...</span>
-                  </div>
-                )}
-                {modelResult.status === 'error' && (
-                  <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400">
-                    {modelResult.error}
-                  </div>
-                )}
-                {modelResult.status === 'success' &&
-                  modelResult.result &&
-                  modelResult.result.images.length > 0 && (
-                    <>
-                      <div className="rounded-lg overflow-hidden border border-gray-700">
-                        <img
-                          src={getImageSrc(modelResult.result.images[0]!)}
-                          alt={`Generated by ${model?.name ?? modelId}`}
-                          className="w-full h-auto"
-                        />
-                      </div>
-                      {modelResult.result.usage?.unitsBilled != null && (
-                        <p className="text-xs text-gray-500">
-                          Billed {modelResult.result.usage.unitsBilled} fal unit
-                          {modelResult.result.usage.unitsBilled === 1
-                            ? ''
-                            : 's'}{' '}
-                          — multiply by the endpoint unit price for USD cost
-                        </p>
-                      )}
-                    </>
-                  )}
-              </div>
-            )
-          })}
+        )}
+        {activeModels.map((model) => (
+          <ImageModelCard
+            key={model.id}
+            model={model}
+            visible={submitted}
+            showTitle={activeModels.length > 1}
+            onRegister={registerRunner}
+            onRunningChange={handleRunningChange}
+            onImageGenerated={onImageGenerated}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * One model's generation. `useGenerateImage` owns the request lifecycle, so
+ * the card only decides what to render for each of its states — there is no
+ * per-model status bookkeeping left in the parent.
+ */
+function ImageModelCard({
+  model,
+  visible,
+  showTitle,
+  onRegister,
+  onRunningChange,
+  onImageGenerated,
+}: {
+  model: ImageModel
+  visible: boolean
+  showTitle: boolean
+  onRegister: (modelId: string, run: ImageRunner | null) => void
+  onRunningChange: (modelId: string, running: boolean) => void
+  onImageGenerated?: (imageUrl: string) => void
+}) {
+  const { generate, result, isLoading, error } = useGenerateImage({
+    threadId: `image:${model.id}`,
+    // The model is fixed for this card, so the server function's per-model
+    // switch is picked here rather than being sent as a request field.
+    // `options.signal` is the hook's abort signal — forwarding it lets an
+    // unmount or a `stop()` cancel the request rather than orphan it.
+    fetcher: (input, options) =>
+      generateImageFn({
+        data: { prompt: input.prompt, model: model.id },
+        signal: options?.signal,
+      }),
+    onResult: (generated) => {
+      const image = generated.images[0]
+      if (image) onImageGenerated?.(getImageSrc(image))
+    },
+  })
+
+  const run = useCallback(
+    (prompt: MediaPrompt) => {
+      // Deliberately not `reset()` first: reset stops the client, which clears
+      // the `isLoading` that makes a second `generate()` a no-op — that guard
+      // is what swallows a double-click. The stale result a failed re-run
+      // leaves behind is handled by the render gate below instead.
+      void generate({ prompt })
+    },
+    [generate],
+  )
+
+  useEffect(() => {
+    onRegister(model.id, run)
+    return () => onRegister(model.id, null)
+  }, [model.id, run, onRegister])
+
+  useEffect(() => {
+    onRunningChange(model.id, isLoading)
+  }, [model.id, isLoading, onRunningChange])
+
+  if (!visible) return null
+
+  const image = result?.images[0]
+
+  return (
+    <div className="space-y-2">
+      {showTitle && (
+        <h4 className="text-sm font-medium text-gray-300">{model.name}</h4>
+      )}
+      {isLoading && (
+        <div className="flex items-center gap-2 p-4 bg-gray-800 rounded-lg border border-gray-700">
+          <Loader2 className="w-5 h-5 animate-spin text-purple-400" />
+          <span className="text-gray-400">Generating...</span>
         </div>
+      )}
+      {error && !isLoading && (
+        <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400">
+          {error.message}
+        </div>
+      )}
+      {/* `!error`: a failed re-run keeps the previous result on the hook, and
+          it must not render underneath the new error. */}
+      {image && !isLoading && !error && (
+        <>
+          <div className="rounded-lg overflow-hidden border border-gray-700">
+            <img
+              src={getImageSrc(image)}
+              alt={`Generated by ${model.name}`}
+              className="w-full h-auto"
+            />
+          </div>
+          {result?.usage?.unitsBilled != null && (
+            <p className="text-xs text-gray-500">
+              Billed {result.usage.unitsBilled}{' '}
+              {model.provider === 'fal' ? 'fal ' : ''}unit
+              {result.usage.unitsBilled === 1 ? '' : 's'} — multiply by the
+              endpoint unit price for USD cost
+            </p>
+          )}
+        </>
       )}
     </div>
   )

--- a/examples/ts-react-media/src/components/OmniStudio.tsx
+++ b/examples/ts-react-media/src/components/OmniStudio.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import {
   GitBranch,
   Loader2,
@@ -9,21 +9,17 @@ import {
   Upload,
   X,
 } from 'lucide-react'
+import { useGenerateVideo } from '@tanstack/ai-react'
 import type { AttachedMedia } from '@/lib/media'
 import type { OmniTaskMode } from '@/lib/models'
 import type { MediaPromptPart } from '@tanstack/ai/client'
 
-import {
-  createVideoJobFn,
-  getVideoStatusFn,
-  getVideoUrlFn,
-} from '@/lib/server-functions'
+import { generateVideoFn } from '@/lib/server-functions'
 import { readMediaFile, toImagePart, toVideoPart } from '@/lib/media'
 
 const OMNI_MODEL = 'gemini-omni-flash-preview'
 /** Omni bills per second of generated video. */
 const PRICE_PER_SECOND = 0.1
-const POLL_INTERVAL_MS = 4000
 
 type AspectRatio = '16:9' | '9:16'
 
@@ -79,14 +75,21 @@ export default function OmniStudio() {
   const imageInputRef = useRef<HTMLInputElement>(null)
   const videoInputRef = useRef<HTMLInputElement>(null)
   const promptRef = useRef<HTMLTextAreaElement>(null)
-  const pollingRefs = useRef<Map<string, NodeJS.Timeout>>(new Map())
-
-  useEffect(() => {
-    return () => {
-      pollingRefs.current.forEach((interval) => clearInterval(interval))
-      pollingRefs.current.clear()
+  /**
+   * The turn currently on the wire, plus the request settings that go with
+   * it. `useGenerateVideo` builds its client (and captures the fetcher) once,
+   * so per-send values are read from here at call time instead of being
+   * closed over; the hook's callbacks use it to know which turn to update.
+   */
+  const submissionRef = useRef<{
+    localId: string
+    previousInteractionId?: string
+    omniOptions: {
+      duration?: number
+      aspectRatio: AspectRatio
+      task?: OmniTaskMode
     }
-  }, [])
+  } | null>(null)
 
   const updateTurn = (localId: string, patch: Partial<OmniTurn>) => {
     setTurns((prev) =>
@@ -96,44 +99,58 @@ export default function OmniStudio() {
     )
   }
 
-  const stopPolling = (localId: string) => {
-    const interval = pollingRefs.current.get(localId)
-    if (interval) {
-      clearInterval(interval)
-      pollingRefs.current.delete(localId)
-    }
-  }
-
-  const pollTurn = async (localId: string, jobId: string) => {
-    try {
-      const status = await getVideoStatusFn({
-        data: { jobId, model: OMNI_MODEL },
+  // One hook serves the whole session: only one turn can be in flight (the
+  // composer is disabled while generating), and the timeline of finished
+  // clips is this component's own state rather than something the hook models.
+  const { generate, isLoading } = useGenerateVideo({
+    threadId: 'omni-studio',
+    // `options.signal` is the hook's abort signal; cancelling the response is
+    // what ends the server's polling loop instead of leaving it running.
+    fetcher: (input, options) => {
+      const submission = submissionRef.current
+      if (!submission) throw new Error('No Omni turn in flight')
+      return generateVideoFn({
+        data: {
+          prompt: input.prompt,
+          model: OMNI_MODEL,
+          ...(submission.previousInteractionId
+            ? { previousInteractionId: submission.previousInteractionId }
+            : {}),
+          omniOptions: submission.omniOptions,
+        },
+        signal: options?.signal,
       })
-      if (status.status === 'completed') {
-        stopPolling(localId)
-        const urlResult = await getVideoUrlFn({
-          data: { jobId, model: OMNI_MODEL },
-        })
-        if (!urlResult.url) throw new Error('No URL found')
-        updateTurn(localId, { status: 'completed', url: urlResult.url })
-        // Conversational default: the newest finished clip becomes the one
-        // the next prompt continues from.
-        setContinueFrom(localId)
-      } else if (status.status === 'failed') {
-        stopPolling(localId)
-        updateTurn(localId, {
+    },
+    onJobCreated: (jobId) => {
+      const submission = submissionRef.current
+      if (submission) {
+        updateTurn(submission.localId, { status: 'processing', jobId })
+      }
+    },
+    onResult: (result) => {
+      const submission = submissionRef.current
+      if (!submission) return
+      // Clearing the ref is what re-opens the composer to the next send.
+      submissionRef.current = null
+      updateTurn(submission.localId, {
+        status: 'completed',
+        url: result.url,
+      })
+      // Conversational default: the newest finished clip becomes the one
+      // the next prompt continues from.
+      setContinueFrom(submission.localId)
+    },
+    onError: (err) => {
+      const submission = submissionRef.current
+      if (submission) {
+        submissionRef.current = null
+        updateTurn(submission.localId, {
           status: 'error',
-          error: status.error ?? 'Video generation failed',
+          error: err.message,
         })
       }
-    } catch (err) {
-      stopPolling(localId)
-      updateTurn(localId, {
-        status: 'error',
-        error: err instanceof Error ? err.message : 'Failed to get status',
-      })
-    }
-  }
+    },
+  })
 
   const handleImageSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? [])
@@ -158,9 +175,7 @@ export default function OmniStudio() {
     }
   }
 
-  const isBusy = turns.some(
-    (turn) => turn.status === 'submitting' || turn.status === 'processing',
-  )
+  const isBusy = isLoading
 
   const continueFromTurn = continueFrom
     ? turns.find((turn) => turn.localId === continueFrom)
@@ -198,7 +213,11 @@ export default function OmniStudio() {
   }
 
   const handleSend = async () => {
-    if (!prompt.trim() || isBusy) return
+    // `isBusy` comes from React state, which hasn't re-rendered yet for a
+    // second click in the same tick; the ref is set synchronously below and
+    // cleared when the run settles, so it closes that window — without it a
+    // second send would overwrite the submission and strand the first turn.
+    if (!prompt.trim() || isBusy || submissionRef.current) return
 
     const parentJobId = continueFromTurn?.jobId
     const localId = crypto.randomUUID()
@@ -233,31 +252,16 @@ export default function OmniStudio() {
     setImages([])
     setVideo(null)
 
-    try {
-      const result = await createVideoJobFn({
-        data: {
-          prompt: builtPrompt,
-          model: OMNI_MODEL,
-          ...(parentJobId ? { previousInteractionId: parentJobId } : {}),
-          omniOptions: {
-            ...(durationLocked ? {} : { duration }),
-            aspectRatio,
-            ...(task !== 'auto' ? { task } : {}),
-          },
-        },
-      })
-      updateTurn(localId, { status: 'processing', jobId: result.jobId })
-      const interval = setInterval(() => {
-        pollTurn(localId, result.jobId)
-      }, POLL_INTERVAL_MS)
-      pollingRefs.current.set(localId, interval)
-    } catch (err) {
-      updateTurn(localId, {
-        status: 'error',
-        error:
-          err instanceof Error ? err.message : 'Failed to create video job',
-      })
+    submissionRef.current = {
+      localId,
+      ...(parentJobId ? { previousInteractionId: parentJobId } : {}),
+      omniOptions: {
+        ...(durationLocked ? {} : { duration }),
+        aspectRatio,
+        ...(task !== 'auto' ? { task } : {}),
+      },
     }
+    await generate({ prompt: builtPrompt })
   }
 
   const estimatedCost = (duration * PRICE_PER_SECOND).toFixed(2)

--- a/examples/ts-react-media/src/components/SeedanceStudio.tsx
+++ b/examples/ts-react-media/src/components/SeedanceStudio.tsx
@@ -1,0 +1,1213 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Dices,
+  Download,
+  Film,
+  Loader2,
+  Shuffle,
+  Upload,
+  X,
+} from 'lucide-react'
+import type {
+  BytePlusVideoModel,
+  BytePlusVideoModelOrString,
+  BytePlusVideoRatio,
+  BytePlusVideoResolution,
+} from '@tanstack/ai-byteplus'
+import type { TokenUsage } from '@tanstack/ai'
+import type { MediaPromptPart } from '@tanstack/ai/client'
+import type { AttachedMedia } from '@/lib/media'
+import type {
+  SeedanceCapability,
+  SeedanceInputMode,
+  SeedanceJobOptions,
+  SeedanceModelEntry,
+} from '@/lib/seedance'
+
+import { createSeedanceJobFn, getSeedanceJobFn } from '@/lib/server-functions'
+import { readMediaFile, toImagePart } from '@/lib/media'
+import { getRandomVideoPrompt } from '@/lib/prompts'
+import {
+  SEEDANCE_CUSTOM_MODEL_PLACEHOLDER,
+  SEEDANCE_FPS,
+  SEEDANCE_MAX_FRAMES,
+  SEEDANCE_MIN_FRAMES,
+  SEEDANCE_MODELS,
+  SEEDANCE_RATIOS,
+  SEEDANCE_RESOLUTION_TIERS,
+  SEEDANCE_UNKNOWN_MODEL_EXTRAS,
+  describeSeedanceModel,
+  seedanceModel,
+  snapSeedanceFrames,
+} from '@/lib/seedance'
+
+const POLL_INTERVAL_MS = 5000
+/**
+ * Consecutive failed polls tolerated before the job is called failed. A flex
+ * task can sit queued for many minutes, so a single blip on the way to the
+ * status endpoint should not throw away a job that is still running.
+ */
+const MAX_POLL_FAILURES = 3
+/** How many reference images the studio offers on the 2.0 family. */
+const MAX_REFERENCE_IMAGES = 4
+/** Documented seed range; `-1` leaves generation unseeded. */
+const MIN_SEED = -1
+const MAX_SEED = 2 ** 32 - 1
+
+/** What was actually requested, kept alongside the job for the result panel. */
+interface JobSettings {
+  model: BytePlusVideoModelOrString
+  ratio: BytePlusVideoRatio
+  /** A tier this package knows, or whatever a custom model was asked for. */
+  resolution: string
+  /** Seconds, `-1` for model-chosen, or null when a frame count was sent. */
+  duration: number | null
+  frames: number | null
+  seed: number | null
+  serviceTier: 'default' | 'flex' | null
+}
+
+type JobState =
+  | { status: 'idle' }
+  | { status: 'submitting' }
+  | {
+      status: 'pending' | 'processing'
+      jobId: string
+      startedAt: number
+      settings: JobSettings
+    }
+  | {
+      status: 'completed'
+      jobId: string
+      startedAt: number
+      finishedAt: number
+      settings: JobSettings
+      url: string
+      expiresAt?: string
+      usage?: TokenUsage
+    }
+  | { status: 'error'; message: string }
+
+function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000))
+  const minutes = Math.floor(total / 60)
+  const seconds = total % 60
+  return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`
+}
+
+/**
+ * Direct BytePlus Seedance studio: one model at a time, with every control
+ * gated on what that model actually accepts.
+ *
+ * The gating is not cosmetic. Ark rejects an inapplicable field outright
+ * ("the specified parameter `draft` is not supported for model
+ * seedance-1-0-pro …") and sorts prompt media into mutually exclusive task
+ * types, so a form that let you mix a reference image into a first-and-last
+ * frame request, or send `priority` to a 1.x model, would only ever produce a
+ * 400. The capability half of the gating (`capabilities`) is read out of the
+ * adapter package on the server; the option-applicability half comes from
+ * `SEEDANCE_MODELS`.
+ */
+export default function SeedanceStudio({
+  capabilities,
+}: {
+  capabilities: Array<SeedanceCapability>
+}) {
+  const [modelId, setModelId] = useState<BytePlusVideoModel>(
+    'dreamina-seedance-2-0-260128',
+  )
+  const [prompt, setPrompt] = useState('')
+  const [inputMode, setInputMode] = useState<SeedanceInputMode>('text')
+  const [firstFrame, setFirstFrame] = useState<AttachedMedia | null>(null)
+  const [lastFrame, setLastFrame] = useState<AttachedMedia | null>(null)
+  const [references, setReferences] = useState<Array<AttachedMedia>>([])
+
+  const [ratio, setRatio] = useState<BytePlusVideoRatio>('16:9')
+  const [resolution, setResolution] = useState<BytePlusVideoResolution>('720p')
+  const [duration, setDuration] = useState(5)
+  const [autoDuration, setAutoDuration] = useState(false)
+  const [useFrames, setUseFrames] = useState(false)
+  const [frames, setFrames] = useState(121)
+
+  // Advanced escape hatch: a model id this package has no metadata for.
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [customModelId, setCustomModelId] = useState('')
+  const [customResolution, setCustomResolution] = useState('')
+
+  const [seed, setSeed] = useState('')
+  const [watermark, setWatermark] = useState(false)
+  const [generateAudio, setGenerateAudio] = useState(false)
+  const [cameraFixed, setCameraFixed] = useState(false)
+  const [flexTier, setFlexTier] = useState(false)
+  const [draft, setDraft] = useState(false)
+  const [priority, setPriority] = useState(5)
+
+  const [job, setJob] = useState<JobState>({ status: 'idle' })
+  const [now, setNow] = useState(() => Date.now())
+
+  const firstFrameInputRef = useRef<HTMLInputElement>(null)
+  const lastFrameInputRef = useRef<HTMLInputElement>(null)
+  const referenceInputRef = useRef<HTMLInputElement>(null)
+  const pollRef = useRef<NodeJS.Timeout | null>(null)
+  const pollFailuresRef = useRef(0)
+
+  // A non-empty custom id switches the studio into unknown-model mode: the
+  // adapter's per-model guards are off for an id it has no table for, so the
+  // full option surface is offered and Ark judges the request.
+  const customModel = customModelId.trim()
+  const usingCustomId = showAdvanced && customModel.length > 0
+  const activeModel: BytePlusVideoModelOrString = usingCustomId
+    ? customModel
+    : modelId
+
+  // A catalog miss takes the same path as a custom id rather than borrowing
+  // another model's option policy. It cannot happen while
+  // `SeedanceCatalogCoversEveryModel` compiles, which is the point.
+  const catalogEntry = usingCustomId ? undefined : seedanceModel(modelId)
+  const unknownMode = catalogEntry === undefined
+  const entry: SeedanceModelEntry = catalogEntry ?? {
+    id: activeModel,
+    name: activeModel,
+    blurb: 'Custom model id — capabilities unverified',
+    extras: SEEDANCE_UNKNOWN_MODEL_EXTRAS,
+  }
+  const capability = unknownMode
+    ? undefined
+    : capabilities.find((c) => c.model === modelId)
+  const resolutions = unknownMode
+    ? SEEDANCE_RESOLUTION_TIERS
+    : (capability?.resolutions ?? [])
+  const durationRange = capability?.duration ?? { min: 4, max: 12, step: 1 }
+  const canLastFrame = unknownMode || (capability?.supportsLastFrame ?? false)
+  const canReference =
+    unknownMode || (capability?.supportsReferenceMedia ?? false)
+
+  // Everything below clamps the raw control state to the selected model rather
+  // than rewriting it on change, so switching models to compare and switching
+  // back leaves your settings where you left them.
+  const effectiveMode: SeedanceInputMode =
+    (inputMode === 'first-last-frame' && !canLastFrame) ||
+    (inputMode === 'reference' && !canReference)
+      ? 'text'
+      : inputMode
+  const effectiveResolution = resolutions.includes(resolution)
+    ? resolution
+    : (resolutions[resolutions.length - 1] ?? '720p')
+  // A custom tier wins over the picker: a future model may bring one that does
+  // not exist today, which is the whole point of the free-text field.
+  const requestResolution: string =
+    unknownMode && customResolution.trim().length > 0
+      ? customResolution.trim()
+      : effectiveResolution
+  // An unknown model's duration is sent verbatim (the adapter deliberately
+  // does not snap it), so the input is free rather than clamped to a range
+  // borrowed from the models that happen to exist today.
+  const effectiveDuration = unknownMode
+    ? duration
+    : Math.min(durationRange.max, Math.max(durationRange.min, duration))
+  const effectiveFrames = snapSeedanceFrames(frames)
+  const framesActive = entry.extras.frames && useFrames
+  const autoDurationActive = entry.extras.autoDuration && autoDuration
+  const hasImageInput = effectiveMode !== 'text'
+  // `adaptive` follows the input frame, so it is only meaningful — and on the
+  // 1.0 models only accepted — once an image is attached.
+  const effectiveRatio: BytePlusVideoRatio =
+    ratio === 'adaptive' && !hasImageInput ? '16:9' : ratio
+
+  const isBusy =
+    job.status === 'submitting' ||
+    job.status === 'pending' ||
+    job.status === 'processing'
+
+  const stopPolling = () => {
+    if (pollRef.current) {
+      clearTimeout(pollRef.current)
+      pollRef.current = null
+    }
+    pollFailuresRef.current = 0
+  }
+
+  useEffect(() => stopPolling, [])
+
+  // Drive the elapsed-time readout; flex tasks can sit queued for many
+  // minutes, so the wait needs to look like progress.
+  useEffect(() => {
+    if (!isBusy) return
+    const tick = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(tick)
+  }, [isBusy])
+
+  const attachFile = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+    apply: (media: AttachedMedia) => void,
+  ) => {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+    try {
+      apply(await readMediaFile(file))
+    } catch {
+      // Unreadable file — leave the current attachment in place.
+    }
+  }
+
+  /** Queue the next poll. Self-scheduling, so a slow status call can never
+   *  stack up behind the previous one the way a fixed interval would. */
+  const schedulePoll = (jobId: string, model: BytePlusVideoModelOrString) => {
+    pollRef.current = setTimeout(() => {
+      pollJob(jobId, model)
+    }, POLL_INTERVAL_MS)
+  }
+
+  // The model is threaded through rather than read from state: a poll must
+  // keep asking about the model the job was submitted with, even if the picker
+  // or the custom id has moved on since.
+  const pollJob = async (jobId: string, model: BytePlusVideoModelOrString) => {
+    try {
+      const result = await getSeedanceJobFn({ data: { jobId, model } })
+      const { url, expiresAt, usage } = result
+      pollFailuresRef.current = 0
+      if (result.status === 'completed' && url) {
+        stopPolling()
+        setJob((prev) =>
+          prev.status === 'pending' || prev.status === 'processing'
+            ? {
+                status: 'completed',
+                jobId,
+                startedAt: prev.startedAt,
+                finishedAt: Date.now(),
+                settings: prev.settings,
+                url,
+                ...(expiresAt !== undefined && { expiresAt }),
+                ...(usage && { usage }),
+              }
+            : prev,
+        )
+      } else if (result.status === 'failed') {
+        // A terminal state from the provider, as opposed to a failed poll:
+        // this one is the job's own verdict and gets no retries.
+        stopPolling()
+        setJob({
+          status: 'error',
+          message: result.error ?? 'Video generation failed',
+        })
+      } else {
+        const status = result.status === 'pending' ? 'pending' : 'processing'
+        setJob((prev) =>
+          prev.status === 'pending' || prev.status === 'processing'
+            ? { ...prev, status }
+            : prev,
+        )
+        schedulePoll(jobId, model)
+      }
+    } catch (err) {
+      // The status call itself failed. The job is very likely still running —
+      // a flex task can be queued for many minutes — so ride out a few blips
+      // before declaring it dead.
+      pollFailuresRef.current += 1
+      if (pollFailuresRef.current < MAX_POLL_FAILURES) {
+        schedulePoll(jobId, model)
+        return
+      }
+      stopPolling()
+      setJob({
+        status: 'error',
+        message:
+          err instanceof Error
+            ? `${err.message} (after ${MAX_POLL_FAILURES} consecutive failed status checks)`
+            : 'Failed to get status',
+      })
+    }
+  }
+
+  const handleGenerate = async () => {
+    if (!prompt.trim() && !hasImageInput) return
+    stopPolling()
+    setJob({ status: 'submitting' })
+
+    const parts: Array<MediaPromptPart> = []
+    if (prompt.trim()) parts.push({ type: 'text', content: prompt })
+    if (
+      effectiveMode === 'first-frame' ||
+      effectiveMode === 'first-last-frame'
+    ) {
+      if (firstFrame)
+        parts.push(toImagePart(firstFrame, { role: 'start_frame' }))
+      if (effectiveMode === 'first-last-frame' && lastFrame) {
+        parts.push(toImagePart(lastFrame, { role: 'end_frame' }))
+      }
+    }
+    if (effectiveMode === 'reference') {
+      for (const reference of references) {
+        parts.push(toImagePart(reference, { role: 'reference' }))
+      }
+    }
+
+    // Clamped as well as bounded on the input: a number field still accepts
+    // out-of-range values typed or pasted straight in, and Ark rejects a seed
+    // outside `[-1, 2^32-1]`.
+    const parsedSeed = seed.trim() === '' ? null : Number(seed)
+    const seedValue =
+      parsedSeed !== null && Number.isFinite(parsedSeed)
+        ? Math.min(MAX_SEED, Math.max(MIN_SEED, Math.trunc(parsedSeed)))
+        : null
+
+    const settings: JobSettings = {
+      model: activeModel,
+      ratio: effectiveRatio,
+      resolution: requestResolution,
+      duration: framesActive
+        ? null
+        : autoDurationActive
+          ? -1
+          : effectiveDuration,
+      frames: framesActive ? effectiveFrames : null,
+      seed: seedValue,
+      serviceTier: entry.extras.serviceTier
+        ? flexTier
+          ? 'flex'
+          : 'default'
+        : null,
+    }
+
+    // Only fields the selected model accepts go on the wire — Ark 400s on the
+    // rest rather than ignoring them. A custom id accepts everything, and its
+    // sizing goes through the open `size` template because `resolution` is
+    // typed against the tiers this package knows.
+    const options: SeedanceJobOptions = {
+      ...(unknownMode
+        ? { size: `${effectiveRatio}_${requestResolution}` }
+        : { ratio: effectiveRatio, resolution: effectiveResolution }),
+      ...(framesActive
+        ? { frames: effectiveFrames }
+        : { duration: autoDurationActive ? -1 : effectiveDuration }),
+      ...(seedValue !== null && { seed: seedValue }),
+      watermark,
+      ...(entry.extras.generateAudio && { generateAudio }),
+      ...(entry.extras.cameraFixed && { cameraFixed }),
+      ...(entry.extras.serviceTier && {
+        serviceTier: flexTier ? 'flex' : 'default',
+      }),
+      ...(entry.extras.draft && { draft }),
+      ...(entry.extras.priority && { priority }),
+    }
+
+    try {
+      const result = await createSeedanceJobFn({
+        data: {
+          prompt: parts.length === 1 && !hasImageInput ? prompt : parts,
+          model: activeModel,
+          options,
+        },
+      })
+      setJob({
+        status: 'pending',
+        jobId: result.jobId,
+        startedAt: Date.now(),
+        settings,
+      })
+      schedulePoll(result.jobId, activeModel)
+    } catch (err) {
+      setJob({
+        status: 'error',
+        message:
+          err instanceof Error ? err.message : 'Failed to create video job',
+      })
+    }
+  }
+
+  const modeOptions: Array<{
+    value: SeedanceInputMode
+    label: string
+    enabled: boolean
+    hint: string
+  }> = [
+    { value: 'text', label: 'Text only', enabled: true, hint: 'Text-to-video' },
+    {
+      value: 'first-frame',
+      label: 'First frame',
+      enabled: true,
+      hint: 'Animate an opening frame',
+    },
+    {
+      value: 'first-last-frame',
+      label: 'First + last frame',
+      enabled: canLastFrame,
+      hint: canLastFrame
+        ? 'Pin both ends of the shot'
+        : 'This model has no closing-frame mode',
+    },
+    {
+      value: 'reference',
+      label: 'Reference images',
+      enabled: canReference,
+      hint: canReference
+        ? 'Subject and style references (Seedance 2.0)'
+        : 'Reference media is Seedance 2.0 only',
+    },
+  ]
+
+  const modelCardsDisabled = isBusy || unknownMode
+
+  const readyToGenerate =
+    (prompt.trim().length > 0 || hasImageInput) &&
+    (effectiveMode !== 'first-frame' || firstFrame !== null) &&
+    (effectiveMode !== 'first-last-frame' ||
+      (firstFrame !== null && lastFrame !== null)) &&
+    (effectiveMode !== 'reference' || references.length > 0)
+
+  return (
+    <div className="space-y-6">
+      <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-4">
+        <div>
+          <h2 className="text-lg font-medium text-white">Model</h2>
+          <p className="text-sm text-gray-400">
+            Each model exposes a different slice of the Seedance request — the
+            controls below follow the one you pick.
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {SEEDANCE_MODELS.map((model) => {
+            const selected = !unknownMode && model.id === modelId
+            return (
+              <button
+                key={model.id}
+                onClick={() => setModelId(model.id)}
+                disabled={modelCardsDisabled}
+                className={`text-left p-4 rounded-lg border transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                  selected
+                    ? 'bg-blue-600/15 border-blue-500'
+                    : 'bg-gray-800 border-gray-700 hover:border-gray-600'
+                }`}
+              >
+                <div className="font-medium text-white">{model.name}</div>
+                <div className="text-xs text-gray-500 font-mono mt-0.5">
+                  {model.id}
+                </div>
+                <div className="text-xs text-cyan-300 mt-2">
+                  {describeSeedanceModel(
+                    model,
+                    capabilities.find((c) => c.model === model.id),
+                  )}
+                </div>
+                <div className="text-xs text-gray-400 mt-1">{model.blurb}</div>
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="pt-2 border-t border-gray-700">
+          <button
+            onClick={() => setShowAdvanced((prev) => !prev)}
+            disabled={isBusy}
+            className="flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-200 transition-colors disabled:opacity-50"
+          >
+            {showAdvanced ? (
+              <ChevronDown className="w-4 h-4" />
+            ) : (
+              <ChevronRight className="w-4 h-4" />
+            )}
+            Advanced: custom model id
+          </button>
+
+          {showAdvanced && (
+            <div className="mt-3 space-y-3">
+              <input
+                type="text"
+                value={customModelId}
+                onChange={(e) => setCustomModelId(e.target.value)}
+                placeholder={SEEDANCE_CUSTOM_MODEL_PLACEHOLDER}
+                disabled={isBusy}
+                spellCheck={false}
+                className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm font-mono text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-transparent disabled:opacity-50"
+              />
+              <p className="text-xs text-gray-500">
+                For a Seedance model BytePlus ships between releases of{' '}
+                <code className="text-gray-400">@tanstack/ai-byteplus</code>.
+                Leave it empty to go back to the picker.
+              </p>
+              {unknownMode && (
+                <div className="flex items-start gap-3 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+                  <AlertTriangle className="w-4 h-4 text-amber-400 shrink-0 mt-0.5" />
+                  <p className="text-xs text-amber-200/90">
+                    Capabilities unverified — every option below is enabled and
+                    the API validates the request, because the adapter switches
+                    its per-model guards off for an id it has no table for.
+                    Seedance 2.5 additionally requires activation in the Ark
+                    Console; without it the task returns 404{' '}
+                    <code className="text-amber-300">ModelNotOpen</code>.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-medium text-white">Prompt</h2>
+          <button
+            onClick={() =>
+              setPrompt(
+                getRandomVideoPrompt(
+                  hasImageInput ? 'image-to-video' : 'text-to-video',
+                ),
+              )
+            }
+            disabled={isBusy}
+            className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium text-blue-400 hover:text-blue-300 bg-blue-500/10 hover:bg-blue-500/20 rounded-md transition-colors disabled:opacity-50"
+          >
+            <Shuffle className="w-3.5 h-3.5" />
+            Shuffle
+          </button>
+        </div>
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="Describe the shot — quote any dialogue you want in the audio track..."
+          rows={3}
+          disabled={isBusy}
+          className="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none disabled:opacity-50"
+        />
+
+        <div>
+          <h3 className="text-sm font-medium text-gray-300 mb-2">
+            Image conditioning
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {modeOptions.map((option) => (
+              <button
+                key={option.value}
+                onClick={() => setInputMode(option.value)}
+                disabled={isBusy || !option.enabled}
+                title={option.hint}
+                className={`px-3 py-1.5 text-sm rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                  effectiveMode === option.value
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+          {/* Images only: the Seedance 2.0 family also takes reference video
+              and audio, which this studio deliberately leaves out of scope. */}
+          <p className="text-xs text-gray-500 mt-2">
+            Frame roles and reference roles are mutually exclusive modes on
+            Seedance, so the studio sends one or the other — never a mix.
+          </p>
+        </div>
+
+        {(effectiveMode === 'first-frame' ||
+          effectiveMode === 'first-last-frame') && (
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FramePicker
+              label="First frame"
+              media={firstFrame}
+              disabled={isBusy}
+              onPick={() => firstFrameInputRef.current?.click()}
+              onClear={() => setFirstFrame(null)}
+            />
+            {effectiveMode === 'first-last-frame' && (
+              <FramePicker
+                label="Last frame"
+                media={lastFrame}
+                disabled={isBusy}
+                onPick={() => lastFrameInputRef.current?.click()}
+                onClear={() => setLastFrame(null)}
+              />
+            )}
+          </div>
+        )}
+
+        {effectiveMode === 'reference' && (
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">
+              Reference images{' '}
+              <span className="text-gray-500 font-normal">
+                (subject and style, up to {MAX_REFERENCE_IMAGES})
+              </span>
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {references.map((reference) => (
+                <div key={reference.id} className="relative">
+                  <img
+                    src={reference.dataUrl}
+                    alt={reference.name}
+                    className="w-20 h-20 object-cover rounded-lg border border-gray-600"
+                  />
+                  <button
+                    onClick={() =>
+                      setReferences((prev) =>
+                        prev.filter((m) => m.id !== reference.id),
+                      )
+                    }
+                    disabled={isBusy}
+                    className="absolute -top-1.5 -right-1.5 p-0.5 bg-gray-900 hover:bg-gray-700 rounded-full text-white border border-gray-600 disabled:opacity-50"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </div>
+              ))}
+              {references.length < MAX_REFERENCE_IMAGES && (
+                <button
+                  onClick={() => referenceInputRef.current?.click()}
+                  disabled={isBusy}
+                  className="flex flex-col items-center justify-center w-20 h-20 border-2 border-dashed border-gray-600 hover:border-gray-500 rounded-lg text-gray-500 hover:text-gray-400 transition-colors disabled:opacity-50"
+                >
+                  <Upload className="w-4 h-4" />
+                  <span className="text-[10px] mt-0.5">Add</span>
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        <input
+          ref={firstFrameInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={(e) => attachFile(e, setFirstFrame)}
+        />
+        <input
+          ref={lastFrameInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={(e) => attachFile(e, setLastFrame)}
+        />
+        <input
+          ref={referenceInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={(e) =>
+            attachFile(e, (media) =>
+              setReferences((prev) =>
+                [...prev, media].slice(0, MAX_REFERENCE_IMAGES),
+              ),
+            )
+          }
+        />
+      </section>
+
+      <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-5">
+        <h2 className="text-lg font-medium text-white">Output</h2>
+
+        <Control label="Aspect ratio">
+          <div className="flex flex-wrap gap-1">
+            {SEEDANCE_RATIOS.map((option) => (
+              <ChoiceButton
+                key={option}
+                selected={effectiveRatio === option}
+                disabled={isBusy}
+                onClick={() => setRatio(option)}
+              >
+                {option}
+              </ChoiceButton>
+            ))}
+            {hasImageInput && (
+              <ChoiceButton
+                selected={effectiveRatio === 'adaptive'}
+                disabled={isBusy}
+                onClick={() => setRatio('adaptive')}
+              >
+                adaptive
+              </ChoiceButton>
+            )}
+          </div>
+        </Control>
+
+        <Control
+          label="Resolution"
+          hint={
+            unknownMode
+              ? `sent as "${effectiveRatio}_${requestResolution}" — tiers this package knows, or type your own`
+              : `${entry.name} accepts ${resolutions.join(', ')}`
+          }
+        >
+          <div className="flex flex-wrap items-center gap-1">
+            {resolutions.map((option) => (
+              <ChoiceButton
+                key={option}
+                selected={
+                  requestResolution === option && effectiveResolution === option
+                }
+                disabled={isBusy}
+                onClick={() => {
+                  setResolution(option)
+                  setCustomResolution('')
+                }}
+              >
+                {option}
+              </ChoiceButton>
+            ))}
+            {unknownMode && (
+              <input
+                type="text"
+                value={customResolution}
+                onChange={(e) => setCustomResolution(e.target.value)}
+                placeholder="custom tier"
+                disabled={isBusy}
+                spellCheck={false}
+                className="w-32 px-3 py-1 bg-gray-800 border border-gray-700 rounded-md text-sm text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-amber-500 disabled:opacity-50"
+              />
+            )}
+          </div>
+        </Control>
+
+        <Control
+          label="Length"
+          hint={
+            framesActive
+              ? `${effectiveFrames} frames ≈ ${(effectiveFrames / SEEDANCE_FPS).toFixed(2)}s at ${SEEDANCE_FPS} fps`
+              : unknownMode
+                ? 'whole seconds, sent verbatim — no range is assumed for a model this package has no table for'
+                : `${durationRange.min}-${durationRange.max}s, whole seconds`
+          }
+        >
+          <div className="space-y-2">
+            {framesActive ? (
+              <div className="flex items-center gap-3">
+                <input
+                  type="range"
+                  min={SEEDANCE_MIN_FRAMES}
+                  max={SEEDANCE_MAX_FRAMES}
+                  step={4}
+                  value={effectiveFrames}
+                  disabled={isBusy}
+                  onChange={(e) => setFrames(Number(e.target.value))}
+                  className="w-48 accent-blue-500"
+                />
+                <span className="text-sm text-gray-300 w-24">
+                  {effectiveFrames} frames
+                </span>
+              </div>
+            ) : unknownMode ? (
+              <div className="flex items-center gap-3">
+                <input
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={effectiveDuration}
+                  disabled={isBusy || autoDurationActive}
+                  onChange={(e) => setDuration(Number(e.target.value))}
+                  className="w-28 px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-sm text-white focus:outline-none focus:ring-2 focus:ring-amber-500 disabled:opacity-50"
+                />
+                <span className="text-sm text-gray-300">
+                  {autoDurationActive ? 'model picks' : 'seconds'}
+                </span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-3">
+                <input
+                  type="range"
+                  min={durationRange.min}
+                  max={durationRange.max}
+                  step={durationRange.step}
+                  value={effectiveDuration}
+                  disabled={isBusy || autoDurationActive}
+                  onChange={(e) => setDuration(Number(e.target.value))}
+                  className="w-48 accent-blue-500 disabled:opacity-50"
+                />
+                <span className="text-sm text-gray-300 w-24">
+                  {autoDurationActive ? 'model picks' : `${effectiveDuration}s`}
+                </span>
+              </div>
+            )}
+            <div className="flex flex-wrap gap-4">
+              {entry.extras.autoDuration && (
+                <Toggle
+                  label="Let the model choose the length"
+                  hint="Sends duration: -1 (Seedance 2.0 and 1.5-pro only)"
+                  checked={autoDurationActive}
+                  // No catalog model offers both a frame count and a
+                  // model-chosen length, but a custom id offers everything —
+                  // and `frames` wins over `duration` server-side, so the two
+                  // must not read as simultaneously on.
+                  disabled={isBusy || framesActive}
+                  onChange={setAutoDuration}
+                />
+              )}
+              {entry.extras.frames && (
+                <Toggle
+                  label="Use a frame count instead"
+                  hint={`Fractional-second output on the 25 + 4n grid, ${SEEDANCE_FPS} fps`}
+                  checked={framesActive}
+                  disabled={isBusy}
+                  onChange={setUseFrames}
+                />
+              )}
+            </div>
+          </div>
+        </Control>
+
+        <Control label="Seed" hint="-1 or empty leaves generation unseeded">
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              min={MIN_SEED}
+              max={MAX_SEED}
+              step={1}
+              value={seed}
+              onChange={(e) => setSeed(e.target.value)}
+              placeholder="unseeded"
+              disabled={isBusy}
+              className="w-40 px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+            />
+            <button
+              onClick={() =>
+                setSeed(String(Math.floor(Math.random() * 2 ** 32)))
+              }
+              disabled={isBusy}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-blue-400 hover:text-blue-300 bg-blue-500/10 hover:bg-blue-500/20 rounded-md transition-colors disabled:opacity-50"
+            >
+              <Dices className="w-3.5 h-3.5" />
+              Random
+            </button>
+          </div>
+        </Control>
+
+        <div className="grid gap-3 sm:grid-cols-2 pt-2 border-t border-gray-700">
+          <Toggle
+            label="Watermark"
+            hint="Burn a watermark into the output"
+            checked={watermark}
+            disabled={isBusy}
+            onChange={setWatermark}
+          />
+          {/* No `return_last_frame` control: its PNG comes back on the task as
+              `content.last_frame_url`, which neither the adapter's
+              `getVideoUrl` nor core's `VideoUrlResult` carries, so the studio
+              could offer the toggle but never show you the frame. */}
+          {entry.extras.generateAudio && (
+            <Toggle
+              label="Generate audio"
+              hint="Dialogue, effects and score inferred from the prompt"
+              checked={generateAudio}
+              disabled={isBusy}
+              onChange={setGenerateAudio}
+            />
+          )}
+          {entry.extras.cameraFixed && (
+            <Toggle
+              label="Fixed camera"
+              hint="Best-effort 'hold the camera still' instruction (Seedance 1.x)"
+              checked={cameraFixed}
+              disabled={isBusy}
+              onChange={setCameraFixed}
+            />
+          )}
+          {entry.extras.serviceTier && (
+            <Toggle
+              label="Flex tier"
+              hint="Offline batch queue: half price, no latency guarantee — expect a long wait"
+              checked={flexTier}
+              disabled={isBusy}
+              onChange={setFlexTier}
+            />
+          )}
+          {entry.extras.draft && (
+            <Toggle
+              label="Draft render"
+              hint="Cheap low-fidelity preview to check staging (Seedance 1.5-pro)"
+              checked={draft}
+              disabled={isBusy}
+              onChange={setDraft}
+            />
+          )}
+        </div>
+
+        {entry.extras.priority && (
+          <Control label="Queue priority" hint="0-9, Seedance 2.0 family only">
+            <div className="flex items-center gap-3">
+              <input
+                type="range"
+                min={0}
+                max={9}
+                step={1}
+                value={priority}
+                disabled={isBusy}
+                onChange={(e) => setPriority(Number(e.target.value))}
+                className="w-48 accent-blue-500"
+              />
+              <span className="text-sm text-gray-300 w-8">{priority}</span>
+            </div>
+          </Control>
+        )}
+      </section>
+
+      <button
+        onClick={handleGenerate}
+        disabled={isBusy || !readyToGenerate}
+        className="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
+      >
+        {isBusy ? (
+          <>
+            <Loader2 className="w-5 h-5 animate-spin" />
+            Generating...
+          </>
+        ) : (
+          <>
+            <Film className="w-5 h-5" />
+            Generate with {entry.name}
+          </>
+        )}
+      </button>
+
+      {job.status !== 'idle' && (
+        <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-4">
+          {job.status === 'submitting' && (
+            <div className="flex items-center gap-2 text-gray-400">
+              <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
+              Submitting the task...
+            </div>
+          )}
+
+          {(job.status === 'pending' || job.status === 'processing') && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-gray-300">
+                <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
+                <span className="font-medium">
+                  {job.status === 'pending' ? 'Queued' : 'Processing'}
+                </span>
+                <span className="flex items-center gap-1 text-sm text-gray-500">
+                  <Clock className="w-3.5 h-3.5" />
+                  {formatElapsed(now - job.startedAt)}
+                </span>
+              </div>
+              <p className="text-xs text-gray-500 font-mono">{job.jobId}</p>
+              {job.settings.serviceTier === 'flex' && (
+                <p className="text-xs text-amber-400/80">
+                  Flex is the offline batch queue — tasks routinely sit here for
+                  many minutes before they start.
+                </p>
+              )}
+            </div>
+          )}
+
+          {job.status === 'error' && (
+            <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">
+              {job.message}
+            </div>
+          )}
+
+          {job.status === 'completed' && (
+            <div className="space-y-3">
+              <div className="rounded-lg overflow-hidden border border-gray-700">
+                <video
+                  src={job.url}
+                  controls
+                  autoPlay
+                  loop
+                  className="w-full h-auto"
+                />
+              </div>
+              <dl className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-2 text-xs">
+                <Meta label="Model" value={job.settings.model} />
+                <Meta
+                  label="Output"
+                  value={`${job.settings.ratio} · ${job.settings.resolution}`}
+                />
+                <Meta
+                  label="Length"
+                  value={
+                    job.settings.frames !== null
+                      ? `${job.settings.frames} frames @ ${SEEDANCE_FPS} fps`
+                      : job.settings.duration === -1
+                        ? 'model-chosen'
+                        : `${job.settings.duration}s`
+                  }
+                />
+                <Meta
+                  label="Seed"
+                  value={
+                    job.settings.seed === null || job.settings.seed === -1
+                      ? 'unseeded'
+                      : String(job.settings.seed)
+                  }
+                />
+                {job.settings.serviceTier && (
+                  <Meta label="Tier" value={job.settings.serviceTier} />
+                )}
+                <Meta
+                  label="Wall clock"
+                  value={formatElapsed(job.finishedAt - job.startedAt)}
+                />
+                {job.usage && (
+                  <Meta
+                    label="Billed tokens"
+                    value={`${job.usage.unitsBilled ?? job.usage.totalTokens}`}
+                  />
+                )}
+              </dl>
+              <div className="flex items-center justify-between gap-4">
+                <a
+                  href={job.url}
+                  download
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-400 hover:text-blue-300 bg-blue-500/10 hover:bg-blue-500/20 rounded-md transition-colors"
+                >
+                  <Download className="w-4 h-4" />
+                  Download
+                </a>
+                <p className="text-xs text-amber-400/80 text-right">
+                  BytePlus deletes this URL 24 hours after the task finishes
+                  {job.expiresAt
+                    ? ` — ${new Date(job.expiresAt).toLocaleString()}`
+                    : ''}
+                  . Download anything you want to keep.
+                </p>
+              </div>
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  )
+}
+
+function Control({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="text-sm font-medium text-gray-300">{label}</span>
+        {hint && <span className="text-xs text-gray-500">{hint}</span>}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function ChoiceButton({
+  selected,
+  disabled,
+  onClick,
+  children,
+}: {
+  selected: boolean
+  disabled: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`px-3 py-1 text-sm rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+        selected
+          ? 'bg-blue-600 text-white'
+          : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function Toggle({
+  label,
+  hint,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string
+  hint: string
+  checked: boolean
+  disabled: boolean
+  onChange: (value: boolean) => void
+}) {
+  return (
+    <label
+      title={hint}
+      className={`flex items-start gap-2 text-sm ${
+        disabled ? 'opacity-50' : 'cursor-pointer'
+      }`}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 accent-blue-500"
+      />
+      <span>
+        <span className="text-gray-300">{label}</span>
+        <span className="block text-xs text-gray-500">{hint}</span>
+      </span>
+    </label>
+  )
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-gray-500">{label}</dt>
+      <dd className="text-gray-300 break-all">{value}</dd>
+    </div>
+  )
+}
+
+function FramePicker({
+  label,
+  media,
+  disabled,
+  onPick,
+  onClear,
+}: {
+  label: string
+  media: AttachedMedia | null
+  disabled: boolean
+  onPick: () => void
+  onClear: () => void
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-300 mb-2">
+        {label}
+      </label>
+      {media ? (
+        <div className="relative">
+          <img
+            src={media.dataUrl}
+            alt={label}
+            className="w-full max-h-48 object-contain rounded-lg border border-gray-700"
+          />
+          <button
+            onClick={onClear}
+            disabled={disabled}
+            className="absolute top-2 right-2 p-1 bg-gray-900/80 hover:bg-gray-800 rounded-full text-white disabled:opacity-50"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={onPick}
+          disabled={disabled}
+          className="w-full p-6 border-2 border-dashed border-gray-600 hover:border-gray-500 rounded-lg text-gray-400 hover:text-gray-300 transition-colors flex flex-col items-center gap-2 disabled:opacity-50"
+        >
+          <Upload className="w-6 h-6" />
+          <span className="text-sm">Upload an image</span>
+        </button>
+      )}
+    </div>
+  )
+}

--- a/examples/ts-react-media/src/components/SeedanceStudio.tsx
+++ b/examples/ts-react-media/src/components/SeedanceStudio.tsx
@@ -8,6 +8,8 @@ import {
   Download,
   Film,
   Loader2,
+  Music,
+  Play,
   Shuffle,
   Upload,
   X,
@@ -21,6 +23,10 @@ import type {
 } from '@tanstack/ai-byteplus'
 import type { MediaPromptPart } from '@tanstack/ai/client'
 import type { AttachedMedia } from '@/lib/media'
+import type {
+  SeedanceTemplate,
+  SeedanceTemplateMedia,
+} from '@/lib/seedance-templates'
 import type { VideoBilling } from '@/lib/billing'
 import type {
   SeedanceCapability,
@@ -30,7 +36,7 @@ import type {
 } from '@/lib/seedance'
 
 import { generateSeedanceVideoFn } from '@/lib/server-functions'
-import { readMediaFile, toImagePart } from '@/lib/media'
+import { mediaUrlToPart, readMediaFile, toImagePart } from '@/lib/media'
 import { readVideoBilling } from '@/lib/billing'
 import { getRandomVideoPrompt } from '@/lib/prompts'
 import {
@@ -46,6 +52,11 @@ import {
   seedanceModel,
   snapSeedanceFrames,
 } from '@/lib/seedance'
+import {
+  SEEDANCE_TEMPLATES,
+  SEEDANCE_TEMPLATE_MODEL,
+  SEEDANCE_TEMPLATE_RESOLUTION,
+} from '@/lib/seedance-templates'
 
 /** How many reference images the studio offers on the 2.0 family. */
 const MAX_REFERENCE_IMAGES = 4
@@ -99,6 +110,17 @@ export default function SeedanceStudio({
   const [firstFrame, setFirstFrame] = useState<AttachedMedia | null>(null)
   const [lastFrame, setLastFrame] = useState<AttachedMedia | null>(null)
   const [references, setReferences] = useState<Array<AttachedMedia>>([])
+  /**
+   * Template media, kept apart from the uploads: these are remote URLs the app
+   * never holds bytes for, and their order carries the prompt's `@Video1` /
+   * `@Image1` ordinals.
+   */
+  const [templateMedia, setTemplateMedia] = useState<
+    Array<SeedanceTemplateMedia>
+  >([])
+  const [appliedTemplateId, setAppliedTemplateId] = useState<string | null>(
+    null,
+  )
 
   const [ratio, setRatio] = useState<BytePlusVideoRatio>('16:9')
   const [resolution, setResolution] = useState<BytePlusVideoResolution>('720p')
@@ -264,6 +286,58 @@ export default function SeedanceStudio({
     }
   }
 
+  /**
+   * Load a playground template. It sets four things and nothing else:
+   *
+   * 1. the model — Seedance 2.0, since templates need multimodal reference
+   *    media, clearing any custom id that would otherwise override it;
+   * 2. the prompt, verbatim from the console;
+   * 3. reference mode and the template's media (replacing any uploads);
+   * 4. the console's generation defaults for templates — smart length, sound
+   *    on, 720p, and a ratio that follows the reference media.
+   *
+   * The seed is reset because a leftover one silently changes the output.
+   * Watermark, priority, fixed camera, draft and flex tier are deliberately
+   * left as you had them: none of them contradicts a template, and the
+   * console has no opinion about them.
+   */
+  const applyTemplate = (template: SeedanceTemplate) => {
+    if (isBusy) return
+    setModelId(SEEDANCE_TEMPLATE_MODEL)
+    setCustomModelId('')
+    setShowAdvanced(false)
+    setPrompt(template.prompt)
+    setInputMode('reference')
+    setTemplateMedia(template.media)
+    setReferences([])
+    setAppliedTemplateId(template.id)
+    setSeed('')
+    setAutoDuration(true)
+    setGenerateAudio(true)
+    setResolution(SEEDANCE_TEMPLATE_RESOLUTION)
+    setRatio('adaptive')
+  }
+
+  /**
+   * Edit the prompt and the card stops claiming to be applied — what's on
+   * screen is no longer the template the console would have sent.
+   */
+  const handlePromptChange = (value: string) => {
+    setPrompt(value)
+    if (appliedTemplateId !== null) setAppliedTemplateId(null)
+  }
+
+  /** Dropping any of a template's media diverges it the same way. */
+  const removeTemplateMedia = (url: string) => {
+    setTemplateMedia((prev) => prev.filter((m) => m.url !== url))
+    setAppliedTemplateId(null)
+  }
+
+  const clearTemplate = () => {
+    setTemplateMedia([])
+    setAppliedTemplateId(null)
+  }
+
   const handleGenerate = async () => {
     if (!prompt.trim() && !hasImageInput) return
     // `isBusy` comes from React state, which hasn't re-rendered yet for a
@@ -285,6 +359,12 @@ export default function SeedanceStudio({
       }
     }
     if (effectiveMode === 'reference') {
+      // Template media first and in declared order: the adapter keeps the
+      // relative order of the parts within each modality, which is what the
+      // prompt's `@Video1` / `@Image1` ordinals are counting.
+      for (const media of templateMedia) {
+        parts.push(mediaUrlToPart(media.kind, media.url, { role: 'reference' }))
+      }
       for (const reference of references) {
         parts.push(toImagePart(reference, { role: 'reference' }))
       }
@@ -382,15 +462,102 @@ export default function SeedanceStudio({
 
   const modelSelectDisabled = isBusy || unknownMode
 
+  // Reference images are capped across both sources: a template can bring one
+  // (templates 1 and 5 do), and it counts against the same budget as uploads.
+  const templateImageCount = templateMedia.filter(
+    (m) => m.kind === 'image',
+  ).length
+  const referenceImagesLeft = Math.max(
+    0,
+    MAX_REFERENCE_IMAGES - templateImageCount - references.length,
+  )
+  // Seedance rejects a reference audio that is the only reference — it needs
+  // something visual to attach to. Gating it here keeps the studio's promise
+  // that what the form lets you build is what the API accepts.
+  const referenceVisuals =
+    templateMedia.filter((m) => m.kind !== 'audio').length + references.length
+  const audioOnlyReferences =
+    effectiveMode === 'reference' &&
+    templateMedia.some((m) => m.kind === 'audio') &&
+    referenceVisuals === 0
+
   const readyToGenerate =
     (prompt.trim().length > 0 || hasImageInput) &&
     (effectiveMode !== 'first-frame' || firstFrame !== null) &&
     (effectiveMode !== 'first-last-frame' ||
       (firstFrame !== null && lastFrame !== null)) &&
-    (effectiveMode !== 'reference' || references.length > 0)
+    (effectiveMode !== 'reference' ||
+      references.length + templateMedia.length > 0) &&
+    !audioOnlyReferences
 
   return (
     <div className="space-y-6">
+      <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-4">
+        <div>
+          <h2 className="text-lg font-medium text-white">Templates</h2>
+          <p className="text-sm text-gray-400">
+            The Ark playground's own presets — prompt, reference media and
+            settings in one click. All five need multimodal reference media, so
+            applying one switches the model to Seedance 2.0.
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {SEEDANCE_TEMPLATES.map((template) => {
+            const applied = appliedTemplateId === template.id
+            return (
+              <button
+                key={template.id}
+                onClick={() => applyTemplate(template)}
+                disabled={isBusy}
+                className={`text-left rounded-lg border overflow-hidden transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                  applied
+                    ? 'bg-blue-600/15 border-blue-500'
+                    : 'bg-gray-800 border-gray-700 hover:border-gray-600'
+                }`}
+              >
+                {/* Hotlinked from Ark's public presets bucket — hovering plays
+                    the sample rather than autoplaying five clips at once. The
+                    bucket is in cn-beijing and slow to reach, so the label
+                    below sits behind the video and shows through until the
+                    `#t=0.1` seek paints its first frame. */}
+                <div className="relative w-full aspect-video bg-gray-900">
+                  <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 text-gray-600">
+                    <Play className="w-6 h-6" />
+                    <span className="text-[10px]">hover to preview</span>
+                  </div>
+                  <video
+                    src={`${template.previewUrl}#t=0.1`}
+                    muted
+                    loop
+                    playsInline
+                    preload="metadata"
+                    onMouseEnter={(e) => {
+                      void e.currentTarget.play().catch(() => {})
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.pause()
+                      e.currentTarget.currentTime = 0
+                    }}
+                    className="relative w-full h-full object-cover"
+                  />
+                </div>
+                <div className="p-3">
+                  <div className="text-sm font-medium text-white">
+                    {template.name}
+                  </div>
+                  <div className="text-xs text-gray-400 mt-0.5">
+                    {template.blurb}
+                  </div>
+                  <div className="text-xs text-cyan-300 mt-1.5">
+                    {template.media.map((m) => m.label).join(' · ')}
+                  </div>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </section>
+
       <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-4">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-medium text-white">Prompt</h2>
@@ -411,7 +578,7 @@ export default function SeedanceStudio({
         </div>
         <textarea
           value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
+          onChange={(e) => handlePromptChange(e.target.value)}
           placeholder="Describe the shot — quote any dialogue you want in the audio track..."
           rows={3}
           disabled={isBusy}
@@ -439,8 +606,8 @@ export default function SeedanceStudio({
               </button>
             ))}
           </div>
-          {/* Images only: the Seedance 2.0 family also takes reference video
-              and audio, which this studio deliberately leaves out of scope. */}
+          {/* Uploads are images only; reference video and audio reach the
+              request through the templates above, which carry remote URLs. */}
           <p className="text-xs text-gray-500 mt-2">
             Frame roles and reference roles are mutually exclusive modes on
             Seedance, so the studio sends one or the other — never a mix.
@@ -469,12 +636,70 @@ export default function SeedanceStudio({
           </div>
         )}
 
+        {effectiveMode === 'reference' && templateMedia.length > 0 && (
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-sm font-medium text-gray-300">
+                Template media{' '}
+                <span className="text-gray-500 font-normal">
+                  (sent in this order — the prompt's @-tokens count them)
+                </span>
+              </label>
+              <button
+                onClick={clearTemplate}
+                disabled={isBusy}
+                className="text-xs text-gray-400 hover:text-white underline disabled:opacity-50"
+              >
+                Remove all
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {templateMedia.map((media) => (
+                <div
+                  key={media.url}
+                  className="flex items-center gap-2 pl-1.5 pr-2 py-1.5 bg-gray-800 border border-gray-600 rounded-lg"
+                >
+                  {media.kind === 'image' ? (
+                    <img
+                      src={media.url}
+                      alt={media.label}
+                      className="w-10 h-10 object-cover rounded"
+                    />
+                  ) : media.kind === 'video' ? (
+                    <video
+                      src={media.url}
+                      muted
+                      preload="metadata"
+                      className="w-10 h-10 object-cover rounded bg-gray-900"
+                    />
+                  ) : (
+                    <span className="flex items-center justify-center w-10 h-10 rounded bg-gray-900">
+                      <Music className="w-4 h-4 text-gray-400" />
+                    </span>
+                  )}
+                  <span className="text-xs text-gray-300 font-mono">
+                    {media.label}
+                  </span>
+                  <button
+                    onClick={() => removeTemplateMedia(media.url)}
+                    disabled={isBusy}
+                    className="p-0.5 text-gray-500 hover:text-white disabled:opacity-50"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
         {effectiveMode === 'reference' && (
           <div>
             <label className="block text-sm font-medium text-gray-300 mb-2">
               Reference images{' '}
               <span className="text-gray-500 font-normal">
-                (subject and style, up to {MAX_REFERENCE_IMAGES})
+                (subject and style, {referenceImagesLeft} of{' '}
+                {MAX_REFERENCE_IMAGES} slots left)
               </span>
             </label>
             <div className="flex flex-wrap gap-2">
@@ -498,7 +723,7 @@ export default function SeedanceStudio({
                   </button>
                 </div>
               ))}
-              {references.length < MAX_REFERENCE_IMAGES && (
+              {referenceImagesLeft > 0 && (
                 <button
                   onClick={() => referenceInputRef.current?.click()}
                   disabled={isBusy}
@@ -534,7 +759,11 @@ export default function SeedanceStudio({
           onChange={(e) =>
             attachFile(e, (media) =>
               setReferences((prev) =>
-                [...prev, media].slice(0, MAX_REFERENCE_IMAGES),
+                // The template's own reference images share this budget.
+                [...prev, media].slice(
+                  0,
+                  MAX_REFERENCE_IMAGES - templateImageCount,
+                ),
               ),
             )
           }
@@ -880,23 +1109,31 @@ export default function SeedanceStudio({
         )}
       </section>
 
-      <button
-        onClick={handleGenerate}
-        disabled={isBusy || !readyToGenerate}
-        className="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
-      >
-        {isBusy ? (
-          <>
-            <Loader2 className="w-5 h-5 animate-spin" />
-            Generating...
-          </>
-        ) : (
-          <>
-            <Film className="w-5 h-5" />
-            Generate with {entry.name}
-          </>
+      <div className="space-y-2">
+        <button
+          onClick={handleGenerate}
+          disabled={isBusy || !readyToGenerate}
+          className="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
+        >
+          {isBusy ? (
+            <>
+              <Loader2 className="w-5 h-5 animate-spin" />
+              Generating...
+            </>
+          ) : (
+            <>
+              <Film className="w-5 h-5" />
+              Generate with {entry.name}
+            </>
+          )}
+        </button>
+        {audioOnlyReferences && (
+          <p className="text-xs text-amber-400/80 text-center">
+            Reference audio can't be the only reference — pair it with a
+            reference image or video.
+          </p>
         )}
-      </button>
+      </div>
 
       {(isBusy || error || result) && (
         <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-4">

--- a/examples/ts-react-media/src/components/SeedanceStudio.tsx
+++ b/examples/ts-react-media/src/components/SeedanceStudio.tsx
@@ -12,15 +12,16 @@ import {
   Upload,
   X,
 } from 'lucide-react'
+import { useGenerateVideo } from '@tanstack/ai-react'
 import type {
   BytePlusVideoModel,
   BytePlusVideoModelOrString,
   BytePlusVideoRatio,
   BytePlusVideoResolution,
 } from '@tanstack/ai-byteplus'
-import type { TokenUsage } from '@tanstack/ai'
 import type { MediaPromptPart } from '@tanstack/ai/client'
 import type { AttachedMedia } from '@/lib/media'
+import type { VideoBilling } from '@/lib/billing'
 import type {
   SeedanceCapability,
   SeedanceInputMode,
@@ -28,8 +29,9 @@ import type {
   SeedanceModelEntry,
 } from '@/lib/seedance'
 
-import { createSeedanceJobFn, getSeedanceJobFn } from '@/lib/server-functions'
+import { generateSeedanceVideoFn } from '@/lib/server-functions'
 import { readMediaFile, toImagePart } from '@/lib/media'
+import { readVideoBilling } from '@/lib/billing'
 import { getRandomVideoPrompt } from '@/lib/prompts'
 import {
   SEEDANCE_CUSTOM_MODEL_PLACEHOLDER,
@@ -45,13 +47,6 @@ import {
   snapSeedanceFrames,
 } from '@/lib/seedance'
 
-const POLL_INTERVAL_MS = 5000
-/**
- * Consecutive failed polls tolerated before the job is called failed. A flex
- * task can sit queued for many minutes, so a single blip on the way to the
- * status endpoint should not throw away a job that is still running.
- */
-const MAX_POLL_FAILURES = 3
 /** How many reference images the studio offers on the 2.0 family. */
 const MAX_REFERENCE_IMAGES = 4
 /** Documented seed range; `-1` leaves generation unseeded. */
@@ -70,27 +65,6 @@ interface JobSettings {
   seed: number | null
   serviceTier: 'default' | 'flex' | null
 }
-
-type JobState =
-  | { status: 'idle' }
-  | { status: 'submitting' }
-  | {
-      status: 'pending' | 'processing'
-      jobId: string
-      startedAt: number
-      settings: JobSettings
-    }
-  | {
-      status: 'completed'
-      jobId: string
-      startedAt: number
-      finishedAt: number
-      settings: JobSettings
-      url: string
-      expiresAt?: string
-      usage?: TokenUsage
-    }
-  | { status: 'error'; message: string }
 
 function formatElapsed(ms: number): string {
   const total = Math.max(0, Math.round(ms / 1000))
@@ -146,14 +120,27 @@ export default function SeedanceStudio({
   const [draft, setDraft] = useState(false)
   const [priority, setPriority] = useState(5)
 
-  const [job, setJob] = useState<JobState>({ status: 'idle' })
+  /** What the in-flight (or last) task was actually asked for. */
+  const [settings, setSettings] = useState<JobSettings | null>(null)
+  const [startedAt, setStartedAt] = useState<number | null>(null)
+  const [finishedAt, setFinishedAt] = useState<number | null>(null)
+  const [billing, setBilling] = useState<VideoBilling | undefined>(undefined)
   const [now, setNow] = useState(() => Date.now())
 
   const firstFrameInputRef = useRef<HTMLInputElement>(null)
   const lastFrameInputRef = useRef<HTMLInputElement>(null)
   const referenceInputRef = useRef<HTMLInputElement>(null)
-  const pollRef = useRef<NodeJS.Timeout | null>(null)
-  const pollFailuresRef = useRef(0)
+  /**
+   * Model and provider options for the task on the wire. `useGenerateVideo`
+   * builds its client — and captures the fetcher — once, so a submission's
+   * settings are read from here at call time instead of being closed over,
+   * which is also what keeps a running task pinned to the model it was
+   * submitted with while the picker moves on.
+   */
+  const submissionRef = useRef<{
+    model: BytePlusVideoModelOrString
+    options: SeedanceJobOptions
+  } | null>(null)
 
   // A non-empty custom id switches the studio into unknown-model mode: the
   // adapter's per-model guards are off for an id it has no table for, so the
@@ -218,20 +205,42 @@ export default function SeedanceStudio({
   const effectiveRatio: BytePlusVideoRatio =
     ratio === 'adaptive' && !hasImageInput ? '16:9' : ratio
 
-  const isBusy =
-    job.status === 'submitting' ||
-    job.status === 'pending' ||
-    job.status === 'processing'
+  // The server holds the request open and polls Ark itself, streaming job id,
+  // status and the finished url back on the one connection — so the studio
+  // reads the task's whole lifecycle off the hook instead of running a timer.
+  const { generate, result, jobId, videoStatus, isLoading, error } =
+    useGenerateVideo({
+      threadId: 'seedance-studio',
+      // `options.signal` is the hook's abort signal; cancelling the response
+      // is what ends the server's polling loop instead of leaving it running
+      // to the 30-minute ceiling.
+      fetcher: (input, options) => {
+        const submission = submissionRef.current
+        if (!submission) throw new Error('No Seedance task in flight')
+        return generateSeedanceVideoFn({
+          data: {
+            prompt: input.prompt,
+            model: submission.model,
+            options: submission.options,
+          },
+          signal: options?.signal,
+        })
+      },
+      onResult: () => {
+        // Clearing the ref is what re-opens the form to the next task.
+        submissionRef.current = null
+        setFinishedAt(Date.now())
+      },
+      onError: () => {
+        submissionRef.current = null
+      },
+      onChunk: (chunk) => {
+        const usage = readVideoBilling(chunk)
+        if (usage) setBilling(usage)
+      },
+    })
 
-  const stopPolling = () => {
-    if (pollRef.current) {
-      clearTimeout(pollRef.current)
-      pollRef.current = null
-    }
-    pollFailuresRef.current = 0
-  }
-
-  useEffect(() => stopPolling, [])
+  const isBusy = isLoading
 
   // Drive the elapsed-time readout; flex tasks can sit queued for many
   // minutes, so the wait needs to look like progress.
@@ -255,79 +264,13 @@ export default function SeedanceStudio({
     }
   }
 
-  /** Queue the next poll. Self-scheduling, so a slow status call can never
-   *  stack up behind the previous one the way a fixed interval would. */
-  const schedulePoll = (jobId: string, model: BytePlusVideoModelOrString) => {
-    pollRef.current = setTimeout(() => {
-      pollJob(jobId, model)
-    }, POLL_INTERVAL_MS)
-  }
-
-  // The model is threaded through rather than read from state: a poll must
-  // keep asking about the model the job was submitted with, even if the picker
-  // or the custom id has moved on since.
-  const pollJob = async (jobId: string, model: BytePlusVideoModelOrString) => {
-    try {
-      const result = await getSeedanceJobFn({ data: { jobId, model } })
-      const { url, expiresAt, usage } = result
-      pollFailuresRef.current = 0
-      if (result.status === 'completed' && url) {
-        stopPolling()
-        setJob((prev) =>
-          prev.status === 'pending' || prev.status === 'processing'
-            ? {
-                status: 'completed',
-                jobId,
-                startedAt: prev.startedAt,
-                finishedAt: Date.now(),
-                settings: prev.settings,
-                url,
-                ...(expiresAt !== undefined && { expiresAt }),
-                ...(usage && { usage }),
-              }
-            : prev,
-        )
-      } else if (result.status === 'failed') {
-        // A terminal state from the provider, as opposed to a failed poll:
-        // this one is the job's own verdict and gets no retries.
-        stopPolling()
-        setJob({
-          status: 'error',
-          message: result.error ?? 'Video generation failed',
-        })
-      } else {
-        const status = result.status === 'pending' ? 'pending' : 'processing'
-        setJob((prev) =>
-          prev.status === 'pending' || prev.status === 'processing'
-            ? { ...prev, status }
-            : prev,
-        )
-        schedulePoll(jobId, model)
-      }
-    } catch (err) {
-      // The status call itself failed. The job is very likely still running —
-      // a flex task can be queued for many minutes — so ride out a few blips
-      // before declaring it dead.
-      pollFailuresRef.current += 1
-      if (pollFailuresRef.current < MAX_POLL_FAILURES) {
-        schedulePoll(jobId, model)
-        return
-      }
-      stopPolling()
-      setJob({
-        status: 'error',
-        message:
-          err instanceof Error
-            ? `${err.message} (after ${MAX_POLL_FAILURES} consecutive failed status checks)`
-            : 'Failed to get status',
-      })
-    }
-  }
-
   const handleGenerate = async () => {
     if (!prompt.trim() && !hasImageInput) return
-    stopPolling()
-    setJob({ status: 'submitting' })
+    // `isBusy` comes from React state, which hasn't re-rendered yet for a
+    // second click in the same tick; the ref is set synchronously below and
+    // cleared when the task settles, so it closes that window — without it a
+    // second submit would swap the model out from under the running task.
+    if (isBusy || submissionRef.current) return
 
     const parts: Array<MediaPromptPart> = []
     if (prompt.trim()) parts.push({ type: 'text', content: prompt })
@@ -356,7 +299,7 @@ export default function SeedanceStudio({
         ? Math.min(MAX_SEED, Math.max(MIN_SEED, Math.trunc(parsedSeed)))
         : null
 
-    const settings: JobSettings = {
+    const jobSettings: JobSettings = {
       model: activeModel,
       ratio: effectiveRatio,
       resolution: requestResolution,
@@ -396,28 +339,14 @@ export default function SeedanceStudio({
       ...(entry.extras.priority && { priority }),
     }
 
-    try {
-      const result = await createSeedanceJobFn({
-        data: {
-          prompt: parts.length === 1 && !hasImageInput ? prompt : parts,
-          model: activeModel,
-          options,
-        },
-      })
-      setJob({
-        status: 'pending',
-        jobId: result.jobId,
-        startedAt: Date.now(),
-        settings,
-      })
-      schedulePoll(result.jobId, activeModel)
-    } catch (err) {
-      setJob({
-        status: 'error',
-        message:
-          err instanceof Error ? err.message : 'Failed to create video job',
-      })
-    }
+    submissionRef.current = { model: activeModel, options }
+    setSettings(jobSettings)
+    setStartedAt(Date.now())
+    setFinishedAt(null)
+    setBilling(undefined)
+    await generate({
+      prompt: parts.length === 1 && !hasImageInput ? prompt : parts,
+    })
   }
 
   const modeOptions: Array<{
@@ -462,98 +391,6 @@ export default function SeedanceStudio({
 
   return (
     <div className="space-y-6">
-      <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-4">
-        <div>
-          <h2 className="text-lg font-medium text-white">Model</h2>
-          <p className="text-sm text-gray-400">
-            Each model exposes a different slice of the Seedance request — the
-            controls below follow the one you pick.
-          </p>
-        </div>
-        <div className="space-y-3">
-          <select
-            value={unknownMode ? '' : modelId}
-            onChange={(e) => {
-              const picked = SEEDANCE_MODELS.find(
-                (model) => model.id === e.target.value,
-              )
-              if (picked) setModelId(picked.id)
-            }}
-            disabled={modelSelectDisabled}
-            className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {unknownMode && (
-              <option value="">Custom model id: {activeModel}</option>
-            )}
-            {SEEDANCE_MODELS.map((model) => (
-              <option key={model.id} value={model.id}>
-                {model.name} ({model.id})
-              </option>
-            ))}
-          </select>
-          {catalogEntry && !unknownMode && (
-            <div className="p-3 bg-gray-800 border border-gray-700 rounded-lg">
-              <div className="text-xs text-cyan-300">
-                {describeSeedanceModel(
-                  catalogEntry,
-                  capabilities.find((c) => c.model === catalogEntry.id),
-                )}
-              </div>
-              <div className="text-xs text-gray-400 mt-1">
-                {catalogEntry.blurb}
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="pt-2 border-t border-gray-700">
-          <button
-            onClick={() => setShowAdvanced((prev) => !prev)}
-            disabled={isBusy}
-            className="flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-200 transition-colors disabled:opacity-50"
-          >
-            {showAdvanced ? (
-              <ChevronDown className="w-4 h-4" />
-            ) : (
-              <ChevronRight className="w-4 h-4" />
-            )}
-            Advanced: custom model id
-          </button>
-
-          {showAdvanced && (
-            <div className="mt-3 space-y-3">
-              <input
-                type="text"
-                value={customModelId}
-                onChange={(e) => setCustomModelId(e.target.value)}
-                placeholder={SEEDANCE_CUSTOM_MODEL_PLACEHOLDER}
-                disabled={isBusy}
-                spellCheck={false}
-                className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm font-mono text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-transparent disabled:opacity-50"
-              />
-              <p className="text-xs text-gray-500">
-                For a Seedance model BytePlus ships between releases of{' '}
-                <code className="text-gray-400">@tanstack/ai-byteplus</code>.
-                Leave it empty to go back to the picker.
-              </p>
-              {unknownMode && (
-                <div className="flex items-start gap-3 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
-                  <AlertTriangle className="w-4 h-4 text-amber-400 shrink-0 mt-0.5" />
-                  <p className="text-xs text-amber-200/90">
-                    Capabilities unverified — every option below is enabled and
-                    the API validates the request, because the adapter switches
-                    its per-model guards off for an id it has no table for.
-                    Seedance 2.5 additionally requires activation in the Ark
-                    Console; without it the task returns 404{' '}
-                    <code className="text-amber-300">ModelNotOpen</code>.
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      </section>
-
       <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-4">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-medium text-white">Prompt</h2>
@@ -702,6 +539,99 @@ export default function SeedanceStudio({
             )
           }
         />
+      </section>
+
+      <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-4">
+        <div>
+          <h2 className="text-lg font-medium text-white">Model</h2>
+          <p className="text-sm text-gray-400">
+            Each model exposes a different slice of the Seedance request — the
+            image-conditioning modes above and the output controls below both
+            follow the one you pick.
+          </p>
+        </div>
+        <div className="space-y-3">
+          <select
+            value={unknownMode ? '' : modelId}
+            onChange={(e) => {
+              const picked = SEEDANCE_MODELS.find(
+                (model) => model.id === e.target.value,
+              )
+              if (picked) setModelId(picked.id)
+            }}
+            disabled={modelSelectDisabled}
+            className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {unknownMode && (
+              <option value="">Custom model id: {activeModel}</option>
+            )}
+            {SEEDANCE_MODELS.map((model) => (
+              <option key={model.id} value={model.id}>
+                {model.name} ({model.id})
+              </option>
+            ))}
+          </select>
+          {catalogEntry && !unknownMode && (
+            <div className="p-3 bg-gray-800 border border-gray-700 rounded-lg">
+              <div className="text-xs text-cyan-300">
+                {describeSeedanceModel(
+                  catalogEntry,
+                  capabilities.find((c) => c.model === catalogEntry.id),
+                )}
+              </div>
+              <div className="text-xs text-gray-400 mt-1">
+                {catalogEntry.blurb}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="pt-2 border-t border-gray-700">
+          <button
+            onClick={() => setShowAdvanced((prev) => !prev)}
+            disabled={isBusy}
+            className="flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-200 transition-colors disabled:opacity-50"
+          >
+            {showAdvanced ? (
+              <ChevronDown className="w-4 h-4" />
+            ) : (
+              <ChevronRight className="w-4 h-4" />
+            )}
+            Advanced: custom model id
+          </button>
+
+          {showAdvanced && (
+            <div className="mt-3 space-y-3">
+              <input
+                type="text"
+                value={customModelId}
+                onChange={(e) => setCustomModelId(e.target.value)}
+                placeholder={SEEDANCE_CUSTOM_MODEL_PLACEHOLDER}
+                disabled={isBusy}
+                spellCheck={false}
+                className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm font-mono text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-transparent disabled:opacity-50"
+              />
+              <p className="text-xs text-gray-500">
+                For a Seedance model BytePlus ships between releases of{' '}
+                <code className="text-gray-400">@tanstack/ai-byteplus</code>.
+                Leave it empty to go back to the picker.
+              </p>
+              {unknownMode && (
+                <div className="flex items-start gap-3 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+                  <AlertTriangle className="w-4 h-4 text-amber-400 shrink-0 mt-0.5" />
+                  <p className="text-xs text-amber-200/90">
+                    Capabilities unverified — every option below is enabled and
+                    the API validates the request, because the adapter switches
+                    its per-model guards off for an id it has no table for.
+                    Seedance 2.5 additionally requires activation in the Ark
+                    Console; without it the task returns 404{' '}
+                    <code className="text-amber-300">ModelNotOpen</code>.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </section>
 
       <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-5">
@@ -968,29 +898,31 @@ export default function SeedanceStudio({
         )}
       </button>
 
-      {job.status !== 'idle' && (
+      {(isBusy || error || result) && (
         <section className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 space-y-4">
-          {job.status === 'submitting' && (
+          {isBusy && !jobId && (
             <div className="flex items-center gap-2 text-gray-400">
               <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
               Submitting the task...
             </div>
           )}
 
-          {(job.status === 'pending' || job.status === 'processing') && (
+          {isBusy && jobId && (
             <div className="space-y-2">
               <div className="flex items-center gap-2 text-gray-300">
                 <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
                 <span className="font-medium">
-                  {job.status === 'pending' ? 'Queued' : 'Processing'}
+                  {videoStatus?.status === 'processing'
+                    ? 'Processing'
+                    : 'Queued'}
                 </span>
                 <span className="flex items-center gap-1 text-sm text-gray-500">
                   <Clock className="w-3.5 h-3.5" />
-                  {formatElapsed(now - job.startedAt)}
+                  {formatElapsed(now - (startedAt ?? now))}
                 </span>
               </div>
-              <p className="text-xs text-gray-500 font-mono">{job.jobId}</p>
-              {job.settings.serviceTier === 'flex' && (
+              <p className="text-xs text-gray-500 font-mono">{jobId}</p>
+              {settings?.serviceTier === 'flex' && (
                 <p className="text-xs text-amber-400/80">
                   Flex is the offline batch queue — tasks routinely sit here for
                   many minutes before they start.
@@ -999,17 +931,19 @@ export default function SeedanceStudio({
             </div>
           )}
 
-          {job.status === 'error' && (
+          {error && !isBusy && (
             <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">
-              {job.message}
+              {error.message}
             </div>
           )}
 
-          {job.status === 'completed' && (
+          {/* `!error`: a failed task keeps the previous result on the hook,
+              and it must not render underneath the new error. */}
+          {result && !isBusy && !error && settings && (
             <div className="space-y-3">
               <div className="rounded-lg overflow-hidden border border-gray-700">
                 <video
-                  src={job.url}
+                  src={result.url}
                   controls
                   autoPlay
                   loop
@@ -1017,46 +951,48 @@ export default function SeedanceStudio({
                 />
               </div>
               <dl className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-2 text-xs">
-                <Meta label="Model" value={job.settings.model} />
+                <Meta label="Model" value={settings.model} />
                 <Meta
                   label="Output"
-                  value={`${job.settings.ratio} · ${job.settings.resolution}`}
+                  value={`${settings.ratio} · ${settings.resolution}`}
                 />
                 <Meta
                   label="Length"
                   value={
-                    job.settings.frames !== null
-                      ? `${job.settings.frames} frames @ ${SEEDANCE_FPS} fps`
-                      : job.settings.duration === -1
+                    settings.frames !== null
+                      ? `${settings.frames} frames @ ${SEEDANCE_FPS} fps`
+                      : settings.duration === -1
                         ? 'model-chosen'
-                        : `${job.settings.duration}s`
+                        : `${settings.duration}s`
                   }
                 />
                 <Meta
                   label="Seed"
                   value={
-                    job.settings.seed === null || job.settings.seed === -1
+                    settings.seed === null || settings.seed === -1
                       ? 'unseeded'
-                      : String(job.settings.seed)
+                      : String(settings.seed)
                   }
                 />
-                {job.settings.serviceTier && (
-                  <Meta label="Tier" value={job.settings.serviceTier} />
+                {settings.serviceTier && (
+                  <Meta label="Tier" value={settings.serviceTier} />
                 )}
-                <Meta
-                  label="Wall clock"
-                  value={formatElapsed(job.finishedAt - job.startedAt)}
-                />
-                {job.usage && (
+                {startedAt !== null && finishedAt !== null && (
+                  <Meta
+                    label="Wall clock"
+                    value={formatElapsed(finishedAt - startedAt)}
+                  />
+                )}
+                {billing && (
                   <Meta
                     label="Billed tokens"
-                    value={`${job.usage.unitsBilled ?? job.usage.totalTokens}`}
+                    value={`${billing.unitsBilled ?? billing.totalTokens}`}
                   />
                 )}
               </dl>
               <div className="flex items-center justify-between gap-4">
                 <a
-                  href={job.url}
+                  href={result.url}
                   download
                   target="_blank"
                   rel="noreferrer"
@@ -1067,8 +1003,10 @@ export default function SeedanceStudio({
                 </a>
                 <p className="text-xs text-amber-400/80 text-right">
                   BytePlus deletes this URL 24 hours after the task finishes
-                  {job.expiresAt
-                    ? ` — ${new Date(job.expiresAt).toLocaleString()}`
+                  {/* Typed `Date`, but it crosses the wire as an ISO string —
+                      `new Date` takes either. */}
+                  {result.expiresAt
+                    ? ` — ${new Date(result.expiresAt).toLocaleString()}`
                     : ''}
                   . Download anything you want to keep.
                 </p>

--- a/examples/ts-react-media/src/components/SeedanceStudio.tsx
+++ b/examples/ts-react-media/src/components/SeedanceStudio.tsx
@@ -451,7 +451,7 @@ export default function SeedanceStudio({
     },
   ]
 
-  const modelCardsDisabled = isBusy || unknownMode
+  const modelSelectDisabled = isBusy || unknownMode
 
   const readyToGenerate =
     (prompt.trim().length > 0 || hasImageInput) &&
@@ -470,34 +470,40 @@ export default function SeedanceStudio({
             controls below follow the one you pick.
           </p>
         </div>
-        <div className="grid gap-3 sm:grid-cols-2">
-          {SEEDANCE_MODELS.map((model) => {
-            const selected = !unknownMode && model.id === modelId
-            return (
-              <button
-                key={model.id}
-                onClick={() => setModelId(model.id)}
-                disabled={modelCardsDisabled}
-                className={`text-left p-4 rounded-lg border transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
-                  selected
-                    ? 'bg-blue-600/15 border-blue-500'
-                    : 'bg-gray-800 border-gray-700 hover:border-gray-600'
-                }`}
-              >
-                <div className="font-medium text-white">{model.name}</div>
-                <div className="text-xs text-gray-500 font-mono mt-0.5">
-                  {model.id}
-                </div>
-                <div className="text-xs text-cyan-300 mt-2">
-                  {describeSeedanceModel(
-                    model,
-                    capabilities.find((c) => c.model === model.id),
-                  )}
-                </div>
-                <div className="text-xs text-gray-400 mt-1">{model.blurb}</div>
-              </button>
-            )
-          })}
+        <div className="space-y-3">
+          <select
+            value={unknownMode ? '' : modelId}
+            onChange={(e) => {
+              const picked = SEEDANCE_MODELS.find(
+                (model) => model.id === e.target.value,
+              )
+              if (picked) setModelId(picked.id)
+            }}
+            disabled={modelSelectDisabled}
+            className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {unknownMode && (
+              <option value="">Custom model id: {activeModel}</option>
+            )}
+            {SEEDANCE_MODELS.map((model) => (
+              <option key={model.id} value={model.id}>
+                {model.name} ({model.id})
+              </option>
+            ))}
+          </select>
+          {catalogEntry && !unknownMode && (
+            <div className="p-3 bg-gray-800 border border-gray-700 rounded-lg">
+              <div className="text-xs text-cyan-300">
+                {describeSeedanceModel(
+                  catalogEntry,
+                  capabilities.find((c) => c.model === catalogEntry.id),
+                )}
+              </div>
+              <div className="text-xs text-gray-400 mt-1">
+                {catalogEntry.blurb}
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="pt-2 border-t border-gray-700">

--- a/examples/ts-react-media/src/components/SeedanceStudio.tsx
+++ b/examples/ts-react-media/src/components/SeedanceStudio.tsx
@@ -110,6 +110,8 @@ export default function SeedanceStudio({
   const [firstFrame, setFirstFrame] = useState<AttachedMedia | null>(null)
   const [lastFrame, setLastFrame] = useState<AttachedMedia | null>(null)
   const [references, setReferences] = useState<Array<AttachedMedia>>([])
+  /** Last file-attach failure, rendered beside the pickers. */
+  const [attachError, setAttachError] = useState<string | null>(null)
   /**
    * Template media, kept apart from the uploads: these are remote URLs the app
    * never holds bytes for, and their order carries the prompt's `@Video1` /
@@ -279,10 +281,18 @@ export default function SeedanceStudio({
     const file = e.target.files?.[0]
     e.target.value = ''
     if (!file) return
+    setAttachError(null)
     try {
       apply(await readMediaFile(file))
-    } catch {
-      // Unreadable file — leave the current attachment in place.
+    } catch (error) {
+      // The input was already reset above, so without this the failure has no
+      // observable effect at all: no message, no console entry, and the same
+      // file re-picks to the same silence. Surface it next to the picker.
+      setAttachError(
+        `Could not read "${file.name}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
     }
   }
 
@@ -735,6 +745,15 @@ export default function SeedanceStudio({
               )}
             </div>
           </div>
+        )}
+
+        {attachError && (
+          <p
+            role="alert"
+            className="text-sm text-red-400 bg-red-950/40 border border-red-900/60 rounded-lg px-3 py-2"
+          >
+            {attachError}
+          </p>
         )}
 
         <input

--- a/examples/ts-react-media/src/components/VideoGenerator.tsx
+++ b/examples/ts-react-media/src/components/VideoGenerator.tsx
@@ -56,6 +56,7 @@ export default function VideoGenerator({
   const falModels = filteredModels.filter((m) => m.provider === 'fal')
   const xaiModels = filteredModels.filter((m) => m.provider === 'xai')
   const geminiModels = filteredModels.filter((m) => m.provider === 'gemini')
+  const byteplusModels = filteredModels.filter((m) => m.provider === 'byteplus')
 
   // Gemini Omni Flash additionally accepts video prompt parts (a reference
   // clip or a video to edit). Offer the upload whenever an Omni model is in
@@ -371,6 +372,13 @@ export default function VideoGenerator({
             </optgroup>
             <optgroup label="Google (direct)">
               {geminiModels.map((model) => (
+                <option key={model.id} value={model.id}>
+                  {model.name}
+                </option>
+              ))}
+            </optgroup>
+            <optgroup label="BytePlus (direct)">
+              {byteplusModels.map((model) => (
                 <option key={model.id} value={model.id}>
                   {model.name}
                 </option>

--- a/examples/ts-react-media/src/components/VideoGenerator.tsx
+++ b/examples/ts-react-media/src/components/VideoGenerator.tsx
@@ -1,39 +1,60 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Film, Loader2, Shuffle, Upload, Wand2, X } from 'lucide-react'
-import type { VideoMode } from '@/lib/models'
+import { useGenerateVideo } from '@tanstack/ai-react'
+import type { VideoModel, VideoMode } from '@/lib/models'
 import type { AttachedMedia } from '@/lib/media'
-import type { MediaPromptPart } from '@tanstack/ai/client'
+import type { MediaPrompt, MediaPromptPart } from '@tanstack/ai/client'
+import type { VideoBilling } from '@/lib/billing'
 
-import {
-  createVideoJobFn,
-  getVideoStatusFn,
-  getVideoUrlFn,
-} from '@/lib/server-functions'
+import { generateVideoFn } from '@/lib/server-functions'
 import { VIDEO_MODELS } from '@/lib/models'
 import { getRandomVideoPrompt } from '@/lib/prompts'
 import { imageUrlToPart, readMediaFile, toVideoPart } from '@/lib/media'
-
-type JobState =
-  | { status: 'idle' }
-  | { status: 'submitting' }
-  | { status: 'pending'; jobId: string; model: string }
-  | {
-      status: 'processing'
-      jobId: string
-      model: string
-      progress?: number | undefined
-    }
-  | {
-      status: 'completed'
-      url: string
-      jobId: string
-      unitsBilled?: number
-      cost?: number
-    }
-  | { status: 'error'; message: string }
+import { readVideoBilling } from '@/lib/billing'
 
 interface VideoGeneratorProps {
   initialImageUrl?: string | null
+}
+
+/**
+ * One submission. Each card builds its own prompt from this, because which
+ * parts a model may receive depends on the model: only Omni takes a video
+ * part.
+ */
+interface VideoRequest {
+  prompt: string
+  mode: VideoMode
+  imageUrl: string | null
+  video: AttachedMedia | null
+}
+
+/** What each card hands the parent so it can drive that card's hook. */
+interface VideoCardHandle {
+  run: (request: VideoRequest) => void
+  clear: () => void
+}
+
+/**
+ * Image conditioning rides in the prompt: the start frame is an image part
+ * tagged `role: 'start_frame'`, which the fal adapter routes to the
+ * endpoint's start-image field (e.g. `image_url` on Kling i2v) and Omni takes
+ * as an interaction content block. Video parts (a reference clip or a clip to
+ * edit) are an Omni capability only, so they never reach the other providers.
+ */
+function buildVideoPrompt(
+  request: VideoRequest,
+  model: VideoModel,
+): MediaPrompt {
+  const parts: Array<MediaPromptPart> = [
+    { type: 'text', content: request.prompt },
+  ]
+  if (request.mode === 'image-to-video' && request.imageUrl) {
+    parts.push(imageUrlToPart(request.imageUrl, { role: 'start_frame' }))
+  }
+  if (request.video && model.provider === 'gemini') {
+    parts.push(toVideoPart(request.video))
+  }
+  return parts.length === 1 ? request.prompt : parts
 }
 
 export default function VideoGenerator({
@@ -46,17 +67,27 @@ export default function VideoGenerator({
     initialImageUrl ?? null,
   )
   const [attachedVideo, setAttachedVideo] = useState<AttachedMedia | null>(null)
-  const [editPrompts, setEditPrompts] = useState<Record<string, string>>({})
-  const [jobStates, setJobStates] = useState<Record<string, JobState>>({})
+  /** Whether anything has been generated for the current model selection. */
+  const [submitted, setSubmitted] = useState(false)
+  const [running, setRunning] = useState<Record<string, boolean>>({})
   const fileInputRef = useRef<HTMLInputElement>(null)
   const videoInputRef = useRef<HTMLInputElement>(null)
-  const pollingRefs = useRef<Map<string, NodeJS.Timeout>>(new Map())
+  // Generation is started from the click, not from an effect on the cards:
+  // a hook only exists inside a mounted component, so the cards mount with
+  // the picker and hand the parent a way to run and clear them.
+  const cardsRef = useRef(new Map<string, VideoCardHandle>())
 
-  const filteredModels = VIDEO_MODELS.filter((m) => m.mode === mode)
+  const filteredModels: ReadonlyArray<VideoModel> = VIDEO_MODELS.filter(
+    (m) => m.mode === mode,
+  )
   const falModels = filteredModels.filter((m) => m.provider === 'fal')
   const xaiModels = filteredModels.filter((m) => m.provider === 'xai')
   const geminiModels = filteredModels.filter((m) => m.provider === 'gemini')
   const byteplusModels = filteredModels.filter((m) => m.provider === 'byteplus')
+  const activeModels =
+    selectedModel === 'all'
+      ? filteredModels
+      : filteredModels.filter((model) => model.id === selectedModel)
 
   // Gemini Omni Flash additionally accepts video prompt parts (a reference
   // clip or a video to edit). Offer the upload whenever an Omni model is in
@@ -66,6 +97,10 @@ export default function VideoGenerator({
       ? geminiModels.length > 0
       : selectedModel.startsWith('gemini-omni-flash-preview')
 
+  // Each card runs its own generation, so the form is busy while any of them
+  // reports that it is.
+  const isGenerating = Object.values(running).some(Boolean)
+
   useEffect(() => {
     if (initialImageUrl) {
       setImagePreview(initialImageUrl)
@@ -73,17 +108,12 @@ export default function VideoGenerator({
   }, [initialImageUrl])
 
   useEffect(() => {
-    // When mode changes, reset to "all" or first available model
+    // When mode changes, reset to "all" or first available model — and with
+    // it the results, which belong to the models that produced them.
     setSelectedModel('all')
+    setSubmitted(false)
+    setRunning({})
   }, [mode])
-
-  useEffect(() => {
-    return () => {
-      // Clear all polling intervals on unmount
-      pollingRefs.current.forEach((interval) => void clearInterval(interval))
-      pollingRefs.current.clear()
-    }
-  }, [])
 
   const handleImageSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -110,214 +140,42 @@ export default function VideoGenerator({
     if (videoInputRef.current) videoInputRef.current.value = ''
   }
 
-  const pollStatus = async (jobId: string, model: string) => {
-    try {
-      const status = await getVideoStatusFn({ data: { jobId, model } })
+  const handleRunningChange = useCallback((modelId: string, value: boolean) => {
+    setRunning((prev) =>
+      prev[modelId] === value ? prev : { ...prev, [modelId]: value },
+    )
+  }, [])
 
-      if (status.status === 'completed') {
-        const interval = pollingRefs.current.get(model)
-        if (interval) {
-          clearInterval(interval)
-          pollingRefs.current.delete(model)
-        }
-        const urlResult = await getVideoUrlFn({ data: { jobId, model } })
-        if (!urlResult.url) {
-          throw new Error('No URL found')
-        }
-        const url = urlResult.url
+  const registerCard = useCallback(
+    (modelId: string, card: VideoCardHandle | null) => {
+      if (card) cardsRef.current.set(modelId, card)
+      else cardsRef.current.delete(modelId)
+    },
+    [],
+  )
 
-        setJobStates((prev) => ({
-          ...prev,
-          [model]: {
-            status: 'completed',
-            url: url,
-            jobId,
-            unitsBilled: urlResult.usage?.unitsBilled,
-            cost: urlResult.usage?.cost,
-          },
-        }))
-      } else if (status.status === 'processing') {
-        setJobStates((prev) => ({
-          ...prev,
-          [model]: {
-            status: 'processing',
-            jobId,
-            model,
-            progress: status.progress,
-          },
-        }))
-      } else if (status.status === 'failed') {
-        const interval = pollingRefs.current.get(model)
-        if (interval) {
-          clearInterval(interval)
-          pollingRefs.current.delete(model)
-        }
-        setJobStates((prev) => ({
-          ...prev,
-          [model]: {
-            status: 'error',
-            message: status.error ?? 'Video generation failed',
-          },
-        }))
-      } else {
-        setJobStates((prev) => ({
-          ...prev,
-          [model]: { status: 'pending', jobId, model },
-        }))
-      }
-    } catch (err) {
-      const interval = pollingRefs.current.get(model)
-      if (interval) {
-        clearInterval(interval)
-        pollingRefs.current.delete(model)
-      }
-      setJobStates((prev) => ({
-        ...prev,
-        [model]: {
-          status: 'error',
-          message: err instanceof Error ? err.message : 'Failed to get status',
-        },
-      }))
-    }
-  }
-
-  // Poll keyed by the UI model id, not result.model: the direct-xAI
-  // entries share one adapter model ('grok-imagine-video-1.5'),
-  // so result.model wouldn't identify the card (or the adapter) uniquely.
-  const beginPolling = (modelId: string, jobId: string) => {
-    const interval = setInterval(() => {
-      pollStatus(jobId, modelId)
-    }, 4000)
-    pollingRefs.current.set(modelId, interval)
-  }
-
-  const startJobForModel = async (modelId: string) => {
-    setJobStates((prev) => ({
-      ...prev,
-      [modelId]: { status: 'submitting' },
-    }))
-
-    try {
-      const model = VIDEO_MODELS.find((m) => m.id === modelId)
-      const parts: Array<MediaPromptPart> = [{ type: 'text', content: prompt }]
-      // Image-to-video sends the start frame as a prompt part — the fal
-      // adapter routes `role: 'start_frame'` to the endpoint's start-image
-      // field (e.g. `image_url` on Kling i2v); Omni takes it as an
-      // interaction content block.
-      if (mode === 'image-to-video' && imagePreview) {
-        parts.push(imageUrlToPart(imagePreview, { role: 'start_frame' }))
-      }
-      // Video prompt parts (reference clip / video to edit) are an Omni
-      // capability only — never send them to the other providers.
-      if (attachedVideo && model?.provider === 'gemini') {
-        parts.push(toVideoPart(attachedVideo))
-      }
-      const builtPrompt = parts.length === 1 ? prompt : parts
-      const result = await createVideoJobFn({
-        data: {
-          prompt: builtPrompt,
-          model: modelId,
-        },
-      })
-
-      setJobStates((prev) => ({
-        ...prev,
-        [modelId]: {
-          status: 'pending',
-          jobId: result.jobId,
-          model: result.model,
-        },
-      }))
-
-      beginPolling(modelId, result.jobId)
-    } catch (err) {
-      setJobStates((prev) => ({
-        ...prev,
-        [modelId]: {
-          status: 'error',
-          message:
-            err instanceof Error ? err.message : 'Failed to create video job',
-        },
-      }))
-    }
-  }
-
-  /**
-   * Gemini Omni Flash conversational editing: chain a new prompt onto a
-   * completed generation via its interaction id (the jobId). The model
-   * applies the change while preserving everything else in the video.
-   */
-  const handleEditVideo = async (modelId: string, previousJobId: string) => {
-    const editPrompt = editPrompts[modelId]?.trim()
-    if (!editPrompt) return
-
-    setJobStates((prev) => ({
-      ...prev,
-      [modelId]: { status: 'submitting' },
-    }))
-
-    try {
-      const result = await createVideoJobFn({
-        data: {
-          prompt: editPrompt,
-          model: modelId,
-          previousInteractionId: previousJobId,
-        },
-      })
-
-      setJobStates((prev) => ({
-        ...prev,
-        [modelId]: {
-          status: 'pending',
-          jobId: result.jobId,
-          model: result.model,
-        },
-      }))
-      setEditPrompts((prev) => ({ ...prev, [modelId]: '' }))
-
-      beginPolling(modelId, result.jobId)
-    } catch (err) {
-      setJobStates((prev) => ({
-        ...prev,
-        [modelId]: {
-          status: 'error',
-          message: err instanceof Error ? err.message : 'Failed to edit video',
-        },
-      }))
-    }
-  }
-
-  const handleGenerate = async () => {
+  const handleGenerate = () => {
     if (!prompt.trim()) return
     if (mode === 'image-to-video' && !imagePreview) return
 
-    // Clear all existing polling
-    pollingRefs.current.forEach((interval) => clearInterval(interval))
-    pollingRefs.current.clear()
-    setJobStates({})
-
-    if (selectedModel === 'all') {
-      // Fire all requests in parallel
-      await Promise.all(
-        filteredModels.map((model) => startJobForModel(model.id)),
-      )
-    } else {
-      await startJobForModel(selectedModel)
+    const request: VideoRequest = {
+      prompt,
+      mode,
+      imageUrl: imagePreview,
+      video: attachedVideo,
+    }
+    setSubmitted(true)
+    for (const model of activeModels) {
+      cardsRef.current.get(model.id)?.run(request)
     }
   }
 
-  const reset = () => {
-    pollingRefs.current.forEach((interval) => clearInterval(interval))
-    pollingRefs.current.clear()
-    setJobStates({})
+  /** "Generate another": drop the results themselves, not just their panel. */
+  const clearResults = () => {
+    for (const card of cardsRef.current.values()) card.clear()
+    setSubmitted(false)
+    setRunning({})
   }
-
-  const isGenerating = Object.values(jobStates).some(
-    (state) =>
-      state.status === 'submitting' ||
-      state.status === 'pending' ||
-      state.status === 'processing',
-  )
 
   return (
     <div className="space-y-6">
@@ -351,7 +209,11 @@ export default function VideoGenerator({
           </label>
           <select
             value={selectedModel}
-            onChange={(e) => setSelectedModel(e.target.value)}
+            onChange={(e) => {
+              setSelectedModel(e.target.value)
+              setSubmitted(false)
+              setRunning({})
+            }}
             disabled={isGenerating}
             className="w-full px-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
           >
@@ -518,120 +380,211 @@ export default function VideoGenerator({
         </button>
       </div>
 
-      {Object.keys(jobStates).length > 0 && (
-        <div className="space-y-6">
+      <div className="space-y-6">
+        {submitted && (
           <div className="flex items-center justify-between">
             <h3 className="text-lg font-medium text-white">
-              {selectedModel === 'all' ? 'Generated Videos' : 'Generated Video'}
+              {activeModels.length > 1 ? 'Generated Videos' : 'Generated Video'}
             </h3>
             {!isGenerating && (
               <button
-                onClick={reset}
+                onClick={clearResults}
                 className="text-sm text-gray-400 hover:text-white underline"
               >
                 Generate another
               </button>
             )}
           </div>
-          {Object.entries(jobStates).map(([modelId, state]) => {
-            const model = VIDEO_MODELS.find((m) => m.id === modelId)
-            return (
-              <div key={modelId} className="space-y-2">
-                {selectedModel === 'all' && (
-                  <h4 className="text-sm font-medium text-gray-300">
-                    {model?.name ?? modelId}
-                  </h4>
-                )}
-                {state.status === 'submitting' && (
-                  <div className="flex items-center gap-2 p-4 bg-gray-800 rounded-lg border border-gray-700">
-                    <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
-                    <span className="text-gray-400">Submitting...</span>
-                  </div>
-                )}
-                {state.status === 'pending' && (
-                  <div className="flex items-center gap-2 p-4 bg-gray-800 rounded-lg border border-gray-700">
-                    <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
-                    <span className="text-gray-400">Queued...</span>
-                  </div>
-                )}
-                {state.status === 'processing' && (
-                  <div className="flex items-center gap-2 p-4 bg-gray-800 rounded-lg border border-gray-700">
-                    <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
-                    <span className="text-gray-400">
-                      Processing
-                      {state.progress != null ? ` (${state.progress}%)` : '...'}
-                    </span>
-                  </div>
-                )}
-                {state.status === 'error' && (
-                  <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400">
-                    {state.message}
-                  </div>
-                )}
-                {state.status === 'completed' && (
-                  <>
-                    <div className="rounded-lg overflow-hidden border border-gray-700">
-                      <video
-                        src={state.url}
-                        controls
-                        autoPlay
-                        loop
-                        className="w-full h-auto"
-                      />
-                    </div>
-                    {state.cost != null ? (
-                      <p className="text-xs text-gray-500">
-                        Billed ${state.cost.toFixed(3)}
-                        {state.unitsBilled != null
-                          ? ` for ${state.unitsBilled} second${state.unitsBilled === 1 ? '' : 's'} of video`
-                          : ''}
-                      </p>
-                    ) : (
-                      state.unitsBilled != null && (
-                        <p className="text-xs text-gray-500">
-                          Billed {state.unitsBilled} fal unit
-                          {state.unitsBilled === 1 ? '' : 's'} — multiply by the
-                          endpoint unit price for USD cost
-                        </p>
-                      )
-                    )}
-                    {model?.provider === 'gemini' && (
-                      <div className="flex gap-2">
-                        <input
-                          type="text"
-                          value={editPrompts[modelId] ?? ''}
-                          onChange={(e) =>
-                            setEditPrompts((prev) => ({
-                              ...prev,
-                              [modelId]: e.target.value,
-                            }))
-                          }
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter')
-                              handleEditVideo(modelId, state.jobId)
-                          }}
-                          placeholder="Describe an edit — e.g. 'make it nighttime'..."
-                          disabled={isGenerating}
-                          className="flex-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
-                        />
-                        <button
-                          onClick={() => handleEditVideo(modelId, state.jobId)}
-                          disabled={
-                            isGenerating || !editPrompts[modelId]?.trim()
-                          }
-                          className="px-4 py-2 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-1.5"
-                        >
-                          <Wand2 className="w-4 h-4" />
-                          Edit
-                        </button>
-                      </div>
-                    )}
-                  </>
-                )}
-              </div>
-            )
-          })}
+        )}
+        {activeModels.map((model) => (
+          <VideoModelCard
+            key={model.id}
+            model={model}
+            visible={submitted}
+            showTitle={activeModels.length > 1}
+            onRegister={registerCard}
+            onRunningChange={handleRunningChange}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * One model's generation. `useGenerateVideo` drives the whole job lifecycle —
+ * the server streams job id, status and the finished url back on one request,
+ * so there is no polling timer or job-state machine in the UI.
+ */
+function VideoModelCard({
+  model,
+  visible,
+  showTitle,
+  onRegister,
+  onRunningChange,
+}: {
+  model: VideoModel
+  visible: boolean
+  showTitle: boolean
+  onRegister: (modelId: string, card: VideoCardHandle | null) => void
+  onRunningChange: (modelId: string, running: boolean) => void
+}) {
+  const [editPrompt, setEditPrompt] = useState('')
+  const [billing, setBilling] = useState<VideoBilling | undefined>(undefined)
+  // The hook builds its client once, so the fetcher closure is created once
+  // too: anything that changes between runs (here, the Omni interaction being
+  // continued) has to be read from a ref at call time rather than captured.
+  const previousInteractionRef = useRef<string | undefined>(undefined)
+
+  const { generate, reset, result, jobId, videoStatus, isLoading, error } =
+    useGenerateVideo({
+      threadId: `video:${model.id}`,
+      // `options.signal` is the hook's abort signal. Forwarding it matters
+      // more here than for images: cancelling the response is what ends the
+      // server's polling loop instead of leaving it running to the timeout.
+      fetcher: (input, options) =>
+        generateVideoFn({
+          data: {
+            prompt: input.prompt,
+            model: model.id,
+            ...(previousInteractionRef.current
+              ? { previousInteractionId: previousInteractionRef.current }
+              : {}),
+          },
+          signal: options?.signal,
+        }),
+      onChunk: (chunk) => {
+        const usage = readVideoBilling(chunk)
+        if (usage) setBilling(usage)
+      },
+    })
+
+  const clear = useCallback(() => {
+    previousInteractionRef.current = undefined
+    setBilling(undefined)
+    reset()
+  }, [reset])
+
+  const run = useCallback(
+    (request: VideoRequest) => {
+      // A new submission is a fresh video, never a continuation of the clip
+      // this card is showing. Deliberately not `reset()` first: reset stops
+      // the client, which clears the `isLoading` that makes a second
+      // `generate()` a no-op — that guard is what swallows a double-click.
+      // The stale result a failed re-run leaves behind is handled by the
+      // render gate below instead.
+      previousInteractionRef.current = undefined
+      setBilling(undefined)
+      void generate({ prompt: buildVideoPrompt(request, model) })
+    },
+    [generate, model],
+  )
+
+  useEffect(() => {
+    onRegister(model.id, { run, clear })
+    return () => onRegister(model.id, null)
+  }, [model.id, run, clear, onRegister])
+
+  useEffect(() => {
+    onRunningChange(model.id, isLoading)
+  }, [model.id, isLoading, onRunningChange])
+
+  if (!visible) return null
+
+  /**
+   * Gemini Omni Flash conversational editing: chain a new prompt onto the
+   * finished generation via its interaction id (the job id). The model
+   * applies the change while preserving everything else in the video.
+   */
+  const handleEditVideo = () => {
+    const edit = editPrompt.trim()
+    if (!edit || !result || isLoading) return
+    previousInteractionRef.current = result.jobId
+    setBilling(undefined)
+    setEditPrompt('')
+    void generate({ prompt: edit })
+  }
+
+  const status = videoStatus?.status
+
+  return (
+    <div className="space-y-2">
+      {showTitle && (
+        <h4 className="text-sm font-medium text-gray-300">{model.name}</h4>
+      )}
+      {isLoading && (
+        <div className="flex items-center gap-2 p-4 bg-gray-800 rounded-lg border border-gray-700">
+          <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
+          <span className="text-gray-400">
+            {!jobId
+              ? 'Submitting...'
+              : status === 'processing'
+                ? `Processing${
+                    videoStatus?.progress != null
+                      ? ` (${videoStatus.progress}%)`
+                      : '...'
+                  }`
+                : 'Queued...'}
+          </span>
         </div>
+      )}
+      {error && !isLoading && (
+        <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400">
+          {error.message}
+        </div>
+      )}
+      {/* `!error`: a failed re-run keeps the previous clip on the hook, and it
+          must not render underneath the new error. */}
+      {result && !isLoading && !error && (
+        <>
+          <div className="rounded-lg overflow-hidden border border-gray-700">
+            <video
+              src={result.url}
+              controls
+              autoPlay
+              loop
+              className="w-full h-auto"
+            />
+          </div>
+          {billing?.cost != null ? (
+            <p className="text-xs text-gray-500">
+              Billed ${billing.cost.toFixed(3)}
+              {billing.unitsBilled != null
+                ? ` for ${billing.unitsBilled} second${billing.unitsBilled === 1 ? '' : 's'} of video`
+                : ''}
+            </p>
+          ) : (
+            billing?.unitsBilled != null && (
+              <p className="text-xs text-gray-500">
+                Billed {billing.unitsBilled} fal unit
+                {billing.unitsBilled === 1 ? '' : 's'} — multiply by the
+                endpoint unit price for USD cost
+              </p>
+            )
+          )}
+          {model.provider === 'gemini' && (
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={editPrompt}
+                onChange={(e) => setEditPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleEditVideo()
+                }}
+                placeholder="Describe an edit — e.g. 'make it nighttime'..."
+                className="flex-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
+              />
+              <button
+                onClick={handleEditVideo}
+                disabled={!editPrompt.trim()}
+                className="px-4 py-2 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-1.5"
+              >
+                <Wand2 className="w-4 h-4" />
+                Edit
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/examples/ts-react-media/src/lib/billing.ts
+++ b/examples/ts-react-media/src/lib/billing.ts
@@ -1,0 +1,51 @@
+import type { StreamChunk } from '@tanstack/ai'
+
+/**
+ * Billing figures a finished video job reports. `VideoGenerateResult` — what
+ * `useGenerateVideo` hands back as its result — carries only the job id, url
+ * and expiry, so these are read off the terminal `generation:result` chunk
+ * through the hook's `onChunk` instead.
+ */
+export interface VideoBilling {
+  /** Priced units billed — fal units, or seconds of video on xAI Imagine. */
+  unitsBilled?: number
+  /** Provider-reported cost in USD, for providers that report one. */
+  cost?: number
+  /** Token total, for providers that bill media generation as tokens. */
+  totalTokens?: number
+}
+
+function numberField(source: object, key: string): number | undefined {
+  const value: unknown = Reflect.get(source, key)
+  return typeof value === 'number' ? value : undefined
+}
+
+/**
+ * Reads the usage block off a generation's terminal result chunk, or
+ * `undefined` for every other chunk (and for providers that report no usage).
+ */
+export function readVideoBilling(chunk: StreamChunk): VideoBilling | undefined {
+  if (chunk.type !== 'CUSTOM' || chunk.name !== 'generation:result') {
+    return undefined
+  }
+  const value: unknown = chunk.value
+  if (typeof value !== 'object' || value === null) return undefined
+  const usage: unknown = Reflect.get(value, 'usage')
+  if (typeof usage !== 'object' || usage === null) return undefined
+
+  const unitsBilled = numberField(usage, 'unitsBilled')
+  const cost = numberField(usage, 'cost')
+  const totalTokens = numberField(usage, 'totalTokens')
+  if (
+    unitsBilled === undefined &&
+    cost === undefined &&
+    totalTokens === undefined
+  ) {
+    return undefined
+  }
+  return {
+    ...(unitsBilled !== undefined && { unitsBilled }),
+    ...(cost !== undefined && { cost }),
+    ...(totalTokens !== undefined && { totalTokens }),
+  }
+}

--- a/examples/ts-react-media/src/lib/media.ts
+++ b/examples/ts-react-media/src/lib/media.ts
@@ -70,6 +70,26 @@ export function toVideoPart(
 }
 
 /**
+ * Builds a prompt part from a remote media URL, for conditioning inputs the
+ * app never holds bytes for (the Seedance template presets). Adapters pass a
+ * `url` source straight through to the provider, so the file is fetched
+ * server-side by the provider rather than downloaded and re-encoded here.
+ *
+ * `metadata` is only meaningful for images — adapters route video and audio
+ * parts by part type alone.
+ */
+export function mediaUrlToPart(
+  kind: 'image' | 'video' | 'audio',
+  url: string,
+  metadata?: MediaInputMetadata,
+): MediaPromptPart {
+  const source = { type: 'url', value: url } as const
+  if (kind === 'video') return { type: 'video', source }
+  if (kind === 'audio') return { type: 'audio', source }
+  return { type: 'image', source, ...(metadata ? { metadata } : {}) }
+}
+
+/**
  * Builds an image prompt part from a URL string — either a remote URL
  * (passed through as a `url` source) or a `data:` URL (decomposed into a
  * `data` source so adapters that upload files get the raw payload).

--- a/examples/ts-react-media/src/lib/models.ts
+++ b/examples/ts-react-media/src/lib/models.ts
@@ -87,6 +87,15 @@ export const IMAGE_MODELS = [
     sizeType: 'standard' as const,
     provider: 'gemini' as const,
   },
+  {
+    id: 'dola-seedream-5-0-pro-260628',
+    name: 'Seedream 5.0 Pro',
+    description:
+      'BytePlus Seedream image generation, sized with a 1K/2K/4K token',
+    defaultSize: '2K' as const,
+    sizeType: 'standard' as const,
+    provider: 'byteplus' as const,
+  },
 ] as const
 
 export const VIDEO_MODELS = [
@@ -177,6 +186,14 @@ export const VIDEO_MODELS = [
       'Animate an image with Gemini Omni Flash via the Interactions API',
     mode: 'image-to-video' as const,
     provider: 'gemini' as const,
+  },
+  {
+    id: 'dreamina-seedance-2-0-260128',
+    name: 'Seedance 2.0 (Text-to-Video)',
+    description:
+      'BytePlus Seedance text-to-video (4-15s, 480p/720p/1080p/4k) via ModelArk',
+    mode: 'text-to-video' as const,
+    provider: 'byteplus' as const,
   },
 ] as const
 

--- a/examples/ts-react-media/src/lib/seedance-templates.ts
+++ b/examples/ts-react-media/src/lib/seedance-templates.ts
@@ -1,0 +1,155 @@
+import type {
+  BytePlusVideoModel,
+  BytePlusVideoResolution,
+} from '@tanstack/ai-byteplus'
+
+/**
+ * One-click presets replicating the BytePlus Ark playground's video templates.
+ *
+ * Captured 2026-08-01 from the console's static asset config
+ * (`exp_asset_library_v1`) plus the English prompt each card renders into the
+ * composer. Every asset below is an unsigned public object in Ark's own
+ * presets bucket and is **hotlinked, never downloaded** — the adapter passes
+ * URIs straight through to the provider, so nothing is fetched or base64'd on
+ * the way.
+ *
+ * The console's own defaults come with them: reference-generation mode, Auto
+ * ratio, 720p, "Smart length" (a model-chosen duration, i.e. `duration: -1`)
+ * and sound on.
+ */
+
+/** Ark presets bucket root for the playground's template media. */
+const BASE =
+  'https://ark-common-storage-prod-cn-beijing.tos-cn-beijing.volces.com/presets/experience/gen_video/templates/reference'
+
+/**
+ * Which prompt part a template asset becomes. The kind *is* the routing: the
+ * adapter maps every video part to `reference_video` and every audio part to
+ * `reference_audio` regardless of `metadata.role`, and reads the role only on
+ * images (`'reference'` → `reference_image`).
+ */
+export type SeedanceTemplateMediaKind = 'image' | 'video' | 'audio'
+
+export interface SeedanceTemplateMedia {
+  kind: SeedanceTemplateMediaKind
+  url: string
+  /**
+   * Chip label, written as the `@`-token the prompt uses for this asset so
+   * the ordinals stay legible once the media is attached.
+   */
+  label: string
+}
+
+export interface SeedanceTemplate {
+  id: string
+  name: string
+  blurb: string
+  /** Sample result the console shows on the card. */
+  previewUrl: string
+  /** The console's official English prompt, verbatim. */
+  prompt: string
+  /** Attached in this order; `@Video1` is the first video, and so on. */
+  media: Array<SeedanceTemplateMedia>
+}
+
+/**
+ * Templates need multimodal reference media (video and audio prompt parts),
+ * which is the Seedance 2.0 family only — applying one switches the model.
+ */
+export const SEEDANCE_TEMPLATE_MODEL: BytePlusVideoModel =
+  'dreamina-seedance-2-0-260128'
+
+/** The console generates templates at 720p. */
+export const SEEDANCE_TEMPLATE_RESOLUTION: BytePlusVideoResolution = '720p'
+
+/**
+ * The `@Video1` / `@Image1` / `@Audio1` ordinals in these prompts are the
+ * console's own authoring syntax. The console rewrites them to internal
+ * `<<<video_1_1>>>` markers before sending; we deliberately do not reproduce
+ * that, and send the `@`-token prose alongside ordered role-tagged parts.
+ *
+ * LIVE-VERIFIED 2026-08-01 through this studio: template 3 on
+ * `dreamina-seedance-2-0-260128`, 720p, adaptive ratio, two reference videos,
+ * shortened to 4s to keep the run cheap (task `cgt-20260801081634-zlhvm`).
+ * Ark accepted the prose as written — no 400 — and *honoured the ordinals*:
+ * the output's first frame reproduces `@Video1`'s overhead framing and the
+ * last frame reproduces `@Video2`'s finished drawing, with generated
+ * storyboard shots in between. So the tokens are worth keeping verbatim.
+ *
+ * If a future model rejects them, rewrite them in plain language ("the first
+ * reference video") rather than reproducing the console's markers.
+ */
+export const SEEDANCE_TEMPLATES: ReadonlyArray<SeedanceTemplate> = [
+  {
+    id: 'tpl-2a98d017',
+    name: 'Music video from art style',
+    blurb: 'Scores a track to the look of a still',
+    previewUrl: `${BASE}/reference/14_3.mp4`,
+    prompt:
+      'Create a music video for @Audio1 inspired by the visual art style of @Image1.',
+    media: [
+      { kind: 'image', url: `${BASE}/reference/14_1.png`, label: '@Image1' },
+      { kind: 'audio', url: `${BASE}/reference/14_2.wav`, label: '@Audio1' },
+    ],
+  },
+  {
+    id: 'tpl-lx-24',
+    name: 'Kitten cinematic journey',
+    blurb: 'One unbroken take, forest to festive home',
+    previewUrl: `${BASE}/timeline/55_5.mp4`,
+    prompt:
+      "Create a 15-second cinematic short in 4K/60fps HDR with subtle film grain, using a palm-sized, adorable orange-and-white kitten as the sole visual focus, continuously tracked in a single flowing narrative from a cool forest sanctuary to a festive ancient town and finally into a warm New Year home, with no hard cuts and all transitions driven naturally by the kitten's running path. Employ cinematic follow shots with shallow depth of field and filmic camera movement, gradually shifting the color tone from cool blue-green forest light to warm red town sidelight and then to soft yellow indoor glow. The kitten runs through the forest, steps onto a bluestone path that transitions into an old town, rubs against a bronze door knocker and pushes open a vermilion door, then enters a warmly lit home where it sprints to a child's feet and leaps into the child's arms in slow motion; the child smiles, hugs the kitten close, and the kitten nuzzles their chin as family silhouettes glow softly behind them. Light Chinese-style orchestral music follows the motion and swells gently into a festive peak as the frame holds in warm yellow light with subtle golden bokeh and slightly intensified film grain, ending on a tender, immersive cinematic moment with no dialogue or subtitles.",
+    media: [
+      { kind: 'video', url: `${BASE}/timeline/55_1.mp4`, label: '@Video1' },
+      { kind: 'video', url: `${BASE}/timeline/55_2.mp4`, label: '@Video2' },
+      { kind: 'video', url: `${BASE}/timeline/55_3.mp4`, label: '@Video3' },
+    ],
+  },
+  {
+    id: 'tpl-f370edd7',
+    name: 'Child draws a dinosaur',
+    blurb: 'Interpolates the middle between two clips',
+    previewUrl: `${BASE}/timeline/25_3.mp4`,
+    prompt:
+      'Using @Video1 as the opening and @Video2 as the ending, generate the complete process of a child drawing a dinosaur. Storyboard-style shots are allowed.',
+    media: [
+      {
+        kind: 'video',
+        url: `${BASE}/timeline/25_1.mp4`,
+        label: '@Video1 (opening)',
+      },
+      {
+        kind: 'video',
+        url: `${BASE}/timeline/25_2.mp4`,
+        label: '@Video2 (ending)',
+      },
+    ],
+  },
+  {
+    id: 'tpl-lx-20',
+    name: 'Art gallery epilogue',
+    blurb: 'Extends a clip to 15s with scored backing',
+    previewUrl: `${BASE}/timeline/49_4.mp4`,
+    prompt:
+      'Extend @Video1 to a total length of 15 seconds with a warm, healing, and emotionally rich tone, using slow motion, soft lighting, and a warm color filter. The sequence transitions into a bright art gallery where white walls filled with oil paintings are softly lit as visitors move through with quiet admiration; it then follows a gentle, grown-up female protagonist in a simple long dress as she tenderly touches her artwork and smiles, accepts flowers from a viewer in a warm close-up, and finally resolves in an overhead wide shot of her standing at the center of the gallery, paintings behind and smiling audiences before her, surrounded by floating light particles as the frame holds. Use @Audio1 as continuous background music with subtle sparkling light sound effects at the opening transition, no dialogue, and maintain a warm white and creamy yellow palette with soft, shadowless gallery lighting and balanced color saturation.',
+    media: [
+      { kind: 'video', url: `${BASE}/timeline/49_1.mp4`, label: '@Video1' },
+      { kind: 'audio', url: `${BASE}/timeline/49_2.mp3`, label: '@Audio1' },
+    ],
+  },
+  {
+    id: 'tpl-lx-06',
+    name: 'Tech-park concept dive',
+    blurb: 'Borrows one clip’s camera move, one still’s skyline',
+    previewUrl: `${BASE}/reference/35_4.mp4`,
+    prompt:
+      "Following the camera movement style of @Video1, create a conceptual technology park video using @Image1 as the opening frame. The high-rise buildings in the image serve as the visual core, with a first-person aerial dive-in perspective that descends smoothly toward the central tower. Maintain a controlled, cinematic forward-and-downward motion to emphasize scale, structure, and spatial depth, highlighting the park's futuristic architecture, clean geometry, and advanced technological atmosphere. The camera movement remains fluid and immersive, reinforcing a strong sense of innovation and high-tech identity throughout the sequence.",
+    media: [
+      { kind: 'video', url: `${BASE}/reference/35_1.mp4`, label: '@Video1' },
+      // The prompt calls this the "opening frame", but reference and frame
+      // modes are mutually exclusive on the wire, and the console sends it in
+      // reference mode — so it goes as a reference image, not a first frame.
+      { kind: 'image', url: `${BASE}/reference/35_2.png`, label: '@Image1' },
+    ],
+  },
+]

--- a/examples/ts-react-media/src/lib/seedance.ts
+++ b/examples/ts-react-media/src/lib/seedance.ts
@@ -1,0 +1,312 @@
+import type {
+  BytePlusVideoModel,
+  BytePlusVideoModelOrString,
+  BytePlusVideoRatio,
+  BytePlusVideoResolution,
+  BytePlusVideoServiceTier,
+} from '@tanstack/ai-byteplus'
+
+/**
+ * Seedance Studio catalog — the client half of the per-model capability
+ * surface.
+ *
+ * Everything the adapter can tell us at runtime (duration range, resolution
+ * tiers, first/last-frame support, reference-media support) is read from
+ * `@tanstack/ai-byteplus` on the server and shipped down as
+ * {@link SeedanceCapability}; this file only carries what the package
+ * documents in prose rather than in a runtime table: display copy, and the
+ * per-field applicability policy for the provider options.
+ */
+
+/** Which optional provider-option fields a model accepts. */
+export interface SeedanceExtras {
+  /**
+   * `generate_audio` — accepted by every model at the validation layer, but
+   * only the Seedance 2.0 family and 1.5-pro actually produce an audio track.
+   */
+  generateAudio: boolean
+  /** `camera_fixed` — Seedance 1.x only; the 2.0 family rejects it. */
+  cameraFixed: boolean
+  /** `service_tier: 'flex'` — Seedance 1.x only (no offline tier on 2.0). */
+  serviceTier: boolean
+  /** `frames` — Seedance 1.0-pro and 1.0-pro-fast only. */
+  frames: boolean
+  /** `draft` — Seedance 1.5-pro only. */
+  draft: boolean
+  /** `priority` (0-9) — Seedance 2.0 family only. */
+  priority: boolean
+  /** `duration: -1` (model picks the length) — Seedance 2.0 and 1.5-pro. */
+  autoDuration: boolean
+}
+
+export interface SeedanceModelEntry {
+  id: BytePlusVideoModelOrString
+  name: string
+  blurb: string
+  extras: SeedanceExtras
+}
+
+/** Resolves only for `never`; anything else is a compile error naming it. */
+type AssertNever<T extends never> = T
+
+/**
+ * The six Seedance models, with the option applicability probed live against
+ * Ark on 2026-07-31 and documented on `BytePlusVideoProviderOptions`. Ark 400s
+ * on an inapplicable field rather than ignoring it, so these flags decide what
+ * the studio is allowed to send — not just what it renders.
+ */
+export const SEEDANCE_MODELS = [
+  {
+    id: 'dreamina-seedance-2-0-260128',
+    name: 'Seedance 2.0',
+    blurb: 'Flagship — the only Seedance model with a 4k tier',
+    extras: {
+      generateAudio: true,
+      cameraFixed: false,
+      serviceTier: false,
+      frames: false,
+      draft: false,
+      priority: true,
+      autoDuration: true,
+    },
+  },
+  {
+    id: 'dreamina-seedance-2-0-fast-260128',
+    name: 'Seedance 2.0 Fast',
+    blurb: 'Faster 2.0 sibling, capped at 720p',
+    extras: {
+      generateAudio: true,
+      cameraFixed: false,
+      serviceTier: false,
+      frames: false,
+      draft: false,
+      priority: true,
+      autoDuration: true,
+    },
+  },
+  {
+    id: 'dreamina-seedance-2-0-mini-260615',
+    name: 'Seedance 2.0 Mini',
+    blurb: 'Smallest 2.0 model, still takes reference media',
+    extras: {
+      generateAudio: true,
+      cameraFixed: false,
+      serviceTier: false,
+      frames: false,
+      draft: false,
+      priority: true,
+      autoDuration: true,
+    },
+  },
+  {
+    id: 'seedance-1-5-pro-251215',
+    name: 'Seedance 1.5 Pro',
+    blurb: 'Audio-capable 1.x flagship with cheap draft renders',
+    extras: {
+      generateAudio: true,
+      cameraFixed: true,
+      serviceTier: true,
+      frames: false,
+      draft: true,
+      priority: false,
+      autoDuration: true,
+    },
+  },
+  {
+    id: 'seedance-1-0-pro-250528',
+    name: 'Seedance 1.0 Pro',
+    blurb: 'Frame-count output and first-and-last-frame mode',
+    extras: {
+      generateAudio: false,
+      cameraFixed: true,
+      serviceTier: true,
+      frames: true,
+      draft: false,
+      priority: false,
+      autoDuration: false,
+    },
+  },
+  {
+    id: 'seedance-1-0-pro-fast-251015',
+    name: 'Seedance 1.0 Pro Fast',
+    blurb: 'Cheapest run — text-to-video and opening-frame only',
+    extras: {
+      generateAudio: false,
+      cameraFixed: true,
+      serviceTier: true,
+      frames: true,
+      draft: false,
+      priority: false,
+      autoDuration: false,
+    },
+  },
+] as const satisfies ReadonlyArray<SeedanceModelEntry>
+
+/**
+ * Compile-time link between this catalog and the package's model list: a
+ * seventh model shipping in `@tanstack/ai-byteplus` fails the example's build
+ * here — naming the id it is missing — instead of silently going absent from
+ * the picker with no capability copy or option policy.
+ */
+export type SeedanceCatalogCoversEveryModel = AssertNever<
+  Exclude<BytePlusVideoModel, (typeof SEEDANCE_MODELS)[number]['id']>
+>
+
+/**
+ * Look up a catalog entry, or `undefined` for an id this file has no policy
+ * for. There is deliberately no fallback entry: handing back some other
+ * model's option policy would gate the studio on the wrong model's rules —
+ * exactly the class of bug the per-model gating exists to prevent. A custom
+ * id goes through the explicit unknown-model path instead.
+ */
+export function seedanceModel(
+  id: BytePlusVideoModel,
+): SeedanceModelEntry | undefined {
+  return SEEDANCE_MODELS.find((entry) => entry.id === id)
+}
+
+/**
+ * The runtime half of a model's capabilities, derived on the server from the
+ * adapter's own metadata rather than restated here.
+ */
+export interface SeedanceCapability {
+  model: BytePlusVideoModel
+  /** Tiers this model accepts, in ascending order. */
+  resolutions: Array<BytePlusVideoResolution>
+  /** Whole-second range from the adapter's `availableDurations()`. */
+  duration: { min: number; max: number; step: number }
+  /** Whether an `end_frame` image is accepted (`flf2v`). */
+  supportsLastFrame: boolean
+  /** Whether reference images / video / audio are accepted (`r2v`). */
+  supportsReferenceMedia: boolean
+}
+
+/**
+ * Placeholder for the advanced custom-id field: the real Seedance 2.5 id.
+ *
+ * The June date suffix is the whole reason it needs typing out — guessing ids
+ * around the 2026-07-31 announcement never landed on it. The id is reachable
+ * but activation-gated: an account that has not enabled it in the Ark Console
+ * gets 404 `ModelNotOpen`.
+ */
+export const SEEDANCE_CUSTOM_MODEL_PLACEHOLDER = 'dreamina-seedance-2-5-260628'
+
+/**
+ * Option applicability for an id the package has no table for: everything on.
+ *
+ * This is not optimism. `@tanstack/ai-byteplus` deliberately leaves an unknown
+ * id ungated — the adapter's per-model guards switch off and Ark judges the
+ * request — because clamping a future model against today's tables would
+ * reject requests the API would have accepted. The studio mirrors that: it
+ * offers the full surface and lets the API be the authority.
+ */
+export const SEEDANCE_UNKNOWN_MODEL_EXTRAS: SeedanceExtras = {
+  generateAudio: true,
+  cameraFixed: true,
+  serviceTier: true,
+  frames: true,
+  draft: true,
+  priority: true,
+  autoDuration: true,
+}
+
+/**
+ * Every resolution tier Seedance has shipped so far. Which of them a known
+ * model accepts is decided by the adapter (see `SeedanceCapability`); for an
+ * unknown model these are offered as a starting point alongside a free-text
+ * field, since a future model may bring a tier that does not exist today.
+ */
+export const SEEDANCE_RESOLUTION_TIERS: ReadonlyArray<BytePlusVideoResolution> =
+  ['480p', '720p', '1080p', '4k']
+
+/**
+ * The studio's curated slice of `BytePlusVideoProviderOptions`, as sent from
+ * the browser. The server maps it onto the provider's own (snake_case) field
+ * names and drops anything the selected model does not accept.
+ */
+export interface SeedanceJobOptions {
+  ratio?: BytePlusVideoRatio
+  resolution?: BytePlusVideoResolution
+  /**
+   * Full `ratio_resolution` template, used instead of `ratio`/`resolution` for
+   * a custom model id. Those two are typed against the tiers this package
+   * knows; the generic `size` is the open path, and the adapter only checks an
+   * unknown model's template shape before handing the values to Ark.
+   */
+  size?: string
+  /** Whole seconds, or `-1` to let the model choose (2.0 / 1.5-pro only). */
+  duration?: number
+  /** Frame count instead of seconds; wins over `duration` server-side. */
+  frames?: number
+  /** `[-1, 2^32-1]`; `-1` leaves generation unseeded. */
+  seed?: number
+  watermark?: boolean
+  generateAudio?: boolean
+  cameraFixed?: boolean
+  serviceTier?: BytePlusVideoServiceTier
+  draft?: boolean
+  /** Queue priority `[0, 9]`. */
+  priority?: number
+}
+
+/**
+ * How the prompt's media parts are shaped. Seedance sorts them into mutually
+ * exclusive task types, so the studio picks one mode rather than letting a
+ * user mix frame roles with reference roles into a request the adapter would
+ * reject.
+ */
+export type SeedanceInputMode =
+  | 'text'
+  | 'first-frame'
+  | 'first-last-frame'
+  | 'reference'
+
+/**
+ * Aspect ratios the create endpoint accepts. `adaptive` (follow the input
+ * frame) only makes sense with an image attached — Seedance 1.0 rejects it
+ * outright for text-to-video — so the studio offers it conditionally.
+ */
+export const SEEDANCE_RATIOS: ReadonlyArray<BytePlusVideoRatio> = [
+  '16:9',
+  '9:16',
+  '4:3',
+  '3:4',
+  '1:1',
+  '21:9',
+]
+
+/** Seedance renders at 24 fps, which is what makes `frames` a duration. */
+export const SEEDANCE_FPS = 24
+
+/**
+ * Snap a frame count onto the grid Seedance accepts: the integers of the form
+ * `25 + 4n` inside `[29, 289]`.
+ */
+export function snapSeedanceFrames(frames: number): number {
+  const steps = Math.min(66, Math.max(1, Math.round((frames - 25) / 4)))
+  return 25 + steps * 4
+}
+
+/** Smallest / largest frame counts on that grid. */
+export const SEEDANCE_MIN_FRAMES = snapSeedanceFrames(0)
+export const SEEDANCE_MAX_FRAMES = snapSeedanceFrames(Number.MAX_SAFE_INTEGER)
+
+/** One-line capability summary shown under each model in the picker. */
+export function describeSeedanceModel(
+  entry: SeedanceModelEntry,
+  capability: SeedanceCapability | undefined,
+): string {
+  if (!capability) return entry.blurb
+  const parts = [
+    `${capability.duration.min}-${capability.duration.max}s`,
+    capability.resolutions.join(' / '),
+  ]
+  if (entry.extras.generateAudio) parts.push('audio')
+  if (capability.supportsReferenceMedia) parts.push('references')
+  if (capability.supportsLastFrame) parts.push('first+last frame')
+  if (entry.extras.serviceTier) parts.push('flex tier')
+  if (entry.extras.frames) parts.push('frame count')
+  if (entry.extras.draft) parts.push('draft')
+  if (entry.extras.priority) parts.push('priority')
+  return parts.join(' · ')
+}

--- a/examples/ts-react-media/src/lib/server-functions.ts
+++ b/examples/ts-react-media/src/lib/server-functions.ts
@@ -2,6 +2,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { falImage, falVideo } from '@tanstack/ai-fal'
 import { geminiImage, geminiVideo } from '@tanstack/ai-gemini'
 import { grokImage, grokVideo } from '@tanstack/ai-grok'
+import { byteplusImage, byteplusVideo } from '@tanstack/ai-byteplus'
 import { generateImage, generateVideo, getVideoJobStatus } from '@tanstack/ai'
 
 import type {
@@ -99,6 +100,10 @@ function videoAdapterForModel(model: string) {
   }
   if (model === 'grok-imagine-video-1.5/image-to-video') {
     return grokVideo('grok-imagine-video-1.5')
+  }
+  if (model === 'dreamina-seedance-2-0-260128') {
+    // BytePlus ModelArk Seedance task API (ARK_API_KEY).
+    return byteplusVideo('dreamina-seedance-2-0-260128')
   }
   if (model.startsWith('gemini-omni-flash-preview')) {
     // Both UI entries (text-to-video and image-to-video) run on the one
@@ -226,6 +231,18 @@ export const generateImageFn = createServerFn({ method: 'POST' })
           size: '1024x1024',
         })
       }
+      case 'dola-seedream-5-0-pro-260628': {
+        // BytePlus Seedream via ModelArk (ARK_API_KEY). `size` is either a
+        // 1K/2K/4K token or an explicit WIDTHxHEIGHT string — never both.
+        // Seedream models accept reference images, so image prompt parts are
+        // passed straight through.
+        return generateImage({
+          adapter: byteplusImage('dola-seedream-5-0-pro-260628'),
+          prompt: asImagePrompt(data.prompt),
+          numberOfImages: 1,
+          size: '2K',
+        })
+      }
       default:
         throw new Error(`Unknown model: ${data.model}`)
     }
@@ -303,6 +320,19 @@ export const createVideoJobFn = createServerFn({ method: 'POST' })
         // (billed seconds) and usage.cost (exact USD).
         return generateVideo({
           adapter: grokVideo('grok-imagine-video'),
+          prompt: asTextPrompt(data.prompt),
+          size: '16:9_720p',
+          duration: 5,
+        })
+      }
+      case 'dreamina-seedance-2-0-260128': {
+        // BytePlus Seedance via ModelArk (ARK_API_KEY). `size` is a "ratio" or
+        // "ratio_resolution" template; durations are 4-15 integer seconds.
+        // Seedance option applicability is per model and Ark 400s on an
+        // inapplicable field, so no service_tier/frames/camera_fixed here —
+        // the 2.0 family rejects all three.
+        return generateVideo({
+          adapter: byteplusVideo('dreamina-seedance-2-0-260128'),
           prompt: asTextPrompt(data.prompt),
           size: '16:9_720p',
           duration: 5,

--- a/examples/ts-react-media/src/lib/server-functions.ts
+++ b/examples/ts-react-media/src/lib/server-functions.ts
@@ -612,7 +612,11 @@ function seedanceStream(data: SeedanceRequest): AsyncIterable<StreamChunk> {
     // id every one of those guards is off by design: the duration goes
     // through verbatim and Ark is the authority.
     adapter: byteplusVideo(data.model),
-    prompt: asImagePrompt(data.prompt),
+    // Passed through un-narrowed, unlike the other generators: Seedance's
+    // reference mode takes video and audio parts as well as images (the
+    // template presets send both), and which of them a given model allows is
+    // the adapter's call — its error names the model and the part.
+    prompt: data.prompt,
     ...(options.size !== undefined && { size: options.size }),
     ...(duration !== undefined && { duration }),
     modelOptions,

--- a/examples/ts-react-media/src/lib/server-functions.ts
+++ b/examples/ts-react-media/src/lib/server-functions.ts
@@ -2,9 +2,23 @@ import { createServerFn } from '@tanstack/react-start'
 import { falImage, falVideo } from '@tanstack/ai-fal'
 import { geminiImage, geminiVideo } from '@tanstack/ai-gemini'
 import { grokImage, grokVideo } from '@tanstack/ai-grok'
-import { byteplusImage, byteplusVideo } from '@tanstack/ai-byteplus'
+import {
+  BYTEPLUS_VIDEO_MODELS,
+  byteplusImage,
+  byteplusVideo,
+  getBytePlusVideoDurationOptions,
+  resolveBytePlusVideoResolution,
+  supportsLastFrame,
+  supportsReferenceMedia,
+} from '@tanstack/ai-byteplus'
 import { generateImage, generateVideo, getVideoJobStatus } from '@tanstack/ai'
 
+import type {
+  BytePlusVideoModel,
+  BytePlusVideoModelOrString,
+  BytePlusVideoProviderOptions,
+  BytePlusVideoResolution,
+} from '@tanstack/ai-byteplus'
 import type {
   ImagePart,
   MediaInputMetadata,
@@ -13,6 +27,8 @@ import type {
   VideoPart,
 } from '@tanstack/ai/client'
 import type { OmniTaskMode } from './models'
+import type { SeedanceCapability, SeedanceJobOptions } from './seedance'
+import { SEEDANCE_RESOLUTION_TIERS } from './seedance'
 
 /** A prompt restricted to text — accepted by every (incl. text-only) model. */
 type TextPrompt = string | Array<TextPart>
@@ -455,4 +471,157 @@ export const getVideoUrlFn = createServerFn({ method: 'GET' })
       adapter,
       jobId: data.jobId,
     })
+  })
+
+// ============================================================================
+// Seedance Studio — BytePlus ModelArk direct (ARK_API_KEY, server-side only)
+// ============================================================================
+
+/**
+ * The tiers a model accepts. `resolveBytePlusVideoResolution` is the package's
+ * exported gate for exactly this decision — it throws on a tier the model does
+ * not offer — so probing it keeps one source of truth for a matrix that is
+ * neither uniform nor guessable (there is no 2K tier anywhere, and 4k exists
+ * only on `dreamina-seedance-2-0-260128`).
+ */
+function acceptedResolutions(
+  model: BytePlusVideoModel,
+): Array<BytePlusVideoResolution> {
+  return SEEDANCE_RESOLUTION_TIERS.filter((tier) => {
+    try {
+      resolveBytePlusVideoResolution(model, tier)
+      return true
+    } catch {
+      return false
+    }
+  })
+}
+
+/**
+ * Per-model capability table for the Seedance Studio, read out of the adapter
+ * package on the server. No API key is involved: these are static metadata
+ * lookups, not calls to Ark.
+ */
+export const getSeedanceCapabilitiesFn = createServerFn({
+  method: 'GET',
+}).handler(
+  (): Array<SeedanceCapability> =>
+    BYTEPLUS_VIDEO_MODELS.map((model) => {
+      const durations = getBytePlusVideoDurationOptions(model)
+      if (durations.kind !== 'range') {
+        throw new Error(
+          `Expected a duration range for ${model}, got "${durations.kind}"`,
+        )
+      }
+      return {
+        model,
+        resolutions: acceptedResolutions(model),
+        duration: {
+          min: durations.min,
+          max: durations.max,
+          step: durations.step ?? 1,
+        },
+        supportsLastFrame: supportsLastFrame(model),
+        supportsReferenceMedia: supportsReferenceMedia(model),
+      }
+    }),
+)
+
+export const createSeedanceJobFn = createServerFn({ method: 'POST' })
+  .inputValidator(
+    (data: {
+      prompt: MediaPrompt
+      // Open by design: the studio's advanced field takes an id this package
+      // has no metadata for (Seedance 2.5 today), which the adapter forwards
+      // ungated for Ark to judge.
+      model: BytePlusVideoModelOrString
+      options?: SeedanceJobOptions
+    }) => {
+      if (!hasPromptContent(data.prompt)) throw new Error('Prompt is required')
+      if (!data.model) throw new Error('Model is required')
+      return data
+    },
+  )
+  .handler(async ({ data }) => {
+    const options = data.options ?? {}
+
+    // The studio's camelCase controls map one-to-one onto the provider's own
+    // request fields. Applicability is per model and Ark 400s on a field the
+    // model doesn't take (it does not ignore it), so the client only sends
+    // what the selected model accepts — see `SEEDANCE_MODELS` in lib/seedance.
+    //
+    // `ratio` / `resolution` are typed against the tiers this package knows,
+    // so a custom model id sends its sizing through the generic `size`
+    // template instead (see `SeedanceJobOptions.size`).
+    const modelOptions: BytePlusVideoProviderOptions = {
+      ...(options.size === undefined &&
+        options.ratio !== undefined && { ratio: options.ratio }),
+      ...(options.size === undefined &&
+        options.resolution !== undefined && {
+          resolution: options.resolution,
+        }),
+      // `-1` (let the model choose the length) is only reachable through
+      // provider options: the generic `duration` gets snapped into range.
+      ...(options.duration === -1 && { duration: -1 }),
+      ...(options.frames !== undefined && { frames: options.frames }),
+      ...(options.seed !== undefined && { seed: options.seed }),
+      ...(options.watermark !== undefined && { watermark: options.watermark }),
+      ...(options.generateAudio !== undefined && {
+        generate_audio: options.generateAudio,
+      }),
+      ...(options.cameraFixed !== undefined && {
+        camera_fixed: options.cameraFixed,
+      }),
+      ...(options.serviceTier !== undefined && {
+        service_tier: options.serviceTier,
+      }),
+      ...(options.draft !== undefined && { draft: options.draft }),
+      ...(options.priority !== undefined && { priority: options.priority }),
+    }
+
+    // `frames` takes precedence over `duration` server-side, so never send
+    // both; `-1` already went through modelOptions above.
+    const duration =
+      options.frames === undefined &&
+      options.duration !== undefined &&
+      options.duration > 0
+        ? options.duration
+        : undefined
+
+    return await generateVideo({
+      // For a model this package knows, the adapter snaps `duration` into its
+      // range and validates the resolution tier, prompt roles and
+      // frame/reference exclusivity before anything reaches Ark. For a custom
+      // id every one of those guards is off by design: the duration goes
+      // through verbatim and Ark is the authority.
+      adapter: byteplusVideo(data.model),
+      prompt: asImagePrompt(data.prompt),
+      ...(options.size !== undefined && { size: options.size }),
+      ...(duration !== undefined && { duration }),
+      modelOptions,
+    })
+  })
+
+export const getSeedanceJobFn = createServerFn({ method: 'GET' })
+  .inputValidator(
+    (data: { jobId: string; model: BytePlusVideoModelOrString }) => {
+      if (!data.jobId) throw new Error('Job id is required')
+      return data
+    },
+  )
+  .handler(async ({ data }) => {
+    const result = await getVideoJobStatus({
+      adapter: byteplusVideo(data.model),
+      jobId: data.jobId,
+    })
+    // `expiresAt` is a Date on the result; hand the browser an ISO string so
+    // the shape crossing the server-function boundary is unambiguous.
+    return {
+      jobId: result.jobId,
+      status: result.status,
+      ...(result.url !== undefined && { url: result.url }),
+      ...(result.error !== undefined && { error: result.error }),
+      ...(result.expiresAt && { expiresAt: result.expiresAt.toISOString() }),
+      ...(result.usage && { usage: result.usage }),
+    }
   })

--- a/examples/ts-react-media/src/lib/server-functions.ts
+++ b/examples/ts-react-media/src/lib/server-functions.ts
@@ -499,7 +499,7 @@ export const generateVideoFn = createServerFn({ method: 'POST' })
 function acceptedResolutions(
   model: BytePlusVideoModel,
 ): Array<BytePlusVideoResolution> {
-  return SEEDANCE_RESOLUTION_TIERS.filter((tier) => {
+  const accepted = SEEDANCE_RESOLUTION_TIERS.filter((tier) => {
     try {
       resolveBytePlusVideoResolution(model, tier)
       return true
@@ -507,6 +507,21 @@ function acceptedResolutions(
       return false
     }
   })
+
+  // Using a throw as the predicate means *any* change to that function's
+  // contract reads as "no tier is supported". Every Seedance model offers at
+  // least 480p and 720p, so an empty list is drift, not a real answer —
+  // without this the Studio would silently fall back to a hardcoded '720p'
+  // and build requests on a guess. The route has an errorComponent for
+  // exactly this.
+  if (accepted.length === 0) {
+    throw new Error(
+      `Seedance capability probe returned no resolution tiers for "${model}". ` +
+        `resolveBytePlusVideoResolution's contract has probably changed — the ` +
+        `Studio's controls cannot be built from this.`,
+    )
+  }
+  return accepted
 }
 
 /**

--- a/examples/ts-react-media/src/lib/server-functions.ts
+++ b/examples/ts-react-media/src/lib/server-functions.ts
@@ -11,8 +11,13 @@ import {
   supportsLastFrame,
   supportsReferenceMedia,
 } from '@tanstack/ai-byteplus'
-import { generateImage, generateVideo, getVideoJobStatus } from '@tanstack/ai'
+import {
+  generateImage,
+  generateVideo,
+  toServerSentEventsResponse,
+} from '@tanstack/ai'
 
+import type { StreamChunk } from '@tanstack/ai'
 import type {
   BytePlusVideoModel,
   BytePlusVideoModelOrString,
@@ -106,28 +111,11 @@ function asImageToVideoPrompt(
 }
 
 /**
- * Resolves the video adapter for a UI model id. The native grok-imagine
- * entries hit xAI's Imagine API directly via the `grokVideo` adapter
- * (XAI_API_KEY); everything else is a fal-hosted model.
+ * Poll cadence for the streamed video lifecycle. The server holds the request
+ * open and polls the provider itself, so this is the rate at which
+ * `video:status` events reach the browser's `useGenerateVideo`.
  */
-function videoAdapterForModel(model: string) {
-  if (model === 'grok-imagine-video') {
-    return grokVideo('grok-imagine-video')
-  }
-  if (model === 'grok-imagine-video-1.5/image-to-video') {
-    return grokVideo('grok-imagine-video-1.5')
-  }
-  if (model === 'dreamina-seedance-2-0-260128') {
-    // BytePlus ModelArk Seedance task API (ARK_API_KEY).
-    return byteplusVideo('dreamina-seedance-2-0-260128')
-  }
-  if (model.startsWith('gemini-omni-flash-preview')) {
-    // Both UI entries (text-to-video and image-to-video) run on the one
-    // Omni model over the Interactions API (GEMINI_API_KEY).
-    return geminiVideo('gemini-omni-flash-preview')
-  }
-  return falVideo(model)
-}
+const VIDEO_POLL_INTERVAL_MS = 4000
 
 export const generateImageFn = createServerFn({ method: 'POST' })
   .inputValidator((data: { prompt: MediaPrompt; model: string }) => {
@@ -264,214 +252,238 @@ export const generateImageFn = createServerFn({ method: 'POST' })
     }
   })
 
-export const createVideoJobFn = createServerFn({ method: 'POST' })
-  .inputValidator(
-    (data: {
-      prompt: MediaPrompt
-      model: string
-      /**
-       * Gemini Omni Flash conversational editing: the jobId (interaction id)
-       * of a prior Omni generation to refine. Ignored by other models.
-       */
-      previousInteractionId?: string
-      /**
-       * Gemini Omni Flash generation controls (ignored by other models):
-       * clip duration in seconds (3-10, fractional OK, default 10), output
-       * aspect ratio, and an optional task-mode pin — omit `task` to let
-       * the model infer the mode from the prompt and attachments.
-       */
-      omniOptions?: {
-        duration?: number
-        aspectRatio?: '16:9' | '9:16'
-        task?: OmniTaskMode
-      }
-    }) => {
-      if (!hasPromptContent(data.prompt)) throw new Error('Prompt is required')
-      if (!data.model) throw new Error('Model is required')
-      return data
-    },
-  )
-  .handler(async ({ data }) => {
-    // Image-to-video models receive the start frame as a prompt part
-    // (role: 'start_frame') — the fal adapter routes it to the endpoint's
-    // start-image field. Text-to-video models take the text prompt only.
-    switch (data.model) {
-      // Text-to-video models
-      case 'fal-ai/kling-video/v3/pro/text-to-video': {
-        return generateVideo({
-          adapter: falVideo('fal-ai/kling-video/v3/pro/text-to-video'),
-          prompt: asTextPrompt(data.prompt),
-          size: '16:9',
-          modelOptions: {
-            duration: '5',
-          },
-        })
-      }
-      case 'fal-ai/veo3.1': {
-        // NOTE pass aspect ratio, resolution, and duration in model options
-        // This makes use of existing types and avoids type errors
-        return generateVideo({
-          adapter: falVideo('fal-ai/veo3.1'),
-          prompt: asTextPrompt(data.prompt),
-          size: '16:9_1080p',
-          modelOptions: {
-            duration: '4s',
-          },
-        })
-      }
-      case 'xai/grok-imagine-video/text-to-video': {
-        return generateVideo({
-          adapter: falVideo('xai/grok-imagine-video/text-to-video'),
-          prompt: asTextPrompt(data.prompt),
-          size: '16:9_720p',
-          modelOptions: {
-            duration: 5,
-          },
-        })
-      }
-      case 'grok-imagine-video': {
-        // Direct xAI Imagine API (XAI_API_KEY) — no fal in between. The base
-        // grok-imagine-video (v1.0) supports text-to-video; durations are
-        // 1-15 integer seconds. Completed jobs report usage.unitsBilled
-        // (billed seconds) and usage.cost (exact USD).
-        return generateVideo({
-          adapter: grokVideo('grok-imagine-video'),
-          prompt: asTextPrompt(data.prompt),
-          size: '16:9_720p',
-          duration: 5,
-        })
-      }
-      case 'dreamina-seedance-2-0-260128': {
-        // BytePlus Seedance via ModelArk (ARK_API_KEY). `size` is a "ratio" or
-        // "ratio_resolution" template; durations are 4-15 integer seconds.
-        // Seedance option applicability is per model and Ark 400s on an
-        // inapplicable field, so no service_tier/frames/camera_fixed here —
-        // the 2.0 family rejects all three.
-        return generateVideo({
-          adapter: byteplusVideo('dreamina-seedance-2-0-260128'),
-          prompt: asTextPrompt(data.prompt),
-          size: '16:9_720p',
-          duration: 5,
-        })
-      }
-      case 'fal-ai/ltx-2.3/text-to-video/fast': {
-        return generateVideo({
-          adapter: falVideo('fal-ai/ltx-2.3/text-to-video/fast'),
-          prompt: asTextPrompt(data.prompt),
-          size: '16:9_2160p',
-        })
-      }
-      // Image-to-video models
-      case 'fal-ai/kling-video/v3/pro/image-to-video': {
-        return generateVideo({
-          adapter: falVideo('fal-ai/kling-video/v3/pro/image-to-video'),
-          prompt: asImageToVideoPrompt(data.prompt),
-          modelOptions: {
-            generate_audio: true,
-            duration: '5',
-          },
-        })
-      }
-      case 'fal-ai/veo3.1/image-to-video': {
-        return generateVideo({
-          adapter: falVideo('fal-ai/veo3.1/image-to-video'),
-          prompt: asImageToVideoPrompt(data.prompt),
-          size: '16:9_1080p',
-          modelOptions: {
-            duration: '4s',
-          },
-        })
-      }
-      case 'xai/grok-imagine-video/image-to-video': {
-        return generateVideo({
-          adapter: falVideo('xai/grok-imagine-video/image-to-video'),
-          prompt: asImageToVideoPrompt(data.prompt),
-          size: '16:9_720p',
-          modelOptions: {
-            duration: 5,
-          },
-        })
-      }
-      case 'grok-imagine-video-1.5/image-to-video': {
-        // Direct xAI Imagine API. The starting frame is supplied as an image
-        // prompt part (asImageToVideoPrompt requires one); the grokVideo
-        // adapter forwards it to the Imagine endpoint as the start frame.
-        return generateVideo({
-          adapter: grokVideo('grok-imagine-video-1.5'),
-          prompt: asImageToVideoPrompt(data.prompt),
-          size: '16:9_720p',
-          duration: 5,
-        })
-      }
-      case 'fal-ai/ltx-2.3/image-to-video/fast': {
-        return generateVideo({
-          adapter: falVideo('fal-ai/ltx-2.3/image-to-video/fast'),
-          prompt: asImageToVideoPrompt(data.prompt),
-          size: '16:9_2160p',
-        })
-      }
-      // Gemini Omni Flash (Interactions API, GEMINI_API_KEY). One model
-      // serves both UI entries; it accepts text, image, AND video prompt
-      // parts (sent as interaction content blocks: images, then videos,
-      // then text). Clips are 3–10s at 720p (default 10s when `duration`
-      // is omitted); `size` is the output aspect ratio. Passing
-      // `previous_interaction_id` chains a prompt onto a prior generation
-      // for conversational editing.
-      case 'gemini-omni-flash-preview':
-      case 'gemini-omni-flash-preview/image-to-video': {
-        const prompt = asOmniPrompt(data.prompt)
-        if (
-          data.model.endsWith('/image-to-video') &&
-          !data.previousInteractionId &&
-          (typeof prompt === 'string' ||
-            !prompt.some((part) => part.type === 'image'))
-        ) {
-          throw new Error('Start image is required for image-to-video')
-        }
-        const { duration, aspectRatio, task } = data.omniOptions ?? {}
-        return generateVideo({
-          adapter: geminiVideo('gemini-omni-flash-preview'),
-          prompt,
-          size: aspectRatio ?? '16:9',
-          ...(duration !== undefined ? { duration } : {}),
-          ...(data.previousInteractionId || task
-            ? {
-                modelOptions: {
-                  ...(data.previousInteractionId
-                    ? { previous_interaction_id: data.previousInteractionId }
-                    : {}),
-                  ...(task
-                    ? { generation_config: { video_config: { task } } }
-                    : {}),
-                },
-              }
-            : {}),
-        })
-      }
-      default:
-        throw new Error(`Unknown video model: ${data.model}`)
+/** What the browser sends for one video generation. */
+interface VideoRequest {
+  prompt: MediaPrompt
+  model: string
+  /**
+   * Gemini Omni Flash conversational editing: the jobId (interaction id)
+   * of a prior Omni generation to refine. Ignored by other models.
+   */
+  previousInteractionId?: string
+  /**
+   * Gemini Omni Flash generation controls (ignored by other models):
+   * clip duration in seconds (3-10, fractional OK, default 10), output
+   * aspect ratio, and an optional task-mode pin — omit `task` to let
+   * the model infer the mode from the prompt and attachments.
+   */
+  omniOptions?: {
+    duration?: number
+    aspectRatio?: '16:9' | '9:16'
+    task?: OmniTaskMode
+  }
+}
+
+/**
+ * The full create → poll → complete lifecycle for one model, as a chunk
+ * stream. `stream: true` is what moves the polling loop to the server: the
+ * browser's `useGenerateVideo` reads job id, status and result off these
+ * chunks instead of running its own timer.
+ */
+function videoStreamForModel(data: VideoRequest): AsyncIterable<StreamChunk> {
+  // Image-to-video models receive the start frame as a prompt part
+  // (role: 'start_frame') — the fal adapter routes it to the endpoint's
+  // start-image field. Text-to-video models take the text prompt only.
+  switch (data.model) {
+    // Text-to-video models
+    case 'fal-ai/kling-video/v3/pro/text-to-video': {
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: falVideo('fal-ai/kling-video/v3/pro/text-to-video'),
+        prompt: asTextPrompt(data.prompt),
+        size: '16:9',
+        modelOptions: {
+          duration: '5',
+        },
+      })
     }
-  })
+    case 'fal-ai/veo3.1': {
+      // NOTE pass aspect ratio, resolution, and duration in model options
+      // This makes use of existing types and avoids type errors
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: falVideo('fal-ai/veo3.1'),
+        prompt: asTextPrompt(data.prompt),
+        size: '16:9_1080p',
+        modelOptions: {
+          duration: '4s',
+        },
+      })
+    }
+    case 'xai/grok-imagine-video/text-to-video': {
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: falVideo('xai/grok-imagine-video/text-to-video'),
+        prompt: asTextPrompt(data.prompt),
+        size: '16:9_720p',
+        modelOptions: {
+          duration: 5,
+        },
+      })
+    }
+    case 'grok-imagine-video': {
+      // Direct xAI Imagine API (XAI_API_KEY) — no fal in between. The base
+      // grok-imagine-video (v1.0) supports text-to-video; durations are
+      // 1-15 integer seconds. Completed jobs report usage.unitsBilled
+      // (billed seconds) and usage.cost (exact USD).
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: grokVideo('grok-imagine-video'),
+        prompt: asTextPrompt(data.prompt),
+        size: '16:9_720p',
+        duration: 5,
+      })
+    }
+    case 'dreamina-seedance-2-0-260128': {
+      // BytePlus Seedance via ModelArk (ARK_API_KEY). `size` is a "ratio" or
+      // "ratio_resolution" template; durations are 4-15 integer seconds.
+      // Seedance option applicability is per model and Ark 400s on an
+      // inapplicable field, so no service_tier/frames/camera_fixed here —
+      // the 2.0 family rejects all three.
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: byteplusVideo('dreamina-seedance-2-0-260128'),
+        prompt: asTextPrompt(data.prompt),
+        size: '16:9_720p',
+        duration: 5,
+      })
+    }
+    case 'fal-ai/ltx-2.3/text-to-video/fast': {
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: falVideo('fal-ai/ltx-2.3/text-to-video/fast'),
+        prompt: asTextPrompt(data.prompt),
+        size: '16:9_2160p',
+      })
+    }
+    // Image-to-video models
+    case 'fal-ai/kling-video/v3/pro/image-to-video': {
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: falVideo('fal-ai/kling-video/v3/pro/image-to-video'),
+        prompt: asImageToVideoPrompt(data.prompt),
+        modelOptions: {
+          generate_audio: true,
+          duration: '5',
+        },
+      })
+    }
+    case 'fal-ai/veo3.1/image-to-video': {
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: falVideo('fal-ai/veo3.1/image-to-video'),
+        prompt: asImageToVideoPrompt(data.prompt),
+        size: '16:9_1080p',
+        modelOptions: {
+          duration: '4s',
+        },
+      })
+    }
+    case 'xai/grok-imagine-video/image-to-video': {
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: falVideo('xai/grok-imagine-video/image-to-video'),
+        prompt: asImageToVideoPrompt(data.prompt),
+        size: '16:9_720p',
+        modelOptions: {
+          duration: 5,
+        },
+      })
+    }
+    case 'grok-imagine-video-1.5/image-to-video': {
+      // Direct xAI Imagine API. The starting frame is supplied as an image
+      // prompt part (asImageToVideoPrompt requires one); the grokVideo
+      // adapter forwards it to the Imagine endpoint as the start frame.
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: grokVideo('grok-imagine-video-1.5'),
+        prompt: asImageToVideoPrompt(data.prompt),
+        size: '16:9_720p',
+        duration: 5,
+      })
+    }
+    case 'fal-ai/ltx-2.3/image-to-video/fast': {
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: falVideo('fal-ai/ltx-2.3/image-to-video/fast'),
+        prompt: asImageToVideoPrompt(data.prompt),
+        size: '16:9_2160p',
+      })
+    }
+    // Gemini Omni Flash (Interactions API, GEMINI_API_KEY). One model
+    // serves both UI entries; it accepts text, image, AND video prompt
+    // parts (sent as interaction content blocks: images, then videos,
+    // then text). Clips are 3–10s at 720p (default 10s when `duration`
+    // is omitted); `size` is the output aspect ratio. Passing
+    // `previous_interaction_id` chains a prompt onto a prior generation
+    // for conversational editing.
+    case 'gemini-omni-flash-preview':
+    case 'gemini-omni-flash-preview/image-to-video': {
+      const prompt = asOmniPrompt(data.prompt)
+      if (
+        data.model.endsWith('/image-to-video') &&
+        !data.previousInteractionId &&
+        (typeof prompt === 'string' ||
+          !prompt.some((part) => part.type === 'image'))
+      ) {
+        throw new Error('Start image is required for image-to-video')
+      }
+      const { duration, aspectRatio, task } = data.omniOptions ?? {}
+      return generateVideo({
+        stream: true,
+        pollingInterval: VIDEO_POLL_INTERVAL_MS,
+        adapter: geminiVideo('gemini-omni-flash-preview'),
+        prompt,
+        size: aspectRatio ?? '16:9',
+        ...(duration !== undefined ? { duration } : {}),
+        ...(data.previousInteractionId || task
+          ? {
+              modelOptions: {
+                ...(data.previousInteractionId
+                  ? { previous_interaction_id: data.previousInteractionId }
+                  : {}),
+                ...(task
+                  ? { generation_config: { video_config: { task } } }
+                  : {}),
+              },
+            }
+          : {}),
+      })
+    }
+    default:
+      throw new Error(`Unknown video model: ${data.model}`)
+  }
+}
 
-export const getVideoStatusFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { jobId: string; model: string }) => data)
-  .handler(async ({ data }) => {
-    const adapter = videoAdapterForModel(data.model)
-    return await getVideoJobStatus({
-      adapter,
-      jobId: data.jobId,
-    })
+/**
+ * Streams one video generation as Server-Sent Events. `useGenerateVideo`
+ * takes this straight as its `fetcher`: the client parses the SSE body it
+ * returns, so the job id, every status update and the final url all arrive on
+ * the one request — no client-side polling loop and no job ids to thread
+ * through the UI.
+ */
+export const generateVideoFn = createServerFn({ method: 'POST' })
+  .inputValidator((data: VideoRequest) => {
+    if (!hasPromptContent(data.prompt)) throw new Error('Prompt is required')
+    if (!data.model) throw new Error('Model is required')
+    return data
   })
-
-export const getVideoUrlFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { jobId: string; model: string }) => data)
-  .handler(async ({ data }) => {
-    const adapter = videoAdapterForModel(data.model)
-    return await getVideoJobStatus({
-      adapter,
-      jobId: data.jobId,
-    })
-  })
+  // A rejected model / missing start frame throws out of `videoStreamForModel`
+  // before any stream exists, which surfaces as a plain server-function error
+  // (the hook reports it through `error`) rather than a stream that opens only
+  // to fail.
+  .handler(({ data }) => toServerSentEventsResponse(videoStreamForModel(data)))
 
 // ============================================================================
 // Seedance Studio — BytePlus ModelArk direct (ARK_API_KEY, server-side only)
@@ -527,101 +539,98 @@ export const getSeedanceCapabilitiesFn = createServerFn({
     }),
 )
 
-export const createSeedanceJobFn = createServerFn({ method: 'POST' })
-  .inputValidator(
-    (data: {
-      prompt: MediaPrompt
-      // Open by design: the studio's advanced field takes an id this package
-      // has no metadata for (Seedance 2.5 today), which the adapter forwards
-      // ungated for Ark to judge.
-      model: BytePlusVideoModelOrString
-      options?: SeedanceJobOptions
-    }) => {
-      if (!hasPromptContent(data.prompt)) throw new Error('Prompt is required')
-      if (!data.model) throw new Error('Model is required')
-      return data
-    },
-  )
-  .handler(async ({ data }) => {
-    const options = data.options ?? {}
+/** What the studio sends for one Seedance generation. */
+interface SeedanceRequest {
+  prompt: MediaPrompt
+  // Open by design: the studio's advanced field takes an id this package
+  // has no metadata for (Seedance 2.5 today), which the adapter forwards
+  // ungated for Ark to judge.
+  model: BytePlusVideoModelOrString
+  options?: SeedanceJobOptions
+}
 
-    // The studio's camelCase controls map one-to-one onto the provider's own
-    // request fields. Applicability is per model and Ark 400s on a field the
-    // model doesn't take (it does not ignore it), so the client only sends
-    // what the selected model accepts — see `SEEDANCE_MODELS` in lib/seedance.
-    //
-    // `ratio` / `resolution` are typed against the tiers this package knows,
-    // so a custom model id sends its sizing through the generic `size`
-    // template instead (see `SeedanceJobOptions.size`).
-    const modelOptions: BytePlusVideoProviderOptions = {
-      ...(options.size === undefined &&
-        options.ratio !== undefined && { ratio: options.ratio }),
-      ...(options.size === undefined &&
-        options.resolution !== undefined && {
-          resolution: options.resolution,
-        }),
-      // `-1` (let the model choose the length) is only reachable through
-      // provider options: the generic `duration` gets snapped into range.
-      ...(options.duration === -1 && { duration: -1 }),
-      ...(options.frames !== undefined && { frames: options.frames }),
-      ...(options.seed !== undefined && { seed: options.seed }),
-      ...(options.watermark !== undefined && { watermark: options.watermark }),
-      ...(options.generateAudio !== undefined && {
-        generate_audio: options.generateAudio,
-      }),
-      ...(options.cameraFixed !== undefined && {
-        camera_fixed: options.cameraFixed,
-      }),
-      ...(options.serviceTier !== undefined && {
-        service_tier: options.serviceTier,
-      }),
-      ...(options.draft !== undefined && { draft: options.draft }),
-      ...(options.priority !== undefined && { priority: options.priority }),
-    }
+/**
+ * Ceiling on how long the server will sit on a Seedance task. Generous
+ * because the flex tier is an offline batch queue where a task routinely
+ * waits many minutes before it even starts.
+ */
+const SEEDANCE_MAX_DURATION_MS = 30 * 60_000
+/** Seedance tasks are slow; polling faster only burns Ark quota. */
+const SEEDANCE_POLL_INTERVAL_MS = 5000
 
-    // `frames` takes precedence over `duration` server-side, so never send
-    // both; `-1` already went through modelOptions above.
-    const duration =
-      options.frames === undefined &&
-      options.duration !== undefined &&
-      options.duration > 0
-        ? options.duration
-        : undefined
+/** The create → poll → complete lifecycle for one Seedance task. */
+function seedanceStream(data: SeedanceRequest): AsyncIterable<StreamChunk> {
+  const options = data.options ?? {}
 
-    return await generateVideo({
-      // For a model this package knows, the adapter snaps `duration` into its
-      // range and validates the resolution tier, prompt roles and
-      // frame/reference exclusivity before anything reaches Ark. For a custom
-      // id every one of those guards is off by design: the duration goes
-      // through verbatim and Ark is the authority.
-      adapter: byteplusVideo(data.model),
-      prompt: asImagePrompt(data.prompt),
-      ...(options.size !== undefined && { size: options.size }),
-      ...(duration !== undefined && { duration }),
-      modelOptions,
-    })
+  // The studio's camelCase controls map one-to-one onto the provider's own
+  // request fields. Applicability is per model and Ark 400s on a field the
+  // model doesn't take (it does not ignore it), so the client only sends
+  // what the selected model accepts — see `SEEDANCE_MODELS` in lib/seedance.
+  //
+  // `ratio` / `resolution` are typed against the tiers this package knows,
+  // so a custom model id sends its sizing through the generic `size`
+  // template instead (see `SeedanceJobOptions.size`).
+  const modelOptions: BytePlusVideoProviderOptions = {
+    ...(options.size === undefined &&
+      options.ratio !== undefined && { ratio: options.ratio }),
+    ...(options.size === undefined &&
+      options.resolution !== undefined && {
+        resolution: options.resolution,
+      }),
+    // `-1` (let the model choose the length) is only reachable through
+    // provider options: the generic `duration` gets snapped into range.
+    ...(options.duration === -1 && { duration: -1 }),
+    ...(options.frames !== undefined && { frames: options.frames }),
+    ...(options.seed !== undefined && { seed: options.seed }),
+    ...(options.watermark !== undefined && { watermark: options.watermark }),
+    ...(options.generateAudio !== undefined && {
+      generate_audio: options.generateAudio,
+    }),
+    ...(options.cameraFixed !== undefined && {
+      camera_fixed: options.cameraFixed,
+    }),
+    ...(options.serviceTier !== undefined && {
+      service_tier: options.serviceTier,
+    }),
+    ...(options.draft !== undefined && { draft: options.draft }),
+    ...(options.priority !== undefined && { priority: options.priority }),
+  }
+
+  // `frames` takes precedence over `duration` server-side, so never send
+  // both; `-1` already went through modelOptions above.
+  const duration =
+    options.frames === undefined &&
+    options.duration !== undefined &&
+    options.duration > 0
+      ? options.duration
+      : undefined
+
+  return generateVideo({
+    // For a model this package knows, the adapter snaps `duration` into its
+    // range and validates the resolution tier, prompt roles and
+    // frame/reference exclusivity before anything reaches Ark. For a custom
+    // id every one of those guards is off by design: the duration goes
+    // through verbatim and Ark is the authority.
+    adapter: byteplusVideo(data.model),
+    prompt: asImagePrompt(data.prompt),
+    ...(options.size !== undefined && { size: options.size }),
+    ...(duration !== undefined && { duration }),
+    modelOptions,
+    stream: true,
+    pollingInterval: SEEDANCE_POLL_INTERVAL_MS,
+    maxDuration: SEEDANCE_MAX_DURATION_MS,
   })
+}
 
-export const getSeedanceJobFn = createServerFn({ method: 'GET' })
-  .inputValidator(
-    (data: { jobId: string; model: BytePlusVideoModelOrString }) => {
-      if (!data.jobId) throw new Error('Job id is required')
-      return data
-    },
-  )
-  .handler(async ({ data }) => {
-    const result = await getVideoJobStatus({
-      adapter: byteplusVideo(data.model),
-      jobId: data.jobId,
-    })
-    // `expiresAt` is a Date on the result; hand the browser an ISO string so
-    // the shape crossing the server-function boundary is unambiguous.
-    return {
-      jobId: result.jobId,
-      status: result.status,
-      ...(result.url !== undefined && { url: result.url }),
-      ...(result.error !== undefined && { error: result.error }),
-      ...(result.expiresAt && { expiresAt: result.expiresAt.toISOString() }),
-      ...(result.usage && { usage: result.usage }),
-    }
+/**
+ * Streams one Seedance task as Server-Sent Events, for the studio's
+ * `useGenerateVideo`. The browser never sees ARK_API_KEY or a job id it has
+ * to poll with — the server does the waiting and reports status on the wire.
+ */
+export const generateSeedanceVideoFn = createServerFn({ method: 'POST' })
+  .inputValidator((data: SeedanceRequest) => {
+    if (!hasPromptContent(data.prompt)) throw new Error('Prompt is required')
+    if (!data.model) throw new Error('Model is required')
+    return data
   })
+  .handler(({ data }) => toServerSentEventsResponse(seedanceStream(data)))

--- a/examples/ts-react-media/src/routeTree.gen.ts
+++ b/examples/ts-react-media/src/routeTree.gen.ts
@@ -9,8 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SeedanceRouteImport } from './routes/seedance'
 import { Route as IndexRouteImport } from './routes/index'
 
+const SeedanceRoute = SeedanceRouteImport.update({
+  id: '/seedance',
+  path: '/seedance',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -19,28 +25,39 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/seedance': typeof SeedanceRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/seedance': typeof SeedanceRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/seedance': typeof SeedanceRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/seedance'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/seedance'
+  id: '__root__' | '/' | '/seedance'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  SeedanceRoute: typeof SeedanceRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/seedance': {
+      id: '/seedance'
+      path: '/seedance'
+      fullPath: '/seedance'
+      preLoaderRoute: typeof SeedanceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -53,6 +70,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  SeedanceRoute: SeedanceRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/examples/ts-react-media/src/routes/index.tsx
+++ b/examples/ts-react-media/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
-import { Film, ImageIcon, Sparkles } from 'lucide-react'
+import { Link, createFileRoute } from '@tanstack/react-router'
+import { Clapperboard, Film, ImageIcon, Sparkles } from 'lucide-react'
 import ImageGenerator from '@/components/ImageGenerator'
 import VideoGenerator from '@/components/VideoGenerator'
 import OmniStudio from '@/components/OmniStudio'
@@ -59,6 +59,13 @@ function VisualPage() {
             <Sparkles className="w-5 h-5" />
             Omni Studio
           </button>
+          <Link
+            to="/seedance"
+            className="flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-colors bg-gray-800 text-gray-300 hover:bg-gray-700"
+          >
+            <Clapperboard className="w-5 h-5" />
+            Seedance Studio
+          </Link>
         </div>
 
         <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-6">

--- a/examples/ts-react-media/src/routes/seedance.tsx
+++ b/examples/ts-react-media/src/routes/seedance.tsx
@@ -1,0 +1,61 @@
+import { createFileRoute } from '@tanstack/react-router'
+import SeedanceStudio from '@/components/SeedanceStudio'
+import { getSeedanceCapabilitiesFn } from '@/lib/server-functions'
+
+function SeedancePage() {
+  const capabilities = Route.useLoaderData()
+
+  return (
+    <div className="min-h-[calc(100vh-72px)] bg-gray-900 p-6">
+      <div className="max-w-4xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-white mb-2">
+            Seedance Studio
+          </h1>
+          <p className="text-gray-400">
+            BytePlus Seedance video generation, straight from the ModelArk task
+            API — no fal in between. The server holds{' '}
+            <code className="text-gray-300">ARK_API_KEY</code>; the browser only
+            ever sees job ids.
+          </p>
+        </div>
+
+        <SeedanceStudio capabilities={capabilities} />
+      </div>
+    </div>
+  )
+}
+
+function SeedanceError({ error }: { error: Error }) {
+  return (
+    <div className="min-h-[calc(100vh-72px)] bg-gray-900 p-6">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold text-white mb-2">Seedance Studio</h1>
+        <div className="mt-6 p-4 bg-red-500/10 border border-red-500/20 rounded-lg">
+          <p className="text-red-400 text-sm">
+            Could not read the Seedance capability table from{' '}
+            <code>@tanstack/ai-byteplus</code>: {error.message}
+          </p>
+          <p className="text-gray-400 text-sm mt-2">
+            The studio drives every control off that table, so it can't render
+            without it. This means the adapter's model metadata changed shape —
+            rebuild the workspace packages, and check{' '}
+            <code>getSeedanceCapabilitiesFn</code> against the current{' '}
+            <code>availableDurations()</code> contract.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/seedance')({
+  // The capability table is static adapter metadata, so it loads with the
+  // route instead of being restated in the client bundle.
+  loader: () => getSeedanceCapabilitiesFn(),
+  component: SeedancePage,
+  // The loader asserts the adapter's duration options are a range. That holds
+  // for every Seedance model today, but a shape change should explain itself
+  // here rather than surfacing as a bare 500.
+  errorComponent: SeedanceError,
+})

--- a/packages/ai-byteplus/LICENSE
+++ b/packages/ai-byteplus/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Tanner Linsley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/ai-byteplus/README.md
+++ b/packages/ai-byteplus/README.md
@@ -31,6 +31,26 @@ south-east endpoint (`https://ark.ap-southeast.bytepluses.com/api/v3`); per the
 BytePlus docs the EU endpoint serves chat and image only (docs-derived — only
 the ap-southeast host was exercised live).
 
+## Why there's no Volcengine SDK dependency
+
+This package does **not** depend on `@volcengine/ark-runtime` (or any other
+first-party BytePlus/Volcengine SDK). That is deliberate:
+
+- **Chat doesn't need one.** Ark's `/chat/completions` is OpenAI-compatible, so
+  the chat adapter rides the `openai` SDK through `@tanstack/openai-base` — the
+  same path `@tanstack/ai-grok` and `@tanstack/ai-groq` take, with identical
+  dependencies. That reuses the shared streaming, tool-calling and
+  structured-output machinery instead of forking it per provider.
+- **Nothing else is OpenAI-shaped anyway.** Seedance video, Seedream image and
+  Seed Speech are bespoke endpoints on two different hosts with two different
+  auth headers. An SDK would not spare us the wire types; it would add a second
+  dependency that still had to be translated at the boundary.
+
+The cost is that the non-chat wire types are hand-written and pinned by tests
+rather than generated. That is a considered trade, not an oversight — see
+`src/video/wire-types.ts`, `src/image/wire-types.ts` and
+`src/audio/wire-types.ts`, each of which records how its shape was verified.
+
 ## Usage
 
 ### Chat

--- a/packages/ai-byteplus/README.md
+++ b/packages/ai-byteplus/README.md
@@ -106,6 +106,41 @@ return toServerSentEventsResponse(stream)
 **Generated video URLs expire after 24 hours** (the task record itself is kept
 for 7 days), so download anything you need to keep.
 
+### Image (Seedream)
+
+```typescript
+import { generateImage } from '@tanstack/ai'
+import { byteplusImage } from '@tanstack/ai-byteplus'
+
+const result = await generateImage({
+  adapter: byteplusImage('seedream-4-0-250828'),
+  prompt: 'a guitar being played in a store',
+  size: '2K',
+  modelOptions: { watermark: false },
+})
+
+console.log(result.images[0]?.url)
+```
+
+`size` takes either a token (`1K`, `2K`, `4K`) or explicit pixels
+(`2048x2048`) — never a mix. Pass image parts in the `prompt` array to edit or
+condition on existing images (up to 14 references, 10 on
+`dola-seedream-5-0-pro-260628`).
+
+Two behaviors surprise people:
+
+- **`watermark` defaults to `true`.** BytePlus stamps "AI generated" into the
+  bottom-right corner unless you pass `watermark: false`. The adapter never
+  sets it implicitly, so the provider default applies.
+- **`numberOfImages` is an upper bound, not a count.** Seedream has no `n`
+  parameter; asking for more than one image maps to its group-image mode
+  (`sequential_image_generation: 'auto'` with `max_images`), where the model
+  decides how many images the prompt actually warrants. A request for four can
+  return fewer, and the adapter logs a warning when it does.
+
+Result URLs expire after 24 hours; pass `response_format: 'b64_json'` in
+`modelOptions` to get bytes inline instead.
+
 ## Supported models
 
 - **Chat** — `dola-seed-2-1-turbo-260628`, the `seed-2-0-*` family,

--- a/packages/ai-byteplus/README.md
+++ b/packages/ai-byteplus/README.md
@@ -1,0 +1,112 @@
+# @tanstack/ai-byteplus
+
+BytePlus ModelArk adapter for TanStack AI — Seed chat models, Seedance video
+generation, Seedream image generation, and Seed Speech text-to-speech and
+transcription.
+
+## Installation
+
+```bash
+npm install @tanstack/ai-byteplus
+# or
+pnpm add @tanstack/ai-byteplus
+# or
+yarn add @tanstack/ai-byteplus
+```
+
+## Setup
+
+BytePlus splits its models across two products with **two different API keys**:
+
+```bash
+# Ark (ModelArk): chat, Seedance video, Seedream image
+export ARK_API_KEY="..."
+
+# Seed Speech: text-to-speech and transcription — a separate product key
+export BYTEPLUS_VOICE_API_KEY="..."
+```
+
+Ark keys are region-isolated. The default base URL is the Asia-Pacific
+south-east endpoint (`https://ark.ap-southeast.bytepluses.com/api/v3`); the EU
+endpoint serves chat and image only.
+
+## Usage
+
+### Chat
+
+```typescript
+import { byteplusText } from '@tanstack/ai-byteplus'
+import { generate } from '@tanstack/ai'
+
+const adapter = byteplusText('seed-2-0-lite-260428')
+
+const result = await generate({
+  adapter,
+  model: 'seed-2-0-lite-260428',
+  messages: [{ role: 'user', content: 'Explain diffusion models briefly' }],
+})
+
+console.log(result.text)
+```
+
+Seed models reason by default. Reasoning arrives as a separate stream of
+`reasoning_content` deltas and is surfaced as reasoning content, not answer
+text. Pass `thinking: { type: 'disabled' }` in provider options to turn it off.
+
+### Video (Seedance)
+
+```typescript
+import { byteplusVideo } from '@tanstack/ai-byteplus'
+import { generateVideo } from '@tanstack/ai'
+
+const result = await generateVideo({
+  adapter: byteplusVideo('seedance-1-5-pro-251215'),
+  model: 'seedance-1-5-pro-251215',
+  prompt: 'a guitar being played in a store',
+  size: '16:9_720p',
+  duration: 5,
+})
+
+console.log(result.url)
+```
+
+Seedance runs as an async task: the adapter creates the task, polls it, then
+reads the result URL. **Generated video URLs expire after 24 hours** (the task
+record itself is kept for 7 days), so download anything you need to keep.
+
+## Supported models
+
+- **Chat** — `dola-seed-2-1-turbo-260628`, the `seed-2-0-*` family,
+  `seed-1-8-251228`, the `seed-1-6-*` family, plus `glm-*`, `deepseek-*` and
+  `gpt-oss-120b-250805`.
+- **Video** — `dreamina-seedance-2-0-260128` (and `-fast-`/`-mini-`),
+  `seedance-1-5-pro-251215`, `seedance-1-0-pro-250528`,
+  `seedance-1-0-pro-fast-251015`.
+- **Image** — `dola-seedream-5-0-pro-260628`, `seedream-5-0-260128`,
+  `seedream-5-0-lite-260128`, `seedream-4-5-251128`, `seedream-4-0-250828`.
+- **Speech** — `seed-audio-1.0` (TTS) and `seed-asr` (transcription).
+
+BytePlus retires model ids aggressively, so only dated ids that were verified
+live against the API are exported. `BYTEPLUS_CHAT_MODELS`,
+`BYTEPLUS_VIDEO_MODELS`, `BYTEPLUS_IMAGE_MODELS`, `BYTEPLUS_TTS_MODELS` and
+`BYTEPLUS_TRANSCRIPTION_MODELS` are the authoritative lists.
+
+## Seedance: direct vs. via fal
+
+Seedance is also reachable through `@tanstack/ai-fal`, which proxies it along
+with hundreds of other models. This package talks to BytePlus directly, which
+means BytePlus billing and rate limits, the first-class Seedance request fields
+(`camera_fixed`, `generate_audio`, `watermark`, reference-image roles, …), and
+model ids in BytePlus's own naming. Use whichever fits your account; there is
+no reason to install both for Seedance alone.
+
+## Seed Speech needs its own key
+
+The TTS and transcription adapters do **not** talk to Ark. They use
+`voice.ap-southeast-1.bytepluses.com` with an `X-Api-Key` header and the
+Seed Speech product key (`BYTEPLUS_VOICE_API_KEY`). Passing an Ark key there
+fails with `45000010 Invalid X-Api-Key`.
+
+## License
+
+MIT

--- a/packages/ai-byteplus/README.md
+++ b/packages/ai-byteplus/README.md
@@ -27,27 +27,32 @@ export BYTEPLUS_VOICE_API_KEY="..."
 ```
 
 Ark keys are region-isolated. The default base URL is the Asia-Pacific
-south-east endpoint (`https://ark.ap-southeast.bytepluses.com/api/v3`); the EU
-endpoint serves chat and image only.
+south-east endpoint (`https://ark.ap-southeast.bytepluses.com/api/v3`); per the
+BytePlus docs the EU endpoint serves chat and image only (docs-derived — only
+the ap-southeast host was exercised live).
 
 ## Usage
 
 ### Chat
 
 ```typescript
+import { chat } from '@tanstack/ai'
 import { byteplusText } from '@tanstack/ai-byteplus'
-import { generate } from '@tanstack/ai'
 
+// The adapter carries the model — there is no separate `model` option.
 const adapter = byteplusText('seed-2-0-lite-260428')
 
-const result = await generate({
+const text = await chat({
   adapter,
-  model: 'seed-2-0-lite-260428',
   messages: [{ role: 'user', content: 'Explain diffusion models briefly' }],
+  stream: false,
 })
 
-console.log(result.text)
+console.log(text)
 ```
+
+Drop `stream: false` to get the default streaming form, which yields
+`StreamChunk`s you can iterate with `for await`.
 
 Seed models reason by default. Reasoning arrives as a separate stream of
 `reasoning_content` deltas and is surfaced as reasoning content, not answer
@@ -55,24 +60,51 @@ text. Pass `thinking: { type: 'disabled' }` in provider options to turn it off.
 
 ### Video (Seedance)
 
-```typescript
-import { byteplusVideo } from '@tanstack/ai-byteplus'
-import { generateVideo } from '@tanstack/ai'
+Seedance is an async task API, so `generateVideo()` only opens the job and
+returns its `jobId`. Poll `getVideoJobStatus()` until the job settles — the
+video URL arrives with the terminal status.
 
-const result = await generateVideo({
-  adapter: byteplusVideo('seedance-1-5-pro-251215'),
-  model: 'seedance-1-5-pro-251215',
+```typescript
+import { generateVideo, getVideoJobStatus } from '@tanstack/ai'
+import { byteplusVideo } from '@tanstack/ai-byteplus'
+
+const adapter = byteplusVideo('seedance-1-5-pro-251215')
+
+const { jobId } = await generateVideo({
+  adapter,
   prompt: 'a guitar being played in a store',
   size: '16:9_720p',
   duration: 5,
 })
 
-console.log(result.url)
+let status = await getVideoJobStatus({ adapter, jobId })
+while (status.status === 'pending' || status.status === 'processing') {
+  await new Promise((resolve) => setTimeout(resolve, 5000))
+  status = await getVideoJobStatus({ adapter, jobId })
+}
+
+console.log(status.status === 'completed' ? status.url : status.error)
 ```
 
-Seedance runs as an async task: the adapter creates the task, polls it, then
-reads the result URL. **Generated video URLs expire after 24 hours** (the task
-record itself is kept for 7 days), so download anything you need to keep.
+To let the core drive the whole lifecycle instead, pass `stream: true` and hand
+the resulting chunk stream to your transport:
+
+```typescript
+import { generateVideo, toServerSentEventsResponse } from '@tanstack/ai'
+import { byteplusVideo } from '@tanstack/ai-byteplus'
+
+const stream = generateVideo({
+  adapter: byteplusVideo('seedance-1-5-pro-251215'),
+  prompt: 'a guitar being played in a store',
+  stream: true,
+  pollingInterval: 5000,
+})
+
+return toServerSentEventsResponse(stream)
+```
+
+**Generated video URLs expire after 24 hours** (the task record itself is kept
+for 7 days), so download anything you need to keep.
 
 ## Supported models
 
@@ -87,7 +119,10 @@ record itself is kept for 7 days), so download anything you need to keep.
 - **Speech** — `seed-audio-1.0` (TTS) and `seed-asr` (transcription).
 
 BytePlus retires model ids aggressively, so only dated ids that were verified
-live against the API are exported. `BYTEPLUS_CHAT_MODELS`,
+live against the API are exported. (The two Seed Speech ids are the exception:
+`seed-audio-1.0` is undated, `seed-asr` is a synthetic id for an
+endpoint-addressed API that takes no `model` field, and neither could be
+verified live pending a Seed Speech key.) `BYTEPLUS_CHAT_MODELS`,
 `BYTEPLUS_VIDEO_MODELS`, `BYTEPLUS_IMAGE_MODELS`, `BYTEPLUS_TTS_MODELS` and
 `BYTEPLUS_TRANSCRIPTION_MODELS` are the authoritative lists.
 

--- a/packages/ai-byteplus/package.json
+++ b/packages/ai-byteplus/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "@tanstack/ai-utils": "workspace:*",
+    "@tanstack/openai-base": "workspace:*",
     "openai": "^6.41.0"
   }
 }

--- a/packages/ai-byteplus/package.json
+++ b/packages/ai-byteplus/package.json
@@ -58,6 +58,7 @@
     "text-to-speech"
   ],
   "devDependencies": {
+    "@tanstack/ai": "workspace:*",
     "@vitest/coverage-v8": "4.0.14",
     "vite": "^8.1.4"
   },

--- a/packages/ai-byteplus/package.json
+++ b/packages/ai-byteplus/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@tanstack/ai-byteplus",
+  "version": "0.0.0",
+  "description": "BytePlus ModelArk adapter for TanStack AI: Seed LLM chat, Seedance video, Seedream image, and Seed Speech TTS/ASR.",
+  "author": "Tanner Linsley",
+  "license": "MIT",
+  "homepage": "https://tanstack.com/ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TanStack/ai.git",
+    "directory": "packages/ai-byteplus"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
+  "type": "module",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "clean": "premove ./build ./dist",
+    "lint:fix": "oxlint src --type-aware --fix",
+    "test:build": "publint --strict",
+    "test:oxlint": "oxlint src --type-aware",
+    "test:lib": "vitest run",
+    "test:lib:dev": "pnpm test:lib --watch",
+    "test:types": "tsc"
+  },
+  "keywords": [
+    "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
+    "byteplus",
+    "modelark",
+    "seed",
+    "seedance",
+    "seedream",
+    "adapter",
+    "llm",
+    "chat",
+    "video-generation",
+    "image-generation",
+    "text-to-speech"
+  ],
+  "devDependencies": {
+    "@vitest/coverage-v8": "4.0.14",
+    "vite": "^8.1.4"
+  },
+  "peerDependencies": {
+    "@tanstack/ai": "workspace:^",
+    "zod": "^4.0.0"
+  },
+  "dependencies": {
+    "@tanstack/ai-utils": "workspace:*",
+    "openai": "^6.41.0"
+  }
+}

--- a/packages/ai-byteplus/src/adapters/image.ts
+++ b/packages/ai-byteplus/src/adapters/image.ts
@@ -5,6 +5,8 @@ import { generateId } from '@tanstack/ai-utils'
 import {
   bytePlusArkError,
   bytePlusArkHeaders,
+  bytePlusTimeoutSignal,
+  describeBody,
   getBytePlusArkApiKeyFromEnv,
   readJsonBody,
   toHeaderRecord,
@@ -210,10 +212,12 @@ export class BytePlusImageAdapter<
       )
 
       const fetchImpl = this.clientConfig.fetch ?? fetch
+      const signal = bytePlusTimeoutSignal(this.clientConfig.timeout)
       const response = await fetchImpl(
         `${this.clientConfig.baseURL}/images/generations`,
         {
           method: 'POST',
+          ...(signal && { signal }),
           headers: bytePlusArkHeaders(
             this.clientConfig.apiKey,
             toHeaderRecord(this.clientConfig.defaultHeaders),
@@ -243,12 +247,28 @@ export class BytePlusImageAdapter<
     numberOfImages: number | undefined,
   ): ImageGenerationResult {
     // Shape pinned by a live seedream-4-0-250828 call and the Ark OpenAPI
-    // document; anything unexpected falls out as an empty `images` array
-    // below rather than being silently returned.
-    const payload = (body ?? {}) as BytePlusImageGenerationResponse
+    // document. Validate rather than cast: `readJsonBody` returns `undefined`
+    // for an empty body and the raw text for a non-JSON one (an HTML error
+    // page from a proxy in front of the API), and casting either would report
+    // "returned no images" with the body — the only evidence of what actually
+    // happened — thrown away.
+    if (typeof body !== 'object' || body === null) {
+      throw bytePlusArkError(
+        200,
+        body,
+        'image generation returned a non-object body',
+      )
+    }
+    const payload = body as BytePlusImageGenerationResponse
 
     const images: Array<GeneratedImage> = []
     const failures: Array<BytePlusImageErrorObject> = []
+    // Items matching none of the three known shapes. Ark's OpenAPI document
+    // describes a second, nested item form, so this is a live possibility
+    // rather than a defensive branch — and an unrecognized item that is
+    // neither counted nor reported turns provider drift into an
+    // "returned no images" with no attribution at all.
+    let unrecognized = 0
     for (const item of payload.data ?? []) {
       if (item.b64_json) {
         images.push({ b64Json: item.b64_json })
@@ -258,12 +278,31 @@ export class BytePlusImageAdapter<
         // Group-image mode reports per-image failures alongside successes;
         // dropping them silently would make a short result look complete.
         failures.push(item.error)
+      } else {
+        unrecognized += 1
       }
     }
     if (payload.error) failures.push(payload.error)
 
+    if (unrecognized > 0) {
+      logger.errors(
+        `${this.name}.generateImages: ${unrecognized} response item(s) matched ` +
+          `none of b64_json / url / error — the response shape may have changed.`,
+        {
+          source: `${this.name}.generateImages`,
+          provider: this.name,
+          model: this.model,
+          body,
+        },
+      )
+    }
+
     if (images.length === 0) {
-      const detail = describeFailures(failures)
+      const detail =
+        describeFailures(failures) ||
+        (unrecognized > 0
+          ? `${unrecognized} unrecognized response item(s): ${describeBody(body) ?? ''}`
+          : '')
       throw new Error(
         `byteplus: image generation returned no images` +
           (detail ? `: ${detail}` : '.'),
@@ -279,6 +318,15 @@ export class BytePlusImageAdapter<
           model: this.model,
           failures,
         },
+      )
+      // The caller asked for a group and is getting a short array. Warn
+      // unconditionally: the `numberOfImages` warning below only fires when
+      // the count was set explicitly, so a partial failure would otherwise
+      // return successfully with no signal at all.
+      logger.warn(
+        `byteplus: ${failures.length} of ${failures.length + images.length} ` +
+          `images failed to generate; returning ${images.length}.`,
+        { provider: this.name, model: this.model },
       )
     }
 

--- a/packages/ai-byteplus/src/adapters/image.ts
+++ b/packages/ai-byteplus/src/adapters/image.ts
@@ -1,0 +1,361 @@
+import { resolveMediaPrompt } from '@tanstack/ai'
+import { BaseImageAdapter } from '@tanstack/ai/adapters'
+import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
+import { generateId } from '@tanstack/ai-utils'
+import {
+  bytePlusArkError,
+  bytePlusArkHeaders,
+  getBytePlusArkApiKeyFromEnv,
+  readJsonBody,
+  toHeaderRecord,
+  withBytePlusArkDefaults,
+} from '../utils/client'
+import {
+  resolveBytePlusImageSize,
+  resolveBytePlusSequentialImages,
+  validateBytePlusImagePrompt,
+  validateBytePlusReferenceImages,
+} from '../image/image-provider-options'
+import type {
+  GeneratedImage,
+  ImageGenerationOptions,
+  ImageGenerationResult,
+  ImagePart,
+  MediaInputMetadata,
+  TokenUsage,
+} from '@tanstack/ai'
+import type { InternalLogger } from '@tanstack/ai/adapter-internals'
+import type {
+  BytePlusImageErrorObject,
+  BytePlusImageGenerationRequest,
+  BytePlusImageGenerationResponse,
+  BytePlusImageUsage,
+} from '../image/wire-types'
+import type {
+  BytePlusImageModelInputModalitiesByName,
+  BytePlusImageModelProviderOptionsByName,
+  BytePlusImageProviderOptions,
+} from '../image/image-provider-options'
+import type {
+  BytePlusImageModel,
+  BytePlusImageModelSizeByName,
+} from '../model-meta'
+import type { BytePlusArkConfig } from '../utils/client'
+
+/**
+ * Configuration for the BytePlus Seedream image adapter.
+ */
+export interface BytePlusImageConfig extends BytePlusArkConfig {}
+
+/**
+ * Roles Seedream can honour. Every input image is a reference — there is no
+ * inpainting mask, control-image or frame channel — so this is an allow-list
+ * rather than a deny-list: a role added to the core union later (or a
+ * video-oriented one like `start_frame`) fails loudly here instead of being
+ * silently flattened into a plain reference.
+ */
+const SUPPORTED_INPUT_ROLES: ReadonlySet<string> = new Set([
+  'reference',
+  'character',
+])
+
+/**
+ * Converts a prompt image part to the string Seedream's `image` field takes:
+ * URLs pass through (BytePlus fetches them server-side), data sources become
+ * data URIs. BytePlus requires the format in `data:image/<format>;base64,` to
+ * be lowercase, so the mime type is lowercased on the way out.
+ */
+function imagePartToImageRef(part: ImagePart<MediaInputMetadata>): string {
+  const { source } = part
+  if (source.type === 'url') return source.value
+  if (source.value.startsWith('data:')) return source.value
+  return `data:${source.mimeType.toLowerCase()};base64,${source.value}`
+}
+
+/**
+ * Renders provider error objects as `code: message` pairs for a log line or
+ * an error message.
+ */
+function describeFailures(
+  failures: ReadonlyArray<BytePlusImageErrorObject>,
+): string {
+  return failures
+    .map((failure) =>
+      [failure.code, failure.message].filter(Boolean).join(': '),
+    )
+    .filter((text) => text.length > 0)
+    .join('; ')
+}
+
+/**
+ * Maps Seedream's usage block onto `TokenUsage`.
+ *
+ * BytePlus bills per generated image and does not count input tokens, so
+ * `promptTokens` is always 0 and `generated_images` is surfaced as
+ * `unitsBilled` — the count the price is applied to.
+ */
+function buildBytePlusImageUsage(
+  usage: BytePlusImageUsage | undefined,
+): TokenUsage | undefined {
+  if (!usage) return undefined
+
+  const completionTokens = usage.output_tokens ?? 0
+  return {
+    promptTokens: 0,
+    completionTokens,
+    totalTokens: usage.total_tokens ?? completionTokens,
+    ...(usage.generated_images !== undefined && {
+      unitsBilled: usage.generated_images,
+    }),
+  }
+}
+
+/**
+ * BytePlus Seedream image generation adapter.
+ *
+ * Drives Ark's `POST /images/generations` endpoint directly rather than
+ * through the OpenAI SDK: the endpoint takes size tokens (`2K`) as well as
+ * pixel sizes, has no `n` parameter, and carries reference images for editing
+ * in the generation request instead of a separate edits endpoint.
+ *
+ * Features:
+ * - Text-to-image and image-conditioned generation (editing, multi-reference)
+ *   from a single call, with per-model reference-count limits enforced.
+ * - Size validation across both accepted forms.
+ * - `numberOfImages` mapped onto Seedream's group-image mode.
+ *
+ * @example
+ * ```typescript
+ * const adapter = byteplusImage('seedream-4-0-250828')
+ * const result = await generateImage({
+ *   adapter,
+ *   prompt: 'A guitar in a sunlit workshop',
+ *   size: '2K',
+ *   modelOptions: { watermark: false },
+ * })
+ * ```
+ */
+export class BytePlusImageAdapter<
+  TModel extends BytePlusImageModel,
+> extends BaseImageAdapter<
+  TModel,
+  BytePlusImageProviderOptions,
+  BytePlusImageModelProviderOptionsByName,
+  BytePlusImageModelSizeByName,
+  BytePlusImageModelInputModalitiesByName
+> {
+  override readonly kind = 'image' as const
+  readonly name = 'byteplus' as const
+
+  /** Config with the Ark base URL resolved and trailing slashes trimmed. */
+  private readonly clientConfig: Omit<BytePlusImageConfig, 'baseURL'> & {
+    baseURL: string
+  }
+
+  constructor(model: TModel, config: BytePlusImageConfig) {
+    super(model, {})
+    this.clientConfig = withBytePlusArkDefaults(config)
+  }
+
+  async generateImages(
+    options: ImageGenerationOptions<
+      BytePlusImageProviderOptions,
+      BytePlusImageModelSizeByName[TModel]
+    >,
+  ): Promise<ImageGenerationResult> {
+    const { numberOfImages, size, modelOptions, logger } = options
+    const model = this.model
+
+    const resolved = resolveMediaPrompt(options.prompt)
+
+    if (resolved.videos.length > 0 || resolved.audios.length > 0) {
+      throw new Error(
+        `byteplus.generateImages does not support video / audio prompt parts on model ${model}.`,
+      )
+    }
+
+    const unsupportedRole = resolved.images.find(
+      (part) =>
+        part.metadata?.role !== undefined &&
+        !SUPPORTED_INPUT_ROLES.has(part.metadata.role),
+    )
+    if (unsupportedRole) {
+      throw new Error(
+        `byteplus: Seedream has no ${unsupportedRole.metadata?.role} input; ` +
+          `it accepts reference images only (${[...SUPPORTED_INPUT_ROLES].join(', ')}).`,
+      )
+    }
+
+    validateBytePlusImagePrompt(model, resolved.text)
+    validateBytePlusReferenceImages(model, resolved.images.length)
+
+    const imageRefs = resolved.images.map(imagePartToImageRef)
+    const request: BytePlusImageGenerationRequest = {
+      ...(imageRefs.length > 0 && { image: imageRefs }),
+      ...(size !== undefined && {
+        size: resolveBytePlusImageSize(size),
+      }),
+      ...resolveBytePlusSequentialImages(model, numberOfImages),
+      // Explicit provider options win over the values derived from the
+      // generic options above (e.g. forcing `sequential_image_generation`).
+      ...modelOptions,
+      model,
+      prompt: resolved.text,
+    }
+
+    try {
+      logger.request(
+        `activity=image provider=${this.name} model=${model} size=${request.size ?? 'default'} refs=${imageRefs.length}`,
+        { provider: this.name, model },
+      )
+
+      const fetchImpl = this.clientConfig.fetch ?? fetch
+      const response = await fetchImpl(
+        `${this.clientConfig.baseURL}/images/generations`,
+        {
+          method: 'POST',
+          headers: bytePlusArkHeaders(
+            this.clientConfig.apiKey,
+            toHeaderRecord(this.clientConfig.defaultHeaders),
+          ),
+          body: JSON.stringify(request),
+        },
+      )
+
+      const body = await readJsonBody(response)
+      if (!response.ok) {
+        throw bytePlusArkError(response.status, body, 'image generation')
+      }
+
+      return this.transformResponse(body, logger, numberOfImages)
+    } catch (error: unknown) {
+      logger.errors(`${this.name}.generateImages fatal`, {
+        error: toRunErrorPayload(error, `${this.name}.generateImages failed`),
+        source: `${this.name}.generateImages`,
+      })
+      throw error
+    }
+  }
+
+  private transformResponse(
+    body: unknown,
+    logger: InternalLogger,
+    numberOfImages: number | undefined,
+  ): ImageGenerationResult {
+    // Shape pinned by a live seedream-4-0-250828 call and the Ark OpenAPI
+    // document; anything unexpected falls out as an empty `images` array
+    // below rather than being silently returned.
+    const payload = (body ?? {}) as BytePlusImageGenerationResponse
+
+    const images: Array<GeneratedImage> = []
+    const failures: Array<BytePlusImageErrorObject> = []
+    for (const item of payload.data ?? []) {
+      if (item.b64_json) {
+        images.push({ b64Json: item.b64_json })
+      } else if (item.url) {
+        images.push({ url: item.url })
+      } else if (item.error) {
+        // Group-image mode reports per-image failures alongside successes;
+        // dropping them silently would make a short result look complete.
+        failures.push(item.error)
+      }
+    }
+    if (payload.error) failures.push(payload.error)
+
+    if (images.length === 0) {
+      const detail = describeFailures(failures)
+      throw new Error(
+        `byteplus: image generation returned no images` +
+          (detail ? `: ${detail}` : '.'),
+      )
+    }
+
+    if (failures.length > 0) {
+      logger.errors(
+        `${this.name}.generateImages dropped ${failures.length} failed image(s): ${describeFailures(failures)}`,
+        {
+          source: `${this.name}.generateImages`,
+          provider: this.name,
+          model: this.model,
+          failures,
+        },
+      )
+    }
+
+    if (numberOfImages !== undefined && images.length < numberOfImages) {
+      logger.warn(
+        `byteplus: requested ${numberOfImages} images, received ${images.length}. ` +
+          `Seedream has no exact count — sequential_image_generation.max_images is ` +
+          `an upper bound and the model decides how many the prompt warrants.`,
+        { provider: this.name, model: this.model },
+      )
+    }
+
+    const usage = buildBytePlusImageUsage(payload.usage)
+
+    return {
+      id: generateId(this.name),
+      model: this.model,
+      images,
+      ...(usage ? { usage } : {}),
+    }
+  }
+}
+
+/**
+ * Creates a BytePlus Seedream image adapter with an explicit API key.
+ * Type resolution happens here at the call site.
+ *
+ * @param model - The model name (e.g., 'seedream-4-0-250828')
+ * @param apiKey - Your BytePlus Ark API key
+ * @param config - Optional additional configuration
+ * @returns Configured BytePlus image adapter instance with resolved types
+ *
+ * @example
+ * ```typescript
+ * const adapter = createBytePlusImage('seedream-5-0-260128', 'ark-...')
+ *
+ * const result = await generateImage({
+ *   adapter,
+ *   prompt: 'A cute baby sea otter',
+ *   size: '2K',
+ * })
+ * ```
+ */
+export function createBytePlusImage<TModel extends BytePlusImageModel>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<BytePlusImageConfig, 'apiKey'>,
+): BytePlusImageAdapter<TModel> {
+  return new BytePlusImageAdapter(model, { apiKey, ...config })
+}
+
+/**
+ * Creates a BytePlus Seedream image adapter, reading `ARK_API_KEY` from the
+ * environment. Type resolution happens here at the call site.
+ *
+ * Note that Ark keys are region-isolated: a key issued for `ap-southeast`
+ * does not work against the EU host.
+ *
+ * @param model - The model name (e.g., 'seedream-4-0-250828')
+ * @param config - Optional configuration (excluding apiKey, auto-detected)
+ * @returns Configured BytePlus image adapter instance with resolved types
+ * @throws Error if ARK_API_KEY is not found in environment
+ *
+ * @example
+ * ```typescript
+ * const adapter = byteplusImage('seedream-4-0-250828')
+ *
+ * const result = await generateImage({
+ *   adapter,
+ *   prompt: 'A beautiful sunset over mountains',
+ *   modelOptions: { watermark: false },
+ * })
+ * ```
+ */
+export function byteplusImage<TModel extends BytePlusImageModel>(
+  model: TModel,
+  config?: Omit<BytePlusImageConfig, 'apiKey'>,
+): BytePlusImageAdapter<TModel> {
+  return createBytePlusImage(model, getBytePlusArkApiKeyFromEnv(), config)
+}

--- a/packages/ai-byteplus/src/adapters/text.ts
+++ b/packages/ai-byteplus/src/adapters/text.ts
@@ -1,0 +1,532 @@
+import OpenAI from 'openai'
+import { EventType } from '@tanstack/ai'
+import { OpenAIBaseChatCompletionsTextAdapter } from '@tanstack/openai-base'
+import { generateId } from '@tanstack/ai-utils'
+import {
+  BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS,
+  emitsEncryptedContent,
+  supportsStructuredOutput,
+} from '../model-meta'
+import {
+  getBytePlusArkApiKeyFromEnv,
+  withBytePlusArkDefaults,
+} from '../utils/client'
+import type {
+  StructuredOutputOptions,
+  StructuredOutputResult,
+} from '@tanstack/ai/adapters'
+import type {
+  ContentPart,
+  ContentPartSource,
+  Modality,
+  ModelMessage,
+  StreamChunk,
+  TextOptions,
+} from '@tanstack/ai'
+import type {
+  ChatCompletionContentPart,
+  ChatCompletionMessageParam,
+} from 'openai/resources/chat/completions/completions'
+import type {
+  BYTEPLUS_CHAT_MODELS,
+  BytePlusChatModelToolCapabilitiesByName,
+  ResolveInputModalities,
+  ResolveProviderOptions,
+} from '../model-meta'
+import type {
+  BytePlusAudioMetadata,
+  BytePlusChatContentPart,
+  BytePlusEncryptedContentFields,
+  BytePlusImageMetadata,
+  BytePlusInputAudioContentPart,
+  BytePlusMessageMetadataByModality,
+  BytePlusStreamDeltaExtras,
+  BytePlusVideoMetadata,
+} from '../message-types'
+import type { BytePlusArkConfig } from '../utils/client'
+
+type ResolveToolCapabilities<TModel extends string> =
+  TModel extends keyof BytePlusChatModelToolCapabilitiesByName
+    ? NonNullable<BytePlusChatModelToolCapabilitiesByName[TModel]>
+    : readonly []
+
+/**
+ * Configuration for the BytePlus text adapter.
+ */
+export interface BytePlusTextConfig extends BytePlusArkConfig {}
+
+/**
+ * Re-export of the public provider options type.
+ */
+export type { BytePlusTextProviderOptions } from '../text/text-provider-options'
+
+/**
+ * BytePlus ModelArk Text (Chat) Adapter
+ *
+ * Tree-shakeable adapter for the Seed / GLM / DeepSeek / gpt-oss chat models
+ * on BytePlus ModelArk. Ark serves an OpenAI-compatible Chat Completions
+ * endpoint, so this drives the OpenAI SDK against Ark's `baseURL` — the same
+ * pattern as `ai-groq` and `ai-grok`.
+ *
+ * Three Ark behaviours are handled on top of the shared base:
+ *
+ * 1. **`reasoning_content` deltas** — Ark streams reasoning under
+ *    `delta.reasoning_content` rather than the OpenAI `reasoning` field.
+ * 2. **`encrypted_content` round-trip** — thinking-summary models emit an
+ *    opaque signature over the reasoning trace. See
+ *    {@link BytePlusTextAdapter.processStreamChunks} and
+ *    {@link BytePlusTextAdapter.convertMessage}.
+ * 3. **Per-model structured-output gating** — only 11 of the 18 shipped chat
+ *    models accept `response_format: json_schema`, and Ark rejects
+ *    `json_object` everywhere, so there is no JSON-mode fallback.
+ */
+export class BytePlusTextAdapter<
+  TModel extends (typeof BYTEPLUS_CHAT_MODELS)[number],
+  // `Record<string, any>` (not `unknown`) mirrors the OpenAI/Groq/Grok text
+  // adapters: the resolved provider options are an interface with no index
+  // signature, assignable to `Record<string, any>` but not to
+  // `Record<string, unknown>`. See issue #821.
+  TProviderOptions extends Record<string, any> = ResolveProviderOptions<TModel>,
+  TInputModalities extends ReadonlyArray<Modality> =
+    ResolveInputModalities<TModel>,
+  TToolCapabilities extends ReadonlyArray<string> =
+    ResolveToolCapabilities<TModel>,
+> extends OpenAIBaseChatCompletionsTextAdapter<
+  TModel,
+  TProviderOptions,
+  TInputModalities,
+  BytePlusMessageMetadataByModality,
+  TToolCapabilities
+> {
+  override readonly kind = 'text' as const
+  override readonly name = 'byteplus' as const
+
+  constructor(config: BytePlusTextConfig, model: TModel) {
+    super(model, 'byteplus', new OpenAI(withBytePlusArkDefaults(config)))
+  }
+
+  /**
+   * Surfaces Ark's reasoning deltas. Thinking-enabled models stream the
+   * reasoning trace as `delta.reasoning_content` (the OpenAI chunk shape has
+   * no reasoning field); the base routes this hook through both `chatStream`
+   * and `structuredOutputStream`.
+   */
+  protected override extractReasoning(
+    chunk: OpenAI.Chat.Completions.ChatCompletionChunk,
+  ): { text: string } | undefined {
+    const delta = chunk.choices[0]?.delta as
+      | BytePlusStreamDeltaExtras
+      | undefined
+    const raw = delta?.reasoning_content
+    if (typeof raw === 'string' && raw.length > 0) {
+      return { text: raw }
+    }
+    return undefined
+  }
+
+  /**
+   * Captures Ark's `encrypted_content` and attaches it to the reasoning
+   * step's `STEP_FINISHED` event as its `signature`.
+   *
+   * On a thinking-summary model Ark streams the whole blob as one dedicated
+   * chunk (empty `content` and `reasoning_content`) sitting between the
+   * reasoning deltas and the content deltas — so it is always captured before
+   * the base closes the reasoning lifecycle at the first content delta.
+   *
+   * `signature` is the framework's existing provider-signature seam: the chat
+   * engine stores it on the `ThinkingPart`, which
+   * `buildAssistantMessages` carries into `ModelMessage.thinking[].signature`,
+   * which {@link BytePlusTextAdapter.convertMessage} echoes back to Ark on the
+   * next turn. No base-class change is needed — this is the same round-trip
+   * Anthropic's thinking signatures use.
+   *
+   * Only `chatStream` is covered: `structuredOutputStream` drives the SDK
+   * directly in the base with no per-chunk seam, so a structured-output turn
+   * does not capture the blob. Ark accepts a following turn without it, so the
+   * consequence is a lost reasoning-cache hit, not a failed request.
+   */
+  protected override async *processStreamChunks(
+    stream: AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>,
+    options: TextOptions,
+    aguiState: {
+      runId: string
+      threadId: string
+      messageId: string
+      hasEmittedRunStarted: boolean
+    },
+  ): AsyncIterable<StreamChunk> {
+    const captured: { encryptedContent?: string } = {}
+
+    for await (const event of super.processStreamChunks(
+      captureEncryptedContent(stream, captured),
+      options,
+      aguiState,
+    )) {
+      if (
+        event.type === EventType.STEP_FINISHED &&
+        captured.encryptedContent !== undefined &&
+        event.signature === undefined
+      ) {
+        // `delta` is stamped alongside the signature because the two consumers
+        // read this event differently. `chat()`'s server agent loop accumulates
+        // thinking ONLY from `STEP_FINISHED.delta` and then drops the whole
+        // step — signature included — when the accumulated content is empty
+        // (`finalizeCurrentThinkingStep`); the OpenAI base emits `content` but
+        // never `delta`, so without this the blob never reaches the
+        // continuation message. The client `StreamProcessor` can't double-count
+        // it: it short-circuits STEP_FINISHED content once
+        // `hasSeenReasoningEvents` is set, which the REASONING_MESSAGE_CONTENT
+        // events preceding every STEP_FINISHED here always set.
+        yield {
+          ...event,
+          signature: captured.encryptedContent,
+          delta: event.delta ?? event.content ?? '',
+        }
+        continue
+      }
+      yield event
+    }
+  }
+
+  /**
+   * Echoes a captured `encrypted_content` blob back on outgoing assistant
+   * messages so multi-turn conversations replay it verbatim, as Ark's
+   * thinking-summary docs require.
+   *
+   * The gate is `emitsEncryptedContent(this.model)` — the model being called
+   * now, not the provenance of the history. That guarantees a signature is
+   * never sent to a model that has no `encrypted_content` concept. It does
+   * NOT identify who produced the signature: `ModelMessage` carries no
+   * provider field, so a foreign signature (e.g. an Anthropic thinking
+   * signature in replayed cross-provider history) WILL be forwarded when the
+   * current model is a thinking-summary model. No shape guard is attempted —
+   * the blob is opaque and Ark is the only party that can validate it.
+   *
+   * Absence is never an error: a live probe confirmed Ark accepts a turn whose
+   * assistant message omits `encrypted_content`.
+   */
+  protected override convertMessage(
+    message: ModelMessage,
+  ): ChatCompletionMessageParam {
+    const converted = super.convertMessage(message)
+    if (converted.role !== 'assistant' || !emitsEncryptedContent(this.model)) {
+      return converted
+    }
+
+    const encryptedContent = lastThinkingSignature(message)
+    if (encryptedContent === undefined) return converted
+
+    // Intersection rather than a cast: `encrypted_content` is an Ark-only
+    // field with no slot on the OpenAI message param, and the intersection is
+    // still assignable to `ChatCompletionMessageParam`.
+    const withEncrypted: typeof converted & BytePlusEncryptedContentFields = {
+      ...converted,
+      encrypted_content: encryptedContent,
+    }
+    return withEncrypted
+  }
+
+  /**
+   * Adds the Ark-only content parts on top of the base's text/image handling:
+   * `video_url`, URL-addressed `input_audio`, and the extra `image_url`
+   * fields (`detail: 'xhigh'`, `image_pixel_limit`).
+   */
+  protected override convertContentPart(
+    part: ContentPart,
+  ): ChatCompletionContentPart | null {
+    if (part.type === 'image') {
+      const metadata = part.metadata as BytePlusImageMetadata | undefined
+      return asChatContentPart({
+        type: 'image_url',
+        image_url: {
+          url: toUrlOrDataUri(part.source),
+          detail: metadata?.detail ?? 'auto',
+          ...(metadata?.image_pixel_limit && {
+            image_pixel_limit: metadata.image_pixel_limit,
+          }),
+        },
+      })
+    }
+
+    if (part.type === 'video') {
+      const metadata = part.metadata as BytePlusVideoMetadata | undefined
+      return asChatContentPart({
+        type: 'video_url',
+        video_url: {
+          url: toUrlOrDataUri(part.source),
+          ...(metadata?.fps !== undefined && { fps: metadata.fps }),
+        },
+      })
+    }
+
+    if (part.type === 'audio') {
+      const metadata = part.metadata as BytePlusAudioMetadata | undefined
+      // Ark takes audio either by URL or as inline base64 with an explicit
+      // container format; unlike images there is no data-URI form.
+      if (part.source.type === 'url') {
+        return asChatContentPart({
+          type: 'input_audio',
+          input_audio: { url: part.source.value },
+        })
+      }
+      const format = metadata?.format ?? audioFormatFromMimeType(part.source)
+      if (format === undefined) {
+        throw new Error(
+          `Audio content part for ${this.name} has an unrecognised mimeType ` +
+            `(${part.source.mimeType || 'none'}). Set the container format ` +
+            `explicitly via the part's metadata.format, or supply a URL source.`,
+        )
+      }
+      return asChatContentPart({
+        type: 'input_audio',
+        input_audio: { data: stripDataUriPrefix(part.source.value), format },
+      })
+    }
+
+    return super.convertContentPart(part)
+  }
+
+  /**
+   * Only the models in {@link BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS} accept
+   * `response_format: json_schema`; the rest reject it with a 400.
+   *
+   * Returning `false` for a rejecting model does not make structured output
+   * work — the engine's separate finalization call sends the same
+   * `response_format` and fails too (that path is stopped by the guard in
+   * {@link BytePlusTextAdapter.structuredOutput}). What it buys is keeping
+   * `response_format` out of the *streaming chat* request, so an ordinary
+   * `chat()` call that happens to carry an `outputSchema` still streams
+   * normally instead of 400-ing on every turn.
+   */
+  override supportsCombinedToolsAndSchema(): boolean {
+    return supportsStructuredOutput(this.model)
+  }
+
+  override async structuredOutput(
+    options: StructuredOutputOptions<TProviderOptions>,
+  ): Promise<StructuredOutputResult<unknown>> {
+    const unsupported = this.structuredOutputUnsupportedMessage()
+    if (unsupported) {
+      options.chatOptions.logger.errors(
+        `${this.name}.structuredOutput unsupported model`,
+        {
+          error: { message: unsupported },
+          source: `${this.name}.structuredOutput`,
+        },
+      )
+      throw new Error(unsupported)
+    }
+    return await super.structuredOutput(options)
+  }
+
+  override async *structuredOutputStream(
+    options: StructuredOutputOptions<TProviderOptions>,
+  ): AsyncIterable<StreamChunk> {
+    const unsupported = this.structuredOutputUnsupportedMessage()
+    if (unsupported) {
+      // Mirror the base's contract: failures inside structuredOutputStream
+      // surface as a RUN_STARTED → RUN_ERROR pair rather than a throw, so
+      // consumers keep a single error-handling path.
+      const timestamp = Date.now()
+      const runId = generateId(this.name)
+      yield {
+        type: EventType.RUN_STARTED,
+        runId,
+        threadId: options.chatOptions.threadId ?? generateId(this.name),
+        model: options.chatOptions.model,
+        timestamp,
+        parentRunId: options.chatOptions.parentRunId,
+      }
+      yield {
+        type: EventType.RUN_ERROR,
+        runId,
+        model: options.chatOptions.model,
+        timestamp,
+        message: unsupported,
+        code: 'unsupported-structured-output',
+        error: { message: unsupported, code: 'unsupported-structured-output' },
+      }
+      options.chatOptions.logger.errors(
+        `${this.name}.structuredOutputStream unsupported model`,
+        {
+          error: { message: unsupported },
+          source: `${this.name}.structuredOutputStream`,
+        },
+      )
+      return
+    }
+    yield* super.structuredOutputStream(options)
+  }
+
+  /**
+   * Explains why structured output is unavailable, or `undefined` when the
+   * model supports it. Ark rejects `response_format: json_object` on every
+   * model, so there is no JSON-mode fallback to degrade to — failing loud
+   * here beats a raw upstream 400.
+   */
+  private structuredOutputUnsupportedMessage(): string | undefined {
+    if (supportsStructuredOutput(this.model)) return undefined
+    return (
+      `BytePlus model ${this.model} does not support structured output — Ark ` +
+      `rejects both response_format json_schema and json_object on it. Use ` +
+      `one of: ${BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS.join(', ')}.`
+    )
+  }
+}
+
+/**
+ * Passes Ark's chunks through untouched while recording the single
+ * `encrypted_content` blob a thinking-summary model emits.
+ */
+async function* captureEncryptedContent(
+  stream: AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>,
+  captured: { encryptedContent?: string },
+): AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk> {
+  for await (const chunk of stream) {
+    const delta = chunk.choices[0]?.delta as
+      | BytePlusStreamDeltaExtras
+      | undefined
+    const blob = delta?.encrypted_content
+    if (typeof blob === 'string' && blob.length > 0) {
+      captured.encryptedContent = blob
+    }
+    yield chunk
+  }
+}
+
+/**
+ * The blob to echo back for an assistant message: the last thinking step that
+ * carries a signature.
+ */
+function lastThinkingSignature(message: ModelMessage): string | undefined {
+  const thinking = message.thinking
+  if (!thinking) return undefined
+  for (let i = thinking.length - 1; i >= 0; i--) {
+    const signature = thinking[i]?.signature
+    if (signature) return signature
+  }
+  return undefined
+}
+
+/**
+ * The one place the Ark content-part dialect meets the OpenAI SDK's request
+ * types.
+ *
+ * Ark's union is a superset of OpenAI's: `video_url` has no OpenAI arm at all,
+ * `input_audio` additionally accepts a `url`, and `image_url` carries
+ * `detail: 'xhigh'` and `image_pixel_limit`. `ChatCompletionContentPart` is a
+ * closed type alias in the SDK, so no interface augmentation can admit those
+ * arms and no narrowing can produce them — widening to `object` keeps this to
+ * a single downcast rather than spreading one through each branch of
+ * {@link BytePlusTextAdapter.convertContentPart}.
+ */
+function asChatContentPart(
+  part: BytePlusChatContentPart,
+): ChatCompletionContentPart {
+  const arkPart: object = part
+  return arkPart as ChatCompletionContentPart
+}
+
+/**
+ * Renders a content source as the URL string Ark expects: URLs pass through,
+ * inline base64 becomes a `data:` URI.
+ */
+function toUrlOrDataUri(source: ContentPartSource): string {
+  if (source.type !== 'data' || source.value.startsWith('data:')) {
+    return source.value
+  }
+  // A missing mimeType would interpolate as "data:undefined;base64,…" and be
+  // rejected, so fall back the same way the OpenAI base does.
+  return `data:${source.mimeType || 'application/octet-stream'};base64,${source.value}`
+}
+
+/**
+ * Strips a `data:` prefix so inline audio is sent as bare base64.
+ */
+function stripDataUriPrefix(value: string): string {
+  const comma = value.startsWith('data:') ? value.indexOf(',') : -1
+  return comma === -1 ? value : value.slice(comma + 1)
+}
+
+const AUDIO_FORMAT_BY_MIME_SUBTYPE: Record<
+  string,
+  NonNullable<BytePlusInputAudioContentPart['input_audio']['format']>
+> = {
+  mpeg: 'mp3',
+  mp3: 'mp3',
+  wav: 'wav',
+  'x-wav': 'wav',
+  wave: 'wav',
+  ogg: 'ogg',
+  flac: 'flac',
+  'x-flac': 'flac',
+  mp4: 'm4a',
+  m4a: 'm4a',
+  'x-m4a': 'm4a',
+  aac: 'aac',
+  pcm: 'pcm',
+  l16: 'pcm',
+}
+
+/**
+ * Maps an audio part's mimeType to Ark's container format token.
+ */
+function audioFormatFromMimeType(
+  source: ContentPartSource,
+):
+  | NonNullable<BytePlusInputAudioContentPart['input_audio']['format']>
+  | undefined {
+  const mimeType = source.mimeType
+  if (!mimeType) return undefined
+  const subtype = mimeType.split(';')[0]?.split('/')[1]?.toLowerCase()
+  return subtype ? AUDIO_FORMAT_BY_MIME_SUBTYPE[subtype] : undefined
+}
+
+/**
+ * Creates a BytePlus text adapter with an explicit API key.
+ *
+ * @param model - The chat model id (e.g., `'seed-2-0-lite-260428'`)
+ * @param apiKey - Your BytePlus Ark API key
+ * @param config - Optional additional configuration
+ *
+ * @example
+ * ```typescript
+ * const adapter = createBytePlusText('seed-2-0-lite-260428', 'ark-...')
+ * ```
+ */
+export function createBytePlusText<
+  TModel extends (typeof BYTEPLUS_CHAT_MODELS)[number],
+>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<BytePlusTextConfig, 'apiKey'>,
+): BytePlusTextAdapter<TModel> {
+  return new BytePlusTextAdapter({ apiKey, ...config }, model)
+}
+
+/**
+ * Creates a BytePlus text adapter with the API key read from `ARK_API_KEY`.
+ *
+ * @param model - The chat model id (e.g., `'seed-2-0-lite-260428'`)
+ * @param config - Optional configuration (excluding `apiKey`)
+ * @throws Error if `ARK_API_KEY` is not set
+ *
+ * @example
+ * ```typescript
+ * const adapter = byteplusText('seed-2-0-lite-260428')
+ *
+ * const stream = chat({
+ *   adapter,
+ *   messages: [{ role: 'user', content: 'Hello!' }],
+ * })
+ * ```
+ */
+export function byteplusText<
+  TModel extends (typeof BYTEPLUS_CHAT_MODELS)[number],
+>(
+  model: TModel,
+  config?: Omit<BytePlusTextConfig, 'apiKey'>,
+): BytePlusTextAdapter<TModel> {
+  const apiKey = getBytePlusArkApiKeyFromEnv()
+  return createBytePlusText(model, apiKey, config)
+}

--- a/packages/ai-byteplus/src/adapters/text.ts
+++ b/packages/ai-byteplus/src/adapters/text.ts
@@ -76,9 +76,10 @@ export type { BytePlusTextProviderOptions } from '../text/text-provider-options'
  *    opaque signature over the reasoning trace. See
  *    {@link BytePlusTextAdapter.processStreamChunks} and
  *    {@link BytePlusTextAdapter.convertMessage}.
- * 3. **Per-model structured-output gating** — only 11 of the 18 shipped chat
- *    models accept `response_format: json_schema`, and Ark rejects
- *    `json_object` everywhere, so there is no JSON-mode fallback.
+ * 3. **Per-model structured-output gating** — only 10 of the 18 shipped chat
+ *    models honour `response_format: json_schema` (glm-4-7 accepts it and then
+ *    ignores the schema), and Ark rejects `json_object` everywhere, so there
+ *    is no JSON-mode fallback.
  */
 export class BytePlusTextAdapter<
   TModel extends (typeof BYTEPLUS_CHAT_MODELS)[number],

--- a/packages/ai-byteplus/src/adapters/text.ts
+++ b/packages/ai-byteplus/src/adapters/text.ts
@@ -292,12 +292,18 @@ export class BytePlusTextAdapter<
    * `response_format: json_schema`; the rest reject it with a 400.
    *
    * Returning `false` for a rejecting model does not make structured output
-   * work — the engine's separate finalization call sends the same
-   * `response_format` and fails too (that path is stopped by the guard in
-   * {@link BytePlusTextAdapter.structuredOutput}). What it buys is keeping
-   * `response_format` out of the *streaming chat* request, so an ordinary
-   * `chat()` call that happens to carry an `outputSchema` still streams
-   * normally instead of 400-ing on every turn.
+   * work — Ark has no `json_object` fallback to downgrade to. What it buys is
+   * keeping `response_format` out of the request the engine would otherwise
+   * build: with the hook false the engine takes its separate finalization
+   * path, and the guard in {@link BytePlusTextAdapter.structuredOutput} /
+   * {@link BytePlusTextAdapter.structuredOutputStream} stops that *before*
+   * any HTTP call. So a `chat({ outputSchema })` on a rejecting model fails
+   * loudly, named, without a schema Ark would 400 on ever leaving the
+   * process — rather than 400-ing on every turn, or (worse) parsing prose as
+   * if it were JSON.
+   *
+   * Tools without a schema are unaffected: `tools` alone never involves
+   * `response_format`.
    */
   override supportsCombinedToolsAndSchema(): boolean {
     return supportsStructuredOutput(this.model)

--- a/packages/ai-byteplus/src/adapters/transcription.ts
+++ b/packages/ai-byteplus/src/adapters/transcription.ts
@@ -1,0 +1,432 @@
+import { BaseTranscriptionAdapter } from '@tanstack/ai/adapters'
+import { arrayBufferToBase64, generateId } from '@tanstack/ai-utils'
+import {
+  BYTEPLUS_VOICE_BASE_URL,
+  bytePlusVoiceError,
+  bytePlusVoiceHeaders,
+  getBytePlusVoiceApiKeyFromEnv,
+  readJsonBody,
+  withBytePlusVoiceDefaults,
+} from '../utils/client'
+import {
+  BYTEPLUS_ASR_RESOURCE_HEADER,
+  BYTEPLUS_ASR_RESOURCE_ID,
+} from '../audio/wire-types'
+import type {
+  TokenUsage,
+  TranscriptionOptions,
+  TranscriptionResult,
+  TranscriptionSegment,
+  TranscriptionWord,
+} from '@tanstack/ai'
+import type { BytePlusVoiceConfig } from '../utils/client'
+import type { BytePlusTranscriptionModel } from '../model-meta'
+import type {
+  BytePlusASRAudio,
+  BytePlusASRRecognizeRequest,
+  BytePlusASRRecognizeResponse,
+  BytePlusASRUtterance,
+} from '../audio/wire-types'
+import type { BytePlusTranscriptionProviderOptions } from '../audio/transcription-provider-options'
+
+/** Path of the synchronous ("flash") Seed ASR endpoint. */
+const RECOGNIZE_FLASH_PATH = '/api/v3/auc/bigmodel/recognize/flash'
+
+/**
+ * BytePlus-specific extension of `TranscriptionWord` carrying the per-word
+ * confidence Seed ASR returns. The cross-provider contract has no field for
+ * it, so callers who want it narrow the array — the same pattern the Grok
+ * adapter uses:
+ *
+ * ```ts
+ * const words = result.words as Array<BytePlusTranscriptionWord> | undefined
+ * ```
+ */
+export interface BytePlusTranscriptionWord extends TranscriptionWord {
+  /** Model confidence for the word, when Seed ASR returns one. */
+  confidence?: number
+}
+
+/** Default `user.uid` echoed into BytePlus' request logs. */
+const DEFAULT_UID = 'tanstack-ai'
+
+/**
+ * BytePlus Seed Speech transcription (ASR) adapter.
+ *
+ * Talks to `POST {baseURL}/api/v3/auc/bigmodel/recognize/flash` — the
+ * synchronous "flash" endpoint, which returns the whole transcript in one
+ * response rather than requiring a submit/poll cycle. It accepts audio up to
+ * 2 hours long or 100 MB, either as a publicly reachable URL or as base64
+ * bytes.
+ *
+ * Two BytePlus-specific details:
+ *
+ * - The model is selected by the `X-Api-Resource-Id` header
+ *   (`volc.seedasr.auc_turbo`), not by a `model` field in the body. The
+ *   package's `seed-asr` model id exists to satisfy the SDK contract and to
+ *   give logs a stable value.
+ * - Authentication uses `X-Api-Key` with the **Seed Speech** key, which is a
+ *   different key from `ARK_API_KEY`.
+ *
+ * All timings on the wire are milliseconds; they are converted to seconds to
+ * match the cross-provider `TranscriptionResult`.
+ *
+ * @example
+ * ```ts
+ * const adapter = byteplusTranscription('seed-asr')
+ * const result = await generateTranscription({
+ *   adapter,
+ *   audio: 'https://example.com/interview.mp3',
+ *   language: 'en-US',
+ * })
+ * ```
+ */
+export class BytePlusTranscriptionAdapter<
+  TModel extends BytePlusTranscriptionModel = BytePlusTranscriptionModel,
+> extends BaseTranscriptionAdapter<
+  TModel,
+  BytePlusTranscriptionProviderOptions
+> {
+  readonly name = 'byteplus' as const
+
+  private readonly apiKey: string
+  private readonly baseURL: string
+  private readonly defaultHeaders: Record<string, string>
+  private readonly fetchImpl: typeof fetch
+
+  constructor(model: TModel, config: BytePlusVoiceConfig) {
+    super(model, config)
+    const resolved = withBytePlusVoiceDefaults(config)
+    this.apiKey = resolved.apiKey
+    this.baseURL = resolved.baseURL ?? BYTEPLUS_VOICE_BASE_URL
+    this.defaultHeaders = resolved.defaultHeaders ?? {}
+    this.fetchImpl = resolved.fetch ?? globalThis.fetch.bind(globalThis)
+  }
+
+  async transcribe(
+    options: TranscriptionOptions<BytePlusTranscriptionProviderOptions>,
+  ): Promise<TranscriptionResult> {
+    const {
+      logger,
+      model,
+      audio,
+      language,
+      prompt,
+      responseFormat,
+      modelOptions,
+    } = options
+
+    logger.request(
+      `activity=generateTranscription provider=byteplus model=${model}`,
+      { provider: 'byteplus', model },
+    )
+
+    if (prompt) {
+      logger.warn(
+        'BytePlus Seed ASR has no prompt-biasing field on the flash endpoint — the `prompt` option is ignored.',
+        { provider: 'byteplus', model },
+      )
+    }
+
+    // The flash endpoint answers with one JSON shape and offers no format
+    // negotiation, so srt/vtt/text/verbose_json can't be honoured. `segments`
+    // on the result carry the timings a caller would have wanted from srt/vtt.
+    if (responseFormat !== undefined && responseFormat !== 'json') {
+      logger.warn(
+        `BytePlus Seed ASR always returns JSON — the requested responseFormat "${responseFormat}" is ignored. Build srt/vtt from result.segments if you need them.`,
+        { provider: 'byteplus', model, responseFormat },
+      )
+    }
+
+    try {
+      const audioPayload = await normalizeAudioInput(
+        audio,
+        modelOptions?.audio_format,
+      )
+      const body = buildRecognizeRequestBody({
+        audio: audioPayload,
+        language,
+        modelOptions,
+      })
+
+      const response = await this.fetchImpl(
+        `${this.baseURL}${RECOGNIZE_FLASH_PATH}`,
+        {
+          method: 'POST',
+          headers: bytePlusVoiceHeaders(this.apiKey, {
+            ...this.defaultHeaders,
+            [BYTEPLUS_ASR_RESOURCE_HEADER]: BYTEPLUS_ASR_RESOURCE_ID,
+          }),
+          body: JSON.stringify(body),
+        },
+      )
+
+      const payload = await readJsonBody(response)
+
+      if (!response.ok) {
+        throw bytePlusVoiceError(response.status, payload, 'transcription')
+      }
+
+      const data = payload as BytePlusASRRecognizeResponse
+      const text = data.result?.text ?? data.transcript
+
+      // The flash endpoint can answer HTTP 200 while carrying the numeric
+      // error envelope, so an absent transcript is a failure rather than an
+      // empty result.
+      if (typeof text !== 'string') {
+        throw bytePlusVoiceError(response.status, payload, 'transcription')
+      }
+
+      // Seed ASR doesn't echo the language back, so report the one that was
+      // actually sent — which is `modelOptions.language` when it overrode the
+      // cross-provider hint.
+      const requestedLanguage = modelOptions?.language ?? language
+
+      return {
+        id: generateId(this.name),
+        model,
+        ...mapRecognizeResponse(data, text),
+        ...(requestedLanguage !== undefined && { language: requestedLanguage }),
+      }
+    } catch (error) {
+      logger.errors('byteplus.transcribe fatal', {
+        error,
+        source: 'byteplus.transcribe',
+      })
+      throw error
+    }
+  }
+}
+
+/**
+ * Build the JSON body for `POST /api/v3/auc/bigmodel/recognize/flash`.
+ *
+ * `show_utterances` defaults to `true` so the response carries the
+ * per-utterance breakdown that populates `segments` and `words`.
+ */
+export function buildRecognizeRequestBody(options: {
+  audio: BytePlusASRAudio
+  language: string | undefined
+  modelOptions: BytePlusTranscriptionProviderOptions | undefined
+}): BytePlusASRRecognizeRequest {
+  const { audio, language, modelOptions } = options
+
+  const resolvedLanguage = modelOptions?.language ?? language
+
+  return {
+    user: { uid: modelOptions?.uid ?? DEFAULT_UID },
+    audio,
+    request: {
+      model_name: modelOptions?.model_name ?? 'bigmodel',
+      show_utterances: modelOptions?.show_utterances ?? true,
+      ...(modelOptions?.enable_itn !== undefined && {
+        enable_itn: modelOptions.enable_itn,
+      }),
+      ...(modelOptions?.enable_punc !== undefined && {
+        enable_punc: modelOptions.enable_punc,
+      }),
+      ...(modelOptions?.enable_ddc !== undefined && {
+        enable_ddc: modelOptions.enable_ddc,
+      }),
+      ...(modelOptions?.enable_speaker_info !== undefined && {
+        enable_speaker_info: modelOptions.enable_speaker_info,
+      }),
+      ...(resolvedLanguage !== undefined && { language: resolvedLanguage }),
+    },
+  }
+}
+
+/**
+ * Turn a recognition response into the transcript-shaped half of a
+ * `TranscriptionResult`. Wire timings are milliseconds; everything returned
+ * here is seconds.
+ */
+export function mapRecognizeResponse(
+  data: BytePlusASRRecognizeResponse,
+  text: string,
+): Omit<TranscriptionResult, 'id' | 'model'> {
+  const utterances = data.result?.utterances ?? data.utterances ?? []
+  // `id` numbers the segments we emit, not the utterances we were given, so
+  // dropping an untimed utterance doesn't leave a hole in the sequence.
+  const segments = utterances
+    .flatMap((utterance) => toSegment(utterance))
+    .map((segment, index) => ({ ...segment, id: index }))
+
+  const words = utterances
+    .flatMap((utterance) => utterance.words ?? [])
+    .flatMap((word) => {
+      if (
+        typeof word.text !== 'string' ||
+        typeof word.start_time !== 'number' ||
+        typeof word.end_time !== 'number'
+      ) {
+        return []
+      }
+      const mapped: BytePlusTranscriptionWord = {
+        word: word.text,
+        start: msToSeconds(word.start_time),
+        end: msToSeconds(word.end_time),
+      }
+      if (word.confidence !== undefined) mapped.confidence = word.confidence
+      return [mapped]
+    })
+
+  const durationMs = data.audio_info?.duration
+  const duration =
+    typeof durationMs === 'number' && durationMs > 0
+      ? msToSeconds(durationMs)
+      : undefined
+
+  // Seed ASR is duration-billed and reports no token counts, so `usage`
+  // carries only the audio length — the same shape the Grok and OpenAI
+  // whisper paths use.
+  const usage: TokenUsage | undefined =
+    duration !== undefined
+      ? {
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+          durationSeconds: duration,
+        }
+      : undefined
+
+  return {
+    text,
+    ...(duration !== undefined && { duration }),
+    ...(segments.length > 0 && { segments }),
+    ...(words.length > 0 && { words }),
+    ...(usage !== undefined && { usage }),
+  }
+}
+
+/**
+ * Convert one utterance into a segment, or nothing when it carries no
+ * timings. The `id` is a placeholder — the caller renumbers after filtering.
+ */
+function toSegment(
+  utterance: BytePlusASRUtterance,
+): Array<TranscriptionSegment> {
+  if (
+    typeof utterance.start_time !== 'number' ||
+    typeof utterance.end_time !== 'number'
+  ) {
+    return []
+  }
+  const speaker = utterance.additions?.speaker
+  return [
+    {
+      id: 0,
+      start: msToSeconds(utterance.start_time),
+      end: msToSeconds(utterance.end_time),
+      text: utterance.text ?? '',
+      ...(speaker !== undefined && { speaker }),
+    },
+  ]
+}
+
+/**
+ * **Must verify when the Seed Speech key lands.** Every timing this adapter
+ * reads — `audio_info.duration`, and each utterance's and word's
+ * `start_time` / `end_time` — is assumed to be milliseconds. That comes from
+ * the Volcengine flash-recognition reference this endpoint derives from
+ * (a 2.499 s clip reports `duration: 2499`), not from a BytePlus response we
+ * have seen. If BytePlus reports seconds instead, every duration, segment and
+ * word timing here is 1000× too small, and this is the only place to fix.
+ */
+function msToSeconds(milliseconds: number): number {
+  return milliseconds / 1000
+}
+
+/**
+ * Turn the cross-provider `audio` input into the endpoint's `audio` block.
+ *
+ * URLs are passed through untouched — Seed ASR fetches them itself, which
+ * avoids pulling large media through this process. Everything else is sent as
+ * base64 `data`, with the container inferred from the input's MIME type or
+ * filename when the caller didn't pin `audio_format`.
+ */
+export async function normalizeAudioInput(
+  audio: TranscriptionOptions['audio'],
+  formatHint: string | undefined,
+): Promise<BytePlusASRAudio> {
+  const withFormat = (
+    payload: BytePlusASRAudio,
+    inferred?: string,
+  ): BytePlusASRAudio => {
+    const format = formatHint ?? inferred
+    return format ? { ...payload, format } : payload
+  }
+
+  if (typeof audio === 'string') {
+    if (/^https?:\/\//i.test(audio)) {
+      return withFormat({ url: audio }, extensionOf(audio))
+    }
+    const dataUrl = /^data:([^;,]+)?(?:;[^,]*)*,(.*)$/s.exec(audio)
+    if (dataUrl) {
+      return withFormat({ data: dataUrl[2] ?? '' }, formatFromMime(dataUrl[1]))
+    }
+    // A bare string that is neither a URL nor a data URL is already base64.
+    return withFormat({ data: audio })
+  }
+
+  if (audio instanceof ArrayBuffer) {
+    return withFormat({ data: arrayBufferToBase64(audio) })
+  }
+
+  const data = arrayBufferToBase64(await audio.arrayBuffer())
+  const inferred =
+    ('name' in audio && typeof audio.name === 'string'
+      ? extensionOf(audio.name)
+      : undefined) ?? formatFromMime(audio.type)
+  return withFormat({ data }, inferred)
+}
+
+function extensionOf(pathOrName: string): string | undefined {
+  const withoutQuery = pathOrName.split(/[?#]/)[0] ?? ''
+  const match = /\.([a-z0-9]+)$/i.exec(withoutQuery)
+  return match?.[1]?.toLowerCase()
+}
+
+function formatFromMime(mime: string | undefined): string | undefined {
+  if (!mime || !mime.startsWith('audio/')) return undefined
+  const subtype = mime.slice('audio/'.length).toLowerCase()
+  if (subtype === 'mpeg') return 'mp3'
+  if (subtype === 'x-wav' || subtype === 'wave') return 'wav'
+  return subtype.replace(/^x-/, '')
+}
+
+/**
+ * Creates a BytePlus Seed Speech transcription adapter with an explicit API
+ * key.
+ *
+ * The key is the **Seed Speech** key, not the Ark key used by the chat, image
+ * and video adapters.
+ */
+export function createBytePlusTranscription<
+  TModel extends BytePlusTranscriptionModel = BytePlusTranscriptionModel,
+>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<BytePlusVoiceConfig, 'apiKey'>,
+): BytePlusTranscriptionAdapter<TModel> {
+  return new BytePlusTranscriptionAdapter(model, { ...config, apiKey })
+}
+
+/**
+ * Creates a BytePlus Seed Speech transcription adapter, reading the API key
+ * from `BYTEPLUS_VOICE_API_KEY`.
+ *
+ * @throws Error if `BYTEPLUS_VOICE_API_KEY` is not set.
+ */
+export function byteplusTranscription<
+  TModel extends BytePlusTranscriptionModel = BytePlusTranscriptionModel,
+>(
+  model: TModel,
+  config?: Omit<BytePlusVoiceConfig, 'apiKey'>,
+): BytePlusTranscriptionAdapter<TModel> {
+  return createBytePlusTranscription(
+    model,
+    getBytePlusVoiceApiKeyFromEnv(),
+    config,
+  )
+}

--- a/packages/ai-byteplus/src/adapters/transcription.ts
+++ b/packages/ai-byteplus/src/adapters/transcription.ts
@@ -1,5 +1,6 @@
 import { BaseTranscriptionAdapter } from '@tanstack/ai/adapters'
 import { arrayBufferToBase64, generateId } from '@tanstack/ai-utils'
+import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
 import {
   BYTEPLUS_VOICE_BASE_URL,
   bytePlusVoiceError,
@@ -19,6 +20,7 @@ import type {
   TranscriptionSegment,
   TranscriptionWord,
 } from '@tanstack/ai'
+import type { InternalLogger } from '@tanstack/ai/adapter-internals'
 import type { BytePlusVoiceConfig } from '../utils/client'
 import type { BytePlusTranscriptionModel } from '../model-meta'
 import type {
@@ -177,6 +179,19 @@ export class BytePlusTranscriptionAdapter<
         throw bytePlusVoiceError(response.status, payload, 'transcription')
       }
 
+      // An empty string is well-formed, so it isn't an error — silence is a
+      // legitimate transcription. But it is also what a 200-wrapped failure
+      // looks like, so say so rather than handing back a successful, empty
+      // result with no signal.
+      if (text === '' && !hasUtterances(data)) {
+        logger.warn(
+          `byteplus: transcription returned an empty transcript with no ` +
+            `utterances. This is a valid result for silent audio, and is also ` +
+            `what a 200-wrapped failure looks like.`,
+          { provider: this.name, model },
+        )
+      }
+
       // Seed ASR doesn't echo the language back, so report the one that was
       // actually sent — which is `modelOptions.language` when it overrode the
       // cross-provider hint.
@@ -185,12 +200,12 @@ export class BytePlusTranscriptionAdapter<
       return {
         id: generateId(this.name),
         model,
-        ...mapRecognizeResponse(data, text),
+        ...mapRecognizeResponse(data, text, logger),
         ...(requestedLanguage !== undefined && { language: requestedLanguage }),
       }
     } catch (error) {
       logger.errors('byteplus.transcribe fatal', {
-        error,
+        error: toRunErrorPayload(error, 'byteplus.transcribe failed'),
         source: 'byteplus.transcribe',
       })
       throw error
@@ -244,6 +259,7 @@ export function buildRecognizeRequestBody(options: {
 export function mapRecognizeResponse(
   data: BytePlusASRRecognizeResponse,
   text: string,
+  logger?: InternalLogger,
 ): Omit<TranscriptionResult, 'id' | 'model'> {
   const utterances = data.result?.utterances ?? data.utterances ?? []
   // `id` numbers the segments we emit, not the utterances we were given, so
@@ -252,24 +268,45 @@ export function mapRecognizeResponse(
     .flatMap((utterance) => toSegment(utterance))
     .map((segment, index) => ({ ...segment, id: index }))
 
-  const words = utterances
-    .flatMap((utterance) => utterance.words ?? [])
-    .flatMap((word) => {
-      if (
-        typeof word.text !== 'string' ||
-        typeof word.start_time !== 'number' ||
-        typeof word.end_time !== 'number'
-      ) {
-        return []
-      }
-      const mapped: BytePlusTranscriptionWord = {
-        word: word.text,
-        start: msToSeconds(word.start_time),
-        end: msToSeconds(word.end_time),
-      }
-      if (word.confidence !== undefined) mapped.confidence = word.confidence
-      return [mapped]
-    })
+  const rawWords = utterances.flatMap((utterance) => utterance.words ?? [])
+  const words = rawWords.flatMap((word) => {
+    if (
+      typeof word.text !== 'string' ||
+      typeof word.start_time !== 'number' ||
+      typeof word.end_time !== 'number'
+    ) {
+      return []
+    }
+    const mapped: BytePlusTranscriptionWord = {
+      word: word.text,
+      start: msToSeconds(word.start_time),
+      end: msToSeconds(word.end_time),
+    }
+    if (word.confidence !== undefined) mapped.confidence = word.confidence
+    return [mapped]
+  })
+
+  // Untimed entries are dropped rather than emitted with NaN timings, but a
+  // silent drop leaves the caller unable to tell "the provider sent no
+  // timings" from "the adapter discarded them" — the two have very different
+  // fixes, and a field rename upstream (e.g. `text` → `word`) would empty
+  // these arrays without a single error anywhere.
+  const droppedWords = rawWords.length - words.length
+  if (droppedWords > 0) {
+    logger?.warn(
+      `byteplus: dropped ${droppedWords} of ${rawWords.length} word(s) with ` +
+        `missing or non-numeric timings.`,
+      { provider: 'byteplus' },
+    )
+  }
+  const droppedSegments = utterances.length - segments.length
+  if (droppedSegments > 0) {
+    logger?.warn(
+      `byteplus: dropped ${droppedSegments} of ${utterances.length} ` +
+        `utterance(s) with missing or non-numeric timings.`,
+      { provider: 'byteplus' },
+    )
+  }
 
   const durationMs = data.audio_info?.duration
   const duration =
@@ -303,6 +340,16 @@ export function mapRecognizeResponse(
  * Convert one utterance into a segment, or nothing when it carries no
  * timings. The `id` is a placeholder — the caller renumbers after filtering.
  */
+/**
+ * True when the response carries at least one utterance, in either envelope
+ * form. Used to tell "silent audio" from a 200-wrapped failure: a genuinely
+ * empty transcript usually still arrives with no utterances, so the pairing is
+ * a hint rather than proof — hence a warning rather than a throw.
+ */
+function hasUtterances(data: BytePlusASRRecognizeResponse): boolean {
+  return (data.result?.utterances ?? data.utterances ?? []).length > 0
+}
+
 function toSegment(
   utterance: BytePlusASRUtterance,
 ): Array<TranscriptionSegment> {

--- a/packages/ai-byteplus/src/adapters/tts.ts
+++ b/packages/ai-byteplus/src/adapters/tts.ts
@@ -29,15 +29,22 @@ const TTS_CREATE_PATH = '/api/v3/tts/create'
 /**
  * Name of the request field carrying the text to speak.
  *
- * **Open question — do not change without a doc citation or a live call.**
- * The Phase 0 research notes record this as `text_prompt`, but BytePlus'
- * published Seed Speech samples are inconsistent about whether the synthesis
- * endpoint takes `text_prompt` (the reference-audio-style naming) or a plain
- * `text`. No Seed Speech key was available to settle it. Isolating the name
- * here keeps the fix to a one-line change once the research agent lands a
- * citation.
+ * **`text_prompt` is correct — do not "fix" this to `text`.** The endpoint
+ * schema (docs.byteplus.com/en/docs/byteplusvoice/seedaudio-01) lists this
+ * body as exactly `model`, `text_prompt`, `references`, `audio_config`,
+ * `watermark`; there is no request-side `text`. The `text` spelling belongs
+ * to the *other* endpoint, `/tts/unidirectional` (TTS 2.0), where it sits
+ * under `req_params.text`. The name stays isolated here so the two spellings
+ * never get conflated.
  */
 const TTS_TEXT_FIELD = 'text_prompt' satisfies keyof BytePlusTTSCreateRequest
+
+/**
+ * Sample rate used when the caller doesn't pick one. The endpoint documents a
+ * default of 40000, which is not among the rates it accepts — so the adapter
+ * never relies on the server default and always sends this instead.
+ */
+const DEFAULT_SAMPLE_RATE = 24000
 
 /**
  * Voice used when neither `TTSOptions.voice` nor `modelOptions.speaker` is
@@ -46,8 +53,12 @@ const TTS_TEXT_FIELD = 'text_prompt' satisfies keyof BytePlusTTSCreateRequest
 export const BYTEPLUS_DEFAULT_TTS_SPEAKER = 'en_female_stokie_uranus_bigtts'
 
 /**
- * Hard cap on the length of a single Seed Speech synthesis, in seconds.
- * Longer scripts must be split across calls and stitched client-side.
+ * Hard cap on a single Seed Speech synthesis, in seconds. Longer scripts must
+ * be split across calls and stitched client-side.
+ *
+ * The cap applies to the *pre-rate* length the service bills on — the
+ * `original_duration` it returns. The delivered clip can run longer than this
+ * when `speech_rate` slows it down.
  */
 export const BYTEPLUS_TTS_MAX_OUTPUT_SECONDS = 120
 
@@ -61,11 +72,15 @@ export const BYTEPLUS_TTS_MAX_OUTPUT_SECONDS = 120
  *   own key (`BYTEPLUS_VOICE_API_KEY`). An `ARK_API_KEY` sent here is
  *   rejected with `45000010 Invalid X-Api-Key`.
  * - **120 s output cap.** A single call synthesises at most
- *   {@link BYTEPLUS_TTS_MAX_OUTPUT_SECONDS} seconds of audio; the service
- *   truncates or rejects longer scripts.
+ *   {@link BYTEPLUS_TTS_MAX_OUTPUT_SECONDS} seconds of audio; longer scripts
+ *   have to be split and stitched client-side. The cap is measured before
+ *   `speech_rate` is applied, so a slowed clip can play for longer than that
+ *   — `result.duration` is the delivered length and `result.originalDuration`
+ *   is the metered one.
  *
  * Streaming synthesis (`tts/unidirectional` and the WebSocket API) is not
- * covered by this adapter.
+ * covered by this adapter — note that endpoint spells the text field `text`,
+ * while this one uses `text_prompt`.
  *
  * @example
  * ```ts
@@ -107,7 +122,7 @@ export class BytePlusTTSAdapter<
       model,
     })
 
-    const { body, audioFormat } = buildTTSRequestBody({
+    const { body, audioFormat, sampleRate } = buildTTSRequestBody({
       model,
       text,
       voice,
@@ -122,7 +137,13 @@ export class BytePlusTTSAdapter<
         `${this.baseURL}${TTS_CREATE_PATH}`,
         {
           method: 'POST',
-          headers: bytePlusVoiceHeaders(this.apiKey, this.defaultHeaders),
+          headers: bytePlusVoiceHeaders(this.apiKey, {
+            ...this.defaultHeaders,
+            // Client-generated per-request id. BytePlus echoes it in their
+            // request logs, which is what support asks for when diagnosing a
+            // synthesis failure.
+            'X-Api-Request-Id': newRequestId(),
+          }),
           body: JSON.stringify(body),
         },
       )
@@ -142,15 +163,17 @@ export class BytePlusTTSAdapter<
         throw bytePlusVoiceError(response.status, payload, 'text-to-speech')
       }
 
-      const duration = toDurationSeconds(data.duration, logger)
+      const duration = toDurationSeconds(data.duration)
+      const originalDuration = toDurationSeconds(data.original_duration)
 
       return {
         id: generateId(this.name),
         model,
         audio: data.audio,
         format: audioFormat,
-        contentType: getContentType(audioFormat, modelOptions?.sample_rate),
+        contentType: getContentType(audioFormat, sampleRate),
         ...(duration !== undefined && { duration }),
+        ...(originalDuration !== undefined && { originalDuration }),
         ...(data.subtitle !== undefined && { subtitle: data.subtitle }),
         ...(data.url !== undefined && { url: data.url }),
       }
@@ -165,11 +188,12 @@ export class BytePlusTTSAdapter<
 }
 
 /**
- * Build the JSON body for `POST /api/v3/tts/create`, resolving the speaker,
+ * Build the JSON body for `POST /api/v3/tts/create`, resolving the voice,
  * output format and rate fields in one place.
  *
- * Returns the request `body` plus the resolved `audioFormat`, which the caller
- * reports on the result and turns into a `contentType`.
+ * Returns the request `body`, the resolved `audioFormat` and the
+ * `sampleRate`, which the caller reports on the result and turns into a
+ * `contentType`.
  */
 export function buildTTSRequestBody(options: {
   model: string
@@ -179,20 +203,30 @@ export function buildTTSRequestBody(options: {
   speed: number | undefined
   modelOptions: BytePlusTTSProviderOptions | undefined
   logger: InternalLogger
-}): { body: BytePlusTTSCreateRequest; audioFormat: BytePlusTTSAudioFormat } {
+}): {
+  body: BytePlusTTSCreateRequest
+  audioFormat: BytePlusTTSAudioFormat
+  sampleRate: number
+} {
   const { model, text, voice, format, speed, modelOptions, logger } = options
 
   const audioFormat = pickAudioFormat(modelOptions?.format, format, logger)
+  // Always explicit: the documented server default (40000) is not one of the
+  // rates the endpoint accepts, so relying on it is a coin flip.
+  const sampleRate = modelOptions?.sample_rate ?? DEFAULT_SAMPLE_RATE
 
-  const audioConfig: BytePlusTTSAudioConfig = { format: audioFormat }
-  if (modelOptions?.sample_rate !== undefined) {
-    audioConfig.sample_rate = modelOptions.sample_rate
+  const audioConfig: BytePlusTTSAudioConfig = {
+    format: audioFormat,
+    sample_rate: sampleRate,
   }
   if (modelOptions?.pitch_rate !== undefined) {
     audioConfig.pitch_rate = modelOptions.pitch_rate
   }
   if (modelOptions?.loudness_rate !== undefined) {
     audioConfig.loudness_rate = modelOptions.loudness_rate
+  }
+  if (modelOptions?.enable_subtitle !== undefined) {
+    audioConfig.enable_subtitle = modelOptions.enable_subtitle
   }
 
   // An explicit `speech_rate` always wins over the derived one — it is the
@@ -207,14 +241,22 @@ export function buildTTSRequestBody(options: {
   const body: BytePlusTTSCreateRequest = {
     model,
     [TTS_TEXT_FIELD]: text,
-    speaker: modelOptions?.speaker ?? voice ?? BYTEPLUS_DEFAULT_TTS_SPEAKER,
+    // The voice belongs inside `references`, not at the top level — a
+    // top-level `speaker` is silently ignored by the server. The flat member
+    // shape here is the best-supported reading of the docs; see
+    // `BytePlusTTSReference` for the unresolved part and the live-probe flag.
+    references: modelOptions?.references ?? [
+      {
+        speaker: modelOptions?.speaker ?? voice ?? BYTEPLUS_DEFAULT_TTS_SPEAKER,
+      },
+    ],
     audio_config: audioConfig,
   }
-  if (modelOptions?.enable_subtitle !== undefined) {
-    body.enable_subtitle = modelOptions.enable_subtitle
+  if (modelOptions?.watermark !== undefined) {
+    body.watermark = modelOptions.watermark
   }
 
-  return { body, audioFormat }
+  return { body, audioFormat, sampleRate }
 }
 
 /**
@@ -227,19 +269,12 @@ export function buildTTSRequestBody(options: {
  *
  * so `0.5 → -50`, `1.0 → 0`, `1.5 → 50`, `2.0 → 100`.
  *
- * What is **documented** is only the numeric range, `-50`..`100`. The
- * multiplier anchors this formula reads into it — `-50` ≈ 0.5× and `100` ≈ 2×
- * — are **inferred** from that range and from how the same field behaves on
- * sibling Volcengine TTS endpoints; they have not been confirmed against a
- * live Seed Speech response. If the true curve turns out to be non-linear,
- * only this function changes.
+ * The range `-50`..`100` and both multiplier anchors (`-50` = 0.5×,
+ * `100` = 2×) are documented, and hold on both the `/tts/create` and
+ * `/tts/unidirectional` endpoints.
  *
- * The clamp is deliberately conservative. `TTSOptions.speed` spans a wider
- * 0.25×–4× than the documented range covers, so anything outside 0.5×–2×
- * clamps (and warns) rather than erroring. Note that at least one reseller
- * lists `speech_rate` on `seed-audio-1.0` as accepting `-50`..`1000`; until
- * that is confirmed in BytePlus' own docs this stays pinned to the documented
- * `100` ceiling, since over-sending is the failure mode that produces a 400.
+ * `TTSOptions.speed` spans a wider 0.25×–4× than the endpoint supports, so
+ * anything outside 0.5×–2× clamps (and warns) rather than erroring.
  */
 export function toSpeechRate(speed: number, logger?: InternalLogger): number {
   const rate = Math.round((speed - 1) * 100)
@@ -287,11 +322,19 @@ function pickAudioFormat(
 }
 
 /**
+ * Build a per-request id for the `X-Api-Request-Id` header. Falls back to the
+ * package's own id generator on runtimes without `crypto.randomUUID`.
+ */
+function newRequestId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? generateId('byteplus-tts')
+}
+
+/**
  * MIME type for a Seed Speech output format.
  *
  * `pcm` is raw little-endian 16-bit samples, so its media type has to carry
- * the sample rate (RFC 3551/3555). When the caller didn't pin one we report
- * the service default of 24 kHz.
+ * the sample rate (RFC 3551/3555). The adapter always resolves a rate, so one
+ * is always available here.
  */
 export function getContentType(
   format: BytePlusTTSAudioFormat,
@@ -310,39 +353,28 @@ export function getContentType(
 }
 
 /**
- * Normalise the `duration` Seed Speech reports into seconds.
+ * Coerce a `duration` / `original_duration` field to a usable number of
+ * seconds.
  *
- * The published docs don't state the unit and no Seed Speech key was
- * available to settle it, but the endpoint's hard
- * {@link BYTEPLUS_TTS_MAX_OUTPUT_SECONDS} second output cap separates the two
- * candidates: a value above the cap cannot be seconds, so it is milliseconds.
+ * Both are documented as float **seconds**, so this only parses the string
+ * form and drops values that can't be a length (zero, negative, non-numeric).
+ * Note that `duration` may legitimately exceed
+ * {@link BYTEPLUS_TTS_MAX_OUTPUT_SECONDS} — a clip synthesised at
+ * `speech_rate: -50` runs at half speed, so up to 120 s of billed audio can
+ * be delivered as up to 240 s of playback. Do not "correct" a large value
+ * here; the cap applies to `original_duration`.
  *
- * Two edges worth knowing:
- * - A clip of 120 ms or shorter is genuinely ambiguous and is reported as
- *   seconds. In practice no synthesis is that short.
- * - A value just over the cap (say `121`) is read as milliseconds and becomes
- *   `0.121 s`. That is the right call if the unit is milliseconds and visibly
- *   wrong if it isn't — which is why the millisecond branch warns rather than
- *   converting silently. If the warning shows up in the field against a real
- *   key, the unit question is settled and this function collapses to one
- *   branch.
+ * The subtitle timings are the mixed-unit exception: those are milliseconds
+ * and are passed through untouched on {@link BytePlusTTSResult.subtitle}.
  */
 export function toDurationSeconds(
   raw: number | string | undefined,
-  logger?: InternalLogger,
 ): number | undefined {
   const value = typeof raw === 'string' ? Number(raw) : raw
   if (value === undefined || !Number.isFinite(value) || value <= 0) {
     return undefined
   }
-  if (value <= BYTEPLUS_TTS_MAX_OUTPUT_SECONDS) return value
-
-  const seconds = value / 1000
-  logger?.warn(
-    `BytePlus Seed Speech reported duration=${value}, which exceeds the ${BYTEPLUS_TTS_MAX_OUTPUT_SECONDS}s output cap — reading it as milliseconds (${seconds}s). The unit is undocumented; please report this so it can be pinned.`,
-    { provider: 'byteplus', rawDuration: raw, durationSeconds: seconds },
-  )
-  return seconds
+  return value
 }
 
 /**

--- a/packages/ai-byteplus/src/adapters/tts.ts
+++ b/packages/ai-byteplus/src/adapters/tts.ts
@@ -1,5 +1,6 @@
 import { BaseTTSAdapter } from '@tanstack/ai/adapters'
 import { generateId } from '@tanstack/ai-utils'
+import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
 import {
   BYTEPLUS_VOICE_BASE_URL,
   bytePlusVoiceError,
@@ -45,6 +46,20 @@ const TTS_TEXT_FIELD = 'text_prompt' satisfies keyof BytePlusTTSCreateRequest
  * never relies on the server default and always sends this instead.
  */
 const DEFAULT_SAMPLE_RATE = 24000
+
+/**
+ * True when a Seed Speech envelope's `code` means success.
+ *
+ * Seed Speech uses `0` for success and a flat numeric code otherwise
+ * (`45000010 Invalid X-Api-Key`). The success envelope has not been confirmed
+ * against a live key, so `code` is accepted as a number, its string form, or
+ * absent — an envelope that omits `code` entirely is treated as success, which
+ * is what the HTTP status already told us.
+ */
+function isZeroCode(code: number | string | undefined): boolean {
+  if (code === undefined) return true
+  return Number(code) === 0
+}
 
 /**
  * Voice used when neither `TTSOptions.voice` nor `modelOptions.speaker` is
@@ -160,14 +175,25 @@ export class BytePlusTTSAdapter<
       // a 200 can carry a non-zero `code`. Check it before looking at `audio`,
       // because a failed call may still return a partial or placeholder
       // payload that would otherwise be handed back as if it were valid.
-      if (typeof data.code === 'number' && data.code !== 0) {
+      //
+      // `code` is accepted as a number *or* a string. The success envelope was
+      // never confirmed against a live key (no voice key yet — see
+      // `audio/wire-types.ts`), and `readStringField` already tolerates both
+      // forms when rendering the error, so requiring a number here would let
+      // `{"code": "45000010"}` through both this gate and the one below.
+      if (!isZeroCode(data.code)) {
         throw bytePlusVoiceError(response.status, payload, 'text-to-speech')
       }
 
       // Belt and braces for a 200 that reports success but carries nothing to
-      // play. `bytePlusVoiceError` surfaces whatever `message` came back.
+      // play. Say that the adapter rejected it, rather than reusing the
+      // envelope-error phrasing — a bare "failed (200)" gives no hint that the
+      // response was well-formed and simply empty.
       if (typeof data.audio !== 'string' || data.audio.length === 0) {
-        throw bytePlusVoiceError(response.status, payload, 'text-to-speech')
+        throw new Error(
+          `BytePlus Seed Speech text-to-speech returned a success response ` +
+            `with no audio (model ${model}).`,
+        )
       }
 
       const duration = toDurationSeconds(data.duration)
@@ -186,7 +212,7 @@ export class BytePlusTTSAdapter<
       }
     } catch (error) {
       logger.errors('byteplus.generateSpeech fatal', {
-        error,
+        error: toRunErrorPayload(error, 'byteplus.generateSpeech failed'),
         source: 'byteplus.generateSpeech',
       })
       throw error

--- a/packages/ai-byteplus/src/adapters/tts.ts
+++ b/packages/ai-byteplus/src/adapters/tts.ts
@@ -156,9 +156,16 @@ export class BytePlusTTSAdapter<
 
       const data = payload as BytePlusTTSCreateResponse
 
-      // A 200 can still carry the numeric error envelope, so treat a missing
-      // audio payload as a failure and let `bytePlusVoiceError` surface
-      // whatever `code`/`message` came back.
+      // Seed Speech reports status in the body, not only in the HTTP status:
+      // a 200 can carry a non-zero `code`. Check it before looking at `audio`,
+      // because a failed call may still return a partial or placeholder
+      // payload that would otherwise be handed back as if it were valid.
+      if (typeof data.code === 'number' && data.code !== 0) {
+        throw bytePlusVoiceError(response.status, payload, 'text-to-speech')
+      }
+
+      // Belt and braces for a 200 that reports success but carries nothing to
+      // play. `bytePlusVoiceError` surfaces whatever `message` came back.
       if (typeof data.audio !== 'string' || data.audio.length === 0) {
         throw bytePlusVoiceError(response.status, payload, 'text-to-speech')
       }

--- a/packages/ai-byteplus/src/adapters/tts.ts
+++ b/packages/ai-byteplus/src/adapters/tts.ts
@@ -1,0 +1,382 @@
+import { BaseTTSAdapter } from '@tanstack/ai/adapters'
+import { generateId } from '@tanstack/ai-utils'
+import {
+  BYTEPLUS_VOICE_BASE_URL,
+  bytePlusVoiceError,
+  bytePlusVoiceHeaders,
+  getBytePlusVoiceApiKeyFromEnv,
+  readJsonBody,
+  withBytePlusVoiceDefaults,
+} from '../utils/client'
+import type { TTSOptions } from '@tanstack/ai'
+import type { InternalLogger } from '@tanstack/ai/adapter-internals'
+import type { BytePlusVoiceConfig } from '../utils/client'
+import type { BytePlusTTSModel } from '../model-meta'
+import type {
+  BytePlusTTSAudioConfig,
+  BytePlusTTSAudioFormat,
+  BytePlusTTSCreateRequest,
+  BytePlusTTSCreateResponse,
+} from '../audio/wire-types'
+import type {
+  BytePlusTTSProviderOptions,
+  BytePlusTTSResult,
+} from '../audio/tts-provider-options'
+
+/** Path of the synchronous Seed Speech synthesis endpoint. */
+const TTS_CREATE_PATH = '/api/v3/tts/create'
+
+/**
+ * Name of the request field carrying the text to speak.
+ *
+ * **Open question — do not change without a doc citation or a live call.**
+ * The Phase 0 research notes record this as `text_prompt`, but BytePlus'
+ * published Seed Speech samples are inconsistent about whether the synthesis
+ * endpoint takes `text_prompt` (the reference-audio-style naming) or a plain
+ * `text`. No Seed Speech key was available to settle it. Isolating the name
+ * here keeps the fix to a one-line change once the research agent lands a
+ * citation.
+ */
+const TTS_TEXT_FIELD = 'text_prompt' satisfies keyof BytePlusTTSCreateRequest
+
+/**
+ * Voice used when neither `TTSOptions.voice` nor `modelOptions.speaker` is
+ * set — the English female "Stokie" voice from the TTS 2.0 generation.
+ */
+export const BYTEPLUS_DEFAULT_TTS_SPEAKER = 'en_female_stokie_uranus_bigtts'
+
+/**
+ * Hard cap on the length of a single Seed Speech synthesis, in seconds.
+ * Longer scripts must be split across calls and stitched client-side.
+ */
+export const BYTEPLUS_TTS_MAX_OUTPUT_SECONDS = 120
+
+/**
+ * BytePlus Seed Speech text-to-speech adapter.
+ *
+ * Talks to `POST {baseURL}/api/v3/tts/create` on the Seed Speech voice host.
+ * Two things differ from the Ark-hosted adapters in this package:
+ *
+ * - **Separate API key.** Seed Speech authenticates with `X-Api-Key` and its
+ *   own key (`BYTEPLUS_VOICE_API_KEY`). An `ARK_API_KEY` sent here is
+ *   rejected with `45000010 Invalid X-Api-Key`.
+ * - **120 s output cap.** A single call synthesises at most
+ *   {@link BYTEPLUS_TTS_MAX_OUTPUT_SECONDS} seconds of audio; the service
+ *   truncates or rejects longer scripts.
+ *
+ * Streaming synthesis (`tts/unidirectional` and the WebSocket API) is not
+ * covered by this adapter.
+ *
+ * @example
+ * ```ts
+ * const adapter = byteplusSpeech('seed-audio-1.0')
+ * const result = await generateSpeech({
+ *   adapter,
+ *   text: 'welcome to the guitar store',
+ *   voice: 'en_female_stokie_uranus_bigtts',
+ *   format: 'mp3',
+ * })
+ * ```
+ */
+export class BytePlusTTSAdapter<
+  TModel extends BytePlusTTSModel = BytePlusTTSModel,
+> extends BaseTTSAdapter<TModel, BytePlusTTSProviderOptions> {
+  readonly name = 'byteplus' as const
+
+  private readonly apiKey: string
+  private readonly baseURL: string
+  private readonly defaultHeaders: Record<string, string>
+  private readonly fetchImpl: typeof fetch
+
+  constructor(model: TModel, config: BytePlusVoiceConfig) {
+    super(model, config)
+    const resolved = withBytePlusVoiceDefaults(config)
+    this.apiKey = resolved.apiKey
+    this.baseURL = resolved.baseURL ?? BYTEPLUS_VOICE_BASE_URL
+    this.defaultHeaders = resolved.defaultHeaders ?? {}
+    this.fetchImpl = resolved.fetch ?? globalThis.fetch.bind(globalThis)
+  }
+
+  async generateSpeech(
+    options: TTSOptions<BytePlusTTSProviderOptions>,
+  ): Promise<BytePlusTTSResult> {
+    const { logger, model, text, voice, format, speed, modelOptions } = options
+
+    logger.request(`activity=generateSpeech provider=byteplus model=${model}`, {
+      provider: 'byteplus',
+      model,
+    })
+
+    const { body, audioFormat } = buildTTSRequestBody({
+      model,
+      text,
+      voice,
+      format,
+      speed,
+      modelOptions,
+      logger,
+    })
+
+    try {
+      const response = await this.fetchImpl(
+        `${this.baseURL}${TTS_CREATE_PATH}`,
+        {
+          method: 'POST',
+          headers: bytePlusVoiceHeaders(this.apiKey, this.defaultHeaders),
+          body: JSON.stringify(body),
+        },
+      )
+
+      const payload = await readJsonBody(response)
+
+      if (!response.ok) {
+        throw bytePlusVoiceError(response.status, payload, 'text-to-speech')
+      }
+
+      const data = payload as BytePlusTTSCreateResponse
+
+      // A 200 can still carry the numeric error envelope, so treat a missing
+      // audio payload as a failure and let `bytePlusVoiceError` surface
+      // whatever `code`/`message` came back.
+      if (typeof data.audio !== 'string' || data.audio.length === 0) {
+        throw bytePlusVoiceError(response.status, payload, 'text-to-speech')
+      }
+
+      const duration = toDurationSeconds(data.duration, logger)
+
+      return {
+        id: generateId(this.name),
+        model,
+        audio: data.audio,
+        format: audioFormat,
+        contentType: getContentType(audioFormat, modelOptions?.sample_rate),
+        ...(duration !== undefined && { duration }),
+        ...(data.subtitle !== undefined && { subtitle: data.subtitle }),
+        ...(data.url !== undefined && { url: data.url }),
+      }
+    } catch (error) {
+      logger.errors('byteplus.generateSpeech fatal', {
+        error,
+        source: 'byteplus.generateSpeech',
+      })
+      throw error
+    }
+  }
+}
+
+/**
+ * Build the JSON body for `POST /api/v3/tts/create`, resolving the speaker,
+ * output format and rate fields in one place.
+ *
+ * Returns the request `body` plus the resolved `audioFormat`, which the caller
+ * reports on the result and turns into a `contentType`.
+ */
+export function buildTTSRequestBody(options: {
+  model: string
+  text: string
+  voice: string | undefined
+  format: TTSOptions['format'] | undefined
+  speed: number | undefined
+  modelOptions: BytePlusTTSProviderOptions | undefined
+  logger: InternalLogger
+}): { body: BytePlusTTSCreateRequest; audioFormat: BytePlusTTSAudioFormat } {
+  const { model, text, voice, format, speed, modelOptions, logger } = options
+
+  const audioFormat = pickAudioFormat(modelOptions?.format, format, logger)
+
+  const audioConfig: BytePlusTTSAudioConfig = { format: audioFormat }
+  if (modelOptions?.sample_rate !== undefined) {
+    audioConfig.sample_rate = modelOptions.sample_rate
+  }
+  if (modelOptions?.pitch_rate !== undefined) {
+    audioConfig.pitch_rate = modelOptions.pitch_rate
+  }
+  if (modelOptions?.loudness_rate !== undefined) {
+    audioConfig.loudness_rate = modelOptions.loudness_rate
+  }
+
+  // An explicit `speech_rate` always wins over the derived one — it is the
+  // native unit and the only way to reach the extremes precisely.
+  const speechRate =
+    modelOptions?.speech_rate ??
+    (speed !== undefined ? toSpeechRate(speed, logger) : undefined)
+  if (speechRate !== undefined) {
+    audioConfig.speech_rate = speechRate
+  }
+
+  const body: BytePlusTTSCreateRequest = {
+    model,
+    [TTS_TEXT_FIELD]: text,
+    speaker: modelOptions?.speaker ?? voice ?? BYTEPLUS_DEFAULT_TTS_SPEAKER,
+    audio_config: audioConfig,
+  }
+  if (modelOptions?.enable_subtitle !== undefined) {
+    body.enable_subtitle = modelOptions.enable_subtitle
+  }
+
+  return { body, audioFormat }
+}
+
+/**
+ * Convert the cross-provider `TTSOptions.speed` multiplier into Seed Speech's
+ * `speech_rate` percentage.
+ *
+ * ```
+ * speech_rate = clamp(round((speed - 1) * 100), -50, 100)
+ * ```
+ *
+ * so `0.5 → -50`, `1.0 → 0`, `1.5 → 50`, `2.0 → 100`.
+ *
+ * What is **documented** is only the numeric range, `-50`..`100`. The
+ * multiplier anchors this formula reads into it — `-50` ≈ 0.5× and `100` ≈ 2×
+ * — are **inferred** from that range and from how the same field behaves on
+ * sibling Volcengine TTS endpoints; they have not been confirmed against a
+ * live Seed Speech response. If the true curve turns out to be non-linear,
+ * only this function changes.
+ *
+ * The clamp is deliberately conservative. `TTSOptions.speed` spans a wider
+ * 0.25×–4× than the documented range covers, so anything outside 0.5×–2×
+ * clamps (and warns) rather than erroring. Note that at least one reseller
+ * lists `speech_rate` on `seed-audio-1.0` as accepting `-50`..`1000`; until
+ * that is confirmed in BytePlus' own docs this stays pinned to the documented
+ * `100` ceiling, since over-sending is the failure mode that produces a 400.
+ */
+export function toSpeechRate(speed: number, logger?: InternalLogger): number {
+  const rate = Math.round((speed - 1) * 100)
+  const clamped = Math.min(100, Math.max(-50, rate))
+  if (clamped !== rate) {
+    logger?.warn(
+      `Speed ${speed}× is outside the range BytePlus Seed Speech documents (0.5×–2×) — clamping speech_rate from ${rate} to ${clamped}.`,
+      { provider: 'byteplus', requestedSpeed: speed, speechRate: clamped },
+    )
+  }
+  return clamped
+}
+
+/**
+ * Map the cross-provider `TTSOptions.format` onto a Seed Speech output
+ * format. An explicit `modelOptions.format` always wins.
+ *
+ * Seed Speech produces `wav`, `mp3`, `pcm` and `ogg_opus`. The generic
+ * `opus` maps onto `ogg_opus`; `aac` and `flac` have no equivalent and fall
+ * back to `mp3` (matching how the other non-OpenAI TTS adapters in this repo
+ * handle unsupported codecs). The fallback is logged so it isn't silent.
+ */
+function pickAudioFormat(
+  override: BytePlusTTSAudioFormat | undefined,
+  format: TTSOptions['format'] | undefined,
+  logger: InternalLogger,
+): BytePlusTTSAudioFormat {
+  if (override) return override
+  if (!format) return 'mp3'
+  switch (format) {
+    case 'mp3':
+    case 'wav':
+    case 'pcm':
+      return format
+    case 'opus':
+      return 'ogg_opus'
+    case 'aac':
+    case 'flac':
+      logger.warn(
+        `BytePlus Seed Speech does not support ${format} output — falling back to mp3. Set modelOptions.format to choose between wav, mp3, pcm and ogg_opus.`,
+        { provider: 'byteplus', requestedFormat: format },
+      )
+      return 'mp3'
+  }
+}
+
+/**
+ * MIME type for a Seed Speech output format.
+ *
+ * `pcm` is raw little-endian 16-bit samples, so its media type has to carry
+ * the sample rate (RFC 3551/3555). When the caller didn't pin one we report
+ * the service default of 24 kHz.
+ */
+export function getContentType(
+  format: BytePlusTTSAudioFormat,
+  sampleRate?: number,
+): string {
+  switch (format) {
+    case 'mp3':
+      return 'audio/mpeg'
+    case 'wav':
+      return 'audio/wav'
+    case 'ogg_opus':
+      return 'audio/ogg;codecs=opus'
+    case 'pcm':
+      return `audio/L16;rate=${sampleRate ?? 24000}`
+  }
+}
+
+/**
+ * Normalise the `duration` Seed Speech reports into seconds.
+ *
+ * The published docs don't state the unit and no Seed Speech key was
+ * available to settle it, but the endpoint's hard
+ * {@link BYTEPLUS_TTS_MAX_OUTPUT_SECONDS} second output cap separates the two
+ * candidates: a value above the cap cannot be seconds, so it is milliseconds.
+ *
+ * Two edges worth knowing:
+ * - A clip of 120 ms or shorter is genuinely ambiguous and is reported as
+ *   seconds. In practice no synthesis is that short.
+ * - A value just over the cap (say `121`) is read as milliseconds and becomes
+ *   `0.121 s`. That is the right call if the unit is milliseconds and visibly
+ *   wrong if it isn't — which is why the millisecond branch warns rather than
+ *   converting silently. If the warning shows up in the field against a real
+ *   key, the unit question is settled and this function collapses to one
+ *   branch.
+ */
+export function toDurationSeconds(
+  raw: number | string | undefined,
+  logger?: InternalLogger,
+): number | undefined {
+  const value = typeof raw === 'string' ? Number(raw) : raw
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return undefined
+  }
+  if (value <= BYTEPLUS_TTS_MAX_OUTPUT_SECONDS) return value
+
+  const seconds = value / 1000
+  logger?.warn(
+    `BytePlus Seed Speech reported duration=${value}, which exceeds the ${BYTEPLUS_TTS_MAX_OUTPUT_SECONDS}s output cap — reading it as milliseconds (${seconds}s). The unit is undocumented; please report this so it can be pinned.`,
+    { provider: 'byteplus', rawDuration: raw, durationSeconds: seconds },
+  )
+  return seconds
+}
+
+/**
+ * Creates a BytePlus Seed Speech TTS adapter with an explicit API key.
+ *
+ * The key is the **Seed Speech** key, not the Ark key used by the chat, image
+ * and video adapters.
+ *
+ * @example
+ * ```ts
+ * const adapter = createBytePlusSpeech('seed-audio-1.0', process.env.BYTEPLUS_VOICE_API_KEY!)
+ * ```
+ */
+export function createBytePlusSpeech<
+  TModel extends BytePlusTTSModel = BytePlusTTSModel,
+>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<BytePlusVoiceConfig, 'apiKey'>,
+): BytePlusTTSAdapter<TModel> {
+  return new BytePlusTTSAdapter(model, { ...config, apiKey })
+}
+
+/**
+ * Creates a BytePlus Seed Speech TTS adapter, reading the API key from
+ * `BYTEPLUS_VOICE_API_KEY`.
+ *
+ * @throws Error if `BYTEPLUS_VOICE_API_KEY` is not set.
+ */
+export function byteplusSpeech<
+  TModel extends BytePlusTTSModel = BytePlusTTSModel,
+>(
+  model: TModel,
+  config?: Omit<BytePlusVoiceConfig, 'apiKey'>,
+): BytePlusTTSAdapter<TModel> {
+  return createBytePlusSpeech(model, getBytePlusVoiceApiKeyFromEnv(), config)
+}

--- a/packages/ai-byteplus/src/adapters/video.ts
+++ b/packages/ai-byteplus/src/adapters/video.ts
@@ -11,6 +11,7 @@ import {
 } from '../utils/client'
 import { getBytePlusVideoDurationOptions } from '../model-meta'
 import {
+  resolveBytePlusVideoResolution,
   resolveBytePlusVideoSize,
   supportsLastFrame,
   supportsReferenceMedia,
@@ -395,7 +396,7 @@ export class BytePlusVideoAdapter<
       ...(parsedSize && {
         ratio: parsedSize.ratio,
         ...(parsedSize.resolution !== undefined && {
-          resolution: parsedSize.resolution.toLowerCase(),
+          resolution: parsedSize.resolution,
         }),
       }),
       ...(duration !== undefined && { duration }),
@@ -403,6 +404,16 @@ export class BytePlusVideoAdapter<
       ...modelOptions,
       model,
       content,
+    }
+
+    // Validate what actually ships, not just what `size` contributed: a
+    // `modelOptions.resolution` overriding an already-checked size would
+    // otherwise reach Ark unchecked.
+    if (request.resolution !== undefined) {
+      request.resolution = resolveBytePlusVideoResolution(
+        model,
+        request.resolution,
+      )
     }
 
     try {

--- a/packages/ai-byteplus/src/adapters/video.ts
+++ b/packages/ai-byteplus/src/adapters/video.ts
@@ -1,0 +1,651 @@
+import { resolveMediaPrompt } from '@tanstack/ai'
+import { BaseVideoAdapter, snapToDurationOption } from '@tanstack/ai/adapters'
+import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
+import {
+  BYTEPLUS_ARK_BASE_URL,
+  bytePlusArkError,
+  bytePlusArkHeaders,
+  getBytePlusArkApiKeyFromEnv,
+  withBytePlusArkDefaults,
+} from '../utils/client'
+import { getBytePlusVideoDurationOptions } from '../model-meta'
+import {
+  resolveBytePlusVideoSize,
+  supportsLastFrame,
+  supportsReferenceMedia,
+} from '../video/video-provider-options'
+import type { DurationOptions } from '@tanstack/ai/adapters'
+import type {
+  AudioPart,
+  ImagePart,
+  MediaInputMetadata,
+  TokenUsage,
+  VideoGenerationOptions,
+  VideoJobResult,
+  VideoPart,
+  VideoStatusResult,
+  VideoUrlResult,
+} from '@tanstack/ai'
+import type {
+  BytePlusVideoContentPart,
+  BytePlusVideoCreateRequest,
+  BytePlusVideoCreateResponse,
+  BytePlusVideoTask,
+  BytePlusVideoTaskStatus,
+  BytePlusVideoTaskUsage,
+} from '../video/wire-types'
+import type {
+  BytePlusVideoModelProviderOptionsByName,
+  BytePlusVideoProviderOptions,
+} from '../video/video-provider-options'
+import type {
+  BytePlusVideoModel,
+  BytePlusVideoModelDurationByName,
+  BytePlusVideoModelInputModalitiesByName,
+  BytePlusVideoModelSizeByName,
+} from '../model-meta'
+import type { BytePlusArkConfig } from '../utils/client'
+
+/**
+ * Configuration for the BytePlus Seedance video adapter.
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export interface BytePlusVideoConfig extends BytePlusArkConfig {}
+
+/** Path of the Seedance task API, relative to the Ark base URL. */
+const TASKS_PATH = '/contents/generations/tasks'
+
+/**
+ * `content.video_url` and `content.last_frame_url` are deleted 24 hours after
+ * the task produces them.
+ */
+const VIDEO_URL_TTL_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Normalizes the OpenAI-shaped `defaultHeaders` config field (which accepts a
+ * `Headers` instance, an entry list, or a record with nullable values) into
+ * the plain record the Ark header builder takes. Non-string values are
+ * dropped rather than serialized.
+ */
+function toHeaderRecord(headers: unknown): Record<string, string> {
+  const record: Record<string, string> = {}
+  if (!headers) return record
+
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      record[key] = value
+    })
+    return record
+  }
+
+  if (Array.isArray(headers)) {
+    for (const pair of headers) {
+      if (!Array.isArray(pair)) continue
+      const [key, value] = pair
+      if (typeof key === 'string' && typeof value === 'string') {
+        record[key] = value
+      }
+    }
+    return record
+  }
+
+  if (typeof headers === 'object') {
+    for (const [key, value] of Object.entries(headers)) {
+      if (typeof value === 'string') record[key] = value
+    }
+  }
+
+  return record
+}
+
+/**
+ * Converts a media prompt part into the URL string Seedance's `content[]`
+ * takes: public URLs pass through (BytePlus fetches them server-side), data
+ * sources become base64 data URIs.
+ */
+function mediaPartToUrl(
+  part:
+    | ImagePart<MediaInputMetadata>
+    | VideoPart<MediaInputMetadata>
+    | AudioPart<MediaInputMetadata>,
+): string {
+  const { source } = part
+  if (source.type === 'url') return source.value
+  if (source.value.startsWith('data:')) return source.value
+  return `data:${source.mimeType.toLowerCase()};base64,${source.value}`
+}
+
+/** Reads a response body as JSON, falling back to raw text for error pages. */
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text) return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+/** Coerces a usage count that the API types as a string but sends as a number. */
+function toTokenCount(value: number | string | undefined): number | undefined {
+  if (typeof value === 'number') return value
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
+/**
+ * Maps a finished task's usage onto `TokenUsage`.
+ *
+ * Seedance bills output only — the API documents input tokens as always 0 and
+ * `total_tokens` as equal to `completion_tokens` — so `promptTokens` is 0 and
+ * the completion count doubles as `unitsBilled`.
+ */
+function buildBytePlusVideoUsage(
+  usage: BytePlusVideoTaskUsage | undefined,
+): TokenUsage | undefined {
+  if (!usage) return undefined
+
+  const completionTokens = toTokenCount(usage.completion_tokens)
+  const totalTokens = toTokenCount(usage.total_tokens)
+  if (completionTokens === undefined && totalTokens === undefined) {
+    return undefined
+  }
+
+  const completion = completionTokens ?? totalTokens ?? 0
+  return {
+    promptTokens: 0,
+    completionTokens: completion,
+    totalTokens: totalTokens ?? completion,
+    unitsBilled: completion,
+  }
+}
+
+/** Formats a terminal task's error detail for a status / failure message. */
+function describeTaskFailure(task: BytePlusVideoTask): string | undefined {
+  const { code, message } = task.error ?? {}
+  if (code && message) return `${code}: ${message}`
+  if (message) return message
+  if (code) return code
+  // `expired` and `cancelled` are terminal without an `error` block.
+  if (task.status === 'expired') {
+    return 'Task expired before it finished (execution_expires_after elapsed).'
+  }
+  if (task.status === 'cancelled') return 'Task was cancelled.'
+  return undefined
+}
+
+/**
+ * BytePlus Seedance video generation adapter.
+ *
+ * Drives Ark's asynchronous task API — `POST /contents/generations/tasks` to
+ * submit, `GET /contents/generations/tasks/{id}` to poll and to read the
+ * finished video URL. Core owns the polling loop; this adapter implements the
+ * three primitives plus the duration metadata.
+ *
+ * Prompt parts map onto Seedance's `content[]` roles, which the API sorts into
+ * mutually exclusive task types:
+ *
+ * - `'start_frame'` (or a single un-roled image) → `first_frame` — the frame
+ *   the video opens on (`i2v`).
+ * - `'end_frame'` → `last_frame` — the frame it closes on (`flf2v`); Seedance
+ *   requires a `first_frame` alongside it, and
+ *   `seedance-1-0-pro-fast-251015` does not support it at all.
+ * - `'reference'` / `'character'` → `reference_image`, video parts →
+ *   `reference_video`, audio parts → `reference_audio` — subject and style
+ *   references the model draws on (`r2v`, Seedance 2.0 family only).
+ *
+ * Frame roles and reference roles cannot be combined in one request, so the
+ * adapter rejects a mix up front rather than surfacing a raw 400.
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ *
+ * @example
+ * ```typescript
+ * const adapter = byteplusVideo('seedance-1-0-pro-fast-251015')
+ *
+ * const { jobId } = await generateVideo({
+ *   adapter,
+ *   prompt: 'a guitar being played in a store',
+ *   size: '16:9_720p',
+ *   duration: 4,
+ *   modelOptions: { service_tier: 'flex' },
+ * })
+ * ```
+ */
+export class BytePlusVideoAdapter<
+  TModel extends BytePlusVideoModel,
+> extends BaseVideoAdapter<
+  TModel,
+  BytePlusVideoProviderOptions,
+  BytePlusVideoModelProviderOptionsByName,
+  BytePlusVideoModelSizeByName,
+  BytePlusVideoModelInputModalitiesByName,
+  BytePlusVideoModelDurationByName
+> {
+  readonly name = 'byteplus' as const
+
+  private readonly clientConfig: BytePlusVideoConfig
+  /** Ark base URL, trailing slashes trimmed so path joins stay single-slashed. */
+  private readonly baseURL: string
+
+  constructor(config: BytePlusVideoConfig, model: TModel) {
+    super({}, model)
+    this.clientConfig = withBytePlusArkDefaults(config)
+    this.baseURL = (this.clientConfig.baseURL ?? BYTEPLUS_ARK_BASE_URL).replace(
+      /\/+$/,
+      '',
+    )
+  }
+
+  private async request(
+    path: string,
+    init?: Omit<RequestInit, 'headers'>,
+  ): Promise<{ response: Response; body: unknown }> {
+    const fetchImpl = this.clientConfig.fetch ?? fetch
+    const response = await fetchImpl(`${this.baseURL}${path}`, {
+      ...init,
+      headers: bytePlusArkHeaders(
+        this.clientConfig.apiKey,
+        toHeaderRecord(this.clientConfig.defaultHeaders),
+      ),
+    })
+    return { response, body: await readJsonBody(response) }
+  }
+
+  /**
+   * Builds the `content[]` array from the resolved prompt, enforcing
+   * Seedance's role vocabulary and mode exclusivity.
+   */
+  private buildContent(
+    resolved: ReturnType<typeof resolveMediaPrompt>,
+  ): Array<BytePlusVideoContentPart> {
+    const model = this.model
+    const content: Array<BytePlusVideoContentPart> = []
+    if (resolved.text) content.push({ type: 'text', text: resolved.text })
+
+    let frameRoles = 0
+    let referenceRoles = 0
+
+    for (const part of resolved.images) {
+      const role = part.metadata?.role
+      switch (role) {
+        case 'mask':
+        case 'control':
+          throw new Error(
+            `byteplus: Seedance has no '${role}' image input on model ${model}. ` +
+              `Use 'start_frame', 'end_frame' or 'reference'.`,
+          )
+        case 'end_frame': {
+          if (!supportsLastFrame(model)) {
+            throw new Error(
+              `byteplus: ${model} does not support a closing frame — it does ` +
+                `text-to-video and first-frame image-to-video only. Drop the ` +
+                `'end_frame' image or switch to a model with first-and-last-frame support.`,
+            )
+          }
+          frameRoles++
+          content.push({
+            type: 'image_url',
+            image_url: { url: mediaPartToUrl(part) },
+            role: 'last_frame',
+          })
+          break
+        }
+        case 'reference':
+        case 'character': {
+          if (!supportsReferenceMedia(model)) {
+            throw new Error(
+              `byteplus: ${model} does not support reference images. Reference ` +
+                `media is available on the Seedance 2.0 family; on this model use ` +
+                `'start_frame' / 'end_frame' images instead.`,
+            )
+          }
+          referenceRoles++
+          content.push({
+            type: 'image_url',
+            image_url: { url: mediaPartToUrl(part) },
+            role: 'reference_image',
+          })
+          break
+        }
+        // An un-roled image is the opening frame, matching the API's own
+        // default and the fal / Veo adapters' positional convention.
+        case 'start_frame':
+        case undefined: {
+          frameRoles++
+          content.push({
+            type: 'image_url',
+            image_url: { url: mediaPartToUrl(part) },
+            role: 'first_frame',
+          })
+          break
+        }
+      }
+    }
+
+    // Video and audio parts only exist in reference mode: Seedance rejects an
+    // un-roled video with "reference media mode requires video role to be
+    // reference_video", and has no frame-style role for either modality.
+    for (const part of resolved.videos) {
+      if (!supportsReferenceMedia(model)) {
+        throw new Error(
+          `byteplus: ${model} does not accept video prompt parts. Reference ` +
+            `video is available on the Seedance 2.0 family only.`,
+        )
+      }
+      referenceRoles++
+      content.push({
+        type: 'video_url',
+        video_url: { url: mediaPartToUrl(part) },
+        role: 'reference_video',
+      })
+    }
+
+    for (const part of resolved.audios) {
+      if (!supportsReferenceMedia(model)) {
+        throw new Error(
+          `byteplus: ${model} does not accept audio prompt parts. Reference ` +
+            `audio is available on the Seedance 2.0 family only.`,
+        )
+      }
+      content.push({
+        type: 'audio_url',
+        audio_url: { url: mediaPartToUrl(part) },
+        role: 'reference_audio',
+      })
+    }
+
+    if (frameRoles > 0 && referenceRoles > 0) {
+      throw new Error(
+        `byteplus: first/last frame inputs cannot be combined with reference ` +
+          `media on model ${model}. Use either frame roles ('start_frame', ` +
+          `'end_frame') or reference roles ('reference', 'character', video, ` +
+          `audio) — not both.`,
+      )
+    }
+
+    if (resolved.audios.length > 0 && referenceRoles === 0) {
+      throw new Error(
+        `byteplus: a reference audio input cannot be the only reference on ` +
+          `model ${model}. Pair it with a reference image or video.`,
+      )
+    }
+
+    if (content.length === 0) {
+      throw new Error(
+        `byteplus: a video prompt must carry text or at least one media input ` +
+          `(model: ${model}).`,
+      )
+    }
+
+    return content
+  }
+
+  async createVideoJob(
+    options: VideoGenerationOptions<
+      BytePlusVideoProviderOptions,
+      BytePlusVideoModelSizeByName[TModel],
+      BytePlusVideoModelDurationByName[TModel]
+    >,
+  ): Promise<VideoJobResult> {
+    const { size, modelOptions, logger } = options
+    const model = this.model
+
+    const content = this.buildContent(resolveMediaPrompt(options.prompt))
+
+    // The generic `size` carries a "ratio_resolution" template and splits back
+    // into Seedance's separate fields. Explicit modelOptions win below.
+    const parsedSize =
+      size !== undefined ? resolveBytePlusVideoSize(model, size) : undefined
+
+    // Coerce the requested duration into the model's range rather than letting
+    // the API reject it. `modelOptions.duration` is deliberately not snapped:
+    // it is the escape hatch for `-1` (model picks the length).
+    const duration =
+      options.duration !== undefined
+        ? this.snapDuration(options.duration)
+        : undefined
+
+    const request: BytePlusVideoCreateRequest = {
+      ...(parsedSize && {
+        ratio: parsedSize.ratio,
+        ...(parsedSize.resolution !== undefined && {
+          resolution: parsedSize.resolution.toLowerCase(),
+        }),
+      }),
+      ...(duration !== undefined && { duration }),
+      // Explicit provider options win over everything derived above.
+      ...modelOptions,
+      model,
+      content,
+    }
+
+    try {
+      logger.request(
+        `activity=video.create provider=${this.name} model=${model} size=${size ?? 'default'} duration=${request.duration ?? 'default'}`,
+        { provider: this.name, model },
+      )
+
+      const { response, body } = await this.request(TASKS_PATH, {
+        method: 'POST',
+        body: JSON.stringify(request),
+      })
+      if (!response.ok) {
+        throw bytePlusArkError(response.status, body, 'video task creation')
+      }
+
+      const { id } = (body ?? {}) as BytePlusVideoCreateResponse
+      if (!id) {
+        throw new Error('byteplus: video task creation returned no task id.')
+      }
+
+      return { jobId: id, model }
+    } catch (error: unknown) {
+      logger.errors(`${this.name}.createVideoJob fatal`, {
+        error: toRunErrorPayload(error, `${this.name}.createVideoJob failed`),
+        source: `${this.name}.createVideoJob`,
+      })
+      throw error
+    }
+  }
+
+  /** Fetches a task, tagging the thrown error with the HTTP status. */
+  private async retrieveTask(jobId: string): Promise<BytePlusVideoTask> {
+    const { response, body } = await this.request(
+      `${TASKS_PATH}/${encodeURIComponent(jobId)}`,
+    )
+    if (!response.ok) {
+      const error = bytePlusArkError(response.status, body, 'video task lookup')
+      ;(error as { status?: number }).status = response.status
+      throw error
+    }
+    return (body ?? {}) as BytePlusVideoTask
+  }
+
+  async getVideoStatus(jobId: string): Promise<VideoStatusResult> {
+    let task: BytePlusVideoTask
+    try {
+      task = await this.retrieveTask(jobId)
+    } catch (error) {
+      // A task record lives 7 days from creation; past that the id 404s.
+      if ((error as { status?: number }).status === 404) {
+        return { jobId, status: 'failed', error: 'Job not found' }
+      }
+      throw error
+    }
+
+    const status = this.mapStatus(task.status)
+    const failure = status === 'failed' ? describeTaskFailure(task) : undefined
+    return {
+      jobId,
+      status,
+      ...(failure !== undefined && { error: failure }),
+    }
+  }
+
+  async getVideoUrl(jobId: string): Promise<VideoUrlResult> {
+    let task: BytePlusVideoTask
+    try {
+      task = await this.retrieveTask(jobId)
+    } catch (error) {
+      if ((error as { status?: number }).status === 404) {
+        throw new Error(`Video job not found: ${jobId}`)
+      }
+      throw error
+    }
+
+    const status = this.mapStatus(task.status)
+    if (status === 'failed') {
+      const failure = describeTaskFailure(task)
+      throw new Error(
+        `Video generation failed${failure ? `: ${failure}` : ''}. Job ID: ${jobId}`,
+      )
+    }
+
+    const url = task.content?.video_url
+    if (!url) {
+      throw new Error(
+        `Video is not ready for download. Check status first. Job ID: ${jobId}`,
+      )
+    }
+
+    // The 24-hour window runs from when the output was produced, which is the
+    // last status change on a succeeded task — `created_at` anchors the
+    // separate 7-day retention of the task record itself, and can be far
+    // earlier (a live `flex` task sat queued ~15 minutes). Corroborated by the
+    // signed TOS link itself, which carries `X-Tos-Expires=86400` from an
+    // `X-Tos-Date` matching `updated_at`. Fall back to `created_at` only when
+    // `updated_at` is missing.
+    const anchorSeconds = task.updated_at ?? task.created_at
+    const expiresAt =
+      anchorSeconds !== undefined
+        ? new Date(anchorSeconds * 1000 + VIDEO_URL_TTL_MS)
+        : undefined
+
+    const usage = buildBytePlusVideoUsage(task.usage)
+    return {
+      jobId,
+      url,
+      ...(expiresAt && { expiresAt }),
+      ...(usage && { usage }),
+    }
+  }
+
+  /**
+   * Maps Seedance task states onto the generic video status set. `expired`
+   * (the task outlived `execution_expires_after`) and `cancelled` are
+   * terminal non-successes, so both report as failed.
+   */
+  protected mapStatus(
+    apiStatus: BytePlusVideoTaskStatus | string | undefined,
+  ): VideoStatusResult['status'] {
+    switch (apiStatus) {
+      case 'queued':
+        return 'pending'
+      case 'running':
+        return 'processing'
+      case 'succeeded':
+        return 'completed'
+      case 'failed':
+      case 'expired':
+      case 'cancelled':
+        return 'failed'
+      case undefined:
+      default:
+        return 'processing'
+    }
+  }
+
+  /**
+   * Seedance accepts any whole second inside a per-model range: 4–15s on the
+   * 2.0 family, 4–12s on 1.5-pro, 2–12s on the 1.0 models.
+   */
+  override availableDurations(): DurationOptions<
+    BytePlusVideoModelDurationByName[TModel]
+  > {
+    return getBytePlusVideoDurationOptions(this.model)
+  }
+
+  /**
+   * Coerce a raw seconds value to the closest duration this model accepts
+   * (clamped to its range and rounded to whole seconds).
+   */
+  override snapDuration(
+    seconds: number,
+  ): BytePlusVideoModelDurationByName[TModel] | undefined {
+    return snapToDurationOption(seconds, this.availableDurations())
+  }
+}
+
+/**
+ * Creates a BytePlus Seedance video adapter with an explicit API key.
+ * Type resolution happens here at the call site.
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ *
+ * @param model - The model name (e.g., 'seedance-1-0-pro-fast-251015')
+ * @param apiKey - Your BytePlus Ark API key
+ * @param config - Optional additional configuration
+ * @returns Configured BytePlus video adapter instance with resolved types
+ *
+ * @example
+ * ```typescript
+ * const adapter = createBytePlusVideo('seedance-1-5-pro-251215', 'ark-...')
+ *
+ * const { jobId } = await generateVideo({
+ *   adapter,
+ *   prompt: 'a guitar being played in a store',
+ *   size: '16:9_1080p',
+ *   duration: 5,
+ * })
+ * ```
+ */
+export function createBytePlusVideo<TModel extends BytePlusVideoModel>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<BytePlusVideoConfig, 'apiKey'>,
+): BytePlusVideoAdapter<TModel> {
+  return new BytePlusVideoAdapter({ apiKey, ...config }, model)
+}
+
+/**
+ * Creates a BytePlus Seedance video adapter, reading `ARK_API_KEY` from the
+ * environment. Type resolution happens here at the call site.
+ *
+ * Note that Ark keys are region-isolated and Seedance is only served from the
+ * Asia-Pacific endpoint — an EU key will not work here.
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ *
+ * @param model - The model name (e.g., 'dreamina-seedance-2-0-260128')
+ * @param config - Optional configuration (excluding apiKey, auto-detected)
+ * @returns Configured BytePlus video adapter instance with resolved types
+ * @throws Error if ARK_API_KEY is not found in environment
+ *
+ * @example
+ * ```typescript
+ * const adapter = byteplusVideo('dreamina-seedance-2-0-260128')
+ *
+ * // Image-to-video: an un-roled image is the opening frame.
+ * const { jobId } = await generateVideo({
+ *   adapter,
+ *   prompt: [
+ *     { type: 'text', content: 'the guitarist starts playing' },
+ *     { type: 'image', source: { type: 'url', value: 'https://example.com/shop.jpg' } },
+ *   ],
+ * })
+ *
+ * const status = await getVideoJobStatus({ adapter, jobId })
+ * ```
+ */
+export function byteplusVideo<TModel extends BytePlusVideoModel>(
+  model: TModel,
+  config?: Omit<BytePlusVideoConfig, 'apiKey'>,
+): BytePlusVideoAdapter<TModel> {
+  const apiKey = getBytePlusArkApiKeyFromEnv()
+  return createBytePlusVideo(model, apiKey, config)
+}

--- a/packages/ai-byteplus/src/adapters/video.ts
+++ b/packages/ai-byteplus/src/adapters/video.ts
@@ -652,28 +652,23 @@ export function createBytePlusVideo<TModel extends BytePlusVideoModelOrString>(
  *
  * `model` also accepts any string, so a Seedance id BytePlus publishes after
  * this release works without upgrading. **Seedance 2.5 is the case this exists
- * for**: announced 2026-07-31 as a consumer product, with the Ark API listed
- * as "available soon". As of that date no 2.5 id resolves on the data plane —
- * 21 candidate ids were probed and every one returned 404
- * `InvalidEndpointOrModel.NotFound` while known controls returned 400
- * `MissingParameter` — so this package deliberately ships no guessed id.
- *
- * New ids land in the ModelArk release notes
- * (https://docs.byteplus.com/en/docs/ModelArk/1159178) first. To check whether
- * one is live, POST `/contents/generations/tasks` with only `{"model": id}`:
- * 404 `InvalidEndpointOrModel.NotFound` means not yet, 400 `MissingParameter`
- * (about `content`) means it is.
+ * for**: `dreamina-seedance-2-5-260628` is real and reachable, but its
+ * capability cells could not be probed from this repo's account (Ark answers
+ * 404 `ModelNotOpen` until the model is activated in the Ark Console), so it
+ * is deliberately absent from the narrowed model tables. Passing it here works
+ * for an account that has activated it.
  *
  * An unknown id relaxes both halves of the adapter: the `size` type widens to
  * any string, provider options are ungated, and the runtime guards that encode
  * per-model capabilities — resolution tiers, closing-frame and reference-media
  * support, frame cardinality and mode exclusivity, duration snapping — stand
- * down so Ark decides. Known ids are unaffected.
+ * down so Ark decides. Known ids are unaffected. See
+ * {@link BytePlusVideoModelOrString} for how to discover and probe an id.
  *
  * @example
  * ```typescript
- * // The day BytePlus publishes the id, before this package ships it:
- * const adapter = byteplusVideo('dreamina-seedance-2-5-XXXXXX')
+ * // Seedance 2.5, before this package ships probe-verified metadata for it:
+ * const adapter = byteplusVideo('dreamina-seedance-2-5-260628')
  * ```
  */
 export function byteplusVideo<TModel extends BytePlusVideoModelOrString>(

--- a/packages/ai-byteplus/src/adapters/video.ts
+++ b/packages/ai-byteplus/src/adapters/video.ts
@@ -9,7 +9,10 @@ import {
   toHeaderRecord,
   withBytePlusArkDefaults,
 } from '../utils/client'
-import { getBytePlusVideoDurationOptions } from '../model-meta'
+import {
+  getBytePlusVideoDurationOptions,
+  isKnownBytePlusVideoModel,
+} from '../model-meta'
 import {
   resolveBytePlusVideoResolution,
   resolveBytePlusVideoSize,
@@ -36,15 +39,11 @@ import type {
   BytePlusVideoTaskStatus,
   BytePlusVideoTaskUsage,
 } from '../video/wire-types'
+import type { BytePlusVideoProviderOptions } from '../video/video-provider-options'
 import type {
-  BytePlusVideoModelProviderOptionsByName,
-  BytePlusVideoProviderOptions,
-} from '../video/video-provider-options'
-import type {
-  BytePlusVideoModel,
-  BytePlusVideoModelDurationByName,
-  BytePlusVideoModelInputModalitiesByName,
-  BytePlusVideoModelSizeByName,
+  BytePlusVideoModelOrString,
+  ResolveBytePlusVideoInputModalities,
+  ResolveBytePlusVideoSize,
 } from '../model-meta'
 import type { BytePlusArkConfig } from '../utils/client'
 
@@ -171,14 +170,14 @@ function describeTaskFailure(task: BytePlusVideoTask): string | undefined {
  * ```
  */
 export class BytePlusVideoAdapter<
-  TModel extends BytePlusVideoModel,
+  TModel extends BytePlusVideoModelOrString,
 > extends BaseVideoAdapter<
   TModel,
   BytePlusVideoProviderOptions,
-  BytePlusVideoModelProviderOptionsByName,
-  BytePlusVideoModelSizeByName,
-  BytePlusVideoModelInputModalitiesByName,
-  BytePlusVideoModelDurationByName
+  Record<TModel, BytePlusVideoProviderOptions>,
+  Record<TModel, ResolveBytePlusVideoSize<TModel>>,
+  Record<TModel, ResolveBytePlusVideoInputModalities<TModel>>,
+  Record<TModel, number>
 > {
   readonly name = 'byteplus' as const
 
@@ -218,6 +217,15 @@ export class BytePlusVideoAdapter<
     const content: Array<BytePlusVideoContentPart> = []
     if (resolved.text) content.push({ type: 'text', text: resolved.text })
 
+    // Every rule below except the role vocabulary itself is a claim about a
+    // *specific* model's capabilities, drawn from probing the six models that
+    // exist today. None of it can be true of a model that does not exist yet,
+    // so for an unknown id the guards stand down and Ark rules — otherwise the
+    // escape hatch would block exactly the requests it exists to enable (see
+    // BytePlusVideoModelOrString). 'mask' / 'control' still throw: Seedance's
+    // wire format has no field to carry them on any model.
+    const gated = isKnownBytePlusVideoModel(model)
+
     let firstFrames = 0
     let lastFrames = 0
     // Audio counts as a reference for the mode-exclusivity check but not for
@@ -235,7 +243,7 @@ export class BytePlusVideoAdapter<
               `Use 'start_frame', 'end_frame' or 'reference'.`,
           )
         case 'end_frame': {
-          if (!supportsLastFrame(model)) {
+          if (gated && !supportsLastFrame(model)) {
             throw new Error(
               `byteplus: ${model} does not support a closing frame — it does ` +
                 `text-to-video and first-frame image-to-video only. Drop the ` +
@@ -252,7 +260,7 @@ export class BytePlusVideoAdapter<
         }
         case 'reference':
         case 'character': {
-          if (!supportsReferenceMedia(model)) {
+          if (gated && !supportsReferenceMedia(model)) {
             throw new Error(
               `byteplus: ${model} does not support reference images. Reference ` +
                 `media is available on the Seedance 2.0 family; on this model use ` +
@@ -286,7 +294,7 @@ export class BytePlusVideoAdapter<
     // un-roled video with "reference media mode requires video role to be
     // reference_video", and has no frame-style role for either modality.
     for (const part of resolved.videos) {
-      if (!supportsReferenceMedia(model)) {
+      if (gated && !supportsReferenceMedia(model)) {
         throw new Error(
           `byteplus: ${model} does not accept video prompt parts. Reference ` +
             `video is available on the Seedance 2.0 family only.`,
@@ -301,7 +309,7 @@ export class BytePlusVideoAdapter<
     }
 
     for (const part of resolved.audios) {
-      if (!supportsReferenceMedia(model)) {
+      if (gated && !supportsReferenceMedia(model)) {
         throw new Error(
           `byteplus: ${model} does not accept audio prompt parts. Reference ` +
             `audio is available on the Seedance 2.0 family only.`,
@@ -316,7 +324,7 @@ export class BytePlusVideoAdapter<
     }
 
     const frames = firstFrames + lastFrames
-    if (frames > 0 && visualReferences + audioReferences > 0) {
+    if (gated && frames > 0 && visualReferences + audioReferences > 0) {
       throw new Error(
         `byteplus: first/last frame inputs cannot be combined with reference ` +
           `media on model ${model}. Use either frame roles ('start_frame', ` +
@@ -325,7 +333,7 @@ export class BytePlusVideoAdapter<
       )
     }
 
-    if (firstFrames > 1) {
+    if (gated && firstFrames > 1) {
       throw new Error(
         `byteplus: ${model} accepts at most one opening frame; received ` +
           `${firstFrames} un-roled or 'start_frame' images. Use metadata.role ` +
@@ -333,7 +341,7 @@ export class BytePlusVideoAdapter<
       )
     }
 
-    if (lastFrames > 1) {
+    if (gated && lastFrames > 1) {
       throw new Error(
         `byteplus: ${model} accepts at most one closing frame; received ` +
           `${lastFrames} 'end_frame' images.`,
@@ -343,14 +351,14 @@ export class BytePlusVideoAdapter<
     // Seedance treats a closing frame as the second half of first-and-last-
     // frame mode: on its own it fails with "last frame image content cannot be
     // mixed with first frame or reference image content".
-    if (lastFrames > 0 && firstFrames === 0) {
+    if (gated && lastFrames > 0 && firstFrames === 0) {
       throw new Error(
         `byteplus: a closing frame needs an opening frame alongside it on ` +
           `model ${model}. Add a 'start_frame' image, or drop the 'end_frame' role.`,
       )
     }
 
-    if (audioReferences > 0 && visualReferences === 0) {
+    if (gated && audioReferences > 0 && visualReferences === 0) {
       throw new Error(
         `byteplus: a reference audio input cannot be the only reference on ` +
           `model ${model}. Pair it with a reference image or video.`,
@@ -370,8 +378,8 @@ export class BytePlusVideoAdapter<
   async createVideoJob(
     options: VideoGenerationOptions<
       BytePlusVideoProviderOptions,
-      BytePlusVideoModelSizeByName[TModel],
-      BytePlusVideoModelDurationByName[TModel]
+      ResolveBytePlusVideoSize<TModel>,
+      number
     >,
   ): Promise<VideoJobResult> {
     const { size, modelOptions, logger } = options
@@ -387,9 +395,16 @@ export class BytePlusVideoAdapter<
     // Coerce the requested duration into the model's range rather than letting
     // the API reject it. `modelOptions.duration` is deliberately not snapped:
     // it is the escape hatch for `-1` (model picks the length).
+    //
+    // An unknown model's duration goes through verbatim. Snapping it would
+    // mean clamping against the ranges today's models happen to have, so a
+    // future model's legitimate 20-second request would silently become 15 —
+    // corrupting the request instead of protecting it.
     const duration =
       options.duration !== undefined
-        ? this.snapDuration(options.duration)
+        ? isKnownBytePlusVideoModel(model)
+          ? this.snapDuration(options.duration)
+          : options.duration
         : undefined
 
     const request: BytePlusVideoCreateRequest = {
@@ -554,11 +569,12 @@ export class BytePlusVideoAdapter<
 
   /**
    * Seedance accepts any whole second inside a per-model range: 4–15s on the
-   * 2.0 family, 4–12s on 1.5-pro, 2–12s on the 1.0 models.
+   * 2.0 family, 4–12s on 1.5-pro, 2–12s on the 1.0 models. An unknown model
+   * reports the union of those ranges as a UI hint — see
+   * `BYTEPLUS_VIDEO_FALLBACK_DURATIONS`, which `createVideoJob` does not snap
+   * against.
    */
-  override availableDurations(): DurationOptions<
-    BytePlusVideoModelDurationByName[TModel]
-  > {
+  override availableDurations(): DurationOptions<number> {
     return getBytePlusVideoDurationOptions(this.model)
   }
 
@@ -566,9 +582,7 @@ export class BytePlusVideoAdapter<
    * Coerce a raw seconds value to the closest duration this model accepts
    * (clamped to its range and rounded to whole seconds).
    */
-  override snapDuration(
-    seconds: number,
-  ): BytePlusVideoModelDurationByName[TModel] | undefined {
+  override snapDuration(seconds: number): number | undefined {
     return snapToDurationOption(seconds, this.availableDurations())
   }
 }
@@ -596,7 +610,7 @@ export class BytePlusVideoAdapter<
  * })
  * ```
  */
-export function createBytePlusVideo<TModel extends BytePlusVideoModel>(
+export function createBytePlusVideo<TModel extends BytePlusVideoModelOrString>(
   model: TModel,
   apiKey: string,
   config?: Omit<BytePlusVideoConfig, 'apiKey'>,
@@ -633,8 +647,36 @@ export function createBytePlusVideo<TModel extends BytePlusVideoModel>(
  *
  * const status = await getVideoJobStatus({ adapter, jobId })
  * ```
+ *
+ * ## Models this package does not know yet
+ *
+ * `model` also accepts any string, so a Seedance id BytePlus publishes after
+ * this release works without upgrading. **Seedance 2.5 is the case this exists
+ * for**: announced 2026-07-31 as a consumer product, with the Ark API listed
+ * as "available soon". As of that date no 2.5 id resolves on the data plane —
+ * 21 candidate ids were probed and every one returned 404
+ * `InvalidEndpointOrModel.NotFound` while known controls returned 400
+ * `MissingParameter` — so this package deliberately ships no guessed id.
+ *
+ * New ids land in the ModelArk release notes
+ * (https://docs.byteplus.com/en/docs/ModelArk/1159178) first. To check whether
+ * one is live, POST `/contents/generations/tasks` with only `{"model": id}`:
+ * 404 `InvalidEndpointOrModel.NotFound` means not yet, 400 `MissingParameter`
+ * (about `content`) means it is.
+ *
+ * An unknown id relaxes both halves of the adapter: the `size` type widens to
+ * any string, provider options are ungated, and the runtime guards that encode
+ * per-model capabilities — resolution tiers, closing-frame and reference-media
+ * support, frame cardinality and mode exclusivity, duration snapping — stand
+ * down so Ark decides. Known ids are unaffected.
+ *
+ * @example
+ * ```typescript
+ * // The day BytePlus publishes the id, before this package ships it:
+ * const adapter = byteplusVideo('dreamina-seedance-2-5-XXXXXX')
+ * ```
  */
-export function byteplusVideo<TModel extends BytePlusVideoModel>(
+export function byteplusVideo<TModel extends BytePlusVideoModelOrString>(
   model: TModel,
   config?: Omit<BytePlusVideoConfig, 'apiKey'>,
 ): BytePlusVideoAdapter<TModel> {

--- a/packages/ai-byteplus/src/adapters/video.ts
+++ b/packages/ai-byteplus/src/adapters/video.ts
@@ -4,6 +4,7 @@ import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
 import {
   bytePlusArkError,
   bytePlusArkHeaders,
+  bytePlusTimeoutSignal,
   getBytePlusArkApiKeyFromEnv,
   readJsonBody,
   toHeaderRecord,
@@ -117,8 +118,16 @@ function buildBytePlusVideoUsage(
   }
 }
 
-/** Formats a terminal task's error detail for a status / failure message. */
-function describeTaskFailure(task: BytePlusVideoTask): string | undefined {
+/**
+ * Formats a terminal task's error detail for a status / failure message.
+ *
+ * Always returns a string. Core surfaces a failed job as
+ * `throw new Error(statusResult.error || 'Video generation failed')`, so
+ * returning `undefined` for a failure Ark reported without an `error` block
+ * would hand the caller an unattributable error. The final fallback is a
+ * snapshot of the identifying fields instead.
+ */
+function describeTaskFailure(task: BytePlusVideoTask): string {
   const { code, message } = task.error ?? {}
   if (code && message) return `${code}: ${message}`
   if (message) return message
@@ -128,7 +137,10 @@ function describeTaskFailure(task: BytePlusVideoTask): string | undefined {
     return 'Task expired before it finished (execution_expires_after elapsed).'
   }
   if (task.status === 'cancelled') return 'Task was cancelled.'
-  return undefined
+  return (
+    `Task reported status "${task.status ?? 'unknown'}" with no error detail ` +
+    `(id=${task.id ?? 'unknown'}, model=${task.model ?? 'unknown'}).`
+  )
 }
 
 /**
@@ -196,8 +208,10 @@ export class BytePlusVideoAdapter<
     init?: Omit<RequestInit, 'headers'>,
   ): Promise<{ response: Response; body: unknown }> {
     const fetchImpl = this.clientConfig.fetch ?? fetch
+    const signal = bytePlusTimeoutSignal(this.clientConfig.timeout)
     const response = await fetchImpl(`${this.clientConfig.baseURL}${path}`, {
       ...init,
+      ...(signal && { signal }),
       headers: bytePlusArkHeaders(
         this.clientConfig.apiKey,
         toHeaderRecord(this.clientConfig.defaultHeaders),
@@ -460,7 +474,17 @@ export class BytePlusVideoAdapter<
     }
   }
 
-  /** Fetches a task, tagging the thrown error with the HTTP status. */
+  /**
+   * Fetches a task, tagging the thrown error with the HTTP status.
+   *
+   * The 200 body is validated rather than cast. `readJsonBody` returns
+   * `undefined` for an empty body and the raw text for a non-JSON one — both
+   * documented failure modes of these hosts (an HTML error page from a proxy
+   * in front of the API). Casting either to `BytePlusVideoTask` yields a task
+   * whose `status` is `undefined`, which {@link mapStatus} would have to
+   * interpret; the honest answer is that the response was not a task at all,
+   * so say so while the body is still in hand.
+   */
   private async retrieveTask(jobId: string): Promise<BytePlusVideoTask> {
     const { response, body } = await this.request(
       `${TASKS_PATH}/${encodeURIComponent(jobId)}`,
@@ -470,7 +494,14 @@ export class BytePlusVideoAdapter<
       ;(error as { status?: number }).status = response.status
       throw error
     }
-    return (body ?? {}) as BytePlusVideoTask
+    if (typeof body !== 'object' || body === null) {
+      throw bytePlusArkError(
+        response.status,
+        body,
+        `video task lookup (job ${jobId}) returned a non-object body`,
+      )
+    }
+    return body as BytePlusVideoTask
   }
 
   async getVideoStatus(jobId: string): Promise<VideoStatusResult> {
@@ -478,9 +509,16 @@ export class BytePlusVideoAdapter<
     try {
       task = await this.retrieveTask(jobId)
     } catch (error) {
-      // A task record lives 7 days from creation; past that the id 404s.
+      // A task record lives 7 days from creation; past that the id 404s. Keep
+      // Ark's own code/message: a 404 from a wrong baseURL, a proxy, or a
+      // region mismatch is not an expired job id, and collapsing them all to
+      // "Job not found" sends the caller hunting the wrong thing.
       if ((error as { status?: number }).status === 404) {
-        return { jobId, status: 'failed', error: 'Job not found' }
+        return {
+          jobId,
+          status: 'failed',
+          error: `Job not found: ${jobId} (${(error as Error).message})`,
+        }
       }
       throw error
     }
@@ -499,17 +537,20 @@ export class BytePlusVideoAdapter<
     try {
       task = await this.retrieveTask(jobId)
     } catch (error) {
+      // See getVideoStatus: Ark's detail distinguishes an expired id from a
+      // misrouted request.
       if ((error as { status?: number }).status === 404) {
-        throw new Error(`Video job not found: ${jobId}`)
+        throw new Error(
+          `Video job not found: ${jobId} (${(error as Error).message})`,
+        )
       }
       throw error
     }
 
     const status = this.mapStatus(task.status)
     if (status === 'failed') {
-      const failure = describeTaskFailure(task)
       throw new Error(
-        `Video generation failed${failure ? `: ${failure}` : ''}. Job ID: ${jobId}`,
+        `Video generation failed: ${describeTaskFailure(task)}. Job ID: ${jobId}`,
       )
     }
 
@@ -546,6 +587,13 @@ export class BytePlusVideoAdapter<
    * Maps Seedance task states onto the generic video status set. `expired`
    * (the task outlived `execution_expires_after`) and `cancelled` are
    * terminal non-successes, so both report as failed.
+   *
+   * An unrecognized state throws rather than defaulting to `processing`.
+   * Core's poll loop treats `processing` as "keep waiting", so mapping an
+   * unknown state — a missing `status`, or a terminal one Ark adds later such
+   * as `rejected` — onto it means polling until `maxDuration` and then
+   * reporting a generic timeout, with the state Ark actually sent never
+   * reaching the caller. Failing here names it.
    */
   protected mapStatus(
     apiStatus: BytePlusVideoTaskStatus | string | undefined,
@@ -563,7 +611,11 @@ export class BytePlusVideoAdapter<
         return 'failed'
       case undefined:
       default:
-        return 'processing'
+        throw new Error(
+          `byteplus: unrecognized Seedance task status ` +
+            `${apiStatus === undefined ? '(missing)' : `"${apiStatus}"`}. ` +
+            `Known states: queued, running, succeeded, failed, expired, cancelled.`,
+        )
     }
   }
 

--- a/packages/ai-byteplus/src/adapters/video.ts
+++ b/packages/ai-byteplus/src/adapters/video.ts
@@ -2,10 +2,11 @@ import { resolveMediaPrompt } from '@tanstack/ai'
 import { BaseVideoAdapter, snapToDurationOption } from '@tanstack/ai/adapters'
 import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
 import {
-  BYTEPLUS_ARK_BASE_URL,
   bytePlusArkError,
   bytePlusArkHeaders,
   getBytePlusArkApiKeyFromEnv,
+  readJsonBody,
+  toHeaderRecord,
   withBytePlusArkDefaults,
 } from '../utils/client'
 import { getBytePlusVideoDurationOptions } from '../model-meta'
@@ -63,43 +64,6 @@ const TASKS_PATH = '/contents/generations/tasks'
 const VIDEO_URL_TTL_MS = 24 * 60 * 60 * 1000
 
 /**
- * Normalizes the OpenAI-shaped `defaultHeaders` config field (which accepts a
- * `Headers` instance, an entry list, or a record with nullable values) into
- * the plain record the Ark header builder takes. Non-string values are
- * dropped rather than serialized.
- */
-function toHeaderRecord(headers: unknown): Record<string, string> {
-  const record: Record<string, string> = {}
-  if (!headers) return record
-
-  if (headers instanceof Headers) {
-    headers.forEach((value, key) => {
-      record[key] = value
-    })
-    return record
-  }
-
-  if (Array.isArray(headers)) {
-    for (const pair of headers) {
-      if (!Array.isArray(pair)) continue
-      const [key, value] = pair
-      if (typeof key === 'string' && typeof value === 'string') {
-        record[key] = value
-      }
-    }
-    return record
-  }
-
-  if (typeof headers === 'object') {
-    for (const [key, value] of Object.entries(headers)) {
-      if (typeof value === 'string') record[key] = value
-    }
-  }
-
-  return record
-}
-
-/**
  * Converts a media prompt part into the URL string Seedance's `content[]`
  * takes: public URLs pass through (BytePlus fetches them server-side), data
  * sources become base64 data URIs.
@@ -114,17 +78,6 @@ function mediaPartToUrl(
   if (source.type === 'url') return source.value
   if (source.value.startsWith('data:')) return source.value
   return `data:${source.mimeType.toLowerCase()};base64,${source.value}`
-}
-
-/** Reads a response body as JSON, falling back to raw text for error pages. */
-async function readJsonBody(response: Response): Promise<unknown> {
-  const text = await response.text()
-  if (!text) return undefined
-  try {
-    return JSON.parse(text)
-  } catch {
-    return text
-  }
 }
 
 /** Coerces a usage count that the API types as a string but sends as a number. */
@@ -228,17 +181,14 @@ export class BytePlusVideoAdapter<
 > {
   readonly name = 'byteplus' as const
 
-  private readonly clientConfig: BytePlusVideoConfig
-  /** Ark base URL, trailing slashes trimmed so path joins stay single-slashed. */
-  private readonly baseURL: string
+  /** Config with the Ark base URL resolved and its trailing slashes trimmed. */
+  private readonly clientConfig: Omit<BytePlusVideoConfig, 'baseURL'> & {
+    baseURL: string
+  }
 
   constructor(config: BytePlusVideoConfig, model: TModel) {
     super({}, model)
     this.clientConfig = withBytePlusArkDefaults(config)
-    this.baseURL = (this.clientConfig.baseURL ?? BYTEPLUS_ARK_BASE_URL).replace(
-      /\/+$/,
-      '',
-    )
   }
 
   private async request(
@@ -246,7 +196,7 @@ export class BytePlusVideoAdapter<
     init?: Omit<RequestInit, 'headers'>,
   ): Promise<{ response: Response; body: unknown }> {
     const fetchImpl = this.clientConfig.fetch ?? fetch
-    const response = await fetchImpl(`${this.baseURL}${path}`, {
+    const response = await fetchImpl(`${this.clientConfig.baseURL}${path}`, {
       ...init,
       headers: bytePlusArkHeaders(
         this.clientConfig.apiKey,
@@ -267,8 +217,12 @@ export class BytePlusVideoAdapter<
     const content: Array<BytePlusVideoContentPart> = []
     if (resolved.text) content.push({ type: 'text', text: resolved.text })
 
-    let frameRoles = 0
-    let referenceRoles = 0
+    let firstFrames = 0
+    let lastFrames = 0
+    // Audio counts as a reference for the mode-exclusivity check but not for
+    // the "audio can't be the only reference" rule, which wants a visual.
+    let visualReferences = 0
+    let audioReferences = 0
 
     for (const part of resolved.images) {
       const role = part.metadata?.role
@@ -287,7 +241,7 @@ export class BytePlusVideoAdapter<
                 `'end_frame' image or switch to a model with first-and-last-frame support.`,
             )
           }
-          frameRoles++
+          lastFrames++
           content.push({
             type: 'image_url',
             image_url: { url: mediaPartToUrl(part) },
@@ -304,7 +258,7 @@ export class BytePlusVideoAdapter<
                 `'start_frame' / 'end_frame' images instead.`,
             )
           }
-          referenceRoles++
+          visualReferences++
           content.push({
             type: 'image_url',
             image_url: { url: mediaPartToUrl(part) },
@@ -316,7 +270,7 @@ export class BytePlusVideoAdapter<
         // default and the fal / Veo adapters' positional convention.
         case 'start_frame':
         case undefined: {
-          frameRoles++
+          firstFrames++
           content.push({
             type: 'image_url',
             image_url: { url: mediaPartToUrl(part) },
@@ -337,7 +291,7 @@ export class BytePlusVideoAdapter<
             `video is available on the Seedance 2.0 family only.`,
         )
       }
-      referenceRoles++
+      visualReferences++
       content.push({
         type: 'video_url',
         video_url: { url: mediaPartToUrl(part) },
@@ -352,6 +306,7 @@ export class BytePlusVideoAdapter<
             `audio is available on the Seedance 2.0 family only.`,
         )
       }
+      audioReferences++
       content.push({
         type: 'audio_url',
         audio_url: { url: mediaPartToUrl(part) },
@@ -359,7 +314,8 @@ export class BytePlusVideoAdapter<
       })
     }
 
-    if (frameRoles > 0 && referenceRoles > 0) {
+    const frames = firstFrames + lastFrames
+    if (frames > 0 && visualReferences + audioReferences > 0) {
       throw new Error(
         `byteplus: first/last frame inputs cannot be combined with reference ` +
           `media on model ${model}. Use either frame roles ('start_frame', ` +
@@ -368,7 +324,32 @@ export class BytePlusVideoAdapter<
       )
     }
 
-    if (resolved.audios.length > 0 && referenceRoles === 0) {
+    if (firstFrames > 1) {
+      throw new Error(
+        `byteplus: ${model} accepts at most one opening frame; received ` +
+          `${firstFrames} un-roled or 'start_frame' images. Use metadata.role ` +
+          `('end_frame', 'reference') to disambiguate the others.`,
+      )
+    }
+
+    if (lastFrames > 1) {
+      throw new Error(
+        `byteplus: ${model} accepts at most one closing frame; received ` +
+          `${lastFrames} 'end_frame' images.`,
+      )
+    }
+
+    // Seedance treats a closing frame as the second half of first-and-last-
+    // frame mode: on its own it fails with "last frame image content cannot be
+    // mixed with first frame or reference image content".
+    if (lastFrames > 0 && firstFrames === 0) {
+      throw new Error(
+        `byteplus: a closing frame needs an opening frame alongside it on ` +
+          `model ${model}. Add a 'start_frame' image, or drop the 'end_frame' role.`,
+      )
+    }
+
+    if (audioReferences > 0 && visualReferences === 0) {
       throw new Error(
         `byteplus: a reference audio input cannot be the only reference on ` +
           `model ${model}. Pair it with a reference image or video.`,

--- a/packages/ai-byteplus/src/audio/transcription-provider-options.ts
+++ b/packages/ai-byteplus/src/audio/transcription-provider-options.ts
@@ -1,0 +1,46 @@
+/**
+ * Provider-specific options for BytePlus Seed Speech ASR
+ * (`POST /api/v3/auc/bigmodel/recognize/flash`).
+ *
+ * Field names mirror the wire format: everything except `uid` and
+ * `audio_format` is forwarded inside the request's `request` block.
+ */
+export interface BytePlusTranscriptionProviderOptions {
+  /**
+   * Recognition model family. Defaults to `bigmodel`; the specific model is
+   * selected by the `X-Api-Resource-Id` header rather than by this value.
+   */
+  model_name?: string
+  /**
+   * Container hint for the submitted audio (`mp3`, `wav`, `ogg`, …). Only
+   * needed when the format can't be inferred from the input — a `File`'s name
+   * or MIME type, or a data URL's MIME type, is used automatically.
+   */
+  audio_format?: string
+  /** Inverse text normalisation: render spoken numbers, dates etc. as digits. */
+  enable_itn?: boolean
+  /** Insert punctuation into the transcript. */
+  enable_punc?: boolean
+  /** Disfluency removal — drop fillers and stutters. */
+  enable_ddc?: boolean
+  /**
+   * Attach speaker labels to each utterance. When present they are surfaced
+   * as `segment.speaker` on the result.
+   */
+  enable_speaker_info?: boolean
+  /**
+   * Return the per-utterance breakdown as well as the flat transcript.
+   * Defaults to `true` so `segments` and `words` are populated.
+   */
+  show_utterances?: boolean
+  /**
+   * Spoken-language hint (e.g. `en-US`). Overrides the cross-provider
+   * `TranscriptionOptions.language`.
+   */
+  language?: string
+  /**
+   * Caller identifier echoed back in BytePlus' request logs. Useful for
+   * correlating usage; defaults to `tanstack-ai`.
+   */
+  uid?: string
+}

--- a/packages/ai-byteplus/src/audio/tts-provider-options.ts
+++ b/packages/ai-byteplus/src/audio/tts-provider-options.ts
@@ -1,6 +1,8 @@
 import type {
   BytePlusTTSAudioFormat,
-  BytePlusTTSSubtitleEntry,
+  BytePlusTTSReference,
+  BytePlusTTSSampleRate,
+  BytePlusTTSSubtitle,
 } from './wire-types'
 import type { TTSResult } from '@tanstack/ai'
 
@@ -32,28 +34,38 @@ export type BytePlusTTSVoice = 'en_female_stokie_uranus_bigtts' | (string & {})
  */
 export interface BytePlusTTSProviderOptions {
   /**
-   * Voice id. Overrides `TTSOptions.voice` when both are set.
+   * Voice id. Overrides `TTSOptions.voice` when both are set. It is sent as
+   * the `speaker` of a single `references` entry.
    */
   speaker?: BytePlusTTSVoice
+  /**
+   * Full `references` array, for voice cloning or image-referenced delivery.
+   * When set this replaces the entry the adapter would otherwise build from
+   * `speaker` / `TTSOptions.voice`, so include a `speaker` entry yourself if
+   * you still want a stock voice. Address audio references from the text with
+   * `@Audio1`..`@Audio3`.
+   */
+  references?: Array<BytePlusTTSReference>
   /**
    * Output format. Overrides the mapping applied to `TTSOptions.format`,
    * which is useful for `ogg_opus` and for pinning `pcm` explicitly.
    */
   format?: BytePlusTTSAudioFormat
   /**
-   * Output sample rate in Hz. Commonly 8000, 16000, 24000 or 48000; left to
-   * the service default when omitted. For `pcm` output this value is also
-   * what the returned `contentType` (`audio/L16;rate=…`) reports.
+   * Output sample rate in Hz. Defaults to 24000 — the adapter always sends an
+   * explicit rate because the documented server default (40000) is not one of
+   * the values the endpoint accepts. For `pcm` output this is also what the
+   * returned `contentType` (`audio/L16;rate=…`) reports.
    */
-  sample_rate?: number
+  sample_rate?: BytePlusTTSSampleRate
   /**
    * Pitch adjustment in the range `-12`..`12`, where `0` is the voice's
    * natural pitch.
    */
   pitch_rate?: number
   /**
-   * Speaking rate in the range `-50`..`100` (`-50` ≈ 0.5×, `0` = 1×,
-   * `100` ≈ 2×). Overrides the value derived from `TTSOptions.speed`.
+   * Speaking rate in the range `-50`..`100` (`-50` = 0.5×, `0` = 1×,
+   * `100` = 2×). Overrides the value derived from `TTSOptions.speed`.
    */
   speech_rate?: number
   /**
@@ -62,10 +74,15 @@ export interface BytePlusTTSProviderOptions {
    */
   loudness_rate?: number
   /**
-   * Ask for word-level timings alongside the audio. They are surfaced on
-   * {@link BytePlusTTSResult.subtitle}.
+   * Ask for sentence- and word-level timings alongside the audio. They are
+   * surfaced on {@link BytePlusTTSResult.subtitle}.
    */
   enable_subtitle?: boolean
+  /**
+   * Watermark the generated audio. The field name is confirmed against the
+   * endpoint schema; the boolean type is assumed and unprobed.
+   */
+  watermark?: boolean
 }
 
 /**
@@ -83,10 +100,19 @@ export interface BytePlusTTSProviderOptions {
  */
 export interface BytePlusTTSResult extends TTSResult {
   /**
-   * Word timings, present only when `modelOptions.enable_subtitle` was set.
-   * `start_time` / `end_time` are milliseconds.
+   * Sentence and word timings, present only when
+   * `modelOptions.enable_subtitle` was set. Their `start_time` / `end_time`
+   * are **milliseconds**, even though `duration` and
+   * {@link BytePlusTTSResult.originalDuration} are seconds.
    */
-  subtitle?: Array<BytePlusTTSSubtitleEntry>
+  subtitle?: BytePlusTTSSubtitle
+  /**
+   * Length of the audio in seconds *before* `speech_rate` was applied. This
+   * is what BytePlus bills on and what the 120 s cap applies to, so it is the
+   * number to meter against — `duration` reflects the delivered clip and can
+   * exceed 120 s when the speech is slowed down.
+   */
+  originalDuration?: number
   /**
    * Temporary download URL for the same audio that `audio` carries as base64.
    * **Expires roughly 2 hours after generation** — persist the bytes, not the

--- a/packages/ai-byteplus/src/audio/tts-provider-options.ts
+++ b/packages/ai-byteplus/src/audio/tts-provider-options.ts
@@ -1,0 +1,96 @@
+import type {
+  BytePlusTTSAudioFormat,
+  BytePlusTTSSubtitleEntry,
+} from './wire-types'
+import type { TTSResult } from '@tanstack/ai'
+
+/**
+ * Seed Speech voice identifier (`speaker` on the wire).
+ *
+ * Voice ids encode language, gender, character name and model generation:
+ * `en_female_stokie_uranus_bigtts` is the English female "Stokie" voice on
+ * TTS 2.0. The generation suffix matters when picking one:
+ *
+ * - `_uranus_bigtts` — TTS 2.0 voices (the current generation).
+ * - `_mars_bigtts` / `_moon_bigtts` — TTS 1.0 voices.
+ * - `*_emo_v2_*` — TTS 1.0 voices that additionally accept emotion tags.
+ *
+ * The full roster lives at
+ * https://docs.byteplus.com/en/docs/byteplusvoice/voicelist and changes far
+ * more often than this package ships, so the union stays open: any string is
+ * accepted, and the one listed id is the adapter's default.
+ */
+export type BytePlusTTSVoice = 'en_female_stokie_uranus_bigtts' | (string & {})
+
+/**
+ * Provider-specific options for BytePlus Seed Speech TTS
+ * (`POST /api/v3/tts/create`).
+ *
+ * These map 1:1 onto the wire fields so the BytePlus documentation stays
+ * useful; where a cross-provider `TTSOptions` field covers the same ground
+ * (`voice`, `format`, `speed`), the option here wins.
+ */
+export interface BytePlusTTSProviderOptions {
+  /**
+   * Voice id. Overrides `TTSOptions.voice` when both are set.
+   */
+  speaker?: BytePlusTTSVoice
+  /**
+   * Output format. Overrides the mapping applied to `TTSOptions.format`,
+   * which is useful for `ogg_opus` and for pinning `pcm` explicitly.
+   */
+  format?: BytePlusTTSAudioFormat
+  /**
+   * Output sample rate in Hz. Commonly 8000, 16000, 24000 or 48000; left to
+   * the service default when omitted. For `pcm` output this value is also
+   * what the returned `contentType` (`audio/L16;rate=…`) reports.
+   */
+  sample_rate?: number
+  /**
+   * Pitch adjustment in the range `-12`..`12`, where `0` is the voice's
+   * natural pitch.
+   */
+  pitch_rate?: number
+  /**
+   * Speaking rate in the range `-50`..`100` (`-50` ≈ 0.5×, `0` = 1×,
+   * `100` ≈ 2×). Overrides the value derived from `TTSOptions.speed`.
+   */
+  speech_rate?: number
+  /**
+   * Loudness adjustment in the range `-50`..`100`, where `0` is the voice's
+   * natural level.
+   */
+  loudness_rate?: number
+  /**
+   * Ask for word-level timings alongside the audio. They are surfaced on
+   * {@link BytePlusTTSResult.subtitle}.
+   */
+  enable_subtitle?: boolean
+}
+
+/**
+ * BytePlus-specific extension of `TTSResult`.
+ *
+ * The cross-provider `TTSResult` has nowhere to put word timings or the
+ * temporary download URL, so callers who want them narrow the result:
+ *
+ * ```ts
+ * const result: BytePlusTTSResult = await generateSpeech({ adapter, text })
+ * for (const entry of result.subtitle ?? []) {
+ *   console.log(entry.text, entry.start_time)
+ * }
+ * ```
+ */
+export interface BytePlusTTSResult extends TTSResult {
+  /**
+   * Word timings, present only when `modelOptions.enable_subtitle` was set.
+   * `start_time` / `end_time` are milliseconds.
+   */
+  subtitle?: Array<BytePlusTTSSubtitleEntry>
+  /**
+   * Temporary download URL for the same audio that `audio` carries as base64.
+   * **Expires roughly 2 hours after generation** — persist the bytes, not the
+   * link.
+   */
+  url?: string
+}

--- a/packages/ai-byteplus/src/audio/tts-provider-options.ts
+++ b/packages/ai-byteplus/src/audio/tts-provider-options.ts
@@ -88,13 +88,13 @@ export interface BytePlusTTSProviderOptions {
 /**
  * BytePlus-specific extension of `TTSResult`.
  *
- * The cross-provider `TTSResult` has nowhere to put word timings or the
- * temporary download URL, so callers who want them narrow the result:
+ * The cross-provider `TTSResult` has nowhere to put the subtitle timings or
+ * the temporary download URL, so callers who want them narrow the result:
  *
  * ```ts
  * const result: BytePlusTTSResult = await generateSpeech({ adapter, text })
- * for (const entry of result.subtitle ?? []) {
- *   console.log(entry.text, entry.start_time)
+ * for (const sentence of result.subtitle?.sentences ?? []) {
+ *   console.log(sentence.text, sentence.start_time)
  * }
  * ```
  */

--- a/packages/ai-byteplus/src/audio/wire-types.ts
+++ b/packages/ai-byteplus/src/audio/wire-types.ts
@@ -1,0 +1,209 @@
+/**
+ * Minimal wire types for the BytePlus **Seed Speech** HTTP API (TTS + ASR).
+ *
+ * Seed Speech is a separate product from Ark: it lives on
+ * `voice.ap-southeast-1.bytepluses.com`, authenticates with `X-Api-Key`
+ * (a different key from `ARK_API_KEY`), and returns a flat numeric error
+ * envelope instead of Ark's OpenAI-shaped one.
+ *
+ * Only the fields the adapters read or write are modelled here — this is a
+ * hand-written subset, not a generated schema.
+ *
+ * Provenance:
+ * - Endpoints, auth header, format/rate ranges and the 120 s TTS output cap:
+ *   BytePlus Seed Speech docs (`docs.byteplus.com/en/docs/byteplusvoice`),
+ *   captured in the Phase 0 research notes.
+ * - Error envelope `{code, message}`: verified live — an Ark key sent as
+ *   `X-Api-Key` returns HTTP 401 `{"code":45000010,"message":"Invalid X-Api-Key"}`.
+ * - ASR request/response shape (`user`/`audio`/`request` in, `audio_info` +
+ *   `result.utterances` out, all timings in **milliseconds**): the Volcengine
+ *   flash-recognition reference the BytePlus endpoint is derived from
+ *   (`docs.volcengine.com/docs/6561/1631584`).
+ *
+ * No Seed Speech API key was available when these were written, so the TTS
+ * response fields are documented-but-unverified; the adapters parse them
+ * defensively rather than assuming they are always present.
+ */
+
+// ============================================================================
+// TTS — POST /api/v3/tts/create
+// ============================================================================
+
+/** Output container/codec accepted by `audio_config.format`. */
+export type BytePlusTTSAudioFormat = 'wav' | 'mp3' | 'pcm' | 'ogg_opus'
+
+/**
+ * `audio_config` block of a TTS request.
+ *
+ * The three `*_rate` fields are integer percentages relative to the voice's
+ * neutral delivery, not multipliers.
+ */
+export interface BytePlusTTSAudioConfig {
+  /** Output format. Defaults to the service's own default when omitted. */
+  format?: BytePlusTTSAudioFormat
+  /** Output sample rate in Hz (commonly 8000 / 16000 / 24000 / 48000). */
+  sample_rate?: number
+  /** Pitch adjustment, `-12`..`12`. `0` is the voice's natural pitch. */
+  pitch_rate?: number
+  /**
+   * Speaking rate. The documented range is `-50`..`100`; the multiplier
+   * anchors (`-50` ≈ 0.5×, `0` = 1×, `100` ≈ 2×) are inferred rather than
+   * documented — see `toSpeechRate` in `../adapters/tts`.
+   */
+  speech_rate?: number
+  /** Loudness adjustment, `-50`..`100`. `0` is the voice's natural level. */
+  loudness_rate?: number
+}
+
+/** Request body for `POST /api/v3/tts/create`. */
+export interface BytePlusTTSCreateRequest {
+  /** Seed Speech synthesis model, e.g. `seed-audio-1.0`. */
+  model: string
+  /**
+   * The text to speak.
+   *
+   * **Open question.** The Phase 0 research notes record this field as
+   * `text_prompt`, but BytePlus' published samples are inconsistent about
+   * whether it is `text_prompt` or a plain `text`, and no key was available
+   * to settle it. The adapter writes it through the single `TTS_TEXT_FIELD`
+   * constant in `../adapters/tts` so both sides change together.
+   */
+  text_prompt: string
+  /** Voice identifier, e.g. `en_female_stokie_uranus_bigtts`. */
+  speaker: string
+  audio_config?: BytePlusTTSAudioConfig
+  /** Return per-word timing information alongside the audio. */
+  enable_subtitle?: boolean
+}
+
+/** One timed entry of a TTS `subtitle` array. Times are in milliseconds. */
+export interface BytePlusTTSSubtitleEntry {
+  text?: string
+  start_time?: number
+  end_time?: number
+}
+
+/** Response body for `POST /api/v3/tts/create`. */
+export interface BytePlusTTSCreateResponse {
+  /** Base64-encoded audio in the requested `audio_config.format`. */
+  audio?: string
+  /**
+   * Length of the generated audio. The unit is not pinned in the published
+   * docs; see `toDurationSeconds` in `../adapters/tts` for how it is resolved.
+   */
+  duration?: number | string
+  /** Temporary download URL for the same audio. Expires after ~2 hours. */
+  url?: string
+  /** Word timings, present when `enable_subtitle` was set. */
+  subtitle?: Array<BytePlusTTSSubtitleEntry>
+}
+
+// ============================================================================
+// ASR — POST /api/v3/auc/bigmodel/recognize/flash
+// ============================================================================
+
+/**
+ * Value of the `X-Api-Resource-Id` header that selects the Seed ASR turbo
+ * model. The flash endpoint takes no `model` field in its body — the model is
+ * chosen entirely by this header.
+ */
+export const BYTEPLUS_ASR_RESOURCE_ID = 'volc.seedasr.auc_turbo'
+
+/** Header name carrying {@link BYTEPLUS_ASR_RESOURCE_ID}. */
+export const BYTEPLUS_ASR_RESOURCE_HEADER = 'X-Api-Resource-Id'
+
+/**
+ * Audio input. Exactly one of `url` or `data` is sent — the endpoint accepts
+ * files up to 2 hours long / 100 MB.
+ */
+export interface BytePlusASRAudio {
+  /** Publicly reachable URL of the audio file. */
+  url?: string
+  /** Base64-encoded audio bytes. */
+  data?: string
+  /** Container hint, e.g. `mp3`, `wav`, `ogg`. */
+  format?: string
+}
+
+/** `request` block of a recognition call. */
+export interface BytePlusASRRequestOptions {
+  /** Recognition model family. Defaults to `bigmodel`. */
+  model_name?: string
+  /** Inverse text normalisation (spoken numbers → digits). */
+  enable_itn?: boolean
+  /** Insert punctuation. */
+  enable_punc?: boolean
+  /** Disfluency removal ("um", repeated words). */
+  enable_ddc?: boolean
+  /** Attach per-utterance speaker labels. */
+  enable_speaker_info?: boolean
+  /** Return the `utterances` breakdown as well as the flat transcript. */
+  show_utterances?: boolean
+  /** Spoken language hint, e.g. `en-US`. */
+  language?: string
+}
+
+/** Request body for `POST /api/v3/auc/bigmodel/recognize/flash`. */
+export interface BytePlusASRRecognizeRequest {
+  user?: { uid?: string }
+  audio: BytePlusASRAudio
+  request?: BytePlusASRRequestOptions
+}
+
+/** One recognised word. `start_time` / `end_time` are milliseconds. */
+export interface BytePlusASRWord {
+  text?: string
+  start_time?: number
+  end_time?: number
+  confidence?: number
+}
+
+/** One recognised utterance. `start_time` / `end_time` are milliseconds. */
+export interface BytePlusASRUtterance {
+  text?: string
+  start_time?: number
+  end_time?: number
+  words?: Array<BytePlusASRWord>
+  /**
+   * Extra per-utterance annotations. Speaker labels arrive here when
+   * `enable_speaker_info` is set; the exact key is read defensively because it
+   * could not be confirmed against a live response.
+   */
+  additions?: Record<string, string>
+}
+
+export interface BytePlusASRResult {
+  text?: string
+  utterances?: Array<BytePlusASRUtterance>
+}
+
+/**
+ * Response body for `POST /api/v3/auc/bigmodel/recognize/flash`.
+ *
+ * The Volcengine-lineage wire shape nests everything under `result`; BytePlus'
+ * prose docs describe the same payload as "transcript + utterances", so the
+ * flat spelling is tolerated as a fallback.
+ */
+export interface BytePlusASRRecognizeResponse {
+  /** `duration` is the audio length in **milliseconds**. */
+  audio_info?: { duration?: number }
+  result?: BytePlusASRResult
+  /** Flat alias for `result.text`. */
+  transcript?: string
+  /** Flat alias for `result.utterances`. */
+  utterances?: Array<BytePlusASRUtterance>
+}
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+/**
+ * Seed Speech error envelope: a flat numeric `code` plus a `message`, e.g.
+ * `{"code": 45000010, "message": "Invalid X-Api-Key"}` (verified live on a
+ * 401). Format it with `bytePlusVoiceError` from `../utils/client`.
+ */
+export interface BytePlusVoiceErrorBody {
+  code?: number
+  message?: string
+}

--- a/packages/ai-byteplus/src/audio/wire-types.ts
+++ b/packages/ai-byteplus/src/audio/wire-types.ts
@@ -33,69 +33,141 @@
 export type BytePlusTTSAudioFormat = 'wav' | 'mp3' | 'pcm' | 'ogg_opus'
 
 /**
- * `audio_config` block of a TTS request.
+ * Sample rates `audio_config.sample_rate` accepts.
+ *
+ * The docs also state a *default* of 40000, which is not one of the valid
+ * values — a documentation bug. The adapter therefore always sends an
+ * explicit rate rather than relying on the server default.
+ */
+export const BYTEPLUS_TTS_SAMPLE_RATES = [
+  8000, 16000, 24000, 32000, 44100, 48000,
+] as const
+
+/** A sample rate `audio_config.sample_rate` accepts. */
+export type BytePlusTTSSampleRate = (typeof BYTEPLUS_TTS_SAMPLE_RATES)[number]
+
+/**
+ * One entry of the request's `references` array.
+ *
+ * This is where the voice lives: `speaker` names a stock voice, while
+ * `audio_url` / `audio_data` supply reference clips to clone (the `@Audio1`..
+ * `@Audio3` markers in `text_prompt` address them positionally). Exactly one
+ * of `speaker`, `audio_url` or `audio_data` may be set per entry; at most 3
+ * audio references (30 s / 10 MB each) and 1 image reference (10 MB), and
+ * image references are mutually exclusive with audio ones.
+ *
+ * **Member object shape is unresolved — must live-probe when the Seed Speech
+ * key lands.** The docs list the member fields flat (`speaker | audio_data |
+ * audio_url | image_data | image_url`) without a worked example, so whether
+ * the server wants a flat `{ speaker }` or a discriminated `{ type, ... }`
+ * could not be settled. The adapter sends the flat reading — see
+ * `buildTTSRequestBody` in `../adapters/tts`.
+ */
+export interface BytePlusTTSReference {
+  /** Stock voice id, e.g. `en_female_stokie_uranus_bigtts`. */
+  speaker?: string
+  /** URL of a reference clip to clone (≤30 s, ≤10 MB). */
+  audio_url?: string
+  /** Base64 reference clip to clone (≤30 s, ≤10 MB). */
+  audio_data?: string
+  /** URL of a reference image (≤10 MB). Mutually exclusive with audio refs. */
+  image_url?: string
+  /** Base64 reference image (≤10 MB). Mutually exclusive with audio refs. */
+  image_data?: string
+}
+
+/**
+ * `audio_config` block of a TTS request — exactly six fields.
  *
  * The three `*_rate` fields are integer percentages relative to the voice's
  * neutral delivery, not multipliers.
  */
 export interface BytePlusTTSAudioConfig {
-  /** Output format. Defaults to the service's own default when omitted. */
+  /** Output format. Defaults to `wav` server-side. */
   format?: BytePlusTTSAudioFormat
-  /** Output sample rate in Hz (commonly 8000 / 16000 / 24000 / 48000). */
-  sample_rate?: number
-  /** Pitch adjustment, `-12`..`12`. `0` is the voice's natural pitch. */
-  pitch_rate?: number
   /**
-   * Speaking rate. The documented range is `-50`..`100`; the multiplier
-   * anchors (`-50` ≈ 0.5×, `0` = 1×, `100` ≈ 2×) are inferred rather than
-   * documented — see `toSpeechRate` in `../adapters/tts`.
+   * Output sample rate in Hz. See {@link BYTEPLUS_TTS_SAMPLE_RATES} for the
+   * valid values and for why the adapter always sends one.
    */
+  sample_rate?: number
+  /** Speaking rate, `-50`..`100`. `-50` = 0.5×, `0` = 1×, `100` = 2×. */
   speech_rate?: number
   /** Loudness adjustment, `-50`..`100`. `0` is the voice's natural level. */
   loudness_rate?: number
+  /** Pitch adjustment, `-12`..`12`. `0` is the voice's natural pitch. */
+  pitch_rate?: number
+  /** Emit sentence and word timings in the response. Defaults to `false`. */
+  enable_subtitle?: boolean
 }
 
-/** Request body for `POST /api/v3/tts/create`. */
+/** Request body for `POST /api/v3/tts/create` — exactly five fields. */
 export interface BytePlusTTSCreateRequest {
   /** Seed Speech synthesis model, e.g. `seed-audio-1.0`. */
   model: string
   /**
-   * The text to speak.
+   * The text to speak (≤3000 chars). Dual-purpose: either literal text or a
+   * natural-language description of the delivery, and the place the
+   * `@Audio1`..`@Audio3` reference markers go.
    *
-   * **Open question.** The Phase 0 research notes record this field as
-   * `text_prompt`, but BytePlus' published samples are inconsistent about
-   * whether it is `text_prompt` or a plain `text`, and no key was available
-   * to settle it. The adapter writes it through the single `TTS_TEXT_FIELD`
-   * constant in `../adapters/tts` so both sides change together.
+   * **`text_prompt` is correct — do not "fix" this to `text`.** This endpoint
+   * has no request-side `text` field. The `text` spelling belongs to the
+   * *other* endpoint, `/tts/unidirectional` (TTS 2.0), where it sits under
+   * `req_params.text`. Confirmed against
+   * docs.byteplus.com/en/docs/byteplusvoice/seedaudio-01, which lists this
+   * body as exactly `model`, `text_prompt`, `references`, `audio_config`,
+   * `watermark`.
    */
   text_prompt: string
-  /** Voice identifier, e.g. `en_female_stokie_uranus_bigtts`. */
-  speaker: string
+  /** Voice selection and cloning references. See {@link BytePlusTTSReference}. */
+  references?: Array<BytePlusTTSReference>
   audio_config?: BytePlusTTSAudioConfig
-  /** Return per-word timing information alongside the audio. */
-  enable_subtitle?: boolean
+  /**
+   * Watermark the generated audio. The field name is confirmed; the boolean
+   * type is assumed by analogy with Seedream's `watermark` and unprobed.
+   */
+  watermark?: boolean
 }
 
-/** One timed entry of a TTS `subtitle` array. Times are in milliseconds. */
+/**
+ * One timed entry of a TTS subtitle track.
+ *
+ * **Times are milliseconds** — unlike the response's `duration` fields, which
+ * are seconds. The endpoint genuinely mixes units.
+ */
 export interface BytePlusTTSSubtitleEntry {
   text?: string
   start_time?: number
   end_time?: number
 }
 
+/** Sentence- and word-level timings returned when `enable_subtitle` is set. */
+export interface BytePlusTTSSubtitle {
+  sentences?: Array<BytePlusTTSSubtitleEntry>
+  words?: Array<BytePlusTTSSubtitleEntry>
+}
+
 /** Response body for `POST /api/v3/tts/create`. */
 export interface BytePlusTTSCreateResponse {
+  /** Numeric status code. Present on success as well as on failure. */
+  code?: number
+  message?: string
   /** Base64-encoded audio in the requested `audio_config.format`. */
   audio?: string
   /**
-   * Length of the generated audio. The unit is not pinned in the published
-   * docs; see `toDurationSeconds` in `../adapters/tts` for how it is resolved.
+   * Length of the delivered audio in **seconds** (float), after `speech_rate`
+   * is applied. This can legitimately exceed 120 when the clip is slowed
+   * down — the 120 s cap applies to {@link BytePlusTTSCreateResponse.original_duration}.
    */
   duration?: number | string
+  /**
+   * Length in **seconds** (float) before rate adjustment. This is the billing
+   * basis and is capped at 120.
+   */
+  original_duration?: number | string
   /** Temporary download URL for the same audio. Expires after ~2 hours. */
   url?: string
-  /** Word timings, present when `enable_subtitle` was set. */
-  subtitle?: Array<BytePlusTTSSubtitleEntry>
+  /** Sentence and word timings, present when `enable_subtitle` was set. */
+  subtitle?: BytePlusTTSSubtitle
 }
 
 // ============================================================================

--- a/packages/ai-byteplus/src/audio/wire-types.ts
+++ b/packages/ai-byteplus/src/audio/wire-types.ts
@@ -148,8 +148,17 @@ export interface BytePlusTTSSubtitle {
 
 /** Response body for `POST /api/v3/tts/create`. */
 export interface BytePlusTTSCreateResponse {
-  /** Numeric status code. Present on success as well as on failure. */
-  code?: number
+  /**
+   * Status code — `0` on success, a flat error code otherwise.
+   *
+   * Typed as `number | string` because only the *error* envelope was verified
+   * live (HTTP 401 `{"code":45000010,…}`); the success envelope's shape is
+   * docs-derived and no voice key was available to confirm it. Treating a
+   * string code as "not a failure" would return a failed 200 as success, so
+   * the adapter coerces before comparing — see `isZeroCode` in
+   * `adapters/tts.ts`.
+   */
+  code?: number | string
   message?: string
   /** Base64-encoded audio in the requested `audio_config.format`. */
   audio?: string

--- a/packages/ai-byteplus/src/image/image-provider-options.ts
+++ b/packages/ai-byteplus/src/image/image-provider-options.ts
@@ -1,0 +1,279 @@
+/**
+ * Provider options and request validation for Seedream image generation.
+ *
+ * Field names, enums, defaults and ranges come from the harvested Ark
+ * OpenAPI document for the `ImageGenerations` action; the Seedream 4.0
+ * behaviour noted below was confirmed live on 2026-07-31.
+ */
+import { BYTEPLUS_IMAGE_MAX_REFERENCE_IMAGES } from '../model-meta'
+import type {
+  BytePlusImageOutputFormat,
+  BytePlusImageResponseFormat,
+  BytePlusOptimizePromptOptions,
+  BytePlusSequentialImageGeneration,
+  BytePlusSequentialImageGenerationOptions,
+} from './wire-types'
+import type { BytePlusImageModel, BytePlusImageSize } from '../model-meta'
+
+/**
+ * BytePlus documents a 600-word ceiling on the image prompt. Word-based, so
+ * it is only meaningful for space-separated scripts — the check below never
+ * fires for Chinese or Japanese text, which is the intended behaviour.
+ */
+export const BYTEPLUS_IMAGE_MAX_PROMPT_WORDS = 600
+
+/**
+ * Upper bound of `sequential_image_generation_options.max_images`, i.e. the
+ * most images one request can return.
+ */
+export const BYTEPLUS_IMAGE_MAX_SEQUENTIAL_IMAGES = 15
+
+/**
+ * Models that accept `output_format`.
+ *
+ * The Ark OpenAPI document's field note claims 5.0-lite only, but its own
+ * request demo sends `output_format` on `seedream-5-0-260128`, so the whole
+ * 5.0 family is treated as supporting it. The Seedream 4.x snapshots are
+ * documented as not reading it, so `output_format` is omitted from their
+ * provider-options type — but, as with `sequential_image_generation`, it is
+ * not gated at runtime: a value that reaches a model which does not read it
+ * comes back as an Ark error rather than a local rejection.
+ */
+export const BYTEPLUS_OUTPUT_FORMAT_IMAGE_MODELS: ReadonlyArray<BytePlusImageModel> =
+  [
+    'dola-seedream-5-0-pro-260628',
+    'seedream-5-0-260128',
+    'seedream-5-0-lite-260128',
+  ]
+
+/**
+ * Base provider options shared by every Seedream model.
+ */
+export interface BytePlusImageBaseProviderOptions {
+  /**
+   * Return images as expiring links (`url`, valid 24 hours) or inline base64
+   * (`b64_json`).
+   *
+   * @default 'url'
+   */
+  response_format?: BytePlusImageResponseFormat
+
+  /**
+   * Whether to stamp an "AI generated" watermark in the bottom-right corner.
+   *
+   * **BytePlus defaults this to `true`.** Pass `false` for a clean image.
+   */
+  watermark?: boolean
+
+  /**
+   * Group-image mode. Set to `auto` to let the model return a set of related
+   * images (bounded by {@link BytePlusImageBaseProviderOptions.sequential_image_generation_options}).
+   * `generateImage()`'s `numberOfImages` sets this for you; an explicit value
+   * here wins.
+   *
+   * Documented on Seedream 5.0-lite, 4.5 and 4.0. It is sent as given on
+   * every model rather than gated locally — the shipped 5.0 ids post-date the
+   * published parameter table, and an unsupported combination comes back as a
+   * clear Ark error.
+   *
+   * @default 'disabled'
+   */
+  sequential_image_generation?: BytePlusSequentialImageGeneration
+
+  /** Bounds for group-image mode. Only read when the mode is `auto`. */
+  sequential_image_generation_options?: BytePlusSequentialImageGenerationOptions
+
+  /**
+   * Prompt-rewriting configuration. Documented on Seedream 5.0-lite, 4.5 and
+   * 4.0; `mode: 'fast'` is unsupported on 5.0-lite and 4.5.
+   */
+  optimize_prompt_options?: BytePlusOptimizePromptOptions
+}
+
+/**
+ * Provider options for the Seedream 5.0 family, which additionally chooses the
+ * generated file format.
+ */
+export interface BytePlusSeedream5ImageProviderOptions extends BytePlusImageBaseProviderOptions {
+  /**
+   * File format of the generated image.
+   *
+   * @default 'jpeg'
+   */
+  output_format?: BytePlusImageOutputFormat
+}
+
+/**
+ * Every Seedream provider option, used as the adapter's base option type.
+ * Call sites are narrowed per model by
+ * {@link BytePlusImageModelProviderOptionsByName}.
+ */
+export type BytePlusImageProviderOptions = BytePlusSeedream5ImageProviderOptions
+
+/**
+ * Type-only map from image model name to its provider options.
+ */
+export type BytePlusImageModelProviderOptionsByName = {
+  'dola-seedream-5-0-pro-260628': BytePlusSeedream5ImageProviderOptions
+  'seedream-5-0-260128': BytePlusSeedream5ImageProviderOptions
+  'seedream-5-0-lite-260128': BytePlusSeedream5ImageProviderOptions
+  'seedream-4-5-251128': BytePlusImageBaseProviderOptions
+  'seedream-4-0-250828': BytePlusImageBaseProviderOptions
+}
+
+/**
+ * Type-only map from image model name to the non-text prompt modalities it
+ * accepts. Every shipped Seedream model takes reference images for
+ * image-conditioned generation.
+ */
+export type BytePlusImageModelInputModalitiesByName = {
+  [K in BytePlusImageModel]: readonly ['image']
+}
+
+/**
+ * A parsed `size` value: either the shorthand token form or explicit pixels.
+ */
+export type ParsedBytePlusImageSize =
+  | { kind: 'token'; value: '1K' | '2K' | '4K' }
+  | { kind: 'pixels'; width: number; height: number }
+
+const SIZE_TOKENS = ['1K', '2K', '4K'] as const
+
+/**
+ * Parses a Seedream `size` string. Accepts a shorthand token (case-insensitive
+ * — `2k` normalizes to `2K`) or explicit `WIDTHxHEIGHT` pixels, and returns
+ * `undefined` for anything else, including mixtures such as `2K x 1024`.
+ */
+export function parseBytePlusImageSize(
+  size: string,
+): ParsedBytePlusImageSize | undefined {
+  const trimmed = size.trim()
+
+  const token = SIZE_TOKENS.find(
+    (candidate) => candidate.toLowerCase() === trimmed.toLowerCase(),
+  )
+  if (token) return { kind: 'token', value: token }
+
+  // ASCII "x" only: the docs render the separator as U+00D7 (`2048×2048`),
+  // which the API does not accept, so it must not slip through here either.
+  const pixels = /^(\d+)[xX](\d+)$/.exec(trimmed)
+  if (pixels) {
+    const width = Number(pixels[1])
+    const height = Number(pixels[2])
+    if (width > 0 && height > 0) return { kind: 'pixels', width, height }
+  }
+
+  return undefined
+}
+
+/**
+ * Validates the generic `size` option and returns the string to put on the
+ * wire (`2K`, `2048x2048`), or `undefined` when no size was requested.
+ *
+ * This checks the *form* only. Which pixel dimensions a given model actually
+ * accepts is not encoded here, so the message deliberately makes no per-model
+ * claim; an out-of-range size is left to the API to reject.
+ *
+ * @throws Error when the value is neither a size token nor `WIDTHxHEIGHT`.
+ */
+export function resolveBytePlusImageSize(
+  size: BytePlusImageSize | string | undefined,
+): string | undefined {
+  if (size === undefined) return undefined
+
+  const parsed = parseBytePlusImageSize(size)
+  if (!parsed) {
+    throw new Error(
+      `byteplus: size "${size}" is not a Seedream size. Use a size token ` +
+        `(${SIZE_TOKENS.join(', ')}) or explicit pixels with an ASCII "x" ` +
+        `("2048x2048") — never a mix of the two.`,
+    )
+  }
+
+  return parsed.kind === 'token'
+    ? parsed.value
+    : `${parsed.width}x${parsed.height}`
+}
+
+/**
+ * Validates the prompt text against BytePlus's documented limits.
+ *
+ * @throws Error when the prompt is empty or exceeds
+ * {@link BYTEPLUS_IMAGE_MAX_PROMPT_WORDS} words.
+ */
+export function validateBytePlusImagePrompt(
+  model: string,
+  prompt: string,
+): void {
+  if (prompt.trim().length === 0) {
+    throw new Error(
+      `byteplus: model "${model}" requires prompt text. Seedream takes an ` +
+        `instruction even when editing reference images.`,
+    )
+  }
+
+  const words = prompt.trim().split(/\s+/).length
+  if (words > BYTEPLUS_IMAGE_MAX_PROMPT_WORDS) {
+    throw new Error(
+      `byteplus: prompt is ${words} words; model "${model}" accepts at most ` +
+        `${BYTEPLUS_IMAGE_MAX_PROMPT_WORDS}.`,
+    )
+  }
+}
+
+/**
+ * Validates the reference-image count against the model's editing limit.
+ *
+ * @throws Error when more references are supplied than the model accepts.
+ */
+export function validateBytePlusReferenceImages(
+  model: BytePlusImageModel,
+  count: number,
+): void {
+  const max = BYTEPLUS_IMAGE_MAX_REFERENCE_IMAGES[model]
+  if (count > max) {
+    throw new Error(
+      `byteplus: model "${model}" accepts at most ${max} reference images; received ${count}.`,
+    )
+  }
+}
+
+/**
+ * Maps the generic `numberOfImages` option onto Seedream's group-image
+ * parameters.
+ *
+ * The endpoint has no `n`: more than one image per request is only reachable
+ * through `sequential_image_generation: 'auto'`, where `max_images` is an
+ * upper bound and the model decides how many images the prompt actually
+ * warrants. A request for N images can therefore come back with fewer — the
+ * one place BytePlus cannot honour `numberOfImages` exactly.
+ *
+ * @throws Error when the count is not an integer in `[1, 15]`.
+ */
+export function resolveBytePlusSequentialImages(
+  model: string,
+  numberOfImages: number | undefined,
+): {
+  sequential_image_generation?: BytePlusSequentialImageGeneration
+  sequential_image_generation_options?: BytePlusSequentialImageGenerationOptions
+} {
+  if (numberOfImages === undefined) return {}
+
+  if (
+    !Number.isInteger(numberOfImages) ||
+    numberOfImages < 1 ||
+    numberOfImages > BYTEPLUS_IMAGE_MAX_SEQUENTIAL_IMAGES
+  ) {
+    throw new Error(
+      `byteplus: numberOfImages must be a whole number between 1 and ` +
+        `${BYTEPLUS_IMAGE_MAX_SEQUENTIAL_IMAGES} on model "${model}"; received ${numberOfImages}.`,
+    )
+  }
+
+  if (numberOfImages === 1) return {}
+
+  return {
+    sequential_image_generation: 'auto',
+    sequential_image_generation_options: { max_images: numberOfImages },
+  }
+}

--- a/packages/ai-byteplus/src/image/image-provider-options.ts
+++ b/packages/ai-byteplus/src/image/image-provider-options.ts
@@ -224,13 +224,22 @@ export function validateBytePlusImagePrompt(
 /**
  * Validates the reference-image count against the model's editing limit.
  *
- * @throws Error when more references are supplied than the model accepts.
+ * A model this package has no limit for is left to Ark, deliberately and
+ * explicitly. `model` is typed closed, but `wire-types.ts` documents that the
+ * endpoint also accepts preconfigured endpoint ids (`ep-…`), so a JS caller
+ * can reach an id that is not in the table. Reading `undefined` out of it and
+ * comparing `count > undefined` — always false — would disable the guard by
+ * accident and look identical to passing; the explicit early return says the
+ * skip is intended.
+ *
+ * @throws Error when more references are supplied than a *known* model accepts.
  */
 export function validateBytePlusReferenceImages(
   model: BytePlusImageModel,
   count: number,
 ): void {
-  const max = BYTEPLUS_IMAGE_MAX_REFERENCE_IMAGES[model]
+  const max = BYTEPLUS_IMAGE_MAX_REFERENCE_IMAGES[model] as number | undefined
+  if (max === undefined) return
   if (count > max) {
     throw new Error(
       `byteplus: model "${model}" accepts at most ${max} reference images; received ${count}.`,

--- a/packages/ai-byteplus/src/image/wire-types.ts
+++ b/packages/ai-byteplus/src/image/wire-types.ts
@@ -1,0 +1,169 @@
+/**
+ * Wire types for the BytePlus Ark image endpoint (`POST /images/generations`).
+ *
+ * Hand-written minimal shapes covering only the fields this adapter sends and
+ * reads. Provenance for every field is noted inline. Two sources:
+ *
+ * 1. The harvested OpenAPI 3.1 document for the `ark` service, action
+ *    `ImageGenerations` (`x-updated-time: 2026-06-08`) — authoritative for
+ *    field names, enum values, defaults and ranges.
+ * 2. A live `seedream-4-0-250828` call against
+ *    `https://ark.ap-southeast.bytepluses.com/api/v3` on 2026-07-31, which
+ *    pinned the actual response shape.
+ *
+ * The endpoint deviates from OpenAI's `/images/generations` in three ways that
+ * matter: there is no `n` parameter, `size` accepts a shorthand token as well
+ * as `WxH`, and input images for editing ride along in a top-level `image`
+ * field rather than a separate `/images/edits` endpoint.
+ */
+
+/** How generated images come back. `url` links expire 24 hours after generation. */
+export type BytePlusImageResponseFormat = 'url' | 'b64_json'
+
+/** File format of the generated image. Seedream 5.0 family only. */
+export type BytePlusImageOutputFormat = 'png' | 'jpeg'
+
+/**
+ * Group-image ("sequential generation") switch.
+ *
+ * - `auto` — the model decides whether to return a set of related images and
+ *   how many, bounded by `sequential_image_generation_options.max_images`.
+ * - `disabled` — exactly one image.
+ */
+export type BytePlusSequentialImageGeneration = 'auto' | 'disabled'
+
+/** Group-image bounds. Only read when `sequential_image_generation` is `auto`. */
+export interface BytePlusSequentialImageGenerationOptions {
+  /** Upper bound on images returned for this request. Range `[1, 15]`. */
+  max_images?: number
+}
+
+/** Prompt-rewriting configuration. Seedream 5.0-lite / 4.5 / 4.0 only. */
+export interface BytePlusOptimizePromptOptions {
+  /**
+   * `standard` produces higher-quality results but is slower; `fast` is
+   * quicker with average quality (unsupported on Seedream 5.0-lite and 4.5).
+   */
+  mode: 'standard' | 'fast'
+}
+
+/**
+ * Request body for `POST /images/generations`.
+ *
+ * `model` and `prompt` are the only required fields.
+ */
+export interface BytePlusImageGenerationRequest {
+  /** Seedream model id (or a preconfigured endpoint id). */
+  model: string
+
+  /**
+   * Instruction text. The BytePlus docs give the limit as 600 English words.
+   * That ceiling is documentation-derived, not probe-confirmed.
+   */
+  prompt: string
+
+  /**
+   * Input images for image-conditioned generation (editing, reference-guided
+   * generation, multi-reference composition). Each entry is either a publicly
+   * reachable URL or a data URI of the form
+   * `data:image/<format>;base64,<data>` — BytePlus requires `<format>` to be
+   * **lowercase**. Typed as an array because that is the form the OpenAPI
+   * schema documents.
+   */
+  image?: Array<string>
+
+  /**
+   * Output size, as either a shorthand token (`1K`, `2K`, `4K`) or explicit
+   * pixel dimensions (`2048x2048`) — never a mix of the two. Defaults to
+   * `2048x2048` server-side.
+   */
+  size?: string
+
+  /** Defaults to `url` server-side. */
+  response_format?: BytePlusImageResponseFormat
+
+  /**
+   * Generated file format. Only the Seedream 5.0 family accepts this; the
+   * live 4.0 response carried no `output_format` at all. Defaults to `jpeg`.
+   */
+  output_format?: BytePlusImageOutputFormat
+
+  /**
+   * Whether to stamp an "AI generated" watermark in the bottom-right corner.
+   *
+   * **Defaults to `true`** — unlike most providers, BytePlus watermarks unless
+   * you explicitly opt out with `watermark: false`.
+   */
+  watermark?: boolean
+
+  /** Defaults to `disabled` server-side. */
+  sequential_image_generation?: BytePlusSequentialImageGeneration
+
+  /** Only effective when `sequential_image_generation` is `auto`. */
+  sequential_image_generation_options?: BytePlusSequentialImageGenerationOptions
+
+  /** Prompt-rewriting configuration. */
+  optimize_prompt_options?: BytePlusOptimizePromptOptions
+
+  /**
+   * Server-sent-events mode, emitting each image as it finishes. Not used by
+   * this adapter — `generateImage()` resolves a complete result, and the core
+   * `stream: true` path chunks that result itself.
+   */
+  stream?: boolean
+}
+
+/**
+ * One entry of the `data` array — either a generated image or, in group-image
+ * mode, a per-image failure.
+ *
+ * `url` is present when `response_format` is `url`, `b64_json` when it is
+ * `b64_json`. `size` is the *actual* pixel size the model produced (a `1K`
+ * request came back as `1152x864` live), and is only returned by some models.
+ * `error` is set instead of the image fields when that particular image of a
+ * group failed (e.g. `OutputImageSensitiveContentDetected`) while others
+ * succeeded.
+ *
+ * The OpenAPI document contradicts itself here, describing `data` items as a
+ * nested `{error[], imagecontent[]}` wrapper; the live response is the flat
+ * shape modeled below, so that is what this adapter reads.
+ */
+export interface BytePlusImageData {
+  url?: string
+  b64_json?: string
+  size?: string
+  error?: BytePlusImageErrorObject
+}
+
+/**
+ * Usage block. BytePlus bills images, not input tokens: `total_tokens`
+ * currently equals `output_tokens` because input tokens are not counted, and
+ * `generated_images` counts only successful generations.
+ */
+export interface BytePlusImageUsage {
+  generated_images?: number
+  output_tokens?: number
+  total_tokens?: number
+}
+
+/**
+ * Ark error object. Codes are dotted strings for transport-level failures
+ * (`InvalidEndpointOrModel.NotFound`) and bare identifiers for content
+ * failures (`OutputImageSensitiveContentDetected`,
+ * `InputTextSensitiveContentDetected`, `QuotaExceeded`).
+ */
+export interface BytePlusImageErrorObject {
+  code?: string
+  message?: string
+}
+
+/** Response body of `POST /images/generations`. */
+export interface BytePlusImageGenerationResponse {
+  model?: string
+  /** Unix timestamp (seconds) of creation. */
+  created?: number
+  data?: Array<BytePlusImageData>
+  usage?: BytePlusImageUsage
+  /** Present when the request as a whole failed. */
+  error?: BytePlusImageErrorObject
+}

--- a/packages/ai-byteplus/src/index.ts
+++ b/packages/ai-byteplus/src/index.ts
@@ -11,7 +11,131 @@
 //   - speech        → ./adapters/tts           (Seed Speech TTS)
 //   - transcription → ./adapters/transcription (Seed Speech ASR)
 //
+export {
+  BytePlusVideoAdapter,
+  byteplusVideo,
+  createBytePlusVideo,
+} from './adapters/video'
+export type { BytePlusVideoConfig } from './adapters/video'
+export {
+  parseBytePlusVideoSize,
+  resolveBytePlusVideoSize,
+  supportsLastFrame,
+  supportsReferenceMedia,
+} from './video/video-provider-options'
+export type {
+  BytePlusVideoModelProviderOptionsByName,
+  BytePlusVideoProviderOptions,
+  BytePlusVideoServiceTier,
+} from './video/video-provider-options'
+export type {
+  BytePlusVideoContentPart,
+  BytePlusVideoContentRole,
+  BytePlusVideoCreateRequest,
+  BytePlusVideoCreateResponse,
+  BytePlusVideoTask,
+  BytePlusVideoTaskContent,
+  BytePlusVideoTaskError,
+  BytePlusVideoTaskListItem,
+  BytePlusVideoTaskListResponse,
+  BytePlusVideoTaskStatus,
+  BytePlusVideoTaskUsage,
+} from './video/wire-types'
+export {
+  BYTEPLUS_DEFAULT_TTS_SPEAKER,
+  BYTEPLUS_TTS_MAX_OUTPUT_SECONDS,
+  BytePlusTTSAdapter,
+  byteplusSpeech,
+  createBytePlusSpeech,
+  toSpeechRate,
+} from './adapters/tts'
+export type {
+  BytePlusTTSProviderOptions,
+  BytePlusTTSResult,
+  BytePlusTTSVoice,
+} from './audio/tts-provider-options'
+export {
+  BytePlusTranscriptionAdapter,
+  byteplusTranscription,
+  createBytePlusTranscription,
+} from './adapters/transcription'
+export type { BytePlusTranscriptionWord } from './adapters/transcription'
+export type { BytePlusTranscriptionProviderOptions } from './audio/transcription-provider-options'
+export {
+  BYTEPLUS_ASR_RESOURCE_HEADER,
+  BYTEPLUS_ASR_RESOURCE_ID,
+} from './audio/wire-types'
+export type {
+  BytePlusASRAudio,
+  BytePlusASRRecognizeRequest,
+  BytePlusASRRecognizeResponse,
+  BytePlusASRResult,
+  BytePlusASRUtterance,
+  BytePlusASRWord,
+  BytePlusTTSAudioConfig,
+  BytePlusTTSAudioFormat,
+  BytePlusTTSCreateRequest,
+  BytePlusTTSCreateResponse,
+  BytePlusTTSSubtitleEntry,
+  BytePlusVoiceErrorBody,
+} from './audio/wire-types'
+export {
+  BytePlusImageAdapter,
+  byteplusImage,
+  createBytePlusImage,
+} from './adapters/image'
+export type { BytePlusImageConfig } from './adapters/image'
+export {
+  BYTEPLUS_IMAGE_MAX_PROMPT_WORDS,
+  BYTEPLUS_IMAGE_MAX_SEQUENTIAL_IMAGES,
+  BYTEPLUS_OUTPUT_FORMAT_IMAGE_MODELS,
+  parseBytePlusImageSize,
+} from './image/image-provider-options'
+export type {
+  BytePlusImageBaseProviderOptions,
+  BytePlusImageModelInputModalitiesByName,
+  BytePlusImageModelProviderOptionsByName,
+  BytePlusImageProviderOptions,
+  BytePlusSeedream5ImageProviderOptions,
+  ParsedBytePlusImageSize,
+} from './image/image-provider-options'
+export type {
+  BytePlusImageData,
+  BytePlusImageErrorObject,
+  BytePlusImageGenerationRequest,
+  BytePlusImageGenerationResponse,
+  BytePlusImageOutputFormat,
+  BytePlusImageResponseFormat,
+  BytePlusImageUsage,
+  BytePlusOptimizePromptOptions,
+  BytePlusSequentialImageGeneration,
+  BytePlusSequentialImageGenerationOptions,
+} from './image/wire-types'
+
 // Adapters exported by later phases — append a block above this line.
+
+export {
+  BytePlusTextAdapter,
+  byteplusText,
+  createBytePlusText,
+} from './adapters/text'
+export type { BytePlusTextConfig } from './adapters/text'
+
+export type {
+  BytePlusAudioMetadata,
+  BytePlusChatContentPart,
+  BytePlusDocumentMetadata,
+  BytePlusEncryptedContentFields,
+  BytePlusImageMetadata,
+  BytePlusImagePixelLimit,
+  BytePlusImageUrlContentPart,
+  BytePlusInputAudioContentPart,
+  BytePlusMessageMetadataByModality,
+  BytePlusStreamDeltaExtras,
+  BytePlusTextMetadata,
+  BytePlusVideoMetadata,
+  BytePlusVideoUrlContentPart,
+} from './message-types'
 
 // ============================================================================
 // Client configuration
@@ -36,10 +160,12 @@ export type { BytePlusArkConfig, BytePlusVoiceConfig } from './utils/client'
 // ============================================================================
 
 export type {
+  BytePlusNamedToolChoice,
   BytePlusReasoningEffort,
   BytePlusServiceTier,
   BytePlusTextProviderOptions,
   BytePlusThinkingOption,
+  BytePlusToolChoice,
 } from './text/text-provider-options'
 
 // ============================================================================

--- a/packages/ai-byteplus/src/index.ts
+++ b/packages/ai-byteplus/src/index.ts
@@ -186,9 +186,11 @@ export {
   BYTEPLUS_TRANSCRIPTION_MODELS,
   BYTEPLUS_TTS_MODELS,
   BYTEPLUS_VIDEO_DURATIONS,
+  BYTEPLUS_VIDEO_FALLBACK_DURATIONS,
   BYTEPLUS_VIDEO_MODELS,
   emitsEncryptedContent,
   getBytePlusVideoDurationOptions,
+  isKnownBytePlusVideoModel,
   supportsStructuredOutput,
 } from './model-meta'
 export type {
@@ -209,11 +211,14 @@ export type {
   BytePlusVideoModel,
   BytePlusVideoModelDurationByName,
   BytePlusVideoModelInputModalitiesByName,
+  BytePlusVideoModelOrString,
   BytePlusVideoModelResolutionByName,
   BytePlusVideoModelSizeByName,
   BytePlusVideoRatio,
   BytePlusVideoResolution,
   BytePlusVideoSize,
+  ResolveBytePlusVideoInputModalities,
+  ResolveBytePlusVideoSize,
   ResolveInputModalities,
   ResolveProviderOptions,
 } from './model-meta'

--- a/packages/ai-byteplus/src/index.ts
+++ b/packages/ai-byteplus/src/index.ts
@@ -117,8 +117,6 @@ export type {
   BytePlusSequentialImageGenerationOptions,
 } from './image/wire-types'
 
-// Adapters exported by later phases — append a block above this line.
-
 export {
   BytePlusTextAdapter,
   byteplusText,

--- a/packages/ai-byteplus/src/index.ts
+++ b/packages/ai-byteplus/src/index.ts
@@ -64,6 +64,7 @@ export type { BytePlusTranscriptionProviderOptions } from './audio/transcription
 export {
   BYTEPLUS_ASR_RESOURCE_HEADER,
   BYTEPLUS_ASR_RESOURCE_ID,
+  BYTEPLUS_TTS_SAMPLE_RATES,
 } from './audio/wire-types'
 export type {
   BytePlusASRAudio,
@@ -76,6 +77,9 @@ export type {
   BytePlusTTSAudioFormat,
   BytePlusTTSCreateRequest,
   BytePlusTTSCreateResponse,
+  BytePlusTTSReference,
+  BytePlusTTSSampleRate,
+  BytePlusTTSSubtitle,
   BytePlusTTSSubtitleEntry,
   BytePlusVoiceErrorBody,
 } from './audio/wire-types'

--- a/packages/ai-byteplus/src/index.ts
+++ b/packages/ai-byteplus/src/index.ts
@@ -1,0 +1,88 @@
+// ============================================================================
+// Adapters
+// ============================================================================
+//
+// Tree-shakeable adapters live in ./adapters and are re-exported here, one
+// block per generation kind:
+//
+//   - text          → ./adapters/text          (Seed chat models on Ark)
+//   - video         → ./adapters/video         (Seedance task API)
+//   - image         → ./adapters/image         (Seedream)
+//   - speech        → ./adapters/tts           (Seed Speech TTS)
+//   - transcription → ./adapters/transcription (Seed Speech ASR)
+//
+// Adapters exported by later phases — append a block above this line.
+
+// ============================================================================
+// Client configuration
+// ============================================================================
+
+export {
+  BYTEPLUS_ARK_BASE_URL,
+  BYTEPLUS_VOICE_BASE_URL,
+  bytePlusArkError,
+  bytePlusArkHeaders,
+  bytePlusVoiceError,
+  bytePlusVoiceHeaders,
+  getBytePlusArkApiKeyFromEnv,
+  getBytePlusVoiceApiKeyFromEnv,
+  withBytePlusArkDefaults,
+  withBytePlusVoiceDefaults,
+} from './utils/client'
+export type { BytePlusArkConfig, BytePlusVoiceConfig } from './utils/client'
+
+// ============================================================================
+// Provider options
+// ============================================================================
+
+export type {
+  BytePlusReasoningEffort,
+  BytePlusServiceTier,
+  BytePlusTextProviderOptions,
+  BytePlusThinkingOption,
+} from './text/text-provider-options'
+
+// ============================================================================
+// Model metadata
+// ============================================================================
+
+export {
+  BYTEPLUS_CHAT_MODELS,
+  BYTEPLUS_IMAGE_MAX_REFERENCE_IMAGES,
+  BYTEPLUS_IMAGE_MODELS,
+  BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS,
+  BYTEPLUS_THINKING_SUMMARY_MODELS,
+  BYTEPLUS_TRANSCRIPTION_MODELS,
+  BYTEPLUS_TTS_MODELS,
+  BYTEPLUS_VIDEO_DURATIONS,
+  BYTEPLUS_VIDEO_MODELS,
+  emitsEncryptedContent,
+  getBytePlusVideoDurationOptions,
+  supportsStructuredOutput,
+} from './model-meta'
+export type {
+  BytePlusChatModel,
+  BytePlusChatModelProviderOptionsByName,
+  BytePlusChatModelStructuredOutputByName,
+  BytePlusChatModelToolCapabilitiesByName,
+  BytePlusImageModel,
+  BytePlusImageModelSizeByName,
+  BytePlusImageSize,
+  BytePlusImageSizeToken,
+  BytePlusModelInputModalitiesByName,
+  BytePlusProviderToolKind,
+  BytePlusStructuredOutputChatModel,
+  BytePlusThinkingSummaryModel,
+  BytePlusTranscriptionModel,
+  BytePlusTTSModel,
+  BytePlusVideoModel,
+  BytePlusVideoModelDurationByName,
+  BytePlusVideoModelInputModalitiesByName,
+  BytePlusVideoModelResolutionByName,
+  BytePlusVideoModelSizeByName,
+  BytePlusVideoRatio,
+  BytePlusVideoResolution,
+  BytePlusVideoSize,
+  ResolveInputModalities,
+  ResolveProviderOptions,
+} from './model-meta'

--- a/packages/ai-byteplus/src/index.ts
+++ b/packages/ai-byteplus/src/index.ts
@@ -19,6 +19,7 @@ export {
 export type { BytePlusVideoConfig } from './adapters/video'
 export {
   parseBytePlusVideoSize,
+  resolveBytePlusVideoResolution,
   resolveBytePlusVideoSize,
   supportsLastFrame,
   supportsReferenceMedia,

--- a/packages/ai-byteplus/src/message-types.ts
+++ b/packages/ai-byteplus/src/message-types.ts
@@ -1,0 +1,169 @@
+/**
+ * BytePlus ModelArk chat message types.
+ *
+ * Ark's `/chat/completions` wire format is OpenAI Chat Completions plus a few
+ * Ark-only extensions, so the OpenAI SDK types (via `@tanstack/openai-base`)
+ * cover everything except the fields below. This file is the source of truth
+ * for the Ark-only parts of a chat message:
+ *
+ * - `encrypted_content` on the assistant message (thinking-summary models)
+ * - `video_url` content parts (no OpenAI equivalent)
+ * - `input_audio` accepting a `url` as well as inline base64
+ *
+ * Field shapes verified live against
+ * `https://ark.ap-southeast.bytepluses.com/api/v3` on 2026-07-31 — see the
+ * probe findings referenced from `model-meta.ts`.
+ */
+
+/**
+ * Opaque signature blob emitted alongside `reasoning_content` by the
+ * thinking-summary models (see `BYTEPLUS_THINKING_SUMMARY_MODELS`).
+ *
+ * Non-streaming responses carry it on `choices[].message.encrypted_content`;
+ * streaming delivers the whole blob as one dedicated chunk
+ * (`delta.encrypted_content`, with empty `content` / `reasoning_content`)
+ * between the reasoning deltas and the content deltas.
+ *
+ * When present it should be echoed back verbatim on the assistant message in
+ * the next turn. Probing showed omitting it does *not* fail a request, so it
+ * is preserved-and-replayed rather than required.
+ */
+export interface BytePlusEncryptedContentFields {
+  encrypted_content?: string
+}
+
+/**
+ * Streaming delta fields Ark adds on top of the OpenAI chunk shape.
+ */
+export interface BytePlusStreamDeltaExtras extends BytePlusEncryptedContentFields {
+  reasoning_content?: string
+}
+
+/**
+ * Bounds on how large an image is scaled to before tokenization.
+ *
+ * Probe-verified to live *inside* `image_url` (a number at the content-part
+ * level is silently ignored; Ark validates the object form — asking for
+ * `min_pixels` below the model's floor is rejected with a specific error).
+ */
+export interface BytePlusImagePixelLimit {
+  max_pixels?: number
+  min_pixels?: number
+}
+
+/**
+ * Image content part. Ark's `image_url` extends OpenAI's with an `xhigh`
+ * detail level and {@link BytePlusImagePixelLimit}.
+ */
+export interface BytePlusImageUrlContentPart {
+  type: 'image_url'
+  image_url: {
+    url: string
+    detail?: 'auto' | 'low' | 'high' | 'xhigh'
+    image_pixel_limit?: BytePlusImagePixelLimit
+  }
+}
+
+/**
+ * Video content part. Ark accepts a public URL or a `data:` URI; there is no
+ * OpenAI Chat Completions equivalent, so this shape is defined here.
+ */
+export interface BytePlusVideoUrlContentPart {
+  type: 'video_url'
+  video_url: {
+    url: string
+    /**
+     * Frame sampling rate in frames per second. Omitted by the adapter unless
+     * the caller sets it through content-part metadata.
+     */
+    fps?: number
+  }
+}
+
+/**
+ * Audio content part. Ark extends OpenAI's `input_audio` (inline base64 +
+ * `format`) with a `url` alternative.
+ */
+export interface BytePlusInputAudioContentPart {
+  type: 'input_audio'
+  input_audio: {
+    /** Base64 audio payload. Mutually exclusive with `url`. */
+    data?: string
+    /** Container format of `data`. Required whenever `data` is set. */
+    format?: 'wav' | 'mp3' | 'ogg' | 'flac' | 'm4a' | 'aac' | 'pcm'
+    /** Public audio URL. Mutually exclusive with `data`. */
+    url?: string
+  }
+}
+
+/**
+ * The Ark-only content parts, as a single union. The adapter funnels these
+ * through one documented cast when handing them to the OpenAI SDK, whose
+ * content-part union has no arm for `video_url`, for URL-addressed audio, or
+ * for the extra `image_url` fields.
+ */
+export type BytePlusChatContentPart =
+  | BytePlusImageUrlContentPart
+  | BytePlusVideoUrlContentPart
+  | BytePlusInputAudioContentPart
+
+/**
+ * Metadata for BytePlus text content parts. Ark has no text-part options.
+ */
+export interface BytePlusTextMetadata {}
+
+/**
+ * Metadata for BytePlus image content parts.
+ */
+export interface BytePlusImageMetadata {
+  /**
+   * Processing detail for the image. Ark adds `xhigh` to OpenAI's set.
+   *
+   * @default 'auto'
+   */
+  detail?: 'auto' | 'low' | 'high' | 'xhigh'
+
+  /**
+   * Bounds the pixel count the image is scaled to before tokenization —
+   * see {@link BytePlusImagePixelLimit}. Lower `max_pixels` trades detail for
+   * input tokens.
+   */
+  image_pixel_limit?: BytePlusImagePixelLimit
+}
+
+/**
+ * Metadata for BytePlus audio content parts.
+ */
+export interface BytePlusAudioMetadata {
+  /**
+   * Container format for inline base64 audio. Inferred from the part's
+   * `mimeType` when omitted.
+   */
+  format?: BytePlusInputAudioContentPart['input_audio']['format']
+}
+
+/**
+ * Metadata for BytePlus video content parts.
+ */
+export interface BytePlusVideoMetadata {
+  /** Frame sampling rate in frames per second. */
+  fps?: number
+}
+
+/**
+ * Metadata for BytePlus document content parts. Ark's chat API takes no
+ * document parts — the field exists so the modality map stays total.
+ */
+export interface BytePlusDocumentMetadata {}
+
+/**
+ * Map of modality to BytePlus-specific content-part metadata. Used for type
+ * inference when constructing multimodal messages.
+ */
+export interface BytePlusMessageMetadataByModality {
+  text: BytePlusTextMetadata
+  image: BytePlusImageMetadata
+  audio: BytePlusAudioMetadata
+  video: BytePlusVideoMetadata
+  document: BytePlusDocumentMetadata
+}

--- a/packages/ai-byteplus/src/model-meta.ts
+++ b/packages/ai-byteplus/src/model-meta.ts
@@ -618,6 +618,66 @@ export type BytePlusVideoModelSizeByName = {
 }
 
 /**
+ * A Seedance model id: one this package knows, or any other string.
+ *
+ * The open half is a deliberate escape hatch for models BytePlus ships between
+ * releases of this package. **Seedance 2.5 is the live example**: it was
+ * announced 2026-07-31 as a consumer product only, with the Ark API listed as
+ * "available soon". No 2.5 model id resolves on the data plane yet (21
+ * candidate ids all returned 404 `InvalidEndpointOrModel.NotFound` against
+ * controls that returned 400 `MissingParameter`), so shipping a guessed id
+ * would be shipping a broken one. Passing the real id the day BytePlus
+ * publishes it works without upgrading.
+ *
+ * Watch surface: the ModelArk release notes
+ * (https://docs.byteplus.com/en/docs/ModelArk/1159178) list new model ids
+ * first. To re-probe, POST `/contents/generations/tasks` with only
+ * `{"model": "<id>"}` — 404 `InvalidEndpointOrModel.NotFound` means the id is
+ * not live, 400 `MissingParameter` (complaining about `content`) means it is.
+ *
+ * Unknown ids trade compile-time narrowing for reach: the full size surface is
+ * accepted, provider options are ungated, and the adapter's model-specific
+ * runtime guards stand down so a new model's legitimate request reaches Ark.
+ * Known ids keep their probe-verified narrowing.
+ */
+export type BytePlusVideoModelOrString = BytePlusVideoModel | (string & {})
+
+/**
+ * Resolve the `size` type for a video model: the model's probe-verified
+ * template union when known, otherwise the full template surface plus any
+ * string (a future model may bring ratios or resolution tiers that do not
+ * exist today).
+ */
+export type ResolveBytePlusVideoSize<TModel extends string> =
+  TModel extends BytePlusVideoModel
+    ? BytePlusVideoModelSizeByName[TModel]
+    : BytePlusVideoSize | (string & {})
+
+/**
+ * Resolve the accepted non-text prompt modalities for a video model. Unknown
+ * models accept all three rather than none, so a new model's reference media
+ * is not a compile error.
+ */
+export type ResolveBytePlusVideoInputModalities<TModel extends string> =
+  TModel extends BytePlusVideoModel
+    ? BytePlusVideoModelInputModalitiesByName[TModel]
+    : readonly ['image', 'video', 'audio']
+
+const VIDEO_MODEL_SET: ReadonlySet<string> = new Set(BYTEPLUS_VIDEO_MODELS)
+
+/**
+ * True when the id is one this package has probe-verified metadata for.
+ *
+ * The adapter uses this to decide whether its model-specific guards apply:
+ * see {@link BytePlusVideoModelOrString}.
+ */
+export function isKnownBytePlusVideoModel(
+  model: string,
+): model is BytePlusVideoModel {
+  return VIDEO_MODEL_SET.has(model)
+}
+
+/**
  * Per-model duration type. Seedance accepts any integer second inside the
  * model's range, so this is a continuous range expressed as `number` — a
  * literal union cannot represent it. (The API also accepts `duration: -1` on
@@ -681,12 +741,33 @@ export const BYTEPLUS_VIDEO_DURATIONS: {
 }
 
 /**
- * Look up the duration options for a Seedance video model.
+ * Duration hint for a model this package has no table for.
+ *
+ * Spans every range Seedance has shipped so far (2s on the 1.0 models through
+ * 15s on the 2.0 family) so `availableDurations()` can still drive a UI. It is
+ * a hint, not a contract: the adapter does **not** snap an unknown model's
+ * duration against it, because clamping a future model's legitimate 20-second
+ * request down to 15 would corrupt the request rather than protect it.
  */
-export function getBytePlusVideoDurationOptions<
-  TModel extends BytePlusVideoModel,
->(model: TModel): DurationOptions<BytePlusVideoModelDurationByName[TModel]> {
-  return BYTEPLUS_VIDEO_DURATIONS[model]
+export const BYTEPLUS_VIDEO_FALLBACK_DURATIONS: DurationOptions<number> = {
+  kind: 'range',
+  min: 2,
+  max: 15,
+  step: 1,
+  unit: 'seconds',
+}
+
+/**
+ * Look up the duration options for a Seedance video model, falling back to
+ * {@link BYTEPLUS_VIDEO_FALLBACK_DURATIONS} for an id this package does not
+ * know.
+ */
+export function getBytePlusVideoDurationOptions(
+  model: BytePlusVideoModelOrString,
+): DurationOptions<number> {
+  return isKnownBytePlusVideoModel(model)
+    ? BYTEPLUS_VIDEO_DURATIONS[model]
+    : BYTEPLUS_VIDEO_FALLBACK_DURATIONS
 }
 
 // ============================================================================

--- a/packages/ai-byteplus/src/model-meta.ts
+++ b/packages/ai-byteplus/src/model-meta.ts
@@ -73,7 +73,7 @@ const SEED_2_0_LITE_260428 = {
   supports: {
     input: ['text', 'image', 'video', 'audio'],
     output: ['text'],
-    // Live-probed: rejects both json_schema and json_object.
+    // Live-probed 2026-07-31: rejects both json_schema and json_object.
     capabilities: ['reasoning', 'tool_calling'],
     tools: [] as const,
   },
@@ -87,7 +87,7 @@ const SEED_2_0_MINI_260428 = {
   supports: {
     input: ['text', 'image', 'video', 'audio'],
     output: ['text'],
-    // Live-probed: rejects both json_schema and json_object.
+    // Live-probed 2026-07-31: rejects both json_schema and json_object.
     capabilities: ['reasoning', 'tool_calling'],
     tools: [] as const,
   },
@@ -101,7 +101,8 @@ const SEED_2_0_PRO_260328 = {
   supports: {
     input: ['text', 'image', 'video'],
     output: ['text'],
-    // Live-probed: accepts json_schema, despite the docs table saying otherwise.
+    // Live-probed 2026-07-31: accepts json_schema, despite the docs table
+    // saying otherwise.
     capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
     tools: [] as const,
   },
@@ -219,7 +220,8 @@ const GLM_5_2_260617 = {
   supports: {
     input: ['text'],
     output: ['text'],
-    // Live-probed: accepts json_schema, despite the docs table saying otherwise.
+    // Live-probed 2026-07-31: accepts json_schema, despite the docs table
+    // saying otherwise.
     capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
     tools: [] as const,
   },
@@ -233,7 +235,8 @@ const GLM_4_7_251222 = {
   supports: {
     input: ['text'],
     output: ['text'],
-    // Live-probed: accepts json_schema, despite the docs table saying otherwise.
+    // Live-probed 2026-07-31: accepts json_schema, despite the docs table
+    // saying otherwise.
     capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
     tools: [] as const,
   },
@@ -274,7 +277,7 @@ const DEEPSEEK_V3_2_251201 = {
   supports: {
     input: ['text'],
     output: ['text'],
-    // Live-probed: rejects both json_schema and json_object.
+    // Live-probed 2026-07-31: rejects both json_schema and json_object.
     capabilities: ['reasoning', 'tool_calling'],
     tools: [] as const,
   },
@@ -362,8 +365,8 @@ export function emitsEncryptedContent(model: string): boolean {
 /**
  * Chat models that accept `response_format: {type: 'json_schema'}`.
  *
- * This list is live-probed, not docs-derived — the BytePlus capability tables
- * are wrong for five of these models. The seven models NOT listed here
+ * Live-probed against all 18 chat models on 2026-07-31, not docs-derived — the
+ * BytePlus capability tables are wrong for five. The seven models NOT listed here
  * (`seed-2-0-lite-260428`, `seed-2-0-mini-260428`,
  * `seed-2-0-code-preview-260328`, both `deepseek-v4-*`, `deepseek-v3-2-251201`
  * and `gpt-oss-120b-250805`) answer a JSON schema with 400 InvalidParameter —

--- a/packages/ai-byteplus/src/model-meta.ts
+++ b/packages/ai-byteplus/src/model-meta.ts
@@ -1,8 +1,13 @@
 /**
  * BytePlus ModelArk model metadata.
  *
- * Every model id in this file was verified live against
- * `https://ark.ap-southeast.bytepluses.com/api/v3` on 2026-07-31. BytePlus
+ * Every Ark model id in this file — chat, video and image — was verified live
+ * against `https://ark.ap-southeast.bytepluses.com/api/v3` on 2026-07-31. The
+ * two Seed Speech ids are the exception: they live on the voice host, which
+ * needs a separate key that was not available, so they are docs-derived.
+ * Capability metadata is a mix of probed and docs-derived facts; anything not
+ * confirmed against the live API is annotated as such at its declaration.
+ * BytePlus
  * deactivates model ids aggressively (the whole `seedance-1-0-lite-*` family,
  * `seed-1-6-lite-*`, `seedream-3-0-*`, and the `doubao-`/`skylark-` names are
  * all 404s internationally), so only dated, probe-confirmed ids are shipped.
@@ -68,7 +73,8 @@ const SEED_2_0_LITE_260428 = {
   supports: {
     input: ['text', 'image', 'video', 'audio'],
     output: ['text'],
-    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    // Live-probed: rejects both json_schema and json_object.
+    capabilities: ['reasoning', 'tool_calling'],
     tools: [] as const,
   },
 } as const satisfies ModelMeta
@@ -81,7 +87,8 @@ const SEED_2_0_MINI_260428 = {
   supports: {
     input: ['text', 'image', 'video', 'audio'],
     output: ['text'],
-    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    // Live-probed: rejects both json_schema and json_object.
+    capabilities: ['reasoning', 'tool_calling'],
     tools: [] as const,
   },
 } as const satisfies ModelMeta
@@ -94,7 +101,8 @@ const SEED_2_0_PRO_260328 = {
   supports: {
     input: ['text', 'image', 'video'],
     output: ['text'],
-    capabilities: ['reasoning', 'tool_calling'],
+    // Live-probed: accepts json_schema, despite the docs table saying otherwise.
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
     tools: [] as const,
   },
 } as const satisfies ModelMeta
@@ -211,7 +219,8 @@ const GLM_5_2_260617 = {
   supports: {
     input: ['text'],
     output: ['text'],
-    capabilities: ['reasoning', 'tool_calling'],
+    // Live-probed: accepts json_schema, despite the docs table saying otherwise.
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
     tools: [] as const,
   },
 } as const satisfies ModelMeta
@@ -224,7 +233,8 @@ const GLM_4_7_251222 = {
   supports: {
     input: ['text'],
     output: ['text'],
-    capabilities: ['reasoning', 'tool_calling'],
+    // Live-probed: accepts json_schema, despite the docs table saying otherwise.
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
     tools: [] as const,
   },
 } as const satisfies ModelMeta
@@ -255,7 +265,7 @@ const DEEPSEEK_V4_FLASH_260425 = {
   },
 } as const satisfies ModelMeta
 
-// Reasoning is the one model on Ark that defaults to `thinking: disabled`.
+// The one model on Ark that defaults to `thinking: disabled`.
 const DEEPSEEK_V3_2_251201 = {
   name: 'deepseek-v3-2-251201',
   context_window: 128_000,
@@ -264,7 +274,8 @@ const DEEPSEEK_V3_2_251201 = {
   supports: {
     input: ['text'],
     output: ['text'],
-    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    // Live-probed: rejects both json_schema and json_object.
+    capabilities: ['reasoning', 'tool_calling'],
     tools: [] as const,
   },
 } as const satisfies ModelMeta
@@ -351,14 +362,21 @@ export function emitsEncryptedContent(model: string): boolean {
 /**
  * Chat models that accept `response_format: {type: 'json_schema'}`.
  *
- * The remaining models (`seed-2-0-pro-260328`, `seed-2-0-code-preview-260328`,
- * the GLM and DeepSeek-v4 families, and `gpt-oss-120b-250805`) reject a JSON
- * schema, so structured output has to fall back to tool-shaped extraction.
+ * This list is live-probed, not docs-derived — the BytePlus capability tables
+ * are wrong for five of these models. The seven models NOT listed here
+ * (`seed-2-0-lite-260428`, `seed-2-0-mini-260428`,
+ * `seed-2-0-code-preview-260328`, both `deepseek-v4-*`, `deepseek-v3-2-251201`
+ * and `gpt-oss-120b-250805`) answer a JSON schema with 400 InvalidParameter —
+ * and they reject `{type: 'json_object'}` too, so there is no JSON-mode
+ * fallback and structured output must go through tool-shaped extraction.
+ *
+ * Note that the default chat model `seed-2-0-lite-260428` is one of the
+ * rejecting models: structured-output work needs `seed-2-0-lite-260228` or
+ * `dola-seed-2-1-turbo-260628`.
  */
 export const BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS = [
   DOLA_SEED_2_1_TURBO.name,
-  SEED_2_0_LITE_260428.name,
-  SEED_2_0_MINI_260428.name,
+  SEED_2_0_PRO_260328.name,
   SEED_2_0_LITE_260228.name,
   SEED_2_0_MINI_260215.name,
   SEED_1_8_251228.name,
@@ -366,7 +384,8 @@ export const BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS = [
   SEED_1_6_250615.name,
   SEED_1_6_FLASH_250715.name,
   SEED_1_6_FLASH_250615.name,
-  DEEPSEEK_V3_2_251201.name,
+  GLM_5_2_260617.name,
+  GLM_4_7_251222.name,
 ] as const
 
 const STRUCTURED_OUTPUT_MODEL_SET: ReadonlySet<string> = new Set(
@@ -473,6 +492,11 @@ export type BytePlusVideoSize<
   TResolution extends BytePlusVideoResolution = BytePlusVideoResolution,
 > = BytePlusVideoRatio | `${BytePlusVideoRatio}_${TResolution}`
 
+// The Seedance 2.0 family's `audio` input modality is docs-derived, not
+// live-probed: the docs' multimodal-reference caps list `reference_audio`
+// parts (up to 3, never sent without a visual reference). Every 2.0 model id
+// below is itself probe-verified live; only the audio-reference capability
+// rests on the docs.
 const DREAMINA_SEEDANCE_2_0 = {
   name: 'dreamina-seedance-2-0-260128',
   supports: {
@@ -729,6 +753,10 @@ export type BytePlusImageModelSizeByName = {
  * Maximum number of reference images accepted per editing request.
  * Seedream 5.0 Pro caps at 10 references; the other editing-capable models
  * accept up to 14.
+ *
+ * Docs-derived, not live-probed. The 14 for `seedream-5-0-260128` is weaker
+ * still — the docs never state a cap for that model, so it is inferred from
+ * the rest of the family.
  */
 export const BYTEPLUS_IMAGE_MAX_REFERENCE_IMAGES: {
   readonly [K in BytePlusImageModel]: number

--- a/packages/ai-byteplus/src/model-meta.ts
+++ b/packages/ai-byteplus/src/model-meta.ts
@@ -621,19 +621,32 @@ export type BytePlusVideoModelSizeByName = {
  * A Seedance model id: one this package knows, or any other string.
  *
  * The open half is a deliberate escape hatch for models BytePlus ships between
- * releases of this package. **Seedance 2.5 is the live example**: it was
- * announced 2026-07-31 as a consumer product only, with the Ark API listed as
- * "available soon". No 2.5 model id resolves on the data plane yet (21
- * candidate ids all returned 404 `InvalidEndpointOrModel.NotFound` against
- * controls that returned 400 `MissingParameter`), so shipping a guessed id
- * would be shipping a broken one. Passing the real id the day BytePlus
- * publishes it works without upgrading.
+ * releases of this package. **Seedance 2.5 is the live example.** Its real id
+ * is `dreamina-seedance-2-5-260628` — note the June date suffix, which is why
+ * guessing ids around its 2026-07-31 announcement never landed. It is absent
+ * from the table below because its capability cells are unverified, not
+ * because it is unreachable: probing it returns 404 `ModelNotOpen` ("your
+ * account has not activated the model"), so no capability question can be
+ * answered until someone enables it in the Ark Console. Passing it through
+ * the escape hatch works today for an account that has.
  *
- * Watch surface: the ModelArk release notes
- * (https://docs.byteplus.com/en/docs/ModelArk/1159178) list new model ids
- * first. To re-probe, POST `/contents/generations/tasks` with only
- * `{"model": "<id>"}` — 404 `InvalidEndpointOrModel.NotFound` means the id is
- * not live, 400 `MissingParameter` (complaining about `content`) means it is.
+ * Adding a model here *narrows* it — the adapter's guards switch on and reject
+ * against this file's tables. For a model whose real limits are unknown that
+ * is strictly worse than the open path, which lets Ark judge. So an id lands
+ * here only once probed.
+ *
+ * Discovering ids: `GET /models` on the Ark data plane enumerates the catalog
+ * (id, `task_type`, `modalities`, `status`) and is how 2.5 was found. It is
+ * not exhaustive — `seedream-5-0-lite-260128` answers requests but is missing
+ * from the listing — so absence there is not evidence of absence. The ModelArk
+ * release notes (https://docs.byteplus.com/en/docs/ModelArk/1159178) are the
+ * other watch surface.
+ *
+ * To probe an id, POST `/contents/generations/tasks` with only
+ * `{"model": "<id>"}`. Three outcomes, all live-verified:
+ * - 400 `MissingParameter` (about `content`) — live and usable.
+ * - 404 `ModelNotOpen` — real, but not activated on this account.
+ * - 404 `InvalidEndpointOrModel.NotFound` — no such model.
  *
  * Unknown ids trade compile-time narrowing for reach: the full size surface is
  * accepted, provider options are ungated, and the adapter's model-specific

--- a/packages/ai-byteplus/src/model-meta.ts
+++ b/packages/ai-byteplus/src/model-meta.ts
@@ -235,9 +235,11 @@ const GLM_4_7_251222 = {
   supports: {
     input: ['text'],
     output: ['text'],
-    // Live-probed 2026-07-31: accepts json_schema, despite the docs table
-    // saying otherwise.
-    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    // Adherence-probed 2026-07-31: ACCEPTS a json_schema with 200 but ignores
+    // it and answers in prose, so it is not a structured-output model. A
+    // status-code-only probe reads this as support — see the note on
+    // BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS.
+    capabilities: ['reasoning', 'tool_calling'],
     tools: [] as const,
   },
 } as const satisfies ModelMeta
@@ -366,12 +368,20 @@ export function emitsEncryptedContent(model: string): boolean {
  * Chat models that accept `response_format: {type: 'json_schema'}`.
  *
  * Live-probed against all 18 chat models on 2026-07-31, not docs-derived — the
- * BytePlus capability tables are wrong for five. The seven models NOT listed here
- * (`seed-2-0-lite-260428`, `seed-2-0-mini-260428`,
- * `seed-2-0-code-preview-260328`, both `deepseek-v4-*`, `deepseek-v3-2-251201`
- * and `gpt-oss-120b-250805`) answer a JSON schema with 400 InvalidParameter —
- * and they reject `{type: 'json_object'}` too, so there is no JSON-mode
- * fallback and structured output must go through tool-shaped extraction.
+ * BytePlus capability tables are wrong here in both directions.
+ *
+ * Membership needs TWO things, because the API has both failure modes:
+ * 1. The request is accepted. Seven models (`seed-2-0-lite-260428`,
+ *    `seed-2-0-mini-260428`, `seed-2-0-code-preview-260328`, both
+ *    `deepseek-v4-*`, `deepseek-v3-2-251201`, `gpt-oss-120b-250805`) answer a
+ *    JSON schema with 400 InvalidParameter — and reject
+ *    `{type: 'json_object'}` too, so there is no JSON-mode fallback.
+ * 2. The schema is actually honoured. `glm-4-7-251222` accepts the request
+ *    with 200 and then ignores the schema, answering in prose (reproduced
+ *    twice by the adherence probe). A status-code-only probe wrongly reads
+ *    that as support, so it is excluded.
+ *
+ * Models that fail either check need tool-shaped extraction instead.
  *
  * Note that the default chat model `seed-2-0-lite-260428` is one of the
  * rejecting models: structured-output work needs `seed-2-0-lite-260228` or
@@ -388,7 +398,6 @@ export const BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS = [
   SEED_1_6_FLASH_250715.name,
   SEED_1_6_FLASH_250615.name,
   GLM_5_2_260617.name,
-  GLM_4_7_251222.name,
 ] as const
 
 const STRUCTURED_OUTPUT_MODEL_SET: ReadonlySet<string> = new Set(
@@ -479,11 +488,15 @@ export type BytePlusVideoRatio =
 /**
  * Resolution tiers accepted by the Seedance task API.
  *
- * `480p`, `720p` and `1080p` are probe-verified; `2k`/`4k` (Seedance 2.0 only)
- * come from the BytePlus video docs and should be re-checked against a live
- * 4K task before being relied on.
+ * All four are probe-verified per model (2026-07-31). Two findings contradict
+ * the BytePlus prose docs: there is **no 2K tier on any Seedance model** —
+ * `2k`/`2K` is rejected everywhere, including on the 2.0 flagship documented
+ * as reaching 4K — and `4k` exists only on `dreamina-seedance-2-0-260128`.
+ *
+ * The API matches this field case-insensitively (`4K`, `4k` and `1080P` are
+ * all accepted), so this package standardizes on the lowercase spelling.
  */
-export type BytePlusVideoResolution = '480p' | '720p' | '1080p' | '2k' | '4k'
+export type BytePlusVideoResolution = '480p' | '720p' | '1080p' | '4k'
 
 /**
  * Generic `size` template for Seedance models: either a bare aspect ratio
@@ -582,14 +595,17 @@ export type BytePlusVideoModelInputModalitiesByName = {
 
 /**
  * Type-only map from video model name to the resolutions it accepts.
+ *
+ * Probe-verified per model on 2026-07-31. Note `seedance-1-0-pro-fast-251015`
+ * does accept `1080p`, despite the BytePlus docs listing it as 480p/720p.
  */
 export type BytePlusVideoModelResolutionByName = {
-  [DREAMINA_SEEDANCE_2_0.name]: BytePlusVideoResolution
+  [DREAMINA_SEEDANCE_2_0.name]: '480p' | '720p' | '1080p' | '4k'
   [DREAMINA_SEEDANCE_2_0_FAST.name]: '480p' | '720p'
   [DREAMINA_SEEDANCE_2_0_MINI.name]: '480p' | '720p'
   [SEEDANCE_1_5_PRO.name]: '480p' | '720p' | '1080p'
   [SEEDANCE_1_0_PRO.name]: '480p' | '720p' | '1080p'
-  [SEEDANCE_1_0_PRO_FAST.name]: '480p' | '720p'
+  [SEEDANCE_1_0_PRO_FAST.name]: '480p' | '720p' | '1080p'
 }
 
 /**

--- a/packages/ai-byteplus/src/model-meta.ts
+++ b/packages/ai-byteplus/src/model-meta.ts
@@ -1,0 +1,813 @@
+/**
+ * BytePlus ModelArk model metadata.
+ *
+ * Every model id in this file was verified live against
+ * `https://ark.ap-southeast.bytepluses.com/api/v3` on 2026-07-31. BytePlus
+ * deactivates model ids aggressively (the whole `seedance-1-0-lite-*` family,
+ * `seed-1-6-lite-*`, `seedream-3-0-*`, and the `doubao-`/`skylark-` names are
+ * all 404s internationally), so only dated, probe-confirmed ids are shipped.
+ *
+ * Prefix rules, also probe-confirmed:
+ * - `dola-seed-2-1-turbo-260628` and `dola-seedream-5-0-pro-260628` are the
+ *   canonical ids; the bare forms resolve as aliases but the API echoes the
+ *   prefixed id back.
+ * - The Seedance 2.0 family *requires* the `dreamina-` prefix.
+ * - Older models reject the `dola-` prefix outright.
+ */
+import type { DurationOptions } from '@tanstack/ai/adapters'
+import type { BytePlusTextProviderOptions } from './text/text-provider-options'
+
+/**
+ * BytePlus exposes no server-side provider tools (no hosted web search, code
+ * interpreter, …) on the international Ark endpoint, so every chat model
+ * advertises an empty tool set. Typing it as `never` makes passing another
+ * provider's `ProviderTool` to a BytePlus adapter a compile-time error.
+ */
+export type BytePlusProviderToolKind = never
+
+/**
+ * Internal metadata structure describing a BytePlus model.
+ */
+interface ModelMeta {
+  name: string
+  supports: {
+    input: ReadonlyArray<'text' | 'image' | 'audio' | 'video' | 'document'>
+    output: ReadonlyArray<'text' | 'image' | 'audio' | 'video'>
+    capabilities?: ReadonlyArray<
+      'reasoning' | 'tool_calling' | 'structured_outputs'
+    >
+    tools?: ReadonlyArray<BytePlusProviderToolKind>
+  }
+  context_window?: number
+  max_input_tokens?: number
+  max_output_tokens?: number
+}
+
+// ============================================================================
+// Chat models (Seed / GLM / DeepSeek / gpt-oss on Ark)
+// ============================================================================
+
+const DOLA_SEED_2_1_TURBO = {
+  name: 'dola-seed-2-1-turbo-260628',
+  context_window: 256_000,
+  max_input_tokens: 256_000,
+  max_output_tokens: 256_000,
+  supports: {
+    input: ['text', 'image', 'video'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const SEED_2_0_LITE_260428 = {
+  name: 'seed-2-0-lite-260428',
+  context_window: 256_000,
+  max_input_tokens: 256_000,
+  max_output_tokens: 128_000,
+  supports: {
+    input: ['text', 'image', 'video', 'audio'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const SEED_2_0_MINI_260428 = {
+  name: 'seed-2-0-mini-260428',
+  context_window: 256_000,
+  max_input_tokens: 256_000,
+  max_output_tokens: 128_000,
+  supports: {
+    input: ['text', 'image', 'video', 'audio'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const SEED_2_0_PRO_260328 = {
+  name: 'seed-2-0-pro-260328',
+  context_window: 256_000,
+  max_input_tokens: 224_000,
+  max_output_tokens: 128_000,
+  supports: {
+    input: ['text', 'image', 'video'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const SEED_2_0_LITE_260228 = {
+  name: 'seed-2-0-lite-260228',
+  context_window: 256_000,
+  max_input_tokens: 224_000,
+  max_output_tokens: 128_000,
+  supports: {
+    input: ['text', 'image', 'video'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const SEED_2_0_MINI_260215 = {
+  name: 'seed-2-0-mini-260215',
+  context_window: 256_000,
+  max_input_tokens: 224_000,
+  max_output_tokens: 128_000,
+  supports: {
+    input: ['text', 'image', 'video'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const SEED_2_0_CODE_PREVIEW_260328 = {
+  name: 'seed-2-0-code-preview-260328',
+  context_window: 256_000,
+  max_input_tokens: 224_000,
+  max_output_tokens: 128_000,
+  supports: {
+    input: ['text', 'image', 'video'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const SEED_1_8_251228 = {
+  name: 'seed-1-8-251228',
+  context_window: 256_000,
+  max_input_tokens: 224_000,
+  max_output_tokens: 64_000,
+  supports: {
+    input: ['text', 'image', 'video'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const SEED_1_6_250915 = {
+  name: 'seed-1-6-250915',
+  context_window: 256_000,
+  max_input_tokens: 224_000,
+  max_output_tokens: 32_000,
+  supports: {
+    input: ['text', 'image', 'video'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const SEED_1_6_250615 = {
+  name: 'seed-1-6-250615',
+  context_window: 256_000,
+  max_input_tokens: 224_000,
+  max_output_tokens: 32_000,
+  supports: {
+    input: ['text', 'image', 'video'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const SEED_1_6_FLASH_250715 = {
+  name: 'seed-1-6-flash-250715',
+  context_window: 256_000,
+  max_input_tokens: 224_000,
+  max_output_tokens: 32_000,
+  supports: {
+    input: ['text', 'image', 'video'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const SEED_1_6_FLASH_250615 = {
+  name: 'seed-1-6-flash-250615',
+  context_window: 256_000,
+  max_input_tokens: 224_000,
+  max_output_tokens: 32_000,
+  supports: {
+    input: ['text', 'image', 'video'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const GLM_5_2_260617 = {
+  name: 'glm-5-2-260617',
+  context_window: 1_024_000,
+  max_input_tokens: 1_024_000,
+  max_output_tokens: 128_000,
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const GLM_4_7_251222 = {
+  name: 'glm-4-7-251222',
+  context_window: 256_000,
+  max_input_tokens: 224_000,
+  max_output_tokens: 128_000,
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const DEEPSEEK_V4_PRO_260425 = {
+  name: 'deepseek-v4-pro-260425',
+  context_window: 1_024_000,
+  max_input_tokens: 1_024_000,
+  max_output_tokens: 384_000,
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const DEEPSEEK_V4_FLASH_260425 = {
+  name: 'deepseek-v4-flash-260425',
+  context_window: 1_024_000,
+  max_input_tokens: 1_024_000,
+  max_output_tokens: 384_000,
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+// Reasoning is the one model on Ark that defaults to `thinking: disabled`.
+const DEEPSEEK_V3_2_251201 = {
+  name: 'deepseek-v3-2-251201',
+  context_window: 128_000,
+  max_input_tokens: 128_000,
+  max_output_tokens: 32_000,
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling', 'structured_outputs'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+// The only model accepting `thinking: {type: 'auto'}`. Tool calling is
+// undocumented on Ark and unverified, so it is not advertised.
+const GPT_OSS_120B_250805 = {
+  name: 'gpt-oss-120b-250805',
+  context_window: 128_000,
+  max_input_tokens: 96_000,
+  max_output_tokens: 64_000,
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    capabilities: ['reasoning'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+/**
+ * All supported BytePlus chat model identifiers.
+ */
+export const BYTEPLUS_CHAT_MODELS = [
+  DOLA_SEED_2_1_TURBO.name,
+  SEED_2_0_LITE_260428.name,
+  SEED_2_0_MINI_260428.name,
+  SEED_2_0_PRO_260328.name,
+  SEED_2_0_LITE_260228.name,
+  SEED_2_0_MINI_260215.name,
+  SEED_2_0_CODE_PREVIEW_260328.name,
+  SEED_1_8_251228.name,
+  SEED_1_6_250915.name,
+  SEED_1_6_250615.name,
+  SEED_1_6_FLASH_250715.name,
+  SEED_1_6_FLASH_250615.name,
+  GLM_5_2_260617.name,
+  GLM_4_7_251222.name,
+  DEEPSEEK_V4_PRO_260425.name,
+  DEEPSEEK_V4_FLASH_260425.name,
+  DEEPSEEK_V3_2_251201.name,
+  GPT_OSS_120B_250805.name,
+] as const
+
+/**
+ * Union of all supported BytePlus chat model names.
+ */
+export type BytePlusChatModel = (typeof BYTEPLUS_CHAT_MODELS)[number]
+
+/**
+ * Chat models that emit a `encrypted_content` blob alongside
+ * `reasoning_content` when thinking is enabled ("thinking summary" models).
+ *
+ * The blob is an opaque signature over the reasoning trace: when it is
+ * present it must be echoed back verbatim on the assistant message in the
+ * next turn. Live probing showed omitting it did *not* fail a simple tool
+ * round-trip, so adapters preserve and replay it when present but must never
+ * treat its absence as an error.
+ */
+export const BYTEPLUS_THINKING_SUMMARY_MODELS = [
+  DOLA_SEED_2_1_TURBO.name,
+  SEED_2_0_LITE_260428.name,
+  SEED_2_0_MINI_260428.name,
+  SEED_2_0_PRO_260328.name,
+] as const
+
+/**
+ * Union of chat models that emit `encrypted_content`.
+ */
+export type BytePlusThinkingSummaryModel =
+  (typeof BYTEPLUS_THINKING_SUMMARY_MODELS)[number]
+
+const THINKING_SUMMARY_MODEL_SET: ReadonlySet<string> = new Set(
+  BYTEPLUS_THINKING_SUMMARY_MODELS,
+)
+
+/**
+ * True when the model emits `encrypted_content` that should be round-tripped
+ * on subsequent turns.
+ */
+export function emitsEncryptedContent(model: string): boolean {
+  return THINKING_SUMMARY_MODEL_SET.has(model)
+}
+
+/**
+ * Chat models that accept `response_format: {type: 'json_schema'}`.
+ *
+ * The remaining models (`seed-2-0-pro-260328`, `seed-2-0-code-preview-260328`,
+ * the GLM and DeepSeek-v4 families, and `gpt-oss-120b-250805`) reject a JSON
+ * schema, so structured output has to fall back to tool-shaped extraction.
+ */
+export const BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS = [
+  DOLA_SEED_2_1_TURBO.name,
+  SEED_2_0_LITE_260428.name,
+  SEED_2_0_MINI_260428.name,
+  SEED_2_0_LITE_260228.name,
+  SEED_2_0_MINI_260215.name,
+  SEED_1_8_251228.name,
+  SEED_1_6_250915.name,
+  SEED_1_6_250615.name,
+  SEED_1_6_FLASH_250715.name,
+  SEED_1_6_FLASH_250615.name,
+  DEEPSEEK_V3_2_251201.name,
+] as const
+
+const STRUCTURED_OUTPUT_MODEL_SET: ReadonlySet<string> = new Set(
+  BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS,
+)
+
+/**
+ * True when the model supports native JSON-schema structured output.
+ */
+export function supportsStructuredOutput(model: string): boolean {
+  return STRUCTURED_OUTPUT_MODEL_SET.has(model)
+}
+
+/**
+ * Type-only map from chat model name to whether it supports native
+ * JSON-schema structured output.
+ */
+export type BytePlusChatModelStructuredOutputByName = {
+  [K in BytePlusChatModel]: K extends BytePlusStructuredOutputChatModel
+    ? true
+    : false
+}
+
+/**
+ * Union of chat models supporting native JSON-schema structured output.
+ */
+export type BytePlusStructuredOutputChatModel =
+  (typeof BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS)[number]
+
+/**
+ * Type-only map from chat model name to its supported input modalities.
+ * Used for type inference when constructing multimodal messages.
+ */
+export type BytePlusModelInputModalitiesByName = {
+  [DOLA_SEED_2_1_TURBO.name]: typeof DOLA_SEED_2_1_TURBO.supports.input
+  [SEED_2_0_LITE_260428.name]: typeof SEED_2_0_LITE_260428.supports.input
+  [SEED_2_0_MINI_260428.name]: typeof SEED_2_0_MINI_260428.supports.input
+  [SEED_2_0_PRO_260328.name]: typeof SEED_2_0_PRO_260328.supports.input
+  [SEED_2_0_LITE_260228.name]: typeof SEED_2_0_LITE_260228.supports.input
+  [SEED_2_0_MINI_260215.name]: typeof SEED_2_0_MINI_260215.supports.input
+  [SEED_2_0_CODE_PREVIEW_260328.name]: typeof SEED_2_0_CODE_PREVIEW_260328.supports.input
+  [SEED_1_8_251228.name]: typeof SEED_1_8_251228.supports.input
+  [SEED_1_6_250915.name]: typeof SEED_1_6_250915.supports.input
+  [SEED_1_6_250615.name]: typeof SEED_1_6_250615.supports.input
+  [SEED_1_6_FLASH_250715.name]: typeof SEED_1_6_FLASH_250715.supports.input
+  [SEED_1_6_FLASH_250615.name]: typeof SEED_1_6_FLASH_250615.supports.input
+  [GLM_5_2_260617.name]: typeof GLM_5_2_260617.supports.input
+  [GLM_4_7_251222.name]: typeof GLM_4_7_251222.supports.input
+  [DEEPSEEK_V4_PRO_260425.name]: typeof DEEPSEEK_V4_PRO_260425.supports.input
+  [DEEPSEEK_V4_FLASH_260425.name]: typeof DEEPSEEK_V4_FLASH_260425.supports.input
+  [DEEPSEEK_V3_2_251201.name]: typeof DEEPSEEK_V3_2_251201.supports.input
+  [GPT_OSS_120B_250805.name]: typeof GPT_OSS_120B_250805.supports.input
+}
+
+/**
+ * Type-only map from chat model name to its supported provider tools.
+ * BytePlus exposes no provider-tool factories, so every model gets an empty
+ * tuple — passing another provider's tool is then a compile-time error.
+ */
+export type BytePlusChatModelToolCapabilitiesByName = {
+  [K in BytePlusChatModel]: ReadonlyArray<BytePlusProviderToolKind>
+}
+
+/**
+ * Type-only map from chat model name to its provider options type.
+ */
+export type BytePlusChatModelProviderOptionsByName = {
+  [K in BytePlusChatModel]: BytePlusTextProviderOptions
+}
+
+// ============================================================================
+// Video models (Seedance, async task API)
+// ============================================================================
+
+/**
+ * Output aspect ratios accepted by the Seedance task API. `adaptive` is only
+ * meaningful for image-to-video, where the ratio follows the input frame.
+ */
+export type BytePlusVideoRatio =
+  | '16:9'
+  | '9:16'
+  | '4:3'
+  | '3:4'
+  | '1:1'
+  | '21:9'
+  | 'adaptive'
+
+/**
+ * Resolution tiers accepted by the Seedance task API.
+ *
+ * `480p`, `720p` and `1080p` are probe-verified; `2k`/`4k` (Seedance 2.0 only)
+ * come from the BytePlus video docs and should be re-checked against a live
+ * 4K task before being relied on.
+ */
+export type BytePlusVideoResolution = '480p' | '720p' | '1080p' | '2k' | '4k'
+
+/**
+ * Generic `size` template for Seedance models: either a bare aspect ratio
+ * ("16:9") or `ratio_resolution` ("16:9_720p"). The Seedance API takes the
+ * two as separate `ratio` / `resolution` fields; the adapter splits this
+ * template back apart.
+ */
+export type BytePlusVideoSize<
+  TResolution extends BytePlusVideoResolution = BytePlusVideoResolution,
+> = BytePlusVideoRatio | `${BytePlusVideoRatio}_${TResolution}`
+
+const DREAMINA_SEEDANCE_2_0 = {
+  name: 'dreamina-seedance-2-0-260128',
+  supports: {
+    input: ['text', 'image', 'video', 'audio'],
+    output: ['video', 'audio'],
+  },
+} as const satisfies ModelMeta
+
+const DREAMINA_SEEDANCE_2_0_FAST = {
+  name: 'dreamina-seedance-2-0-fast-260128',
+  supports: {
+    input: ['text', 'image', 'video', 'audio'],
+    output: ['video', 'audio'],
+  },
+} as const satisfies ModelMeta
+
+const DREAMINA_SEEDANCE_2_0_MINI = {
+  name: 'dreamina-seedance-2-0-mini-260615',
+  supports: {
+    input: ['text', 'image', 'video', 'audio'],
+    output: ['video', 'audio'],
+  },
+} as const satisfies ModelMeta
+
+const SEEDANCE_1_5_PRO = {
+  name: 'seedance-1-5-pro-251215',
+  supports: {
+    input: ['text', 'image'],
+    output: ['video', 'audio'],
+  },
+} as const satisfies ModelMeta
+
+const SEEDANCE_1_0_PRO = {
+  name: 'seedance-1-0-pro-250528',
+  supports: {
+    input: ['text', 'image'],
+    output: ['video'],
+  },
+} as const satisfies ModelMeta
+
+const SEEDANCE_1_0_PRO_FAST = {
+  name: 'seedance-1-0-pro-fast-251015',
+  supports: {
+    input: ['text', 'image'],
+    output: ['video'],
+  },
+} as const satisfies ModelMeta
+
+/**
+ * All supported Seedance video model identifiers.
+ */
+export const BYTEPLUS_VIDEO_MODELS = [
+  DREAMINA_SEEDANCE_2_0.name,
+  DREAMINA_SEEDANCE_2_0_FAST.name,
+  DREAMINA_SEEDANCE_2_0_MINI.name,
+  SEEDANCE_1_5_PRO.name,
+  SEEDANCE_1_0_PRO.name,
+  SEEDANCE_1_0_PRO_FAST.name,
+] as const
+
+/**
+ * Union of all supported Seedance video model names.
+ */
+export type BytePlusVideoModel = (typeof BYTEPLUS_VIDEO_MODELS)[number]
+
+/**
+ * Type-only map from video model name to the non-text prompt modalities it
+ * accepts. The Seedance 2.0 family takes multimodal references (start/end
+ * frames, reference images, reference video and audio); the 1.x models take
+ * start/end frames only.
+ */
+export type BytePlusVideoModelInputModalitiesByName = {
+  [DREAMINA_SEEDANCE_2_0.name]: readonly ['image', 'video', 'audio']
+  [DREAMINA_SEEDANCE_2_0_FAST.name]: readonly ['image', 'video', 'audio']
+  [DREAMINA_SEEDANCE_2_0_MINI.name]: readonly ['image', 'video', 'audio']
+  [SEEDANCE_1_5_PRO.name]: readonly ['image']
+  [SEEDANCE_1_0_PRO.name]: readonly ['image']
+  [SEEDANCE_1_0_PRO_FAST.name]: readonly ['image']
+}
+
+/**
+ * Type-only map from video model name to the resolutions it accepts.
+ */
+export type BytePlusVideoModelResolutionByName = {
+  [DREAMINA_SEEDANCE_2_0.name]: BytePlusVideoResolution
+  [DREAMINA_SEEDANCE_2_0_FAST.name]: '480p' | '720p'
+  [DREAMINA_SEEDANCE_2_0_MINI.name]: '480p' | '720p'
+  [SEEDANCE_1_5_PRO.name]: '480p' | '720p' | '1080p'
+  [SEEDANCE_1_0_PRO.name]: '480p' | '720p' | '1080p'
+  [SEEDANCE_1_0_PRO_FAST.name]: '480p' | '720p'
+}
+
+/**
+ * Type-only map from video model name to its accepted `size` strings.
+ */
+export type BytePlusVideoModelSizeByName = {
+  [K in BytePlusVideoModel]: BytePlusVideoSize<
+    BytePlusVideoModelResolutionByName[K]
+  >
+}
+
+/**
+ * Per-model duration type. Seedance accepts any integer second inside the
+ * model's range, so this is a continuous range expressed as `number` — a
+ * literal union cannot represent it. (The API also accepts `duration: -1` on
+ * Seedance 2.0 and 1.5-pro to let the model choose; that is reachable through
+ * provider options, not through the generic `duration`.)
+ */
+export type BytePlusVideoModelDurationByName = {
+  [K in BytePlusVideoModel]: number
+}
+
+/**
+ * Runtime duration table backing `availableDurations()` / `snapDuration()`.
+ */
+export const BYTEPLUS_VIDEO_DURATIONS: {
+  readonly [TModel in BytePlusVideoModel]: DurationOptions<
+    BytePlusVideoModelDurationByName[TModel]
+  >
+} = {
+  'dreamina-seedance-2-0-260128': {
+    kind: 'range',
+    min: 4,
+    max: 15,
+    step: 1,
+    unit: 'seconds',
+  },
+  'dreamina-seedance-2-0-fast-260128': {
+    kind: 'range',
+    min: 4,
+    max: 15,
+    step: 1,
+    unit: 'seconds',
+  },
+  'dreamina-seedance-2-0-mini-260615': {
+    kind: 'range',
+    min: 4,
+    max: 15,
+    step: 1,
+    unit: 'seconds',
+  },
+  'seedance-1-5-pro-251215': {
+    kind: 'range',
+    min: 4,
+    max: 12,
+    step: 1,
+    unit: 'seconds',
+  },
+  'seedance-1-0-pro-250528': {
+    kind: 'range',
+    min: 2,
+    max: 12,
+    step: 1,
+    unit: 'seconds',
+  },
+  'seedance-1-0-pro-fast-251015': {
+    kind: 'range',
+    min: 2,
+    max: 12,
+    step: 1,
+    unit: 'seconds',
+  },
+}
+
+/**
+ * Look up the duration options for a Seedance video model.
+ */
+export function getBytePlusVideoDurationOptions<
+  TModel extends BytePlusVideoModel,
+>(model: TModel): DurationOptions<BytePlusVideoModelDurationByName[TModel]> {
+  return BYTEPLUS_VIDEO_DURATIONS[model]
+}
+
+// ============================================================================
+// Image models (Seedream)
+// ============================================================================
+
+/**
+ * Shorthand size tokens accepted by `/images/generations`. A request uses
+ * either a token or an explicit `WxH` string — never both.
+ */
+export type BytePlusImageSizeToken = '1K' | '2K' | '4K'
+
+/**
+ * Accepted `size` values for Seedream models: a shorthand token or an
+ * explicit pixel size such as `2048x2048`.
+ */
+export type BytePlusImageSize = BytePlusImageSizeToken | `${number}x${number}`
+
+const DOLA_SEEDREAM_5_0_PRO = {
+  name: 'dola-seedream-5-0-pro-260628',
+  supports: {
+    input: ['text', 'image'],
+    output: ['image'],
+  },
+} as const satisfies ModelMeta
+
+const SEEDREAM_5_0 = {
+  name: 'seedream-5-0-260128',
+  supports: {
+    input: ['text', 'image'],
+    output: ['image'],
+  },
+} as const satisfies ModelMeta
+
+const SEEDREAM_5_0_LITE = {
+  name: 'seedream-5-0-lite-260128',
+  supports: {
+    input: ['text', 'image'],
+    output: ['image'],
+  },
+} as const satisfies ModelMeta
+
+const SEEDREAM_4_5 = {
+  name: 'seedream-4-5-251128',
+  supports: {
+    input: ['text', 'image'],
+    output: ['image'],
+  },
+} as const satisfies ModelMeta
+
+const SEEDREAM_4_0 = {
+  name: 'seedream-4-0-250828',
+  supports: {
+    input: ['text', 'image'],
+    output: ['image'],
+  },
+} as const satisfies ModelMeta
+
+/**
+ * All supported Seedream image model identifiers.
+ */
+export const BYTEPLUS_IMAGE_MODELS = [
+  DOLA_SEEDREAM_5_0_PRO.name,
+  SEEDREAM_5_0.name,
+  SEEDREAM_5_0_LITE.name,
+  SEEDREAM_4_5.name,
+  SEEDREAM_4_0.name,
+] as const
+
+/**
+ * Union of all supported Seedream image model names.
+ */
+export type BytePlusImageModel = (typeof BYTEPLUS_IMAGE_MODELS)[number]
+
+/**
+ * Type-only map from image model name to its accepted `size` strings.
+ */
+export type BytePlusImageModelSizeByName = {
+  [K in BytePlusImageModel]: BytePlusImageSize
+}
+
+/**
+ * Maximum number of reference images accepted per editing request.
+ * Seedream 5.0 Pro caps at 10 references; the other editing-capable models
+ * accept up to 14.
+ */
+export const BYTEPLUS_IMAGE_MAX_REFERENCE_IMAGES: {
+  readonly [K in BytePlusImageModel]: number
+} = {
+  'dola-seedream-5-0-pro-260628': 10,
+  'seedream-5-0-260128': 14,
+  'seedream-5-0-lite-260128': 14,
+  'seedream-4-5-251128': 14,
+  'seedream-4-0-250828': 14,
+}
+
+// ============================================================================
+// Seed Speech models (voice host — separate product and API key)
+// ============================================================================
+
+const SEED_AUDIO_1_0 = {
+  name: 'seed-audio-1.0',
+  supports: {
+    input: ['text', 'audio'],
+    output: ['audio'],
+  },
+} as const satisfies ModelMeta
+
+// Seed Speech ASR is endpoint-addressed: `POST /api/v3/auc/bigmodel/recognize/
+// flash` selects the model through the `X-Api-Resource-Id` header
+// (`volc.seedasr.auc_turbo`) and takes no `model` field in the body. This
+// synthetic identifier satisfies the SDK's `TranscriptionOptions.model`
+// contract and gives logging and fixture matching a stable value.
+const SEED_ASR = {
+  name: 'seed-asr',
+  supports: {
+    input: ['audio'],
+    output: ['text'],
+  },
+} as const satisfies ModelMeta
+
+/**
+ * All supported Seed Speech TTS model identifiers.
+ *
+ * Note: TTS runs on `voice.ap-southeast-1.bytepluses.com` with an
+ * `X-Api-Key` header and a *different* API key from Ark.
+ */
+export const BYTEPLUS_TTS_MODELS = [SEED_AUDIO_1_0.name] as const
+
+/**
+ * All supported Seed Speech transcription model identifiers.
+ */
+export const BYTEPLUS_TRANSCRIPTION_MODELS = [SEED_ASR.name] as const
+
+/**
+ * Union of all supported Seed Speech TTS model names.
+ */
+export type BytePlusTTSModel = (typeof BYTEPLUS_TTS_MODELS)[number]
+
+/**
+ * Union of all supported Seed Speech transcription model names.
+ */
+export type BytePlusTranscriptionModel =
+  (typeof BYTEPLUS_TRANSCRIPTION_MODELS)[number]
+
+// ============================================================================
+// Type resolution helpers
+// ============================================================================
+
+/**
+ * Resolve provider options for a specific model. Models listed in the chat
+ * map get their explicit options; anything else falls back to the base chat
+ * options.
+ */
+export type ResolveProviderOptions<TModel extends string> =
+  TModel extends keyof BytePlusChatModelProviderOptionsByName
+    ? BytePlusChatModelProviderOptionsByName[TModel]
+    : BytePlusTextProviderOptions
+
+/**
+ * Resolve input modalities for a specific model. Models missing from the map
+ * are treated as text-only.
+ */
+export type ResolveInputModalities<TModel extends string> =
+  TModel extends keyof BytePlusModelInputModalitiesByName
+    ? BytePlusModelInputModalitiesByName[TModel]
+    : readonly ['text']

--- a/packages/ai-byteplus/src/text/text-provider-options.ts
+++ b/packages/ai-byteplus/src/text/text-provider-options.ts
@@ -1,15 +1,20 @@
 /**
  * BytePlus ModelArk chat provider options.
  *
- * These are the Ark-only extensions on top of the OpenAI-compatible
- * `/chat/completions` body. Everything else (temperature, top_p, tools,
- * response_format, …) is handled by the shared OpenAI base adapter.
+ * Ark's `/chat/completions` is OpenAI-compatible, so most of this is the
+ * familiar sampling surface; `thinking`, `reasoning_effort`,
+ * `repetition_penalty` and `service_tier` are the Ark-only additions.
  *
- * Verified live against `https://ark.ap-southeast.bytepluses.com/api/v3`
- * (2026-07-31): `thinking: {type: 'enabled'}` returns `reasoning_content` +
- * `encrypted_content` on the assistant message, and OpenAI-shaped
- * `tools[].type: 'function'` is accepted (the docs' `'function_call'` value
- * is rejected with 400 InvalidParameter).
+ * Every field below was accepted by a live request against
+ * `https://ark.ap-southeast.bytepluses.com/api/v3` on 2026-07-31. Two probe
+ * results are encoded as TSDoc warnings rather than types because they are
+ * cross-field constraints TypeScript can't express: `max_tokens` and
+ * `max_completion_tokens` are mutually exclusive, and `reasoning_effort`
+ * combined with `thinking: {type: 'disabled'}` is a 400.
+ *
+ * `response_format` is deliberately absent — the chat activity owns it via
+ * `outputSchema` / structured output, and Ark rejects `json_object` outright
+ * on every model.
  */
 
 /**
@@ -27,6 +32,10 @@ export interface BytePlusThinkingOption {
 /**
  * Reasoning budget hint. `none` and `xhigh` are only accepted by
  * `glm-5-2-260617`; `max` by `glm-5-2-260617` and the `deepseek-v4-*` models.
+ *
+ * Cannot be combined with `thinking: {type: 'disabled'}` — Ark rejects the
+ * pair with `400 InvalidParameter` ("Invalid combination of reasoning_effort
+ * and thinking type").
  */
 export type BytePlusReasoningEffort =
   | 'none'
@@ -44,9 +53,30 @@ export type BytePlusReasoningEffort =
 export type BytePlusServiceTier = 'default' | 'flex'
 
 /**
+ * Forces the model to call one specific function.
+ */
+export interface BytePlusNamedToolChoice {
+  type: 'function'
+  function: { name: string }
+}
+
+/**
+ * Controls which (if any) tool the model calls.
+ */
+export type BytePlusToolChoice =
+  | 'none'
+  | 'auto'
+  | 'required'
+  | BytePlusNamedToolChoice
+
+/**
  * Provider options for BytePlus chat models.
  */
 export interface BytePlusTextProviderOptions {
+  // --------------------------------------------------------------------
+  // Ark-only
+  // --------------------------------------------------------------------
+
   /** Reasoning switch — see {@link BytePlusThinkingOption}. */
   thinking?: BytePlusThinkingOption
 
@@ -60,4 +90,62 @@ export interface BytePlusTextProviderOptions {
 
   /** Request routing tier — see {@link BytePlusServiceTier}. */
   service_tier?: BytePlusServiceTier
+
+  // --------------------------------------------------------------------
+  // OpenAI-compatible sampling surface
+  // --------------------------------------------------------------------
+
+  /** Sampling temperature. Higher values produce more varied output. */
+  temperature?: number
+
+  /** Nucleus sampling cutoff. */
+  top_p?: number
+
+  /** Restricts sampling to the `k` most likely tokens. */
+  top_k?: number
+
+  /**
+   * Maximum tokens to generate. Mutually exclusive with
+   * `max_completion_tokens` — sending both is a 400.
+   */
+  max_tokens?: number
+
+  /**
+   * OpenAI's newer name for {@link BytePlusTextProviderOptions.max_tokens}.
+   * Mutually exclusive with it.
+   */
+  max_completion_tokens?: number
+
+  /** Penalizes tokens by how often they have already appeared. */
+  frequency_penalty?: number
+
+  /** Penalizes tokens that have appeared at all, regardless of count. */
+  presence_penalty?: number
+
+  /** Up to four strings that stop generation when produced. */
+  stop?: string | Array<string>
+
+  /** Number of completions to generate. */
+  n?: number
+
+  /** Best-effort determinism hint for repeated identical requests. */
+  seed?: number
+
+  /** Return log probabilities for the generated tokens. */
+  logprobs?: boolean
+
+  /** How many alternatives to report per token. Requires `logprobs`. */
+  top_logprobs?: number
+
+  /** Additive bias per token id, applied before sampling. */
+  logit_bias?: Record<string, number>
+
+  /** Opaque end-user identifier forwarded for abuse monitoring. */
+  user?: string
+
+  /** Whether the model may emit several tool calls in one turn. */
+  parallel_tool_calls?: boolean
+
+  /** Tool-selection strategy — see {@link BytePlusToolChoice}. */
+  tool_choice?: BytePlusToolChoice
 }

--- a/packages/ai-byteplus/src/text/text-provider-options.ts
+++ b/packages/ai-byteplus/src/text/text-provider-options.ts
@@ -1,0 +1,63 @@
+/**
+ * BytePlus ModelArk chat provider options.
+ *
+ * These are the Ark-only extensions on top of the OpenAI-compatible
+ * `/chat/completions` body. Everything else (temperature, top_p, tools,
+ * response_format, …) is handled by the shared OpenAI base adapter.
+ *
+ * Verified live against `https://ark.ap-southeast.bytepluses.com/api/v3`
+ * (2026-07-31): `thinking: {type: 'enabled'}` returns `reasoning_content` +
+ * `encrypted_content` on the assistant message, and OpenAI-shaped
+ * `tools[].type: 'function'` is accepted (the docs' `'function_call'` value
+ * is rejected with 400 InvalidParameter).
+ */
+
+/**
+ * Reasoning ("deep thinking") switch.
+ *
+ * - `enabled` — the model reasons before answering (default on every model
+ *   except `deepseek-v3-2-251201`, where reasoning defaults to off).
+ * - `disabled` — skip reasoning.
+ * - `auto` — let the model decide. Only accepted by `gpt-oss-120b-250805`.
+ */
+export interface BytePlusThinkingOption {
+  type: 'enabled' | 'disabled' | 'auto'
+}
+
+/**
+ * Reasoning budget hint. `none` and `xhigh` are only accepted by
+ * `glm-5-2-260617`; `max` by `glm-5-2-260617` and the `deepseek-v4-*` models.
+ */
+export type BytePlusReasoningEffort =
+  | 'none'
+  | 'minimal'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh'
+  | 'max'
+
+/**
+ * Request routing tier. `flex` routes to the batch queue at a lower price with
+ * no latency guarantee; `default` is the standard online tier.
+ */
+export type BytePlusServiceTier = 'default' | 'flex'
+
+/**
+ * Provider options for BytePlus chat models.
+ */
+export interface BytePlusTextProviderOptions {
+  /** Reasoning switch — see {@link BytePlusThinkingOption}. */
+  thinking?: BytePlusThinkingOption
+
+  /** Reasoning budget hint — see {@link BytePlusReasoningEffort}. */
+  reasoning_effort?: BytePlusReasoningEffort
+
+  /**
+   * Penalty applied to repeated tokens. Values above 1 discourage repetition.
+   */
+  repetition_penalty?: number
+
+  /** Request routing tier — see {@link BytePlusServiceTier}. */
+  service_tier?: BytePlusServiceTier
+}

--- a/packages/ai-byteplus/src/utils/client.ts
+++ b/packages/ai-byteplus/src/utils/client.ts
@@ -108,28 +108,82 @@ export function getBytePlusVoiceApiKeyFromEnv(): string {
 
 /**
  * Returns an Ark client config with the default Ark base URL applied when not
- * already set.
+ * already set, and any trailing slashes trimmed so path joins stay
+ * single-slashed.
+ *
+ * The returned `baseURL` is always a string: adapters that build request paths
+ * by interpolation can use it directly without re-applying a default (which
+ * would otherwise risk interpolating `undefined` into a URL). The config's own
+ * type is preserved, so adapter-specific config fields survive the call.
  */
-export function withBytePlusArkDefaults(
-  config: BytePlusArkConfig,
-): BytePlusArkConfig {
+export function withBytePlusArkDefaults<TConfig extends BytePlusArkConfig>(
+  config: TConfig,
+): Omit<TConfig, 'baseURL'> & { baseURL: string } {
   return {
     ...config,
-    baseURL: config.baseURL || BYTEPLUS_ARK_BASE_URL,
+    baseURL: (config.baseURL || BYTEPLUS_ARK_BASE_URL).replace(/\/+$/, ''),
   }
 }
 
 /**
  * Returns a Seed Speech config with the default voice base URL applied (and
  * any trailing slashes trimmed) when not already set.
+ *
+ * As with {@link withBytePlusArkDefaults}, the returned `baseURL` is always a
+ * string, so adapters can interpolate it without re-applying a fallback, and
+ * the config's own type is preserved.
  */
-export function withBytePlusVoiceDefaults(
-  config: BytePlusVoiceConfig,
-): BytePlusVoiceConfig {
+export function withBytePlusVoiceDefaults<TConfig extends BytePlusVoiceConfig>(
+  config: TConfig,
+): Omit<TConfig, 'baseURL'> & { baseURL: string } {
   return {
     ...config,
     baseURL: (config.baseURL || BYTEPLUS_VOICE_BASE_URL).replace(/\/+$/, ''),
   }
+}
+
+/**
+ * Normalizes the OpenAI-shaped `defaultHeaders` config field (which accepts a
+ * `Headers` instance, an entry list, or a record with nullable values) into
+ * the plain record the header builders below take. Non-string values are
+ * dropped rather than serialized.
+ *
+ * Shared by every fetch-based adapter (image, video, speech): they all read
+ * `defaultHeaders` off a config typed by the OpenAI SDK but issue plain JSON
+ * requests.
+ */
+export function toHeaderRecord(
+  headers: BytePlusArkConfig['defaultHeaders'],
+): Record<string, string> {
+  const record: Record<string, string> = {}
+  if (!headers) return record
+
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      record[key] = value
+    })
+    return record
+  }
+
+  // The entry-list form is typed as arrays of nullable values rather than
+  // strict [name, value] tuples, so both halves are checked.
+  if (Array.isArray(headers)) {
+    for (const [key, value] of headers) {
+      if (typeof key === 'string' && typeof value === 'string') {
+        record[key] = value
+      }
+    }
+    return record
+  }
+
+  // Record form. A value may be null/undefined (openai's "unset this header"
+  // signal) or an array for a repeated header; neither maps onto a single
+  // string, so both are dropped.
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'string') record[key] = value
+  }
+
+  return record
 }
 
 /**
@@ -140,9 +194,13 @@ export function bytePlusArkHeaders(
   extraHeaders?: Record<string, string>,
 ): Record<string, string> {
   return {
+    // `extraHeaders` first so the Authorization / Content-Type below always
+    // win — otherwise a caller-supplied `Authorization` in `defaultHeaders`
+    // could silently clobber the bearer token and turn every request into a
+    // 401 that looks like a bad key.
+    ...extraHeaders,
     'Content-Type': 'application/json',
     Authorization: `Bearer ${apiKey}`,
-    ...extraHeaders,
   }
 }
 
@@ -154,9 +212,32 @@ export function bytePlusVoiceHeaders(
   extraHeaders?: Record<string, string>,
 ): Record<string, string> {
   return {
+    // `extraHeaders` first so the X-Api-Key / Content-Type below always win —
+    // see {@link bytePlusArkHeaders}. Seed Speech answers a clobbered key with
+    // `45000010 Invalid X-Api-Key`, which reads as a misconfigured key rather
+    // than a header collision.
+    ...extraHeaders,
     'Content-Type': 'application/json',
     'X-Api-Key': apiKey,
-    ...extraHeaders,
+  }
+}
+
+/**
+ * Reads a response body as JSON, tolerating the non-JSON failures both
+ * BytePlus hosts can return (an empty body, or an HTML error page from a proxy
+ * in front of the API).
+ *
+ * Returns the parsed value, the raw text when it is not JSON, or `undefined`
+ * for an empty body — all three of which {@link bytePlusArkError} and
+ * {@link bytePlusVoiceError} know how to render.
+ */
+export async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text) return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
   }
 }
 

--- a/packages/ai-byteplus/src/utils/client.ts
+++ b/packages/ai-byteplus/src/utils/client.ts
@@ -17,8 +17,10 @@ import type { ClientOptions } from 'openai'
 /**
  * Default Ark data-plane base URL (Asia-Pacific south-east).
  *
- * The EU endpoint (`https://ark.eu-west.bytepluses.com/api/v3`) serves chat
- * and image only — Seedance video is not available there.
+ * Per the BytePlus docs the EU endpoint
+ * (`https://ark.eu-west.bytepluses.com/api/v3`) serves chat and image only —
+ * Seedance video is not available there. Docs-derived: only the ap-southeast
+ * host was exercised live.
  */
 export const BYTEPLUS_ARK_BASE_URL =
   'https://ark.ap-southeast.bytepluses.com/api/v3'
@@ -68,16 +70,21 @@ export interface BytePlusVoiceConfig {
 }
 
 /**
- * Gets the BytePlus Ark API key from environment variables.
- * @throws Error if ARK_API_KEY is not found
+ * Gets the BytePlus Ark API key from environment variables, preferring
+ * `ARK_API_KEY` and falling back to `BYTEPLUS_API_KEY`.
+ * @throws Error if neither variable is set
  */
 export function getBytePlusArkApiKeyFromEnv(): string {
   try {
     return getApiKeyFromEnv('ARK_API_KEY')
   } catch {
-    throw new Error(
-      'ARK_API_KEY is required. Please set it in your environment variables or use the factory function with an explicit API key.',
-    )
+    try {
+      return getApiKeyFromEnv('BYTEPLUS_API_KEY')
+    } catch {
+      throw new Error(
+        'ARK_API_KEY or BYTEPLUS_API_KEY is required. Please set one of these environment variables or use the factory function with an explicit API key.',
+      )
+    }
   }
 }
 
@@ -153,6 +160,22 @@ export function bytePlusVoiceHeaders(
   }
 }
 
+/**
+ * Best-effort human-readable rendering of a response body we could not pull a
+ * `message` out of — a raw string passes through, any other object is
+ * serialized so the detail reaches the error instead of being dropped.
+ */
+function describeBody(body: unknown): string | undefined {
+  if (typeof body === 'string') return body || undefined
+  if (typeof body !== 'object' || body === null) return undefined
+  try {
+    return JSON.stringify(body)
+  } catch {
+    // Circular or otherwise unserializable — the status code stands alone.
+    return undefined
+  }
+}
+
 function readStringField(value: unknown, field: string): string | undefined {
   if (typeof value !== 'object' || value === null || !(field in value)) {
     return undefined
@@ -183,7 +206,7 @@ export function bytePlusArkError(
       : undefined
   const code = readStringField(error, 'code')
   const message = readStringField(error, 'message')
-  const detail = message ?? (typeof body === 'string' ? body : undefined)
+  const detail = message ?? describeBody(body)
   return new Error(
     `${prefix} failed (${status}${code ? ` ${code}` : ''})${
       detail ? `: ${detail}` : ''
@@ -207,7 +230,7 @@ export function bytePlusVoiceError(
     : 'BytePlus Seed Speech request'
   const code = readStringField(body, 'code')
   const message = readStringField(body, 'message')
-  const detail = message ?? (typeof body === 'string' ? body : undefined)
+  const detail = message ?? describeBody(body)
   return new Error(
     `${prefix} failed (${status}${code ? ` ${code}` : ''})${
       detail ? `: ${detail}` : ''

--- a/packages/ai-byteplus/src/utils/client.ts
+++ b/packages/ai-byteplus/src/utils/client.ts
@@ -1,0 +1,216 @@
+import { getApiKeyFromEnv } from '@tanstack/ai-utils'
+import type { ClientOptions } from 'openai'
+
+/**
+ * BytePlus splits its APIs across two hosts with two different products,
+ * two different auth headers, and two different API keys:
+ *
+ * - **Ark (ModelArk)** — chat, video (Seedance) and image (Seedream).
+ *   `Authorization: Bearer $ARK_API_KEY`.
+ * - **Seed Speech** — TTS and ASR on the voice host.
+ *   `X-Api-Key: $BYTEPLUS_VOICE_API_KEY`.
+ *
+ * Ark keys are region-isolated: a key issued for `ap-southeast` does not work
+ * against the EU host and vice versa.
+ */
+
+/**
+ * Default Ark data-plane base URL (Asia-Pacific south-east).
+ *
+ * The EU endpoint (`https://ark.eu-west.bytepluses.com/api/v3`) serves chat
+ * and image only — Seedance video is not available there.
+ */
+export const BYTEPLUS_ARK_BASE_URL =
+  'https://ark.ap-southeast.bytepluses.com/api/v3'
+
+/**
+ * Default Seed Speech base URL. Endpoint paths are appended under
+ * `/api/v3` (e.g. `/api/v3/tts/create`).
+ */
+export const BYTEPLUS_VOICE_BASE_URL =
+  'https://voice.ap-southeast-1.bytepluses.com'
+
+/**
+ * Configuration for the Ark-hosted adapters (chat, video, image).
+ *
+ * Extends the OpenAI SDK's client options because the chat adapter drives the
+ * OpenAI-compatible `/chat/completions` endpoint through the shared
+ * `@tanstack/openai-base` adapter. `fetch` and `defaultHeaders` are inherited
+ * from `ClientOptions`, and the video/image adapters — which issue plain JSON
+ * requests rather than SDK calls — honour the same two fields so tests can
+ * inject a fetch instead of patching the global one.
+ */
+export interface BytePlusArkConfig extends Omit<ClientOptions, 'apiKey'> {
+  apiKey: string
+}
+
+/**
+ * Configuration for the Seed Speech adapters (TTS, ASR).
+ *
+ * Seed Speech is not OpenAI-compatible, so this is a minimal config for
+ * direct `fetch` calls rather than an OpenAI `ClientOptions` extension.
+ */
+export interface BytePlusVoiceConfig {
+  /** Seed Speech API key — *not* the Ark key. Sent as `X-Api-Key`. */
+  apiKey: string
+
+  /** Overrides {@link BYTEPLUS_VOICE_BASE_URL}. */
+  baseURL?: string
+
+  /** Additional headers merged into every request (e.g., test ids). */
+  defaultHeaders?: Record<string, string>
+
+  /**
+   * Override the underlying fetch. Defaults to the global `fetch`. Useful for
+   * proxying, instrumentation, or pointing requests at a mock in tests.
+   */
+  fetch?: typeof fetch
+}
+
+/**
+ * Gets the BytePlus Ark API key from environment variables.
+ * @throws Error if ARK_API_KEY is not found
+ */
+export function getBytePlusArkApiKeyFromEnv(): string {
+  try {
+    return getApiKeyFromEnv('ARK_API_KEY')
+  } catch {
+    throw new Error(
+      'ARK_API_KEY is required. Please set it in your environment variables or use the factory function with an explicit API key.',
+    )
+  }
+}
+
+/**
+ * Gets the Seed Speech API key from environment variables.
+ *
+ * Seed Speech is a separate BytePlus product from Ark with its own key — an
+ * Ark key sent as `X-Api-Key` is rejected with `45000010 Invalid X-Api-Key`.
+ *
+ * @throws Error if BYTEPLUS_VOICE_API_KEY is not found
+ */
+export function getBytePlusVoiceApiKeyFromEnv(): string {
+  try {
+    return getApiKeyFromEnv('BYTEPLUS_VOICE_API_KEY')
+  } catch {
+    throw new Error(
+      'BYTEPLUS_VOICE_API_KEY is required for Seed Speech (TTS/ASR). This is a different key from ARK_API_KEY. Please set it in your environment variables or use the factory function with an explicit API key.',
+    )
+  }
+}
+
+/**
+ * Returns an Ark client config with the default Ark base URL applied when not
+ * already set.
+ */
+export function withBytePlusArkDefaults(
+  config: BytePlusArkConfig,
+): BytePlusArkConfig {
+  return {
+    ...config,
+    baseURL: config.baseURL || BYTEPLUS_ARK_BASE_URL,
+  }
+}
+
+/**
+ * Returns a Seed Speech config with the default voice base URL applied (and
+ * any trailing slashes trimmed) when not already set.
+ */
+export function withBytePlusVoiceDefaults(
+  config: BytePlusVoiceConfig,
+): BytePlusVoiceConfig {
+  return {
+    ...config,
+    baseURL: (config.baseURL || BYTEPLUS_VOICE_BASE_URL).replace(/\/+$/, ''),
+  }
+}
+
+/**
+ * Headers for a JSON request against the Ark data plane.
+ */
+export function bytePlusArkHeaders(
+  apiKey: string,
+  extraHeaders?: Record<string, string>,
+): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${apiKey}`,
+    ...extraHeaders,
+  }
+}
+
+/**
+ * Headers for a JSON request against the Seed Speech host.
+ */
+export function bytePlusVoiceHeaders(
+  apiKey: string,
+  extraHeaders?: Record<string, string>,
+): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    'X-Api-Key': apiKey,
+    ...extraHeaders,
+  }
+}
+
+function readStringField(value: unknown, field: string): string | undefined {
+  if (typeof value !== 'object' || value === null || !(field in value)) {
+    return undefined
+  }
+  const candidate = Reflect.get(value, field)
+  if (typeof candidate === 'string') return candidate
+  if (typeof candidate === 'number') return String(candidate)
+  return undefined
+}
+
+/**
+ * Formats an Ark error response into an `Error`.
+ *
+ * Ark uses the OpenAI error envelope with dotted string codes:
+ * `{"error": {"code": "InvalidEndpointOrModel.NotFound", "message": "…"}}`.
+ * Bodies that don't match (HTML error pages, proxy responses) fall back to
+ * the raw text so the failure stays diagnosable.
+ */
+export function bytePlusArkError(
+  status: number,
+  body: unknown,
+  context?: string,
+): Error {
+  const prefix = context ? `BytePlus Ark ${context}` : 'BytePlus Ark request'
+  const error =
+    typeof body === 'object' && body !== null && 'error' in body
+      ? Reflect.get(body, 'error')
+      : undefined
+  const code = readStringField(error, 'code')
+  const message = readStringField(error, 'message')
+  const detail = message ?? (typeof body === 'string' ? body : undefined)
+  return new Error(
+    `${prefix} failed (${status}${code ? ` ${code}` : ''})${
+      detail ? `: ${detail}` : ''
+    }`,
+  )
+}
+
+/**
+ * Formats a Seed Speech error response into an `Error`.
+ *
+ * Seed Speech does not use the Ark envelope — it returns a flat numeric code:
+ * `{"code": 45000010, "message": "Invalid X-Api-Key"}`.
+ */
+export function bytePlusVoiceError(
+  status: number,
+  body: unknown,
+  context?: string,
+): Error {
+  const prefix = context
+    ? `BytePlus Seed Speech ${context}`
+    : 'BytePlus Seed Speech request'
+  const code = readStringField(body, 'code')
+  const message = readStringField(body, 'message')
+  const detail = message ?? (typeof body === 'string' ? body : undefined)
+  return new Error(
+    `${prefix} failed (${status}${code ? ` ${code}` : ''})${
+      detail ? `: ${detail}` : ''
+    }`,
+  )
+}

--- a/packages/ai-byteplus/src/utils/client.ts
+++ b/packages/ai-byteplus/src/utils/client.ts
@@ -41,6 +41,14 @@ export const BYTEPLUS_VOICE_BASE_URL =
  * from `ClientOptions`, and the video/image adapters — which issue plain JSON
  * requests rather than SDK calls — honour the same two fields so tests can
  * inject a fetch instead of patching the global one.
+ *
+ * Two inherited fields differ in reach, because the fetch-based adapters have
+ * no SDK to delegate to:
+ * - `timeout` is honoured everywhere — the fetch-based adapters convert it to
+ *   an `AbortSignal` (see {@link bytePlusTimeoutSignal}).
+ * - `maxRetries` applies to the **chat adapter only**. The video, image and
+ *   speech adapters do not retry; video polling is driven by core's loop,
+ *   which owns its own retry policy.
  */
 export interface BytePlusArkConfig extends Omit<ClientOptions, 'apiKey'> {
   apiKey: string
@@ -187,39 +195,84 @@ export function toHeaderRecord(
 }
 
 /**
+ * Drops any caller-supplied header whose name case-insensitively collides with
+ * one the adapter sets itself, then applies the adapter's own.
+ *
+ * Spreading `reserved` last is not enough on its own: HTTP header names are
+ * case-insensitive, but plain object keys are not, so `authorization` and
+ * `Authorization` are two distinct properties that both survive the spread.
+ * `fetch` then feeds the object to the `Headers` constructor, which *appends*
+ * rather than replaces — turning the pair into
+ * `authorization: "Bearer wrong, Bearer right"` and 401ing every request with
+ * what reads like a bad key. `toHeaderRecord` lowercases names whenever
+ * `defaultHeaders` arrives as a `Headers` instance, so that collision is
+ * reachable through ordinary config, not just a hand-built record.
+ */
+function applyReservedHeaders(
+  extraHeaders: Record<string, string> | undefined,
+  reserved: Record<string, string>,
+): Record<string, string> {
+  const blocked = new Set(Object.keys(reserved).map((key) => key.toLowerCase()))
+  const merged: Record<string, string> = {}
+  for (const [key, value] of Object.entries(extraHeaders ?? {})) {
+    if (!blocked.has(key.toLowerCase())) merged[key] = value
+  }
+  return { ...merged, ...reserved }
+}
+
+/**
+ * Turns the OpenAI-shaped `timeout` config field (milliseconds) into the
+ * `signal` a plain `fetch` needs, or `undefined` when no timeout is set.
+ *
+ * `BytePlusArkConfig` extends the OpenAI SDK's `ClientOptions` because the
+ * chat adapter drives the SDK, which honours `timeout` and `maxRetries`
+ * itself. The video, image and speech adapters issue plain JSON requests, so
+ * without this they would accept a `timeout` and ignore it — a stalled Ark
+ * connection hanging the caller forever despite an explicit setting.
+ *
+ * `maxRetries` has no equivalent here and stays SDK-path-only; it is
+ * documented as such on {@link BytePlusArkConfig}.
+ */
+export function bytePlusTimeoutSignal(
+  timeout: number | undefined,
+): AbortSignal | undefined {
+  return typeof timeout === 'number' && timeout > 0
+    ? AbortSignal.timeout(timeout)
+    : undefined
+}
+
+/**
  * Headers for a JSON request against the Ark data plane.
+ *
+ * A caller-supplied `Authorization` or `Content-Type` in `defaultHeaders` is
+ * dropped in any casing — see {@link applyReservedHeaders}.
  */
 export function bytePlusArkHeaders(
   apiKey: string,
   extraHeaders?: Record<string, string>,
 ): Record<string, string> {
-  return {
-    // `extraHeaders` first so the Authorization / Content-Type below always
-    // win — otherwise a caller-supplied `Authorization` in `defaultHeaders`
-    // could silently clobber the bearer token and turn every request into a
-    // 401 that looks like a bad key.
-    ...extraHeaders,
+  return applyReservedHeaders(extraHeaders, {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${apiKey}`,
-  }
+  })
 }
 
 /**
  * Headers for a JSON request against the Seed Speech host.
+ *
+ * As with {@link bytePlusArkHeaders}, a caller-supplied `X-Api-Key` is dropped
+ * in any casing. Seed Speech answers a clobbered key with
+ * `45000010 Invalid X-Api-Key`, which reads as a misconfigured key rather than
+ * a header collision.
  */
 export function bytePlusVoiceHeaders(
   apiKey: string,
   extraHeaders?: Record<string, string>,
 ): Record<string, string> {
-  return {
-    // `extraHeaders` first so the X-Api-Key / Content-Type below always win —
-    // see {@link bytePlusArkHeaders}. Seed Speech answers a clobbered key with
-    // `45000010 Invalid X-Api-Key`, which reads as a misconfigured key rather
-    // than a header collision.
-    ...extraHeaders,
+  return applyReservedHeaders(extraHeaders, {
     'Content-Type': 'application/json',
     'X-Api-Key': apiKey,
-  }
+  })
 }
 
 /**
@@ -245,8 +298,12 @@ export async function readJsonBody(response: Response): Promise<unknown> {
  * Best-effort human-readable rendering of a response body we could not pull a
  * `message` out of — a raw string passes through, any other object is
  * serialized so the detail reaches the error instead of being dropped.
+ *
+ * Exported for adapters that need to attach a body to an error they raise
+ * themselves rather than one derived from a non-OK response — e.g. the image
+ * adapter reporting a 200 whose `data[]` items match no known shape.
  */
-function describeBody(body: unknown): string | undefined {
+export function describeBody(body: unknown): string | undefined {
   if (typeof body === 'string') return body || undefined
   if (typeof body !== 'object' || body === null) return undefined
   try {

--- a/packages/ai-byteplus/src/video/video-provider-options.ts
+++ b/packages/ai-byteplus/src/video/video-provider-options.ts
@@ -30,8 +30,10 @@
  * @experimental Video generation is an experimental feature and may change.
  */
 
+import { isKnownBytePlusVideoModel } from '../model-meta'
 import type {
   BytePlusVideoModel,
+  BytePlusVideoModelOrString,
   BytePlusVideoRatio,
   BytePlusVideoResolution,
 } from '../model-meta'
@@ -248,8 +250,10 @@ const BYTEPLUS_VIDEO_LAST_FRAME_MODELS: ReadonlySet<string> = new Set([
 ])
 
 /**
- * True when the model supports reference-media mode (reference images, video
- * and audio).
+ * True when the model is *known* to support reference-media mode (reference
+ * images, video and audio). An id this package has no metadata for answers
+ * `false`; callers must decide whether that means "no" or "unknown" — the
+ * adapter treats it as unknown and lets Ark rule.
  *
  * @experimental Video generation is an experimental feature and may change.
  */
@@ -258,7 +262,8 @@ export function supportsReferenceMedia(model: string): boolean {
 }
 
 /**
- * True when the model supports pinning the video's closing frame.
+ * True when the model is *known* to support pinning the video's closing
+ * frame. Same unknown-id caveat as {@link supportsReferenceMedia}.
  *
  * @experimental Video generation is an experimental feature and may change.
  */
@@ -295,19 +300,23 @@ export function parseBytePlusVideoSize(
  * Validates a resolution against a model's tiers, returning it lowercased.
  *
  * Used for both halves of the request: the resolution parsed out of the
- * generic `size`, and a `modelOptions.resolution` that overrides it.
+ * generic `size`, and a `modelOptions.resolution` that overrides it. A model
+ * this package has no table for is normalized but not checked — see
+ * {@link BytePlusVideoModelOrString}.
  *
- * @throws Error when the model does not offer the tier.
+ * @throws Error when a known model does not offer the tier.
  *
  * @experimental Video generation is an experimental feature and may change.
  */
 export function resolveBytePlusVideoResolution(
-  model: BytePlusVideoModel,
+  model: BytePlusVideoModelOrString,
   resolution: string,
-): BytePlusVideoResolution {
-  const normalized = resolution.toLowerCase() as BytePlusVideoResolution
+): string {
+  const normalized = resolution.toLowerCase()
+  if (!isKnownBytePlusVideoModel(model)) return normalized
+
   const allowed = BYTEPLUS_VIDEO_RESOLUTIONS[model]
-  if (!allowed.includes(normalized)) {
+  if (!allowed.includes(normalized as BytePlusVideoResolution)) {
     throw new Error(
       `byteplus: resolution "${resolution}" is not supported by model ` +
         `"${model}". Supported resolutions: ${allowed.join(', ')}.`,
@@ -320,17 +329,22 @@ export function resolveBytePlusVideoResolution(
  * Validates a `size` template against a model and returns the request fields
  * it maps onto, with the resolution lowercased.
  *
- * @throws Error when the template is malformed, the ratio is unknown, or the
- * resolution is not offered by this model.
+ * For an unknown model only the template's *shape* is checked — enough to
+ * split it into `ratio` and `resolution` — because a future model may bring
+ * ratios and tiers that do not exist today. Ark validates the values.
+ *
+ * @throws Error when the template is malformed, or (known models only) the
+ * ratio is unknown or the resolution is not offered by this model.
  *
  * @experimental Video generation is an experimental feature and may change.
  */
 export function resolveBytePlusVideoSize(
-  model: BytePlusVideoModel,
+  model: BytePlusVideoModelOrString,
   size: string,
-): { ratio: string; resolution?: BytePlusVideoResolution } {
+): { ratio: string; resolution?: string } {
   const parsed = parseBytePlusVideoSize(size)
-  if (!parsed || !BYTEPLUS_VIDEO_RATIOS.includes(parsed.ratio)) {
+  const known = isKnownBytePlusVideoModel(model)
+  if (!parsed || (known && !BYTEPLUS_VIDEO_RATIOS.includes(parsed.ratio))) {
     throw new Error(
       `byteplus: size "${size}" is not supported by model "${model}". Expected ` +
         `"ratio" or "ratio_resolution" (e.g. "16:9_720p") with ratio one of: ` +

--- a/packages/ai-byteplus/src/video/video-provider-options.ts
+++ b/packages/ai-byteplus/src/video/video-provider-options.ts
@@ -1,0 +1,311 @@
+/**
+ * Provider options and per-model capability tables for the BytePlus Seedance
+ * video models.
+ *
+ * Every applicability claim below was probed live against
+ * `https://ark.ap-southeast.bytepluses.com/api/v3` on 2026-07-31. The probe
+ * sent an out-of-range `seed` alongside the field under test, so requests that
+ * passed validation still failed before a task was created (nothing billed):
+ * an error naming the field under test means "rejected", an error naming
+ * `seed` means "accepted". Ark reports only one arbitrary invalid parameter
+ * per request, so each cell was retried until a verdict repeated.
+ *
+ * Ark rejects an inapplicable field outright — "the specified parameter
+ * `draft` is not supported for model seedance-1-0-pro in t2v, must be empty" —
+ * so these tables are not cosmetic: sending a field to the wrong model is a
+ * 400, not a no-op.
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ */
+
+import type {
+  BytePlusVideoModel,
+  BytePlusVideoRatio,
+  BytePlusVideoResolution,
+} from '../model-meta'
+
+/**
+ * Inference queue for the request.
+ *
+ * - `default` — online inference: lower RPM and concurrency quotas, lowest
+ *   latency.
+ * - `flex` — offline batch inference: higher daily token quotas at half the
+ *   price, with no latency guarantee. Task ids come back with a `cgt-batch-`
+ *   prefix (live-verified).
+ *
+ * Only the Seedance 1.x models accept this field. The Seedance 2.0 family
+ * rejects it ("service_tier is not supported … must be empty").
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export type BytePlusVideoServiceTier = 'default' | 'flex'
+
+/**
+ * Provider-specific options for Seedance video generation. These map one-to-one
+ * onto the create-task request body and take precedence over the values the
+ * adapter derives from the generic `size` / `duration` options.
+ *
+ * Fields are model-dependent; each one documents where it applies. Passing a
+ * field to a model that does not accept it is a 400 from Ark, not a silent
+ * ignore.
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export interface BytePlusVideoProviderOptions {
+  /**
+   * Output aspect ratio. Overrides the ratio half of the generic `size`.
+   *
+   * `adaptive` (follow the input frame) is the default on Seedance 2.0 and
+   * 1.5-pro but is rejected by Seedance 1.0-pro / 1.0-pro-fast for
+   * text-to-video.
+   */
+  ratio?: BytePlusVideoRatio
+
+  /**
+   * Output resolution tier. Overrides the resolution half of the generic
+   * `size`. Matched case-insensitively by the API; this package uses
+   * lowercase throughout. `4k` exists only on `dreamina-seedance-2-0-260128`,
+   * and there is no 2K tier on any model.
+   */
+  resolution?: BytePlusVideoResolution
+
+  /**
+   * Whole seconds of output. Overrides the generic `duration`, and unlike it
+   * is sent verbatim rather than snapped into the model's range.
+   *
+   * `-1` asks the model to choose its own length; accepted by Seedance 2.0
+   * and 1.5-pro only.
+   */
+  duration?: number
+
+  /**
+   * Frame count instead of `duration`, for fractional-second output. Takes
+   * precedence over `duration` server-side. Valid values are the integers of
+   * the form `25 + 4n` within `[29, 289]`, at 24 fps.
+   *
+   * Seedance 1.0-pro and 1.0-pro-fast only.
+   */
+  frames?: number
+
+  /**
+   * Randomness seed, an integer in `[-1, 2^32-1]`. `-1` (the default) leaves
+   * generation unseeded. Accepted by every Seedance model.
+   */
+  seed?: number
+
+  /**
+   * Appends a "fix the camera" instruction to the prompt. Best-effort — the
+   * model is not constrained to obey it.
+   *
+   * Seedance 1.5-pro, 1.0-pro and 1.0-pro-fast only; the 2.0 family rejects
+   * it.
+   */
+  camera_fixed?: boolean
+
+  /** Burn a watermark into the output. Defaults to `false`. */
+  watermark?: boolean
+
+  /**
+   * Generate an audio track synchronized with the visuals — dialogue, effects
+   * and score inferred from the prompt. Quote dialogue in the prompt for
+   * better results.
+   *
+   * Accepted by every model at the API's validation layer, but only Seedance
+   * 2.0 and 1.5-pro actually produce audio.
+   */
+  generate_audio?: boolean
+
+  /**
+   * Inference queue. Seedance 1.x only — the 2.0 family has no offline tier.
+   */
+  service_tier?: BytePlusVideoServiceTier
+
+  /**
+   * Also return the video's final frame as a watermark-free PNG, readable from
+   * the finished task as `content.last_frame_url`. Chain it into the next
+   * task's first frame to extend a shot. Accepted by every model.
+   */
+  return_last_frame?: boolean
+
+  /**
+   * Render a cheap, low-fidelity preview to sanity-check staging and camera
+   * work before paying for the real thing.
+   *
+   * Seedance 1.5-pro only.
+   */
+  draft?: boolean
+
+  /**
+   * Queue priority, `[0, 9]`. Seedance 2.0 family only — 1.5-pro rejects it,
+   * and the 1.0 models accept it without acting on it.
+   */
+  priority?: number
+
+  /**
+   * Seconds after `created_at` at which an unfinished task is abandoned and
+   * marked `expired`. Documented range `[3600, 259200]`, default 172800
+   * (48 hours). The floor is enforced on Seedance 1.x but not on the 2.0
+   * family.
+   */
+  execution_expires_after?: number
+
+  /**
+   * URL that receives a POST with the full task payload on every status
+   * change. BytePlus retries a failed delivery three times.
+   */
+  callback_url?: string
+
+  /**
+   * Stable opaque identifier for the end user driving the request, for abuse
+   * attribution. Max 64 characters — hash the real identifier rather than
+   * sending it.
+   */
+  safety_identifier?: string
+}
+
+/**
+ * Type-only map from video model name to its provider options. Seedance takes
+ * the same option surface across models; applicability is per-field and
+ * documented on {@link BytePlusVideoProviderOptions}.
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export type BytePlusVideoModelProviderOptionsByName = {
+  [K in BytePlusVideoModel]: BytePlusVideoProviderOptions
+}
+
+/**
+ * Aspect ratios accepted by the create endpoint.
+ *
+ * `adaptive` is rejected by Seedance 1.0-pro / 1.0-pro-fast for text-to-video
+ * but is the documented default for their image-to-video path, so it is not
+ * filtered per model here.
+ */
+const BYTEPLUS_VIDEO_RATIOS: ReadonlyArray<string> = [
+  '16:9',
+  '9:16',
+  '4:3',
+  '3:4',
+  '1:1',
+  '21:9',
+  'adaptive',
+]
+
+/**
+ * Resolutions each model accepts, live-probed.
+ *
+ * Two findings here contradict the BytePlus prose docs and are worth calling
+ * out: there is no 2K tier on any Seedance model (`2k`/`2K` is rejected
+ * everywhere, including on the 2.0 flagship whose docs advertise "up to 4K"),
+ * and `seedance-1-0-pro-fast-251015` does accept `1080p` despite being
+ * documented as 480p/720p only.
+ */
+const BYTEPLUS_VIDEO_RESOLUTIONS: {
+  readonly [K in BytePlusVideoModel]: ReadonlyArray<BytePlusVideoResolution>
+} = {
+  'dreamina-seedance-2-0-260128': ['480p', '720p', '1080p', '4k'],
+  'dreamina-seedance-2-0-fast-260128': ['480p', '720p'],
+  'dreamina-seedance-2-0-mini-260615': ['480p', '720p'],
+  'seedance-1-5-pro-251215': ['480p', '720p', '1080p'],
+  'seedance-1-0-pro-250528': ['480p', '720p', '1080p'],
+  'seedance-1-0-pro-fast-251015': ['480p', '720p', '1080p'],
+}
+
+/**
+ * Models accepting reference-media mode (`r2v`): reference images, video and
+ * audio that the output draws on without pinning specific frames. The 1.x
+ * models reject it with "the specified task_type r2v does not support model …".
+ */
+const BYTEPLUS_VIDEO_REFERENCE_MEDIA_MODELS: ReadonlySet<string> = new Set([
+  'dreamina-seedance-2-0-260128',
+  'dreamina-seedance-2-0-fast-260128',
+  'dreamina-seedance-2-0-mini-260615',
+])
+
+/**
+ * Models accepting a closing frame (`flf2v`, first-and-last-frame mode).
+ * `seedance-1-0-pro-fast-251015` is the one Seedance model without it — it
+ * does text-to-video and single-first-frame image-to-video only.
+ */
+const BYTEPLUS_VIDEO_LAST_FRAME_MODELS: ReadonlySet<string> = new Set([
+  'dreamina-seedance-2-0-260128',
+  'dreamina-seedance-2-0-fast-260128',
+  'dreamina-seedance-2-0-mini-260615',
+  'seedance-1-5-pro-251215',
+  'seedance-1-0-pro-250528',
+])
+
+/**
+ * True when the model supports reference-media mode (reference images, video
+ * and audio).
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export function supportsReferenceMedia(model: string): boolean {
+  return BYTEPLUS_VIDEO_REFERENCE_MEDIA_MODELS.has(model)
+}
+
+/**
+ * True when the model supports pinning the video's closing frame.
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export function supportsLastFrame(model: string): boolean {
+  return BYTEPLUS_VIDEO_LAST_FRAME_MODELS.has(model)
+}
+
+/**
+ * Splits a `size` template into its Seedance request fields.
+ *
+ * The template is either a bare aspect ratio (`'16:9'`) or
+ * `ratio_resolution` (`'16:9_720p'`), mirroring the grok video adapter.
+ * Returns `undefined` when the string doesn't match the template at all.
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export function parseBytePlusVideoSize(
+  size: string,
+): { ratio: string; resolution?: string } | undefined {
+  const match = /^(\d+:\d+|adaptive)(?:_(.+))?$/.exec(size)
+  const [, ratio, resolution] = match ?? []
+  if (ratio === undefined) return undefined
+  return { ratio, ...(resolution !== undefined && { resolution }) }
+}
+
+/**
+ * Validates a `size` template against a model and returns the request fields
+ * it maps onto.
+ *
+ * @throws Error when the template is malformed, the ratio is unknown, or the
+ * resolution is not offered by this model.
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export function resolveBytePlusVideoSize(
+  model: BytePlusVideoModel,
+  size: string,
+): { ratio: string; resolution?: string } {
+  const parsed = parseBytePlusVideoSize(size)
+  if (!parsed || !BYTEPLUS_VIDEO_RATIOS.includes(parsed.ratio)) {
+    throw new Error(
+      `byteplus: size "${size}" is not supported by model "${model}". Expected ` +
+        `"ratio" or "ratio_resolution" (e.g. "16:9_720p") with ratio one of: ` +
+        `${BYTEPLUS_VIDEO_RATIOS.join(', ')}.`,
+    )
+  }
+
+  const allowed = BYTEPLUS_VIDEO_RESOLUTIONS[model]
+  if (
+    parsed.resolution !== undefined &&
+    !allowed.includes(
+      parsed.resolution.toLowerCase() as BytePlusVideoResolution,
+    )
+  ) {
+    throw new Error(
+      `byteplus: resolution "${parsed.resolution}" is not supported by model ` +
+        `"${model}". Supported resolutions: ${allowed.join(', ')}.`,
+    )
+  }
+
+  return parsed
+}

--- a/packages/ai-byteplus/src/video/video-provider-options.ts
+++ b/packages/ai-byteplus/src/video/video-provider-options.ts
@@ -15,6 +15,18 @@
  * so these tables are not cosmetic: sending a field to the wrong model is a
  * 400, not a no-op.
  *
+ * **Where the adapter guards, and where it doesn't** (deliberate, not an
+ * oversight). Scalar applicability — `service_tier`, `draft`, `priority`,
+ * `frames`, `camera_fixed` — is left to Ark, whose 400 names the offending
+ * field and the model precisely enough to act on, and whose per-model rules
+ * shift as BytePlus ships models. Duplicating that here would mean a table
+ * that silently goes stale and starts rejecting requests the API would have
+ * accepted. The adapter guards locally only where the API's own error is
+ * misleading or arrives too late to be actionable: prompt media shape (role
+ * vocabulary, frame-vs-reference exclusivity, frame cardinality) and the
+ * resolution tier, both of which are derived from a caller's `prompt` /
+ * `size` rather than passed through verbatim.
+ *
  * @experimental Video generation is an experimental feature and may change.
  */
 
@@ -261,6 +273,10 @@ export function supportsLastFrame(model: string): boolean {
  * `ratio_resolution` (`'16:9_720p'`), mirroring the grok video adapter.
  * Returns `undefined` when the string doesn't match the template at all.
  *
+ * The resolution half comes back lowercased. Ark itself matches the field
+ * case-insensitively, but this package standardizes on lowercase so callers
+ * can compare the result against {@link BytePlusVideoResolution} directly.
+ *
  * @experimental Video generation is an experimental feature and may change.
  */
 export function parseBytePlusVideoSize(
@@ -269,12 +285,40 @@ export function parseBytePlusVideoSize(
   const match = /^(\d+:\d+|adaptive)(?:_(.+))?$/.exec(size)
   const [, ratio, resolution] = match ?? []
   if (ratio === undefined) return undefined
-  return { ratio, ...(resolution !== undefined && { resolution }) }
+  return {
+    ratio,
+    ...(resolution !== undefined && { resolution: resolution.toLowerCase() }),
+  }
+}
+
+/**
+ * Validates a resolution against a model's tiers, returning it lowercased.
+ *
+ * Used for both halves of the request: the resolution parsed out of the
+ * generic `size`, and a `modelOptions.resolution` that overrides it.
+ *
+ * @throws Error when the model does not offer the tier.
+ *
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export function resolveBytePlusVideoResolution(
+  model: BytePlusVideoModel,
+  resolution: string,
+): BytePlusVideoResolution {
+  const normalized = resolution.toLowerCase() as BytePlusVideoResolution
+  const allowed = BYTEPLUS_VIDEO_RESOLUTIONS[model]
+  if (!allowed.includes(normalized)) {
+    throw new Error(
+      `byteplus: resolution "${resolution}" is not supported by model ` +
+        `"${model}". Supported resolutions: ${allowed.join(', ')}.`,
+    )
+  }
+  return normalized
 }
 
 /**
  * Validates a `size` template against a model and returns the request fields
- * it maps onto.
+ * it maps onto, with the resolution lowercased.
  *
  * @throws Error when the template is malformed, the ratio is unknown, or the
  * resolution is not offered by this model.
@@ -284,7 +328,7 @@ export function parseBytePlusVideoSize(
 export function resolveBytePlusVideoSize(
   model: BytePlusVideoModel,
   size: string,
-): { ratio: string; resolution?: string } {
+): { ratio: string; resolution?: BytePlusVideoResolution } {
   const parsed = parseBytePlusVideoSize(size)
   if (!parsed || !BYTEPLUS_VIDEO_RATIOS.includes(parsed.ratio)) {
     throw new Error(
@@ -294,18 +338,10 @@ export function resolveBytePlusVideoSize(
     )
   }
 
-  const allowed = BYTEPLUS_VIDEO_RESOLUTIONS[model]
-  if (
-    parsed.resolution !== undefined &&
-    !allowed.includes(
-      parsed.resolution.toLowerCase() as BytePlusVideoResolution,
-    )
-  ) {
-    throw new Error(
-      `byteplus: resolution "${parsed.resolution}" is not supported by model ` +
-        `"${model}". Supported resolutions: ${allowed.join(', ')}.`,
-    )
+  return {
+    ratio: parsed.ratio,
+    ...(parsed.resolution !== undefined && {
+      resolution: resolveBytePlusVideoResolution(model, parsed.resolution),
+    }),
   }
-
-  return parsed
 }

--- a/packages/ai-byteplus/src/video/wire-types.ts
+++ b/packages/ai-byteplus/src/video/wire-types.ts
@@ -95,8 +95,12 @@ export interface BytePlusVideoAudioContent {
 }
 
 /**
- * One entry of the `content[]` array. The array is capped at 5 items
- * (`maxItems` on the create schema).
+ * One entry of the `content[]` array.
+ *
+ * The create schema declares `maxItems: 5`, but the live API does not enforce
+ * it — 7 entries (6 reference images plus text) were accepted on
+ * `dreamina-seedance-2-0-260128`. The adapter therefore does not cap the array
+ * locally; a genuinely over-long request gets whatever Ark decides to say.
  */
 export type BytePlusVideoContentPart =
   | BytePlusVideoTextContent

--- a/packages/ai-byteplus/src/video/wire-types.ts
+++ b/packages/ai-byteplus/src/video/wire-types.ts
@@ -288,9 +288,6 @@ export interface BytePlusVideoTaskListResponse {
   total?: number
 }
 
-/**
- * Response of `DELETE /contents/generations/tasks/{id}`, which cancels a
- * `queued` task and deletes anything already terminal. The documented success
- * body is an empty object.
- */
-export interface BytePlusVideoDeleteResponse {}
+// `DELETE /contents/generations/tasks/{id}` cancels a `queued` task and
+// deletes anything already terminal; its documented success body is an empty
+// object, so no response interface is declared for it.

--- a/packages/ai-byteplus/src/video/wire-types.ts
+++ b/packages/ai-byteplus/src/video/wire-types.ts
@@ -1,0 +1,292 @@
+/**
+ * Wire types for the BytePlus Ark Seedance video task API
+ * (`/contents/generations/tasks`).
+ *
+ * Hand-written minimal shapes covering only the fields this adapter sends and
+ * reads, with provenance noted inline. Three sources:
+ *
+ * 1. The harvested OpenAPI 3.1 documents for the `ark` service, actions
+ *    `CreateContentsGenerationsTasks` (`x-updated-time: 2026-05-07`),
+ *    `GetContentsGenerationsTask` (`2026-04-14`),
+ *    `ListContentsGenerationsTasks` (`2026-03-24`) and
+ *    `DeleteContentsGenerationsTasks` — authoritative for field names,
+ *    defaults and response shapes.
+ * 2. Live calls against `https://ark.ap-southeast.bytepluses.com/api/v3` on
+ *    2026-07-31 with a real `ARK_API_KEY`, which pinned the create response,
+ *    the per-model parameter applicability (see
+ *    `video-provider-options.ts`) and the `content[]` role vocabulary.
+ * 3. The Seedance prose docs, for the retention windows.
+ *
+ * Two casing traps worth knowing: the response frame-rate field is
+ * `framespersecond` (all lowercase, no underscores), and `resolution` is
+ * matched case-insensitively on the way in (`4K`, `4k` and even `1080P` are
+ * all accepted — live-verified), so this package standardizes on lowercase.
+ */
+
+/**
+ * Task lifecycle states.
+ *
+ * `queued` and `running` are non-terminal; the rest are terminal. `cancelled`
+ * records are dropped 24 hours after cancellation, and only a `queued` task
+ * can be cancelled at all.
+ *
+ * Source: `GetContentsGenerationsTask` / `ListContentsGenerationsTasks`
+ * `status` descriptions. (The Get document omits `expired` from its list
+ * while the List document includes it; `execution_expires_after` is documented
+ * as producing `expired` on both, so it is included here.)
+ */
+export type BytePlusVideoTaskStatus =
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled'
+  | 'expired'
+
+/**
+ * Role of a media item inside `content[]`.
+ *
+ * Live-verified: an unknown role is rejected with "invalid role specified for
+ * image content", and the API sorts requests into task types from the roles
+ * present — `i2v` (first frame), `flf2v` (first + last frame) and `r2v`
+ * (reference media). The two families are mutually exclusive: mixing them
+ * fails with "first/last frame content cannot be mixed with reference media
+ * content".
+ */
+export type BytePlusVideoContentRole =
+  | 'first_frame'
+  | 'last_frame'
+  | 'reference_image'
+  | 'reference_video'
+  | 'reference_audio'
+
+/** Instruction text for the generation. */
+export interface BytePlusVideoTextContent {
+  type: 'text'
+  text: string
+}
+
+/**
+ * An image input. A public URL is fetched by BytePlus server-side; a
+ * `data:` URI carries the bytes inline.
+ */
+export interface BytePlusVideoImageContent {
+  type: 'image_url'
+  image_url: { url: string }
+  /** Omitted for a bare first frame — the API defaults to `first_frame`. */
+  role?: BytePlusVideoContentRole
+}
+
+/** A video input. Reference-media mode requires `role: 'reference_video'`. */
+export interface BytePlusVideoVideoContent {
+  type: 'video_url'
+  video_url: { url: string }
+  role?: BytePlusVideoContentRole
+}
+
+/**
+ * An audio input. Live-verified: audio can only accompany another reference
+ * input — "reference_audio cannot be the only reference input".
+ */
+export interface BytePlusVideoAudioContent {
+  type: 'audio_url'
+  audio_url: { url: string }
+  role?: BytePlusVideoContentRole
+}
+
+/**
+ * One entry of the `content[]` array. The array is capped at 5 items
+ * (`maxItems` on the create schema).
+ */
+export type BytePlusVideoContentPart =
+  | BytePlusVideoTextContent
+  | BytePlusVideoImageContent
+  | BytePlusVideoVideoContent
+  | BytePlusVideoAudioContent
+
+/**
+ * Request body for `POST /contents/generations/tasks`.
+ *
+ * Only `model` and `content` are required. Every other field is
+ * model-dependent — Ark rejects an inapplicable field outright ("the
+ * specified parameter `draft` is not supported for model … must be empty")
+ * rather than ignoring it, so the adapter only sends what the caller asked
+ * for. See `video-provider-options.ts` for the live-probed applicability
+ * matrix.
+ */
+export interface BytePlusVideoCreateRequest {
+  /** Seedance model id (or a preconfigured endpoint id). */
+  model: string
+
+  /** Prompt text plus any image / video / audio inputs, max 5 entries. */
+  content: Array<BytePlusVideoContentPart>
+
+  /** Output aspect ratio, e.g. `16:9`. `adaptive` follows the input frame. */
+  ratio?: string
+
+  /** Resolution tier, e.g. `720p`. Matched case-insensitively by the API. */
+  resolution?: string
+
+  /** Whole seconds of output. `-1` lets the model choose (Seedance 2.0 / 1.5). */
+  duration?: number
+
+  /** Frame count, an alternative to `duration` that allows fractional seconds. */
+  frames?: number
+
+  /** Randomness seed; integers in `[-1, 2^32-1]`, where `-1` means unseeded. */
+  seed?: number
+
+  /** Appends a "fix the camera" instruction to the prompt. Default `false`. */
+  camera_fixed?: boolean
+
+  /** Burn a watermark into the output. Default `false`. */
+  watermark?: boolean
+
+  /** Generate a synchronized audio track. Default `false`. */
+  generate_audio?: boolean
+
+  /** `default` (online) or `flex` (offline batch, half price). */
+  service_tier?: string
+
+  /** Also return the final frame as a PNG. Default `false`. */
+  return_last_frame?: boolean
+
+  /** Cheap low-fidelity preview render. Default `false`. */
+  draft?: boolean
+
+  /** Queue priority `[0, 9]`. */
+  priority?: number
+
+  /** Seconds from `created_at` after which the task is marked `expired`. */
+  execution_expires_after?: number
+
+  /** URL that receives a POST with the task payload on each status change. */
+  callback_url?: string
+
+  /** Opaque per-end-user identifier for abuse attribution, max 64 chars. */
+  safety_identifier?: string
+}
+
+/**
+ * Response of `POST /contents/generations/tasks`.
+ *
+ * Live-verified: the body is just the task id (e.g.
+ * `cgt-batch-20260731174311-zmz5s`; the `-batch` infix appears when the task
+ * is routed to the `flex` offline queue).
+ */
+export interface BytePlusVideoCreateResponse {
+  id?: string
+}
+
+/**
+ * Error detail attached to a terminal task.
+ *
+ * Codes are the dotted/PascalCase Ark strings — the create, get and list
+ * documents enumerate `InputTextSensitiveContentDetected`,
+ * `InputImageSensitiveContentDetected`, `OutputVideoSensitiveContentDetected`
+ * and `QuotaExceeded` under `x-error-code`. The set is open-ended, so this
+ * stays a plain `string`.
+ */
+export interface BytePlusVideoTaskError {
+  code?: string
+  message?: string
+}
+
+/**
+ * Token usage for a finished task. Video generation bills output only, so
+ * `total_tokens` equals `completion_tokens` and there is no prompt count.
+ *
+ * The schema types both counts as `string` while the documented example
+ * response shows bare numbers, so both are accepted and coerced.
+ */
+export interface BytePlusVideoTaskUsage {
+  completion_tokens?: number | string
+  total_tokens?: number | string
+  /** Only present when a provider tool (web search) ran. */
+  tool_usage?: { web_search?: number }
+}
+
+/** Output URLs of a succeeded task. Both links expire 24 hours after success. */
+export interface BytePlusVideoTaskContent {
+  /** MP4 download URL. */
+  video_url?: string
+  /** Final frame as PNG; only when `return_last_frame` was set. */
+  last_frame_url?: string
+}
+
+/**
+ * Response of `GET /contents/generations/tasks/{id}`.
+ *
+ * `content` appears once the task succeeds; `error` appears when it fails.
+ * Note `duration` comes back as a string here while the list endpoint types
+ * it as an integer, so both are accepted.
+ */
+export interface BytePlusVideoTask {
+  id?: string
+  /** `{model name}-{version}` actually used — not necessarily the id sent. */
+  model?: string
+  status?: BytePlusVideoTaskStatus
+  error?: BytePlusVideoTaskError
+  /** Unix seconds. Anchors the 7-day task-record retention. */
+  created_at?: number
+  /** Unix seconds of the last status change — for a succeeded task, when the
+   * output (and its 24-hour URL) was produced. */
+  updated_at?: number
+  content?: BytePlusVideoTaskContent
+  seed?: number
+  resolution?: string
+  ratio?: string
+  duration?: number | string
+  frames?: number
+  /** Frame rate. Lowercase and unseparated on the wire — not `frames_per_second`. */
+  framespersecond?: number
+  generate_audio?: boolean
+  service_tier?: string
+  draft?: boolean
+  draft_task_id?: string
+  execution_expires_after?: number
+  safety_identifier?: string
+  usage?: BytePlusVideoTaskUsage
+
+  // The two fields below came back on a live succeeded task
+  // (`seedance-1-0-pro-fast-251015`, 2026-07-31) but are absent from the
+  // harvested Get schema.
+  /** Queue priority the task ran at. */
+  priority?: number
+  /** Container of the generated video, e.g. `mp4`. */
+  output_format?: string
+}
+
+/**
+ * One entry of the list response.
+ *
+ * The list document declares the same fields as the get document (including
+ * `error` — despite BytePlus prose elsewhere calling the list-side field
+ * `failure_reason`, no such field exists in the harvested schema, so it is
+ * not typed here).
+ */
+export interface BytePlusVideoTaskListItem extends BytePlusVideoTask {}
+
+/**
+ * Response of `GET /contents/generations/tasks`.
+ *
+ * Supported query parameters: `page_num` and `page_size` (both `[1, 500]`),
+ * `filter.status`, repeated `filter.task_ids`, and `filter.service_tier`.
+ *
+ * **`flex` tasks are missing from the default listing.** An unfiltered list
+ * returned `{total: 0, items: []}` both while a live `flex` task was running
+ * and immediately after it succeeded, so offline-tier work is invisible here
+ * unless `filter.service_tier=flex` is passed. Poll a known task id rather
+ * than relying on the listing to discover tasks.
+ */
+export interface BytePlusVideoTaskListResponse {
+  items?: Array<BytePlusVideoTaskListItem>
+  total?: number
+}
+
+/**
+ * Response of `DELETE /contents/generations/tasks/{id}`, which cancels a
+ * `queued` task and deletes anything already terminal. The documented success
+ * body is an empty object.
+ */
+export interface BytePlusVideoDeleteResponse {}

--- a/packages/ai-byteplus/tests/client.test.ts
+++ b/packages/ai-byteplus/tests/client.test.ts
@@ -181,6 +181,84 @@ describe('headers', () => {
       'X-Test-Id': 'abc',
     })
   })
+
+  // Header names are case-insensitive but object keys are not, so a
+  // differently-cased duplicate survives the spread and `fetch`'s Headers
+  // constructor *appends* it: `authorization: "Bearer wrong, Bearer right"`,
+  // which 401s and reads like a bad key. `toHeaderRecord` lowercases names for
+  // the `Headers` form of `defaultHeaders`, so this is reachable from ordinary
+  // config. Assert through `new Headers(...)` — the object alone can look fine
+  // while the wire value is the concatenation.
+  it.each([
+    ['lowercase', 'authorization'],
+    ['canonical', 'Authorization'],
+    ['upper', 'AUTHORIZATION'],
+    ['mixed', 'AuThOrIzAtIoN'],
+  ])(
+    'drops a %s caller Authorization rather than appending to it',
+    (_label, key) => {
+      const built = bytePlusArkHeaders('ark-test-key', {
+        [key]: 'Bearer wrong-key',
+      })
+      expect(new Headers(built).get('authorization')).toBe(
+        'Bearer ark-test-key',
+      )
+    },
+  )
+
+  it.each([
+    ['lowercase', 'x-api-key'],
+    ['canonical', 'X-Api-Key'],
+    ['upper', 'X-API-KEY'],
+  ])(
+    'drops a %s caller X-Api-Key rather than appending to it',
+    (_label, key) => {
+      const built = bytePlusVoiceHeaders('voice-test-key', {
+        [key]: 'wrong-key',
+      })
+      expect(new Headers(built).get('x-api-key')).toBe('voice-test-key')
+    },
+  )
+
+  it('drops a differently-cased Content-Type on both hosts', () => {
+    expect(
+      new Headers(
+        bytePlusArkHeaders('ark-test-key', { 'content-type': 'text/plain' }),
+      ).get('content-type'),
+    ).toBe('application/json')
+    expect(
+      new Headers(
+        bytePlusVoiceHeaders('voice-key', { 'CONTENT-TYPE': 'text/plain' }),
+      ).get('content-type'),
+    ).toBe('application/json')
+  })
+
+  // The `Headers` form is the realistic route to the collision above:
+  // `Headers.forEach` yields lowercased names, so a caller who passes
+  // `new Headers({ Authorization: ... })` as `defaultHeaders` lands on the
+  // lowercase key even though they wrote the canonical one.
+  it('survives a Headers-instance defaultHeaders carrying an auth key', () => {
+    const built = bytePlusArkHeaders(
+      'ark-test-key',
+      toHeaderRecord(
+        new Headers({ Authorization: 'Bearer stale', 'X-Trace': 't1' }),
+      ),
+    )
+    expect(new Headers(built).get('authorization')).toBe('Bearer ark-test-key')
+    expect(new Headers(built).get('x-trace')).toBe('t1')
+  })
+
+  it('survives an entry-list defaultHeaders carrying an auth key', () => {
+    const built = bytePlusVoiceHeaders(
+      'voice-key',
+      toHeaderRecord([
+        ['X-Api-Key', 'stale'],
+        ['X-Trace', 't1'],
+      ]),
+    )
+    expect(new Headers(built).get('x-api-key')).toBe('voice-key')
+    expect(new Headers(built).get('x-trace')).toBe('t1')
+  })
 })
 
 describe('toHeaderRecord', () => {

--- a/packages/ai-byteplus/tests/client.test.ts
+++ b/packages/ai-byteplus/tests/client.test.ts
@@ -12,7 +12,11 @@ import {
   withBytePlusVoiceDefaults,
 } from '../src/index'
 
-const ENV_KEYS = ['ARK_API_KEY', 'BYTEPLUS_VOICE_API_KEY'] as const
+const ENV_KEYS = [
+  'ARK_API_KEY',
+  'BYTEPLUS_API_KEY',
+  'BYTEPLUS_VOICE_API_KEY',
+] as const
 const originalEnv = new Map(ENV_KEYS.map((key) => [key, process.env[key]]))
 
 afterEach(() => {
@@ -32,9 +36,24 @@ describe('API key resolution', () => {
     expect(getBytePlusArkApiKeyFromEnv()).toBe('ark-test-key')
   })
 
-  it('names ARK_API_KEY when it is missing', () => {
+  it('falls back to BYTEPLUS_API_KEY when ARK_API_KEY is unset', () => {
     delete process.env.ARK_API_KEY
-    expect(() => getBytePlusArkApiKeyFromEnv()).toThrow(/ARK_API_KEY/)
+    process.env.BYTEPLUS_API_KEY = 'byteplus-test-key'
+    expect(getBytePlusArkApiKeyFromEnv()).toBe('byteplus-test-key')
+  })
+
+  it('prefers ARK_API_KEY over the BYTEPLUS_API_KEY fallback', () => {
+    process.env.ARK_API_KEY = 'ark-test-key'
+    process.env.BYTEPLUS_API_KEY = 'byteplus-test-key'
+    expect(getBytePlusArkApiKeyFromEnv()).toBe('ark-test-key')
+  })
+
+  it('names both variables when neither is set', () => {
+    delete process.env.ARK_API_KEY
+    delete process.env.BYTEPLUS_API_KEY
+    expect(() => getBytePlusArkApiKeyFromEnv()).toThrow(
+      /ARK_API_KEY or BYTEPLUS_API_KEY/,
+    )
   })
 
   it('reads the Seed Speech key from BYTEPLUS_VOICE_API_KEY', () => {
@@ -139,6 +158,19 @@ describe('error formatting', () => {
     )
     expect(error.message).toBe(
       'BytePlus Seed Speech speech synthesis failed (401 45000010): Invalid X-Api-Key',
+    )
+  })
+
+  it('serializes an object body that carries no message', () => {
+    expect(
+      bytePlusArkError(500, { error: { type: 'server_error' } }).message,
+    ).toBe(
+      'BytePlus Ark request failed (500): {"error":{"type":"server_error"}}',
+    )
+    expect(
+      bytePlusVoiceError(500, { detail: 'upstream timeout' }).message,
+    ).toBe(
+      'BytePlus Seed Speech request failed (500): {"detail":"upstream timeout"}',
     )
   })
 

--- a/packages/ai-byteplus/tests/client.test.ts
+++ b/packages/ai-byteplus/tests/client.test.ts
@@ -11,6 +11,7 @@ import {
   withBytePlusArkDefaults,
   withBytePlusVoiceDefaults,
 } from '../src/index'
+import { readJsonBody, toHeaderRecord } from '../src/utils/client'
 
 const ENV_KEYS = [
   'ARK_API_KEY',
@@ -90,6 +91,34 @@ describe('config defaults', () => {
     expect(config.baseURL).toBe('https://ark.eu-west.bytepluses.com/api/v3')
   })
 
+  it('trims trailing slashes from an explicit Ark base URL', () => {
+    const config = withBytePlusArkDefaults({
+      apiKey: 'ark-test-key',
+      baseURL: 'https://ark.eu-west.bytepluses.com/api/v3//',
+    })
+    expect(config.baseURL).toBe('https://ark.eu-west.bytepluses.com/api/v3')
+  })
+
+  it('resolves a base URL for a null or empty override', () => {
+    // openai's ClientOptions types baseURL as nullable, so adapters that
+    // interpolate it must never see undefined.
+    expect(
+      withBytePlusArkDefaults({ apiKey: 'ark-test-key', baseURL: null })
+        .baseURL,
+    ).toBe(BYTEPLUS_ARK_BASE_URL)
+    expect(
+      withBytePlusArkDefaults({ apiKey: 'ark-test-key', baseURL: '' }).baseURL,
+    ).toBe(BYTEPLUS_ARK_BASE_URL)
+  })
+
+  it('preserves adapter-specific config fields', () => {
+    const config = withBytePlusArkDefaults({
+      apiKey: 'ark-test-key',
+      maxRetries: 4,
+    })
+    expect(config.maxRetries).toBe(4)
+  })
+
   it('applies the Seed Speech base URL', () => {
     const config = withBytePlusVoiceDefaults({ apiKey: 'voice-test-key' })
     expect(config.baseURL).toBe(BYTEPLUS_VOICE_BASE_URL)
@@ -119,10 +148,102 @@ describe('headers', () => {
     })
   })
 
-  it('merges extra headers over the defaults', () => {
+  it('merges extra headers alongside the auth headers', () => {
     expect(
       bytePlusArkHeaders('ark-test-key', { 'X-Test-Id': 'abc' }),
     ).toMatchObject({ 'X-Test-Id': 'abc' })
+  })
+
+  it('does not let extra headers clobber the Ark bearer token', () => {
+    // A caller-supplied Authorization in defaultHeaders would otherwise turn
+    // every request into a 401 that reads like a bad API key.
+    expect(
+      bytePlusArkHeaders('ark-test-key', {
+        Authorization: 'Bearer wrong-key',
+        'Content-Type': 'text/plain',
+      }),
+    ).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer ark-test-key',
+    })
+  })
+
+  it('does not let extra headers clobber X-Api-Key', () => {
+    expect(
+      bytePlusVoiceHeaders('voice-test-key', {
+        'X-Api-Key': 'wrong-key',
+        'Content-Type': 'text/plain',
+        'X-Test-Id': 'abc',
+      }),
+    ).toEqual({
+      'Content-Type': 'application/json',
+      'X-Api-Key': 'voice-test-key',
+      'X-Test-Id': 'abc',
+    })
+  })
+})
+
+describe('toHeaderRecord', () => {
+  it('returns an empty record for absent headers', () => {
+    expect(toHeaderRecord(undefined)).toEqual({})
+    expect(toHeaderRecord(null)).toEqual({})
+  })
+
+  it('flattens a Headers instance', () => {
+    const headers = new Headers({ 'X-Test-Id': 'abc' })
+    expect(toHeaderRecord(headers)).toEqual({ 'x-test-id': 'abc' })
+  })
+
+  it('reads an entry list', () => {
+    expect(
+      toHeaderRecord([
+        ['X-Test-Id', 'abc'],
+        ['X-Other', 'def'],
+      ]),
+    ).toEqual({ 'X-Test-Id': 'abc', 'X-Other': 'def' })
+  })
+
+  it('drops non-string values rather than serializing them', () => {
+    // openai's ClientOptions allows null/undefined as a "remove this header"
+    // signal, and an array for a repeated header. None of the three maps onto
+    // a single string, and none may reach the request as "null" or "a,b".
+    expect(
+      toHeaderRecord({
+        'X-Test-Id': 'abc',
+        'X-Removed': null,
+        'X-Absent': undefined,
+        'X-Repeated': ['a', 'b'],
+      }),
+    ).toEqual({ 'X-Test-Id': 'abc' })
+  })
+
+  it('skips entry-list pairs with a null value', () => {
+    expect(
+      toHeaderRecord([
+        ['X-Test-Id', 'abc'],
+        ['X-Removed', null],
+      ]),
+    ).toEqual({ 'X-Test-Id': 'abc' })
+  })
+})
+
+describe('readJsonBody', () => {
+  it('parses a JSON body', async () => {
+    const response = new Response(JSON.stringify({ id: 'cgt-1' }))
+    await expect(readJsonBody(response)).resolves.toEqual({ id: 'cgt-1' })
+  })
+
+  it('returns undefined for an empty body', async () => {
+    await expect(readJsonBody(new Response(''))).resolves.toBeUndefined()
+  })
+
+  it('falls back to raw text for a non-JSON body', async () => {
+    // Proxies in front of either host answer with HTML, which must still reach
+    // the error formatters instead of throwing a SyntaxError here.
+    const response = new Response('<html>Bad Gateway</html>', { status: 502 })
+    await expect(readJsonBody(response)).resolves.toBe(
+      '<html>Bad Gateway</html>',
+    )
   })
 })
 

--- a/packages/ai-byteplus/tests/client.test.ts
+++ b/packages/ai-byteplus/tests/client.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  BYTEPLUS_ARK_BASE_URL,
+  BYTEPLUS_VOICE_BASE_URL,
+  bytePlusArkError,
+  bytePlusArkHeaders,
+  bytePlusVoiceError,
+  bytePlusVoiceHeaders,
+  getBytePlusArkApiKeyFromEnv,
+  getBytePlusVoiceApiKeyFromEnv,
+  withBytePlusArkDefaults,
+  withBytePlusVoiceDefaults,
+} from '../src/index'
+
+const ENV_KEYS = ['ARK_API_KEY', 'BYTEPLUS_VOICE_API_KEY'] as const
+const originalEnv = new Map(ENV_KEYS.map((key) => [key, process.env[key]]))
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const original = originalEnv.get(key)
+    if (original === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = original
+    }
+  }
+})
+
+describe('API key resolution', () => {
+  it('reads the Ark key from ARK_API_KEY', () => {
+    process.env.ARK_API_KEY = 'ark-test-key'
+    expect(getBytePlusArkApiKeyFromEnv()).toBe('ark-test-key')
+  })
+
+  it('names ARK_API_KEY when it is missing', () => {
+    delete process.env.ARK_API_KEY
+    expect(() => getBytePlusArkApiKeyFromEnv()).toThrow(/ARK_API_KEY/)
+  })
+
+  it('reads the Seed Speech key from BYTEPLUS_VOICE_API_KEY', () => {
+    process.env.BYTEPLUS_VOICE_API_KEY = 'voice-test-key'
+    expect(getBytePlusVoiceApiKeyFromEnv()).toBe('voice-test-key')
+  })
+
+  it('points at the separate Seed Speech key when it is missing', () => {
+    delete process.env.BYTEPLUS_VOICE_API_KEY
+    expect(() => getBytePlusVoiceApiKeyFromEnv()).toThrow(
+      /BYTEPLUS_VOICE_API_KEY/,
+    )
+  })
+})
+
+describe('config defaults', () => {
+  it('applies the Ark base URL and preserves the injected fetch', () => {
+    const injectedFetch: typeof fetch = () => {
+      throw new Error('not called')
+    }
+    const config = withBytePlusArkDefaults({
+      apiKey: 'ark-test-key',
+      fetch: injectedFetch,
+    })
+    expect(config.baseURL).toBe(BYTEPLUS_ARK_BASE_URL)
+    expect(config.fetch).toBe(injectedFetch)
+  })
+
+  it('keeps an explicit Ark base URL (e.g. the EU host)', () => {
+    const config = withBytePlusArkDefaults({
+      apiKey: 'ark-test-key',
+      baseURL: 'https://ark.eu-west.bytepluses.com/api/v3',
+    })
+    expect(config.baseURL).toBe('https://ark.eu-west.bytepluses.com/api/v3')
+  })
+
+  it('applies the Seed Speech base URL', () => {
+    const config = withBytePlusVoiceDefaults({ apiKey: 'voice-test-key' })
+    expect(config.baseURL).toBe(BYTEPLUS_VOICE_BASE_URL)
+  })
+
+  it('trims trailing slashes from an explicit Seed Speech base URL', () => {
+    const config = withBytePlusVoiceDefaults({
+      apiKey: 'voice-test-key',
+      baseURL: 'https://voice.example.com//',
+    })
+    expect(config.baseURL).toBe('https://voice.example.com')
+  })
+})
+
+describe('headers', () => {
+  it('sends the Ark key as a bearer token', () => {
+    expect(bytePlusArkHeaders('ark-test-key')).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer ark-test-key',
+    })
+  })
+
+  it('sends the Seed Speech key as X-Api-Key', () => {
+    expect(bytePlusVoiceHeaders('voice-test-key')).toEqual({
+      'Content-Type': 'application/json',
+      'X-Api-Key': 'voice-test-key',
+    })
+  })
+
+  it('merges extra headers over the defaults', () => {
+    expect(
+      bytePlusArkHeaders('ark-test-key', { 'X-Test-Id': 'abc' }),
+    ).toMatchObject({ 'X-Test-Id': 'abc' })
+  })
+})
+
+describe('error formatting', () => {
+  it('reads code and message out of the Ark envelope', () => {
+    const error = bytePlusArkError(
+      404,
+      {
+        error: {
+          code: 'InvalidEndpointOrModel.NotFound',
+          message: 'The model does not exist.',
+        },
+      },
+      'video task creation',
+    )
+    expect(error.message).toBe(
+      'BytePlus Ark video task creation failed (404 InvalidEndpointOrModel.NotFound): The model does not exist.',
+    )
+  })
+
+  it('falls back to the raw body when Ark returns something else', () => {
+    const error = bytePlusArkError(502, '<html>Bad Gateway</html>')
+    expect(error.message).toBe(
+      'BytePlus Ark request failed (502): <html>Bad Gateway</html>',
+    )
+  })
+
+  it('reads the flat numeric code out of the Seed Speech envelope', () => {
+    const error = bytePlusVoiceError(
+      401,
+      { code: 45000010, message: 'Invalid X-Api-Key' },
+      'speech synthesis',
+    )
+    expect(error.message).toBe(
+      'BytePlus Seed Speech speech synthesis failed (401 45000010): Invalid X-Api-Key',
+    )
+  })
+
+  it('degrades to the status alone for an unreadable body', () => {
+    expect(bytePlusVoiceError(500, undefined).message).toBe(
+      'BytePlus Seed Speech request failed (500)',
+    )
+  })
+})

--- a/packages/ai-byteplus/tests/image.test.ts
+++ b/packages/ai-byteplus/tests/image.test.ts
@@ -1,0 +1,800 @@
+import { describe, expect, it, vi } from 'vitest'
+import { generateImage } from '@tanstack/ai'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import {
+  BytePlusImageAdapter,
+  byteplusImage,
+  createBytePlusImage,
+} from '../src/adapters/image'
+import { parseBytePlusImageSize } from '../src/image/image-provider-options'
+import type { BytePlusSeedream5ImageProviderOptions } from '../src/image/image-provider-options'
+import type { BytePlusImageGenerationRequest } from '../src/image/wire-types'
+import type {
+  ImagePart,
+  MediaInputMetadata,
+  MediaPromptPart,
+} from '@tanstack/ai'
+
+const testLogger = resolveDebugOption(false)
+
+const IMAGE_URL =
+  'https://ark-content-generation-v2-ap-southeast-1.tos-ap-southeast-1.volces.com/seedream/x.png'
+
+/** Live-verified `seedream-4-0-250828` response body (2026-07-31). */
+const successBody = {
+  model: 'seedream-4-0-250828',
+  created: 1_754_000_000,
+  data: [{ url: IMAGE_URL, size: '1152x864' }],
+  usage: { generated_images: 1, output_tokens: 3888, total_tokens: 3888 },
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * A `vi.fn` fetch stub with the real fetch parameter list, so call assertions
+ * (`mock.calls[0]`) stay typed as `[input, init?]`.
+ */
+function mockFetch(handler: () => Response) {
+  return vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+    handler(),
+  )
+}
+
+/** Reads the JSON body the adapter sent on its first (only) request. */
+function sentRequest(
+  fetchMock: ReturnType<typeof mockFetch>,
+): BytePlusImageGenerationRequest {
+  const init = fetchMock.mock.calls[0]?.[1]
+  return JSON.parse(String(init?.body))
+}
+
+function adapterWithFetch(
+  fetchMock: ReturnType<typeof mockFetch>,
+  model:
+    | 'seedream-4-0-250828'
+    | 'seedream-5-0-lite-260128'
+    | 'dola-seedream-5-0-pro-260628' = 'seedream-4-0-250828',
+) {
+  return createBytePlusImage(model, 'ark-test-key', { fetch: fetchMock })
+}
+
+function imagePart(value: string): ImagePart<MediaInputMetadata> {
+  return { type: 'image', source: { type: 'url', value } }
+}
+
+/**
+ * A logger whose every level is captured. `resolveDebugOption` with a partial
+ * config turns all categories on, so `logger.errors()` and `logger.warn()`
+ * both reach the spy (the shared `testLogger` uses `false`, which silences
+ * everything including errors).
+ */
+function capturingLogger() {
+  const spy = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+  return { spy, logger: resolveDebugOption({ logger: spy }) }
+}
+
+/** Joins every message a spy level received, for substring assertions. */
+function messages(level: ReturnType<typeof vi.fn>): string {
+  return level.mock.calls.map((call) => String(call[0])).join('\n')
+}
+
+describe('factories', () => {
+  it('creates an adapter with the provided API key', () => {
+    const adapter = createBytePlusImage('seedream-4-0-250828', 'ark-test-key')
+    expect(adapter).toBeInstanceOf(BytePlusImageAdapter)
+    expect(adapter.kind).toBe('image')
+    expect(adapter.name).toBe('byteplus')
+    expect(adapter.model).toBe('seedream-4-0-250828')
+  })
+
+  it('byteplusImage reads ARK_API_KEY from the environment', () => {
+    vi.stubEnv('ARK_API_KEY', 'env-key')
+    try {
+      expect(byteplusImage('seedream-5-0-260128')).toBeInstanceOf(
+        BytePlusImageAdapter,
+      )
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('byteplusImage names ARK_API_KEY when it is missing', () => {
+    vi.stubEnv('ARK_API_KEY', '')
+    try {
+      expect(() => byteplusImage('seedream-5-0-260128')).toThrow(/ARK_API_KEY/)
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+})
+
+describe('request shape', () => {
+  it('posts to the Ark images endpoint with a bearer token', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar in a sunlit workshop',
+      logger: testLogger,
+    })
+
+    const [url, init] = fetchMock.mock.calls[0] ?? []
+    expect(url).toBe(
+      'https://ark.ap-southeast.bytepluses.com/api/v3/images/generations',
+    )
+    expect(init?.method).toBe('POST')
+    expect(init?.headers).toMatchObject({
+      Authorization: 'Bearer ark-test-key',
+      'Content-Type': 'application/json',
+    })
+    expect(sentRequest(fetchMock)).toEqual({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar in a sunlit workshop',
+    })
+  })
+
+  it('honours a custom base URL and merges configured default headers', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    const adapter = createBytePlusImage('seedream-4-0-250828', 'ark-test-key', {
+      // The trailing slash must not survive into the request path.
+      baseURL: 'https://ark.eu-west.bytepluses.com/api/v3/',
+      defaultHeaders: { 'X-Test-Id': 'abc', 'X-Dropped': null },
+      fetch: fetchMock,
+    })
+    await adapter.generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      logger: testLogger,
+    })
+
+    const [url, init] = fetchMock.mock.calls[0] ?? []
+    expect(url).toBe(
+      'https://ark.eu-west.bytepluses.com/api/v3/images/generations',
+    )
+    expect(init?.headers).toMatchObject({
+      Authorization: 'Bearer ark-test-key',
+      'X-Test-Id': 'abc',
+    })
+    // Null-valued entries are dropped rather than serialized as "null".
+    expect(init?.headers).not.toHaveProperty('X-Dropped')
+  })
+
+  it('sends a size token unchanged and normalizes its case', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      // Lowercase tokens are normalized at runtime for JS callers; the type
+      // only advertises the canonical uppercase form.
+      size: '2k' as '2K',
+      logger: testLogger,
+    })
+    expect(sentRequest(fetchMock).size).toBe('2K')
+  })
+
+  it('sends explicit pixel sizes', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      size: '2048x2048',
+      logger: testLogger,
+    })
+    expect(sentRequest(fetchMock).size).toBe('2048x2048')
+  })
+
+  it('rejects a size that mixes the token and pixel forms', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: 'a guitar',
+        // Invalid at runtime and at compile time; the cast keeps the
+        // runtime-validation path reachable from the test.
+        size: '2K x 1024' as '2K',
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/never a mix of the two/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps prompt image parts to the image reference array', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: [
+        { type: 'text', content: 'put the guitar on a beach' },
+        imagePart('https://example.com/guitar.png'),
+        {
+          type: 'image',
+          source: { type: 'data', value: 'AAAA', mimeType: 'image/PNG' },
+        },
+      ],
+      logger: testLogger,
+    })
+
+    const request = sentRequest(fetchMock)
+    expect(request.image).toEqual([
+      'https://example.com/guitar.png',
+      // BytePlus requires a lowercase format in the data URI.
+      'data:image/png;base64,AAAA',
+    ])
+    expect(request.prompt).toBe('put the guitar on a beach')
+  })
+
+  it('enforces the per-model reference-image limit', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    const prompt: Array<MediaPromptPart> = [
+      { type: 'text', content: 'blend these' },
+      ...Array.from({ length: 11 }, (_, index) =>
+        imagePart(`https://example.com/${index}.png`),
+      ),
+    ]
+
+    // 5.0 Pro caps references at 10; the other models accept 14.
+    await expect(
+      adapterWithFetch(
+        fetchMock,
+        'dola-seedream-5-0-pro-260628',
+      ).generateImages({
+        model: 'dola-seedream-5-0-pro-260628',
+        prompt,
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/at most 10 reference images; received 11/)
+
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt,
+        logger: testLogger,
+      }),
+    ).resolves.toMatchObject({ model: 'seedream-4-0-250828' })
+  })
+
+  it('passes a data-URI image source through untouched', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: [
+        { type: 'text', content: 'restyle this' },
+        {
+          type: 'image',
+          source: {
+            type: 'data',
+            value: 'data:image/jpeg;base64,QUJD',
+            mimeType: 'image/jpeg',
+          },
+        },
+      ],
+      logger: testLogger,
+    })
+
+    // Already a data URI: it must not be wrapped in a second `data:` prefix.
+    expect(sentRequest(fetchMock).image).toEqual([
+      'data:image/jpeg;base64,QUJD',
+    ])
+  })
+
+  it('rejects roles outside the reference allow-list', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: [
+          { type: 'text', content: 'inpaint this' },
+          {
+            type: 'image',
+            source: { type: 'url', value: 'https://example.com/mask.png' },
+            metadata: { role: 'mask' },
+          },
+        ],
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/no mask input/)
+
+    // Video-oriented roles must fail loudly rather than be flattened into a
+    // plain reference — that is the point of the allow-list.
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: [
+          { type: 'text', content: 'start from this' },
+          {
+            type: 'image',
+            source: { type: 'url', value: 'https://example.com/frame.png' },
+            metadata: { role: 'start_frame' },
+          },
+        ],
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/no start_frame input/)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts the reference and character roles', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: [
+        { type: 'text', content: 'put @Image1 next to @Image2' },
+        {
+          type: 'image',
+          source: { type: 'url', value: 'https://example.com/a.png' },
+          metadata: { role: 'reference' },
+        },
+        {
+          type: 'image',
+          source: { type: 'url', value: 'https://example.com/b.png' },
+          metadata: { role: 'character' },
+        },
+      ],
+      logger: testLogger,
+    })
+
+    expect(sentRequest(fetchMock).image).toEqual([
+      'https://example.com/a.png',
+      'https://example.com/b.png',
+    ])
+  })
+
+  it('rejects video and audio prompt parts', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: [
+          { type: 'text', content: 'a still from this' },
+          {
+            type: 'video',
+            source: { type: 'url', value: 'https://example.com/clip.mp4' },
+          },
+        ],
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/does not support video \/ audio prompt parts/)
+  })
+
+  it('requires prompt text even when editing', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: [imagePart('https://example.com/guitar.png')],
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/requires prompt text/)
+  })
+
+  it('rejects a prompt longer than 600 words', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: Array.from({ length: 601 }, () => 'guitar').join(' '),
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/601 words/)
+  })
+
+  it('passes watermark and output_format straight through', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await adapterWithFetch(
+      fetchMock,
+      'seedream-5-0-lite-260128',
+    ).generateImages({
+      model: 'seedream-5-0-lite-260128',
+      prompt: 'a guitar',
+      modelOptions: {
+        watermark: false,
+        output_format: 'png',
+        response_format: 'b64_json',
+      },
+      logger: testLogger,
+    })
+
+    expect(sentRequest(fetchMock)).toMatchObject({
+      watermark: false,
+      output_format: 'png',
+      response_format: 'b64_json',
+    })
+  })
+
+  it('sends output_format on a 4.x model rather than rejecting it locally', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    // Seedream 4.x is documented as not reading output_format, so it is absent
+    // from that model's provider-options type. A caller who reuses a 5.0
+    // options object still gets the value sent — Ark decides, not us. Same
+    // policy as sequential_image_generation.
+    const fiveOhOptions: BytePlusSeedream5ImageProviderOptions = {
+      output_format: 'png',
+    }
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      modelOptions: fiveOhOptions,
+      logger: testLogger,
+    })
+
+    expect(sentRequest(fetchMock).output_format).toBe('png')
+  })
+})
+
+describe('numberOfImages', () => {
+  it('sends no group-image fields for a single image', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      numberOfImages: 1,
+      logger: testLogger,
+    })
+
+    const request = sentRequest(fetchMock)
+    expect(request.sequential_image_generation).toBeUndefined()
+    expect(request.sequential_image_generation_options).toBeUndefined()
+  })
+
+  it('maps more than one image onto group-image mode', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'four seasons of one courtyard',
+      numberOfImages: 4,
+      logger: testLogger,
+    })
+
+    expect(sentRequest(fetchMock)).toMatchObject({
+      sequential_image_generation: 'auto',
+      sequential_image_generation_options: { max_images: 4 },
+    })
+  })
+
+  it('lets explicit provider options override the derived mode', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      numberOfImages: 4,
+      modelOptions: { sequential_image_generation: 'disabled' },
+      logger: testLogger,
+    })
+    expect(sentRequest(fetchMock).sequential_image_generation).toBe('disabled')
+  })
+
+  it('rejects counts outside the group-image range', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: 'a guitar',
+        numberOfImages: 16,
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/between 1 and 15/)
+  })
+})
+
+describe('response mapping', () => {
+  it('maps url results and per-image usage', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    const result = await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      logger: testLogger,
+    })
+
+    expect(result.model).toBe('seedream-4-0-250828')
+    expect(result.id).toMatch(/^byteplus-/)
+    expect(result.images).toEqual([{ url: IMAGE_URL }])
+    expect(result.usage).toEqual({
+      promptTokens: 0,
+      completionTokens: 3888,
+      totalTokens: 3888,
+      unitsBilled: 1,
+    })
+  })
+
+  it('maps b64_json results', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        model: 'seedream-4-0-250828',
+        data: [{ b64_json: 'QUJD', size: '1024x1024' }],
+      }),
+    )
+    const result = await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      modelOptions: { response_format: 'b64_json' },
+      logger: testLogger,
+    })
+
+    expect(result.images).toEqual([{ b64Json: 'QUJD' }])
+    expect(result.usage).toBeUndefined()
+  })
+
+  it('maps every image of a group-image response', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        model: 'seedream-4-0-250828',
+        data: [{ url: 'https://example.com/1.png' }, { b64_json: 'QUJD' }],
+        usage: { generated_images: 2, output_tokens: 100, total_tokens: 100 },
+      }),
+    )
+    const result = await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      numberOfImages: 2,
+      logger: testLogger,
+    })
+
+    expect(result.images).toEqual([
+      { url: 'https://example.com/1.png' },
+      { b64Json: 'QUJD' },
+    ])
+    expect(result.usage?.unitsBilled).toBe(2)
+  })
+
+  it('keeps the successes when part of a group fails, and reports the rest', async () => {
+    const { spy, logger } = capturingLogger()
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        model: 'seedream-4-0-250828',
+        data: [
+          { url: 'https://example.com/1.png', size: '1024x1024' },
+          {
+            error: {
+              code: 'OutputImageSensitiveContentDetected',
+              message: 'The output image may contain sensitive information.',
+            },
+          },
+          { error: { code: 'InternalServiceError', message: 'try again' } },
+        ],
+        usage: { generated_images: 1, output_tokens: 1000, total_tokens: 1000 },
+      }),
+    )
+
+    const result = await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'four seasons of one courtyard',
+      numberOfImages: 4,
+      logger,
+    })
+
+    // The one good image survives rather than the whole call failing.
+    expect(result.images).toEqual([{ url: 'https://example.com/1.png' }])
+
+    // The two failures are reported with their provider codes.
+    const errorLog = messages(spy.error)
+    expect(errorLog).toContain('dropped 2 failed image(s)')
+    expect(errorLog).toContain('OutputImageSensitiveContentDetected')
+    expect(errorLog).toContain('InternalServiceError')
+
+    // And the shortfall against numberOfImages is surfaced separately.
+    expect(messages(spy.warn)).toContain('requested 4 images, received 1')
+  })
+
+  it('warns when the model returns fewer images than requested', async () => {
+    const { spy, logger } = capturingLogger()
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        model: 'seedream-4-0-250828',
+        data: [{ url: 'https://example.com/1.png' }],
+        usage: { generated_images: 1, output_tokens: 10, total_tokens: 10 },
+      }),
+    )
+
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      numberOfImages: 3,
+      logger,
+    })
+
+    // No per-image failure here — just a model that decided one was enough.
+    expect(spy.error).not.toHaveBeenCalled()
+    expect(messages(spy.warn)).toContain('requested 3 images, received 1')
+  })
+
+  it('does not warn when the count is met', async () => {
+    const { spy, logger } = capturingLogger()
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      numberOfImages: 1,
+      logger,
+    })
+    expect(spy.warn).not.toHaveBeenCalled()
+  })
+
+  it('surfaces per-image codes when every image fails', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        model: 'seedream-4-0-250828',
+        data: [
+          { error: { code: 'OutputImageSensitiveContentDetected' } },
+          { error: { code: 'InternalServiceError', message: 'try again' } },
+        ],
+      }),
+    )
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: 'a guitar',
+        numberOfImages: 2,
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(
+      /returned no images: OutputImageSensitiveContentDetected; InternalServiceError: try again/,
+    )
+  })
+
+  it('throws with the response error when no image comes back', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        model: 'seedream-4-0-250828',
+        data: [],
+        error: {
+          code: 'OutputImageSensitiveContentDetected',
+          message:
+            'The request failed because the output image may contain sensitive information.',
+        },
+      }),
+    )
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: 'a guitar',
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(
+      /returned no images: OutputImageSensitiveContentDetected: The request failed/,
+    )
+  })
+})
+
+describe('error handling', () => {
+  it('surfaces the Ark error envelope', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse(
+        {
+          error: {
+            code: 'InputTextSensitiveContentDetected',
+            message:
+              'The request failed because the input text may contain sensitive information.',
+          },
+        },
+        400,
+      ),
+    )
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: 'a guitar',
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(
+      /BytePlus Ark image generation failed \(400 InputTextSensitiveContentDetected\)/,
+    )
+  })
+
+  it('logs the failure through logger.errors before rethrowing', async () => {
+    const { spy, logger } = capturingLogger()
+    const fetchMock = mockFetch(() =>
+      jsonResponse(
+        { error: { code: 'QuotaExceeded', message: 'slow down' } },
+        429,
+      ),
+    )
+
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: 'a guitar',
+        logger,
+      }),
+    ).rejects.toThrow(/QuotaExceeded/)
+
+    expect(messages(spy.error)).toContain('byteplus.generateImages fatal')
+    const meta = spy.error.mock.calls[0]?.[1]
+    expect(meta).toMatchObject({ source: 'byteplus.generateImages' })
+  })
+
+  it('falls back to the raw body for a non-JSON failure', async () => {
+    const fetchMock = mockFetch(
+      () =>
+        new Response('<html>Bad Gateway</html>', {
+          status: 502,
+          headers: { 'Content-Type': 'text/html' },
+        }),
+    )
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: 'a guitar',
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/failed \(502\): <html>Bad Gateway<\/html>/)
+  })
+})
+
+describe('core generateImage() integration', () => {
+  it('drives the adapter through the core entry point', async () => {
+    const fetchMock = mockFetch(() => jsonResponse(successBody))
+    const result = await generateImage({
+      adapter: adapterWithFetch(fetchMock),
+      // Reference images are part of the prompt at the call site: the
+      // adapter's modality map has to admit image parts for this to compile.
+      prompt: [
+        { type: 'text', content: 'put this guitar on a beach' },
+        imagePart('https://example.com/guitar.png'),
+      ],
+      size: '2K',
+      modelOptions: { watermark: false },
+      debug: false,
+    })
+
+    expect(result.images).toEqual([{ url: IMAGE_URL }])
+    expect(sentRequest(fetchMock)).toMatchObject({
+      model: 'seedream-4-0-250828',
+      size: '2K',
+      watermark: false,
+      image: ['https://example.com/guitar.png'],
+    })
+  })
+})
+
+describe('parseBytePlusImageSize', () => {
+  it('accepts the documented forms', () => {
+    expect(parseBytePlusImageSize('1K')).toEqual({ kind: 'token', value: '1K' })
+    expect(parseBytePlusImageSize('4k')).toEqual({ kind: 'token', value: '4K' })
+    expect(parseBytePlusImageSize('2048x2048')).toEqual({
+      kind: 'pixels',
+      width: 2048,
+      height: 2048,
+    })
+  })
+
+  it('rejects everything else', () => {
+    for (const invalid of [
+      '3K',
+      '2K_1024',
+      '1024',
+      '1024x',
+      '0x1024',
+      '',
+      // Internal whitespace is not a documented form.
+      '2048 x 2048',
+      '2048x 2048',
+      // The docs render the separator as U+00D7, which the API rejects.
+      '2048×2048',
+      // Mixing the two forms.
+      '2K x 1024',
+    ]) {
+      expect(parseBytePlusImageSize(invalid)).toBeUndefined()
+    }
+  })
+
+  it('still trims surrounding whitespace', () => {
+    expect(parseBytePlusImageSize('  2K  ')).toEqual({
+      kind: 'token',
+      value: '2K',
+    })
+    expect(parseBytePlusImageSize(' 2048x2048 ')).toEqual({
+      kind: 'pixels',
+      width: 2048,
+      height: 2048,
+    })
+  })
+})

--- a/packages/ai-byteplus/tests/image.test.ts
+++ b/packages/ai-byteplus/tests/image.test.ts
@@ -640,6 +640,95 @@ describe('response mapping', () => {
     )
   })
 
+  // Ark's OpenAPI document describes a second, nested `data[]` item form, so
+  // an item matching none of b64_json / url / error is a live possibility. It
+  // used to be dropped without even being counted, which turned provider drift
+  // into a bare "returned no images" with nothing to act on.
+  it('reports unrecognized data items rather than dropping them', async () => {
+    const { spy, logger } = capturingLogger()
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        model: 'seedream-4-0-250828',
+        data: [{ imagecontent: [{ image_url: 'https://example.com/1.png' }] }],
+      }),
+    )
+
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: 'a guitar',
+        logger,
+      }),
+    ).rejects.toThrow(/1 unrecognized response item/)
+    expect(messages(spy.error)).toContain(
+      'matched none of b64_json / url / error',
+    )
+  })
+
+  it('carries the raw body into the unrecognized-item error', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        model: 'seedream-4-0-250828',
+        data: [{ imagecontent: [{ image_url: 'https://example.com/1.png' }] }],
+      }),
+    )
+
+    await expect(
+      adapterWithFetch(fetchMock).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: 'a guitar',
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/imagecontent/)
+  })
+
+  // `readJsonBody` returns the raw text for a non-JSON body — an HTML error
+  // page from a proxy in front of the API, served with a 200.
+  it.each([
+    ['an empty body', new Response('', { status: 200 })],
+    [
+      'an HTML page',
+      new Response('<html>502 Bad Gateway</html>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    ],
+  ])('throws with the body in hand for %s', async (_label, response) => {
+    await expect(
+      adapterWithFetch(mockFetch(() => response)).generateImages({
+        model: 'seedream-4-0-250828',
+        prompt: 'a guitar',
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/non-object body/)
+  })
+
+  // A partial group failure returns successfully with a short array. The
+  // `numberOfImages` warning only fires when the count was set explicitly, so
+  // without this one a caller who omitted it gets no signal at all.
+  it('warns on a partial failure even when numberOfImages is unset', async () => {
+    const { spy, logger } = capturingLogger()
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        model: 'seedream-4-0-250828',
+        data: [
+          { url: 'https://example.com/1.png' },
+          { error: { code: 'InternalServiceError', message: 'try again' } },
+        ],
+        usage: { generated_images: 1, output_tokens: 10, total_tokens: 10 },
+      }),
+    )
+
+    const result = await adapterWithFetch(fetchMock).generateImages({
+      model: 'seedream-4-0-250828',
+      prompt: 'a guitar',
+      logger,
+    })
+
+    expect(result.images).toHaveLength(1)
+    expect(messages(spy.warn)).toContain('1 of 2 images failed to generate')
+  })
+
   it('throws with the response error when no image comes back', async () => {
     const fetchMock = mockFetch(() =>
       jsonResponse({

--- a/packages/ai-byteplus/tests/model-meta.test.ts
+++ b/packages/ai-byteplus/tests/model-meta.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BYTEPLUS_CHAT_MODELS,
+  BYTEPLUS_IMAGE_MAX_REFERENCE_IMAGES,
+  BYTEPLUS_IMAGE_MODELS,
+  BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS,
+  BYTEPLUS_THINKING_SUMMARY_MODELS,
+  BYTEPLUS_VIDEO_DURATIONS,
+  BYTEPLUS_VIDEO_MODELS,
+  emitsEncryptedContent,
+  getBytePlusVideoDurationOptions,
+  supportsStructuredOutput,
+} from '../src/index'
+
+describe('model lists', () => {
+  it('has no duplicate ids across a kind', () => {
+    for (const models of [
+      BYTEPLUS_CHAT_MODELS,
+      BYTEPLUS_VIDEO_MODELS,
+      BYTEPLUS_IMAGE_MODELS,
+    ]) {
+      expect(new Set(models).size).toBe(models.length)
+    }
+  })
+
+  it('only ships dated model ids', () => {
+    for (const model of [
+      ...BYTEPLUS_CHAT_MODELS,
+      ...BYTEPLUS_VIDEO_MODELS,
+      ...BYTEPLUS_IMAGE_MODELS,
+    ]) {
+      expect(model).toMatch(/-\d{6}$/)
+    }
+  })
+
+  it('keeps the prefixes the API requires', () => {
+    // Seedance 2.0 only resolves with the `dreamina-` prefix, and the 2.1
+    // turbo chat model / 5.0 Pro image model echo back the `dola-` prefix.
+    for (const model of BYTEPLUS_VIDEO_MODELS) {
+      if (model.includes('seedance-2-0')) {
+        expect(model.startsWith('dreamina-')).toBe(true)
+      }
+    }
+    expect(BYTEPLUS_CHAT_MODELS).toContain('dola-seed-2-1-turbo-260628')
+    expect(BYTEPLUS_IMAGE_MODELS).toContain('dola-seedream-5-0-pro-260628')
+  })
+})
+
+describe('chat capability sets', () => {
+  it('draws thinking-summary models from the chat list', () => {
+    for (const model of BYTEPLUS_THINKING_SUMMARY_MODELS) {
+      expect(BYTEPLUS_CHAT_MODELS).toContain(model)
+      expect(emitsEncryptedContent(model)).toBe(true)
+    }
+  })
+
+  it('draws structured-output models from the chat list', () => {
+    for (const model of BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS) {
+      expect(BYTEPLUS_CHAT_MODELS).toContain(model)
+      expect(supportsStructuredOutput(model)).toBe(true)
+    }
+  })
+
+  it('excludes the models that reject a JSON schema', () => {
+    for (const model of [
+      'seed-2-0-pro-260328',
+      'seed-2-0-code-preview-260328',
+      'glm-5-2-260617',
+      'deepseek-v4-pro-260425',
+      'gpt-oss-120b-250805',
+    ]) {
+      expect(supportsStructuredOutput(model)).toBe(false)
+    }
+  })
+
+  it('reports unknown models as unsupported rather than throwing', () => {
+    expect(supportsStructuredOutput('not-a-model')).toBe(false)
+    expect(emitsEncryptedContent('not-a-model')).toBe(false)
+  })
+})
+
+describe('video durations', () => {
+  it('covers every video model', () => {
+    for (const model of BYTEPLUS_VIDEO_MODELS) {
+      expect(BYTEPLUS_VIDEO_DURATIONS[model].kind).toBe('range')
+    }
+  })
+
+  it('encodes the per-family ranges', () => {
+    expect(
+      getBytePlusVideoDurationOptions('dreamina-seedance-2-0-260128'),
+    ).toMatchObject({ min: 4, max: 15 })
+    expect(
+      getBytePlusVideoDurationOptions('seedance-1-5-pro-251215'),
+    ).toMatchObject({ min: 4, max: 12 })
+    expect(
+      getBytePlusVideoDurationOptions('seedance-1-0-pro-250528'),
+    ).toMatchObject({ min: 2, max: 12 })
+  })
+})
+
+describe('image reference limits', () => {
+  it('caps Seedream 5.0 Pro lower than the rest', () => {
+    expect(
+      BYTEPLUS_IMAGE_MAX_REFERENCE_IMAGES['dola-seedream-5-0-pro-260628'],
+    ).toBe(10)
+    for (const model of BYTEPLUS_IMAGE_MODELS) {
+      expect(BYTEPLUS_IMAGE_MAX_REFERENCE_IMAGES[model]).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/ai-byteplus/tests/model-meta.test.ts
+++ b/packages/ai-byteplus/tests/model-meta.test.ts
@@ -61,15 +61,29 @@ describe('chat capability sets', () => {
     }
   })
 
+  // The live probe contradicts the BytePlus capability tables for five models,
+  // so both directions are pinned here.
   it('excludes the models that reject a JSON schema', () => {
     for (const model of [
-      'seed-2-0-pro-260328',
+      'seed-2-0-lite-260428',
+      'seed-2-0-mini-260428',
       'seed-2-0-code-preview-260328',
-      'glm-5-2-260617',
       'deepseek-v4-pro-260425',
+      'deepseek-v4-flash-260425',
+      'deepseek-v3-2-251201',
       'gpt-oss-120b-250805',
     ]) {
       expect(supportsStructuredOutput(model)).toBe(false)
+    }
+  })
+
+  it('includes the models the docs wrongly mark as unsupported', () => {
+    for (const model of [
+      'seed-2-0-pro-260328',
+      'glm-5-2-260617',
+      'glm-4-7-251222',
+    ]) {
+      expect(supportsStructuredOutput(model)).toBe(true)
     }
   })
 

--- a/packages/ai-byteplus/tests/model-meta.test.ts
+++ b/packages/ai-byteplus/tests/model-meta.test.ts
@@ -77,14 +77,21 @@ describe('chat capability sets', () => {
     }
   })
 
+  it('excludes glm-4-7, which accepts a schema but ignores it', () => {
+    // The only model that fails on adherence rather than on the request: it
+    // answers 200 and then returns prose. Pinned separately so a future
+    // status-code-only probe does not "restore" it.
+    expect(supportsStructuredOutput('glm-4-7-251222')).toBe(false)
+  })
+
   it('includes the models the docs wrongly mark as unsupported', () => {
-    for (const model of [
-      'seed-2-0-pro-260328',
-      'glm-5-2-260617',
-      'glm-4-7-251222',
-    ]) {
+    for (const model of ['seed-2-0-pro-260328', 'glm-5-2-260617']) {
       expect(supportsStructuredOutput(model)).toBe(true)
     }
+  })
+
+  it('has exactly the ten verified structured-output models', () => {
+    expect(BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS).toHaveLength(10)
   })
 
   it('reports unknown models as unsupported rather than throwing', () => {

--- a/packages/ai-byteplus/tests/text.test.ts
+++ b/packages/ai-byteplus/tests/text.test.ts
@@ -7,7 +7,7 @@ import {
   vi,
   type Mock,
 } from 'vitest'
-import { EventType } from '@tanstack/ai'
+import { EventType, chat } from '@tanstack/ai'
 import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
 import {
   createBytePlusText as _realCreateBytePlusText,
@@ -282,10 +282,14 @@ describe('BytePlus text adapter', () => {
         (c) => c.type === EventType.STEP_FINISHED,
       )
       expect(stepFinished).toHaveLength(1)
-      expect(
-        stepFinished[0]?.type === EventType.STEP_FINISHED &&
-          stepFinished[0].signature,
-      ).toBe(ENCRYPTED_BLOB)
+      const step = stepFinished[0]
+      if (step?.type !== EventType.STEP_FINISHED) throw new Error('no step')
+      expect(step.signature).toBe(ENCRYPTED_BLOB)
+      // `delta` must carry the reasoning text too. chat()'s agent loop
+      // accumulates thinking only from STEP_FINISHED.delta and discards the
+      // whole step — signature included — when that accumulation is empty, so
+      // a signature without a delta never reaches the continuation message.
+      expect(step.delta).toBe('The user wants a greeting.')
     })
 
     it('does not treat the encrypted chunk as reasoning text', async () => {
@@ -325,6 +329,15 @@ describe('BytePlus text adapter', () => {
       expect(
         chunks.some((c) => c.type === EventType.REASONING_MESSAGE_CONTENT),
       ).toBe(false)
+
+      // Pinning the consequence, not endorsing it: with no reasoning deltas
+      // the base never opens a reasoning lifecycle, so there is no
+      // STEP_FINISHED to stamp and the blob is silently dropped. Live Ark
+      // always sends the encrypted chunk *after* reasoning deltas, but that
+      // ordering is observed behaviour rather than a documented contract — if
+      // this assertion ever fails because a STEP_FINISHED appeared, the
+      // capture path needs revisiting, not this expectation.
+      expect(chunks.some((c) => c.type === EventType.STEP_FINISHED)).toBe(false)
     })
 
     it('emits AG-UI tool-call events with the OpenAI tool shape', async () => {
@@ -558,6 +571,40 @@ describe('BytePlus text adapter', () => {
       })
     })
 
+    it('wraps inline base64 image data in a data: URI', async () => {
+      const content = await contentPartsFor([
+        { type: 'text', content: 'What is this?' },
+        {
+          type: 'image',
+          source: { type: 'data', value: 'QUJD', mimeType: 'image/png' },
+        },
+      ])
+
+      expect(content).toContainEqual({
+        type: 'image_url',
+        image_url: { url: 'data:image/png;base64,QUJD', detail: 'auto' },
+      })
+    })
+
+    it('passes an already-encoded image data URI through untouched', async () => {
+      const content = await contentPartsFor([
+        { type: 'text', content: 'What is this?' },
+        {
+          type: 'image',
+          source: {
+            type: 'data',
+            value: 'data:image/png;base64,QUJD',
+            mimeType: 'image/png',
+          },
+        },
+      ])
+
+      expect(content).toContainEqual({
+        type: 'image_url',
+        image_url: { url: 'data:image/png;base64,QUJD', detail: 'auto' },
+      })
+    })
+
     it('sends video parts as video_url', async () => {
       const content = await contentPartsFor([
         { type: 'text', content: 'Describe this' },
@@ -597,6 +644,45 @@ describe('BytePlus text adapter', () => {
       expect(dataContent).toContainEqual({
         type: 'input_audio',
         input_audio: { data: 'QUJD', format: 'mp3' },
+      })
+    })
+
+    it('strips a data: prefix from inline audio — Ark takes bare base64', async () => {
+      const content = await contentPartsFor([
+        { type: 'text', content: 'Transcribe' },
+        {
+          type: 'audio',
+          source: {
+            type: 'data',
+            value: 'data:audio/wav;base64,QUJD',
+            mimeType: 'audio/wav',
+          },
+        },
+      ])
+
+      expect(content).toContainEqual({
+        type: 'input_audio',
+        input_audio: { data: 'QUJD', format: 'wav' },
+      })
+    })
+
+    it('honours an explicit metadata.format over the mimeType', async () => {
+      const content = await contentPartsFor([
+        { type: 'text', content: 'Transcribe' },
+        {
+          type: 'audio',
+          source: {
+            type: 'data',
+            value: 'QUJD',
+            mimeType: 'application/octet-stream',
+          },
+          metadata: { format: 'flac' },
+        },
+      ])
+
+      expect(content).toContainEqual({
+        type: 'input_audio',
+        input_audio: { data: 'QUJD', format: 'flac' },
       })
     })
 
@@ -708,5 +794,221 @@ describe('BytePlus text adapter', () => {
         response_format: { type: 'json_schema' },
       })
     })
+
+    it('streams structured output on a supported model', async () => {
+      setupMockSdkClient([
+        {
+          id: 'chatcmpl-sos',
+          model: STRUCTURED_MODEL,
+          choices: [{ index: 0, delta: { content: '{"city":' } }],
+        },
+        {
+          id: 'chatcmpl-sos',
+          model: STRUCTURED_MODEL,
+          choices: [
+            {
+              index: 0,
+              delta: { content: '"Paris"}' },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      ])
+      const adapter = createBytePlusText(STRUCTURED_MODEL, 'ark-test-key')
+
+      const chunks = await collect(
+        adapter.structuredOutputStream({
+          chatOptions: {
+            model: STRUCTURED_MODEL,
+            messages: [{ role: 'user', content: 'Where is the Eiffel tower?' }],
+            logger: testLogger,
+          },
+          outputSchema: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+            required: ['city'],
+          },
+        }),
+      )
+
+      expect(chunks.some((c) => c.type === EventType.RUN_ERROR)).toBe(false)
+      const complete = chunks.find(
+        (c) =>
+          c.type === EventType.CUSTOM &&
+          c.name === 'structured-output.complete',
+      )
+      expect(
+        complete?.type === EventType.CUSTOM &&
+          (complete.value as { object: unknown }).object,
+      ).toEqual({ city: 'Paris' })
+    })
+  })
+})
+
+/**
+ * The blob is only useful if it survives the whole round-trip through the
+ * chat engine, not just the adapter's own event stream: the server agent loop
+ * builds the continuation message itself, and it reads thinking from a
+ * different field than the client StreamProcessor does. These tests drive the
+ * real `chat()` agent loop so a regression in that hand-off is caught here
+ * rather than against live Ark.
+ */
+describe('encrypted_content through the chat() agent loop', () => {
+  beforeEach(() => {
+    pendingMockCreate = undefined
+  })
+
+  const lookupWeather: Tool = {
+    name: 'lookup_weather',
+    description: 'Look up the weather for a city',
+    inputSchema: {
+      type: 'object',
+      properties: { city: { type: 'string' } },
+      required: ['city'],
+    },
+    execute: async () => ({ conditions: 'sunny' }),
+  }
+
+  /**
+   * Turn 1: reasoning deltas → the dedicated encrypted chunk → a tool call.
+   * `text` controls whether the assistant also produces content, which selects
+   * between the finish_reason path and the drain path in the base.
+   */
+  function toolCallTurn(
+    model: string,
+    options: { text: boolean },
+  ): Array<Record<string, unknown>> {
+    return [
+      {
+        id: 'chatcmpl-loop',
+        model,
+        choices: [{ index: 0, delta: { reasoning_content: 'Need the tool.' } }],
+      },
+      {
+        id: 'chatcmpl-loop',
+        model,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: '',
+              reasoning_content: '',
+              encrypted_content: ENCRYPTED_BLOB,
+            },
+          },
+        ],
+      },
+      ...(options.text
+        ? [
+            {
+              id: 'chatcmpl-loop',
+              model,
+              choices: [{ index: 0, delta: { content: 'Checking.' } }],
+            },
+          ]
+        : []),
+      {
+        id: 'chatcmpl-loop',
+        model,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_loop_1',
+                  type: 'function',
+                  function: {
+                    name: 'lookup_weather',
+                    arguments: '{"city":"Berlin"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+    ]
+  }
+
+  function finalTurn(model: string): Array<Record<string, unknown>> {
+    return [
+      {
+        id: 'chatcmpl-loop-2',
+        model,
+        choices: [
+          {
+            index: 0,
+            delta: { content: 'It is sunny in Berlin.' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+    ]
+  }
+
+  /**
+   * Runs a two-request agent loop and returns the request body of the
+   * continuation call.
+   */
+  async function continuationRequest(options: { text: boolean }): Promise<any> {
+    const model = THINKING_SUMMARY_MODEL
+    const turns = [
+      toolCallTurn(model, { text: options.text }),
+      finalTurn(model),
+    ]
+    let call = 0
+    const mockCreate = vi.fn().mockImplementation(() => {
+      const chunks = turns[Math.min(call++, turns.length - 1)]!
+      return Promise.resolve(createAsyncIterable(chunks))
+    })
+
+    const adapter = _realCreateBytePlusText(model, 'ark-test-key')
+    ;(adapter as any).client = {
+      chat: { completions: { create: mockCreate } },
+    }
+
+    for await (const _ of chat({
+      adapter,
+      messages: [{ role: 'user', content: 'Weather in Berlin?' }],
+      tools: [lookupWeather],
+    })) {
+      // consume the stream
+    }
+
+    expect(mockCreate).toHaveBeenCalledTimes(2)
+    return mockCreate.mock.calls[1]?.[0]
+  }
+
+  it('echoes encrypted_content on the continuation request', async () => {
+    const body = await continuationRequest({ text: true })
+
+    const assistant = body.messages.find(
+      (m: any) => m.role === 'assistant' && m.tool_calls,
+    )
+    expect(assistant).toBeDefined()
+    expect(assistant.encrypted_content).toBe(ENCRYPTED_BLOB)
+    expect(assistant.tool_calls[0].function.name).toBe('lookup_weather')
+    // The tool result must be there too — otherwise the loop didn't actually
+    // continue and the assertion above proves nothing about a real 2nd turn.
+    expect(
+      body.messages.some(
+        (m: any) => m.role === 'tool' && m.tool_call_id === 'call_loop_1',
+      ),
+    ).toBe(true)
+  })
+
+  it('echoes it on the drain path too (thinking + tool call, no text)', async () => {
+    const body = await continuationRequest({ text: false })
+
+    const assistant = body.messages.find(
+      (m: any) => m.role === 'assistant' && m.tool_calls,
+    )
+    expect(assistant.encrypted_content).toBe(ENCRYPTED_BLOB)
+    // An assistant turn with only tool calls sends `content: null`, per the
+    // Chat Completions contract the base implements.
+    expect(assistant.content).toBeNull()
   })
 })

--- a/packages/ai-byteplus/tests/text.test.ts
+++ b/packages/ai-byteplus/tests/text.test.ts
@@ -1,0 +1,712 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest'
+import { EventType } from '@tanstack/ai'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import {
+  createBytePlusText as _realCreateBytePlusText,
+  byteplusText as _realBytePlusText,
+} from '../src/adapters/text'
+import {
+  BYTEPLUS_CHAT_MODELS,
+  BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS,
+  BYTEPLUS_THINKING_SUMMARY_MODELS,
+} from '../src/model-meta'
+import type { ContentPart, ModelMessage, StreamChunk, Tool } from '@tanstack/ai'
+import type { BytePlusTextProviderOptions } from '../src/index'
+
+// Silent logger for adapter calls under test.
+const testLogger = resolveDebugOption(false)
+
+// Stub the OpenAI SDK so constructing an adapter never opens a real network
+// handle. The per-test mock client is injected post-construction through the
+// wrapped factories below (the ai-groq / ai-grok pattern) rather than by
+// stubbing globals — the built openai-base dist resolves `openai`
+// independently, so vi.mock alone would not intercept it.
+vi.mock('openai', () => {
+  return {
+    default: class {
+      chat = {
+        completions: {
+          create: vi.fn(),
+        },
+      }
+    },
+  }
+})
+
+function createAsyncIterable<T>(chunks: Array<T>): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0
+      return {
+        async next() {
+          if (index < chunks.length) {
+            return { value: chunks[index++]!, done: false }
+          }
+          return { value: undefined as T, done: true }
+        },
+      }
+    },
+  }
+}
+
+let pendingMockCreate: Mock<(...args: Array<unknown>) => unknown> | undefined
+
+function setupMockSdkClient(
+  streamChunks: Array<Record<string, unknown>>,
+  nonStreamResponse?: Record<string, unknown>,
+): Mock<(...args: Array<unknown>) => unknown> {
+  pendingMockCreate = vi.fn().mockImplementation((params) => {
+    if (params.stream) {
+      return Promise.resolve(createAsyncIterable(streamChunks))
+    }
+    return Promise.resolve(nonStreamResponse)
+  })
+  return pendingMockCreate
+}
+
+function applyPendingMock<T extends object>(adapter: T): T {
+  if (pendingMockCreate) {
+    ;(adapter as any).client = {
+      chat: { completions: { create: pendingMockCreate } },
+    }
+    pendingMockCreate = undefined
+  }
+  return adapter
+}
+
+const createBytePlusText: typeof _realCreateBytePlusText = (
+  model,
+  apiKey,
+  config,
+) => applyPendingMock(_realCreateBytePlusText(model, apiKey, config))
+const byteplusText: typeof _realBytePlusText = (model, config) =>
+  applyPendingMock(_realBytePlusText(model, config))
+
+// Models are picked off the exported metadata rather than hard-coded so these
+// tests keep testing the *behaviour* (gating, echoing) if the underlying
+// capability lists are corrected.
+const THINKING_SUMMARY_MODEL = BYTEPLUS_THINKING_SUMMARY_MODELS[0]
+const PLAIN_MODEL = BYTEPLUS_CHAT_MODELS.find(
+  (model) =>
+    !(BYTEPLUS_THINKING_SUMMARY_MODELS as ReadonlyArray<string>).includes(
+      model,
+    ),
+)!
+const STRUCTURED_MODEL = BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS[0]
+const UNSTRUCTURED_MODEL = BYTEPLUS_CHAT_MODELS.find(
+  (model) =>
+    !(BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS as ReadonlyArray<string>).includes(
+      model,
+    ),
+)!
+
+const ENCRYPTED_BLOB = 'ENC-eyJhbGciOiJzaWduZWQifQ.reasoning-signature'
+
+const weatherTool: Tool = {
+  name: 'lookup_weather',
+  description: 'Return the forecast for a location',
+}
+
+/**
+ * The chunk sequence a thinking-summary model produces, as captured live:
+ * reasoning deltas → one dedicated encrypted_content chunk → content deltas →
+ * a finish chunk → a usage-only chunk with empty `choices`.
+ */
+function thinkingStreamChunks(model: string): Array<Record<string, unknown>> {
+  return [
+    {
+      id: 'chatcmpl-think',
+      model,
+      choices: [{ index: 0, delta: { reasoning_content: 'The user ' } }],
+    },
+    {
+      id: 'chatcmpl-think',
+      model,
+      choices: [
+        { index: 0, delta: { reasoning_content: 'wants a greeting.' } },
+      ],
+    },
+    {
+      id: 'chatcmpl-think',
+      model,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: '',
+            reasoning_content: '',
+            encrypted_content: ENCRYPTED_BLOB,
+          },
+        },
+      ],
+    },
+    {
+      id: 'chatcmpl-think',
+      model,
+      choices: [{ index: 0, delta: { content: 'Hello' } }],
+    },
+    {
+      id: 'chatcmpl-think',
+      model,
+      choices: [{ index: 0, delta: { content: '!' }, finish_reason: 'stop' }],
+    },
+    {
+      id: 'chatcmpl-think',
+      model,
+      choices: [],
+      usage: {
+        prompt_tokens: 12,
+        completion_tokens: 7,
+        total_tokens: 19,
+        completion_tokens_details: { reasoning_tokens: 4 },
+      },
+    },
+  ]
+}
+
+async function collect(
+  stream: AsyncIterable<StreamChunk>,
+): Promise<Array<StreamChunk>> {
+  const chunks: Array<StreamChunk> = []
+  for await (const chunk of stream) chunks.push(chunk)
+  return chunks
+}
+
+describe('BytePlus text adapter', () => {
+  beforeEach(() => {
+    pendingMockCreate = undefined
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('construction', () => {
+    it('creates an adapter with an explicit API key', () => {
+      const adapter = createBytePlusText('seed-2-0-lite-260428', 'ark-test-key')
+
+      expect(adapter.kind).toBe('text')
+      expect(adapter.name).toBe('byteplus')
+      expect(adapter.model).toBe('seed-2-0-lite-260428')
+    })
+
+    it('creates an adapter from ARK_API_KEY', () => {
+      vi.stubEnv('ARK_API_KEY', 'env-ark-key')
+
+      const adapter = byteplusText('seed-1-6-250915')
+
+      expect(adapter.model).toBe('seed-1-6-250915')
+    })
+
+    it('throws when ARK_API_KEY is missing', () => {
+      vi.stubEnv('ARK_API_KEY', '')
+
+      expect(() => byteplusText('seed-2-0-lite-260428')).toThrow('ARK_API_KEY')
+    })
+
+    it('accepts a baseURL override (EU endpoint)', () => {
+      const adapter = createBytePlusText(
+        'seed-2-0-lite-260428',
+        'ark-test-key',
+        { baseURL: 'https://ark.eu-west.bytepluses.com/api/v3' },
+      )
+
+      expect(adapter).toBeDefined()
+    })
+  })
+
+  describe('streaming', () => {
+    it('emits reasoning, then text, then usage for a thinking stream', async () => {
+      setupMockSdkClient(thinkingStreamChunks(THINKING_SUMMARY_MODEL))
+      const adapter = createBytePlusText(THINKING_SUMMARY_MODEL, 'ark-test-key')
+
+      const chunks = await collect(
+        adapter.chatStream({
+          model: THINKING_SUMMARY_MODEL,
+          messages: [{ role: 'user', content: 'Say hi' }],
+          logger: testLogger,
+        }),
+      )
+
+      const types = chunks.map((c) => c.type)
+      expect(types[0]).toBe(EventType.RUN_STARTED)
+      expect(types).toContain(EventType.REASONING_MESSAGE_START)
+      expect(types).toContain(EventType.TEXT_MESSAGE_START)
+      expect(types.indexOf(EventType.REASONING_END)).toBeLessThan(
+        types.indexOf(EventType.TEXT_MESSAGE_START),
+      )
+
+      const reasoning = chunks
+        .filter((c) => c.type === EventType.REASONING_MESSAGE_CONTENT)
+        .map((c) => c.delta)
+        .join('')
+      expect(reasoning).toBe('The user wants a greeting.')
+
+      const text = chunks
+        .filter((c) => c.type === EventType.TEXT_MESSAGE_CONTENT)
+        .map((c) => c.delta)
+        .join('')
+      expect(text).toBe('Hello!')
+
+      const runFinished = chunks.find((c) => c.type === EventType.RUN_FINISHED)
+      expect(
+        runFinished?.type === EventType.RUN_FINISHED && runFinished.usage,
+      ).toMatchObject({
+        promptTokens: 12,
+        completionTokens: 7,
+        totalTokens: 19,
+      })
+    })
+
+    it('attaches encrypted_content to the reasoning step as its signature', async () => {
+      setupMockSdkClient(thinkingStreamChunks(THINKING_SUMMARY_MODEL))
+      const adapter = createBytePlusText(THINKING_SUMMARY_MODEL, 'ark-test-key')
+
+      const chunks = await collect(
+        adapter.chatStream({
+          model: THINKING_SUMMARY_MODEL,
+          messages: [{ role: 'user', content: 'Say hi' }],
+          logger: testLogger,
+        }),
+      )
+
+      const stepFinished = chunks.filter(
+        (c) => c.type === EventType.STEP_FINISHED,
+      )
+      expect(stepFinished).toHaveLength(1)
+      expect(
+        stepFinished[0]?.type === EventType.STEP_FINISHED &&
+          stepFinished[0].signature,
+      ).toBe(ENCRYPTED_BLOB)
+    })
+
+    it('does not treat the encrypted chunk as reasoning text', async () => {
+      setupMockSdkClient([
+        {
+          id: 'chatcmpl-enc-only',
+          model: THINKING_SUMMARY_MODEL,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: '',
+                reasoning_content: '',
+                encrypted_content: ENCRYPTED_BLOB,
+              },
+            },
+          ],
+        },
+        {
+          id: 'chatcmpl-enc-only',
+          model: THINKING_SUMMARY_MODEL,
+          choices: [
+            { index: 0, delta: { content: 'Hi' }, finish_reason: 'stop' },
+          ],
+        },
+      ])
+      const adapter = createBytePlusText(THINKING_SUMMARY_MODEL, 'ark-test-key')
+
+      const chunks = await collect(
+        adapter.chatStream({
+          model: THINKING_SUMMARY_MODEL,
+          messages: [{ role: 'user', content: 'Say hi' }],
+          logger: testLogger,
+        }),
+      )
+
+      expect(
+        chunks.some((c) => c.type === EventType.REASONING_MESSAGE_CONTENT),
+      ).toBe(false)
+    })
+
+    it('emits AG-UI tool-call events with the OpenAI tool shape', async () => {
+      const mockCreate = setupMockSdkClient([
+        {
+          id: 'chatcmpl-tool',
+          model: 'seed-2-0-lite-260428',
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_1',
+                    type: 'function',
+                    function: {
+                      name: 'lookup_weather',
+                      arguments: '{"location":',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          id: 'chatcmpl-tool',
+          model: 'seed-2-0-lite-260428',
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  { index: 0, function: { arguments: '"Berlin"}' } },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+        },
+      ])
+      const adapter = createBytePlusText('seed-2-0-lite-260428', 'ark-test-key')
+
+      const chunks = await collect(
+        adapter.chatStream({
+          model: 'seed-2-0-lite-260428',
+          messages: [{ role: 'user', content: 'Weather in Berlin?' }],
+          tools: [weatherTool],
+          logger: testLogger,
+        }),
+      )
+
+      // Ark accepts (and requires) `type: 'function'` — the docs' claimed
+      // `'function_call'` value is rejected with 400 InvalidParameter.
+      expect(mockCreate.mock.calls[0]?.[0]).toMatchObject({
+        tools: [{ type: 'function', function: { name: 'lookup_weather' } }],
+      })
+
+      const toolEnd = chunks.find((c) => c.type === EventType.TOOL_CALL_END)
+      expect(
+        toolEnd?.type === EventType.TOOL_CALL_END && toolEnd.input,
+      ).toEqual({ location: 'Berlin' })
+    })
+  })
+
+  describe('encrypted_content round-trip', () => {
+    const assistantWithSignature: ModelMessage = {
+      role: 'assistant',
+      content: 'Hello!',
+      thinking: [
+        { content: 'The user wants a greeting.', signature: ENCRYPTED_BLOB },
+      ],
+    }
+
+    async function requestBodyFor(
+      model: (typeof BYTEPLUS_CHAT_MODELS)[number],
+      messages: Array<ModelMessage>,
+    ): Promise<any> {
+      const mockCreate = setupMockSdkClient([
+        {
+          id: 'chatcmpl-echo',
+          model,
+          choices: [
+            { index: 0, delta: { content: 'ok' }, finish_reason: 'stop' },
+          ],
+        },
+      ])
+      const adapter = createBytePlusText(model, 'ark-test-key')
+      await collect(adapter.chatStream({ model, messages, logger: testLogger }))
+      return mockCreate.mock.calls[0]?.[0]
+    }
+
+    it('echoes the blob verbatim on the outgoing assistant message', async () => {
+      const body = await requestBodyFor(THINKING_SUMMARY_MODEL, [
+        { role: 'user', content: 'Say hi' },
+        assistantWithSignature,
+        { role: 'user', content: 'Again?' },
+      ])
+
+      expect(body.messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'Hello!',
+        encrypted_content: ENCRYPTED_BLOB,
+      })
+    })
+
+    it('omits the field when the assistant message carries no signature', async () => {
+      const body = await requestBodyFor(THINKING_SUMMARY_MODEL, [
+        { role: 'user', content: 'Say hi' },
+        { role: 'assistant', content: 'Hello!' },
+        { role: 'user', content: 'Again?' },
+      ])
+
+      expect(body.messages[1]).not.toHaveProperty('encrypted_content')
+    })
+
+    it('never forwards a signature on a model that does not emit the blob', async () => {
+      const body = await requestBodyFor(PLAIN_MODEL, [
+        { role: 'user', content: 'Say hi' },
+        assistantWithSignature,
+        { role: 'user', content: 'Again?' },
+      ])
+
+      expect(body.messages[1]).not.toHaveProperty('encrypted_content')
+    })
+
+    it('echoes the last signature when several thinking steps carry one', async () => {
+      const body = await requestBodyFor(THINKING_SUMMARY_MODEL, [
+        { role: 'user', content: 'Say hi' },
+        {
+          role: 'assistant',
+          content: 'Hello!',
+          thinking: [
+            { content: 'first', signature: 'ENC-first' },
+            { content: 'second', signature: 'ENC-second' },
+          ],
+        },
+        { role: 'user', content: 'Again?' },
+      ])
+
+      expect(body.messages[1].encrypted_content).toBe('ENC-second')
+    })
+  })
+
+  describe('provider options', () => {
+    it('forwards Ark-only and sampling options into the request body', async () => {
+      const mockCreate = setupMockSdkClient([
+        {
+          id: 'chatcmpl-opts',
+          model: 'seed-2-0-lite-260428',
+          choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        },
+      ])
+      const adapter = createBytePlusText('seed-2-0-lite-260428', 'ark-test-key')
+
+      const modelOptions: BytePlusTextProviderOptions = {
+        thinking: { type: 'enabled' },
+        reasoning_effort: 'high',
+        repetition_penalty: 1.05,
+        service_tier: 'flex',
+        temperature: 0.4,
+        max_tokens: 256,
+      }
+
+      await collect(
+        adapter.chatStream({
+          model: 'seed-2-0-lite-260428',
+          messages: [{ role: 'user', content: 'Hello' }],
+          modelOptions,
+          logger: testLogger,
+        }),
+      )
+
+      expect(mockCreate.mock.calls[0]?.[0]).toMatchObject({
+        thinking: { type: 'enabled' },
+        reasoning_effort: 'high',
+        repetition_penalty: 1.05,
+        service_tier: 'flex',
+        temperature: 0.4,
+        max_tokens: 256,
+        stream: true,
+        stream_options: { include_usage: true },
+      })
+    })
+  })
+
+  describe('multimodal content parts', () => {
+    async function contentPartsFor(parts: Array<ContentPart>): Promise<any> {
+      const mockCreate = setupMockSdkClient([
+        {
+          id: 'chatcmpl-mm',
+          model: 'seed-2-0-lite-260428',
+          choices: [
+            { index: 0, delta: { content: 'ok' }, finish_reason: 'stop' },
+          ],
+        },
+      ])
+      const adapter = createBytePlusText('seed-2-0-lite-260428', 'ark-test-key')
+      await collect(
+        adapter.chatStream({
+          model: 'seed-2-0-lite-260428',
+          messages: [{ role: 'user', content: parts }],
+          logger: testLogger,
+        }),
+      )
+      const body: any = mockCreate.mock.calls[0]?.[0]
+      return body.messages[0].content
+    }
+
+    it('sends image parts with Ark detail and pixel bounds', async () => {
+      const content = await contentPartsFor([
+        { type: 'text', content: 'What is this?' },
+        {
+          type: 'image',
+          source: { type: 'url', value: 'https://example.com/cat.png' },
+          metadata: {
+            detail: 'xhigh',
+            image_pixel_limit: { max_pixels: 1_000_000 },
+          },
+        },
+      ])
+
+      expect(content).toContainEqual({
+        type: 'image_url',
+        image_url: {
+          url: 'https://example.com/cat.png',
+          detail: 'xhigh',
+          image_pixel_limit: { max_pixels: 1_000_000 },
+        },
+      })
+    })
+
+    it('sends video parts as video_url', async () => {
+      const content = await contentPartsFor([
+        { type: 'text', content: 'Describe this' },
+        {
+          type: 'video',
+          source: { type: 'url', value: 'https://example.com/clip.mp4' },
+          metadata: { fps: 2 },
+        },
+      ])
+
+      expect(content).toContainEqual({
+        type: 'video_url',
+        video_url: { url: 'https://example.com/clip.mp4', fps: 2 },
+      })
+    })
+
+    it('sends URL audio as input_audio.url and inline audio as data + format', async () => {
+      const urlContent = await contentPartsFor([
+        { type: 'text', content: 'Transcribe' },
+        {
+          type: 'audio',
+          source: { type: 'url', value: 'https://example.com/clip.mp3' },
+        },
+      ])
+      expect(urlContent).toContainEqual({
+        type: 'input_audio',
+        input_audio: { url: 'https://example.com/clip.mp3' },
+      })
+
+      const dataContent = await contentPartsFor([
+        { type: 'text', content: 'Transcribe' },
+        {
+          type: 'audio',
+          source: { type: 'data', value: 'QUJD', mimeType: 'audio/mpeg' },
+        },
+      ])
+      expect(dataContent).toContainEqual({
+        type: 'input_audio',
+        input_audio: { data: 'QUJD', format: 'mp3' },
+      })
+    })
+
+    it('fails loud on inline audio with an unrecognised mimeType', async () => {
+      const chunks = await collect(
+        createBytePlusText('seed-2-0-lite-260428', 'ark-test-key').chatStream({
+          model: 'seed-2-0-lite-260428',
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', content: 'Transcribe' },
+                {
+                  type: 'audio',
+                  source: {
+                    type: 'data',
+                    value: 'QUJD',
+                    mimeType: 'audio/weird-codec',
+                  },
+                },
+              ],
+            },
+          ],
+          logger: testLogger,
+        }),
+      )
+
+      const runError = chunks.find((c) => c.type === EventType.RUN_ERROR)
+      expect(
+        runError?.type === EventType.RUN_ERROR && runError.message,
+      ).toContain('unrecognised mimeType')
+    })
+  })
+
+  describe('structured-output gating', () => {
+    it('opts into the native combined tools + schema path only on supported models', () => {
+      expect(
+        createBytePlusText(
+          STRUCTURED_MODEL,
+          'ark-test-key',
+        ).supportsCombinedToolsAndSchema(),
+      ).toBe(true)
+      expect(
+        createBytePlusText(
+          UNSTRUCTURED_MODEL,
+          'ark-test-key',
+        ).supportsCombinedToolsAndSchema(),
+      ).toBe(false)
+    })
+
+    it('throws from structuredOutput on a model Ark rejects json_schema for', async () => {
+      const adapter = createBytePlusText(UNSTRUCTURED_MODEL, 'ark-test-key')
+
+      await expect(
+        adapter.structuredOutput({
+          chatOptions: {
+            model: UNSTRUCTURED_MODEL,
+            messages: [{ role: 'user', content: 'Hi' }],
+            logger: testLogger,
+          },
+          outputSchema: { type: 'object', properties: {} },
+        }),
+      ).rejects.toThrow('does not support structured output')
+    })
+
+    it('emits RUN_ERROR (not a throw) from structuredOutputStream on those models', async () => {
+      const adapter = createBytePlusText(UNSTRUCTURED_MODEL, 'ark-test-key')
+
+      const chunks = await collect(
+        adapter.structuredOutputStream({
+          chatOptions: {
+            model: UNSTRUCTURED_MODEL,
+            messages: [{ role: 'user', content: 'Hi' }],
+            logger: testLogger,
+          },
+          outputSchema: { type: 'object', properties: {} },
+        }),
+      )
+
+      expect(chunks[0]?.type).toBe(EventType.RUN_STARTED)
+      const runError = chunks.find((c) => c.type === EventType.RUN_ERROR)
+      expect(runError?.type === EventType.RUN_ERROR && runError.code).toBe(
+        'unsupported-structured-output',
+      )
+    })
+
+    it('sends response_format json_schema on a supported model', async () => {
+      const mockCreate = setupMockSdkClient([], {
+        choices: [{ message: { content: '{"city":"Paris"}' } }],
+      })
+      const adapter = createBytePlusText(STRUCTURED_MODEL, 'ark-test-key')
+
+      const result = await adapter.structuredOutput({
+        chatOptions: {
+          model: STRUCTURED_MODEL,
+          messages: [{ role: 'user', content: 'Where is the Eiffel tower?' }],
+          logger: testLogger,
+        },
+        outputSchema: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+        },
+      })
+
+      expect(result.data).toEqual({ city: 'Paris' })
+      expect(mockCreate.mock.calls[0]?.[0]).toMatchObject({
+        stream: false,
+        response_format: { type: 'json_schema' },
+      })
+    })
+  })
+})

--- a/packages/ai-byteplus/tests/text.test.ts
+++ b/packages/ai-byteplus/tests/text.test.ts
@@ -7,7 +7,7 @@ import {
   vi,
   type Mock,
 } from 'vitest'
-import { EventType, chat } from '@tanstack/ai'
+import { EventType, StreamProcessor, chat } from '@tanstack/ai'
 import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
 import {
   createBytePlusText as _realCreateBytePlusText,
@@ -113,6 +113,23 @@ const ENCRYPTED_BLOB = 'ENC-eyJhbGciOiJzaWduZWQifQ.reasoning-signature'
 const weatherTool: Tool = {
   name: 'lookup_weather',
   description: 'Return the forecast for a location',
+}
+
+/** A minimal plain-text completion: one content delta, then a finish chunk. */
+function textStreamChunks(model: string): Array<Record<string, unknown>> {
+  return [
+    {
+      id: 'chatcmpl-text',
+      model,
+      choices: [{ index: 0, delta: { content: 'Hello!' } }],
+    },
+    {
+      id: 'chatcmpl-text',
+      model,
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 12, completion_tokens: 7, total_tokens: 19 },
+    },
+  ]
 }
 
 /**
@@ -748,6 +765,58 @@ describe('BytePlus text adapter', () => {
       ).rejects.toThrow('does not support structured output')
     })
 
+    // The two tests above assert the hook's return value and the
+    // structuredOutput* entry points in isolation. This one drives the whole
+    // chat() activity, which is where `supportsCombinedToolsAndSchema()` is
+    // actually consumed (`nativeCombined`, twice, in chat()'s activity), and
+    // pins the end-to-end consequence: on a rejecting model the guard fires
+    // *before* any request, so no schema Ark would 400 on ever leaves the
+    // process. Every structured E2E overrides to a supporting model, so this
+    // path ran nowhere.
+    it('fails before issuing a request when the model rejects json_schema', async () => {
+      const mockCreate = setupMockSdkClient(
+        textStreamChunks(UNSTRUCTURED_MODEL),
+      )
+      const adapter = createBytePlusText(UNSTRUCTURED_MODEL, 'ark-test-key')
+
+      const chunks: Array<StreamChunk> = []
+      for await (const chunk of chat({
+        adapter,
+        messages: [{ role: 'user', content: 'Say hi' }],
+        outputSchema: { type: 'object', properties: {} },
+        stream: true,
+      })) {
+        chunks.push(chunk)
+      }
+
+      // Ark has no json_object fallback, so there is nothing to downgrade to.
+      // The request is never made rather than being made without the schema.
+      expect(mockCreate).not.toHaveBeenCalled()
+
+      // And it surfaces as a named RUN_ERROR, not a raw 400 or silent prose.
+      const runError = chunks.find((c) => c.type === EventType.RUN_ERROR)
+      expect(
+        runError?.type === EventType.RUN_ERROR && runError.message,
+      ).toContain('does not support structured output')
+    })
+
+    it('does forward response_format into the streaming turns on a supported model', async () => {
+      const mockCreate = setupMockSdkClient(textStreamChunks(STRUCTURED_MODEL))
+      const adapter = createBytePlusText(STRUCTURED_MODEL, 'ark-test-key')
+
+      for await (const _ of chat({
+        adapter,
+        messages: [{ role: 'user', content: 'Say hi' }],
+        outputSchema: { type: 'object', properties: {} },
+        stream: true,
+      })) {
+        // consume
+      }
+
+      const request = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>
+      expect(request.response_format).toMatchObject({ type: 'json_schema' })
+    })
+
     it('emits RUN_ERROR (not a throw) from structuredOutputStream on those models', async () => {
       const adapter = createBytePlusText(UNSTRUCTURED_MODEL, 'ark-test-key')
 
@@ -1010,5 +1079,44 @@ describe('encrypted_content through the chat() agent loop', () => {
     // An assistant turn with only tool calls sends `content: null`, per the
     // Chat Completions contract the base implements.
     expect(assistant.content).toBeNull()
+  })
+})
+
+// The adapter stamps `delta` onto a STEP_FINISHED that already carries the
+// same reasoning text via REASONING_MESSAGE_CONTENT, because chat()'s agent
+// loop reads thinking only from STEP_FINISHED.delta and drops the whole step —
+// signature included — when that accumulation is empty.
+//
+// Nothing double-counts today only because StreamProcessor short-circuits
+// STEP_FINISHED content once it has seen reasoning events. That guarantee
+// lives in @tanstack/ai, not here, so without this test a change over there
+// would double every BytePlus reasoning block in the UI while this package
+// stayed green.
+describe('reasoning delta round-trip through StreamProcessor', () => {
+  it('surfaces the thinking text once, with the signature attached', async () => {
+    setupMockSdkClient(thinkingStreamChunks(THINKING_SUMMARY_MODEL))
+    const adapter = createBytePlusText(THINKING_SUMMARY_MODEL, 'ark-test-key')
+
+    const processor = new StreamProcessor()
+    for await (const chunk of adapter.chatStream({
+      model: THINKING_SUMMARY_MODEL,
+      messages: [{ role: 'user', content: 'Say hi' }],
+      logger: testLogger,
+    })) {
+      processor.processChunk(chunk)
+    }
+
+    const thinkingParts = processor
+      .getMessages()
+      .flatMap((message) => message.parts ?? [])
+      .filter((part) => part.type === 'thinking')
+
+    expect(thinkingParts).toHaveLength(1)
+    // Not 'The user wants a greeting.The user wants a greeting.' — the exact
+    // failure the STEP_FINISHED short-circuit prevents.
+    expect(thinkingParts[0]).toMatchObject({
+      content: 'The user wants a greeting.',
+      signature: ENCRYPTED_BLOB,
+    })
   })
 })

--- a/packages/ai-byteplus/tests/transcription.test.ts
+++ b/packages/ai-byteplus/tests/transcription.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { generateTranscription } from '@tanstack/ai'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
 import {
   BytePlusTranscriptionAdapter,
   createBytePlusTranscription,
@@ -387,6 +388,100 @@ describe('BytePlusTranscriptionAdapter', () => {
       expect(mapped.words).toBeUndefined()
       expect(mapped.usage).toBeUndefined()
       expect(mapped.duration).toBeUndefined()
+    })
+
+    // The word-level drop filter had no coverage: every fixture in this file
+    // and in the e2e mount is fully timed, so a field rename upstream
+    // (`word.text` → `word.word`) would have emptied `words` — or shipped
+    // `{ word: undefined, start: NaN }` — with nothing failing.
+    it('drops words with missing or non-numeric timings', async () => {
+      const mapped = mapRecognizeResponse(
+        {
+          result: {
+            text: 'a b c',
+            utterances: [
+              {
+                text: 'a b c',
+                start_time: 0,
+                end_time: 900,
+                words: [
+                  { text: 'a', start_time: 0, end_time: 300 },
+                  { text: 'b', start_time: 300 },
+                  { start_time: 600, end_time: 900 },
+                ],
+              },
+            ],
+          },
+        },
+        'a b c',
+      )
+
+      expect(mapped.words).toEqual([{ word: 'a', start: 0, end: 0.3 }])
+    })
+
+    it('warns when words are dropped rather than dropping them silently', async () => {
+      const logger = captureLogger()
+      mapRecognizeResponse(
+        {
+          result: {
+            text: 'a b',
+            utterances: [
+              {
+                text: 'a b',
+                start_time: 0,
+                end_time: 600,
+                words: [
+                  { text: 'a', start_time: 0, end_time: 300 },
+                  { text: 'b', start_time: 300 },
+                ],
+              },
+            ],
+          },
+        },
+        'a b',
+        resolveDebugOption({ logger }),
+      )
+
+      expect(
+        logger.warnings.some((w) => w.includes('dropped 1 of 2 word(s)')),
+      ).toBe(true)
+    })
+
+    it('warns when utterances are dropped rather than dropping them silently', async () => {
+      const logger = captureLogger()
+      mapRecognizeResponse(
+        {
+          result: {
+            text: 'partial',
+            utterances: [
+              { text: 'no timings' },
+              { text: 'timed', start_time: 0, end_time: 500 },
+            ],
+          },
+        },
+        'partial',
+        resolveDebugOption({ logger }),
+      )
+
+      expect(
+        logger.warnings.some((w) => w.includes('dropped 1 of 2 utterance(s)')),
+      ).toBe(true)
+    })
+
+    // An empty transcript is legitimate for silent audio, so it isn't an
+    // error — but it is also what a 200-wrapped failure looks like, and it
+    // used to be returned as a plain success with no signal at all.
+    it('warns on an empty transcript with no utterances', async () => {
+      const logger = captureLogger()
+      await generateTranscription({
+        adapter: adapterWith(asrFetch({ result: { text: '' } })),
+        audio: 'https://example.com/guitar.mp3',
+        debug: { logger },
+      })
+
+      expect(logger.warnings.some((w) => w.includes('empty transcript'))).toBe(
+        true,
+      )
     })
 
     it('surfaces per-word confidence for callers that narrow the type', async () => {

--- a/packages/ai-byteplus/tests/transcription.test.ts
+++ b/packages/ai-byteplus/tests/transcription.test.ts
@@ -1,0 +1,450 @@
+import { describe, expect, it, vi } from 'vitest'
+import { generateTranscription } from '@tanstack/ai'
+import {
+  BytePlusTranscriptionAdapter,
+  createBytePlusTranscription,
+  mapRecognizeResponse,
+  normalizeAudioInput,
+} from '../src/adapters/transcription'
+import type { Logger } from '@tanstack/ai'
+import type { BytePlusTranscriptionWord } from '../src/adapters/transcription'
+
+const BASE_URL = 'https://voice.test'
+
+/** Captures what the adapter routes through `logger.warn`. */
+function captureLogger(): Logger & { warnings: Array<string> } {
+  const warnings: Array<string> = []
+  return {
+    warnings,
+    debug: () => {},
+    info: () => {},
+    warn: (message: string) => {
+      warnings.push(message)
+    },
+    error: () => {},
+  }
+}
+
+const RECOGNIZE_RESPONSE = {
+  audio_info: { duration: 2499 },
+  result: {
+    text: 'a guitar being played in a store',
+    utterances: [
+      {
+        text: 'a guitar being played',
+        start_time: 450,
+        end_time: 1530,
+        words: [
+          { text: 'a', start_time: 450, end_time: 600 },
+          { text: 'guitar', start_time: 600, end_time: 1100 },
+        ],
+      },
+      {
+        text: 'in a store',
+        start_time: 1530,
+        end_time: 2400,
+        additions: { speaker: '2' },
+      },
+    ],
+  },
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+// A fresh `Response` per call — a `Response` body can only be read once, so a
+// shared instance breaks any test that fetches twice.
+function asrFetch(body: unknown = RECOGNIZE_RESPONSE, status = 200) {
+  return vi
+    .fn<typeof fetch>()
+    .mockImplementation(() => Promise.resolve(jsonResponse(body, status)))
+}
+
+function adapterWith(
+  fetchImpl: typeof fetch,
+  defaultHeaders?: Record<string, string>,
+) {
+  return new BytePlusTranscriptionAdapter('seed-asr', {
+    apiKey: 'voice-key',
+    baseURL: BASE_URL,
+    fetch: fetchImpl,
+    ...(defaultHeaders && { defaultHeaders }),
+  })
+}
+
+function lastRequest(fetchMock: ReturnType<typeof asrFetch>) {
+  const call = fetchMock.mock.calls.at(-1)
+  if (!call) throw new Error('fetch was not called')
+  const [url, init] = call
+  return {
+    url: String(url),
+    init: init as RequestInit,
+    headers: new Headers(init?.headers),
+    body: JSON.parse(String(init?.body)),
+  }
+}
+
+describe('BytePlusTranscriptionAdapter', () => {
+  it('posts to the flash endpoint with the ASR resource header', async () => {
+    const fetchMock = asrFetch()
+    await generateTranscription({
+      adapter: adapterWith(fetchMock),
+      audio: 'https://example.com/guitar.mp3',
+    })
+
+    const { url, init, headers, body } = lastRequest(fetchMock)
+    expect(url).toBe(`${BASE_URL}/api/v3/auc/bigmodel/recognize/flash`)
+    expect(init.method).toBe('POST')
+    expect(headers.get('x-api-key')).toBe('voice-key')
+    expect(headers.get('x-api-resource-id')).toBe('volc.seedasr.auc_turbo')
+
+    expect(body).toEqual({
+      user: { uid: 'tanstack-ai' },
+      audio: { url: 'https://example.com/guitar.mp3', format: 'mp3' },
+      request: { model_name: 'bigmodel', show_utterances: true },
+    })
+  })
+
+  it('maps transcript, segments, words and duration into seconds', async () => {
+    const result = await generateTranscription({
+      adapter: adapterWith(asrFetch()),
+      audio: 'https://example.com/guitar.mp3',
+      language: 'en-US',
+    })
+
+    expect(result.text).toBe('a guitar being played in a store')
+    expect(result.language).toBe('en-US')
+    expect(result.duration).toBe(2.499)
+    expect(result.segments).toEqual([
+      { id: 0, start: 0.45, end: 1.53, text: 'a guitar being played' },
+      { id: 1, start: 1.53, end: 2.4, text: 'in a store', speaker: '2' },
+    ])
+    expect(result.words).toEqual([
+      { word: 'a', start: 0.45, end: 0.6 },
+      { word: 'guitar', start: 0.6, end: 1.1 },
+    ])
+    expect(result.usage).toEqual({
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      durationSeconds: 2.499,
+    })
+    expect(result.id).toMatch(/^byteplus-/)
+  })
+
+  it('reads the flat transcript spelling when result is absent', async () => {
+    const result = await generateTranscription({
+      adapter: adapterWith(
+        asrFetch({
+          transcript: 'flat shape',
+          utterances: [{ text: 'flat shape', start_time: 0, end_time: 1000 }],
+        }),
+      ),
+      audio: 'https://example.com/a.wav',
+    })
+    expect(result.text).toBe('flat shape')
+    expect(result.segments).toEqual([
+      { id: 0, start: 0, end: 1, text: 'flat shape' },
+    ])
+  })
+
+  it('forwards recognition options and the language hint', async () => {
+    const fetchMock = asrFetch()
+    await generateTranscription({
+      adapter: adapterWith(fetchMock),
+      audio: 'https://example.com/a.mp3',
+      language: 'en-US',
+      modelOptions: {
+        enable_itn: true,
+        enable_punc: true,
+        enable_ddc: false,
+        enable_speaker_info: true,
+        show_utterances: false,
+        model_name: 'bigmodel',
+        uid: 'tenant-42',
+      },
+    })
+
+    const { body } = lastRequest(fetchMock)
+    expect(body.user).toEqual({ uid: 'tenant-42' })
+    expect(body.request).toEqual({
+      model_name: 'bigmodel',
+      show_utterances: false,
+      enable_itn: true,
+      enable_punc: true,
+      enable_ddc: false,
+      enable_speaker_info: true,
+      language: 'en-US',
+    })
+  })
+
+  it('lets modelOptions.language override the generic language', async () => {
+    const fetchMock = asrFetch()
+    const result = await generateTranscription({
+      adapter: adapterWith(fetchMock),
+      audio: 'https://example.com/a.mp3',
+      language: 'en',
+      modelOptions: { language: 'zh-CN' },
+    })
+    expect(lastRequest(fetchMock).body.request.language).toBe('zh-CN')
+    // The result reports the language actually sent, not the overridden hint.
+    expect(result.language).toBe('zh-CN')
+  })
+
+  describe('audio input normalisation', () => {
+    it('passes http(s) urls through and infers the container', async () => {
+      await expect(
+        normalizeAudioInput('https://example.com/a.wav?token=1', undefined),
+      ).resolves.toEqual({
+        url: 'https://example.com/a.wav?token=1',
+        format: 'wav',
+      })
+    })
+
+    it('splits data urls into base64 data plus a format', async () => {
+      await expect(
+        normalizeAudioInput('data:audio/mpeg;base64,QUJD', undefined),
+      ).resolves.toEqual({ data: 'QUJD', format: 'mp3' })
+    })
+
+    it('treats a bare string as base64 data', async () => {
+      await expect(normalizeAudioInput('QUJD', undefined)).resolves.toEqual({
+        data: 'QUJD',
+      })
+    })
+
+    it('base64-encodes binary inputs', async () => {
+      const bytes = new Uint8Array([1, 2, 3])
+      const expected = Buffer.from(bytes).toString('base64')
+
+      await expect(
+        normalizeAudioInput(bytes.buffer as ArrayBuffer, undefined),
+      ).resolves.toEqual({ data: expected })
+
+      await expect(
+        normalizeAudioInput(
+          new File([bytes], 'clip.flac', { type: 'audio/flac' }),
+          undefined,
+        ),
+      ).resolves.toEqual({ data: expected, format: 'flac' })
+
+      await expect(
+        normalizeAudioInput(
+          new Blob([bytes], { type: 'audio/ogg' }),
+          undefined,
+        ),
+      ).resolves.toEqual({ data: expected, format: 'ogg' })
+    })
+
+    it('lets modelOptions.audio_format win over the inferred container', async () => {
+      await expect(
+        normalizeAudioInput('https://example.com/a.wav', 'pcm'),
+      ).resolves.toEqual({ url: 'https://example.com/a.wav', format: 'pcm' })
+    })
+
+    it('sends encoded bytes as audio.data on a real request', async () => {
+      const fetchMock = asrFetch()
+      await generateTranscription({
+        adapter: adapterWith(fetchMock),
+        audio: new Uint8Array([1, 2, 3]).buffer as ArrayBuffer,
+        modelOptions: { audio_format: 'wav' },
+      })
+      expect(lastRequest(fetchMock).body.audio).toEqual({
+        data: Buffer.from([1, 2, 3]).toString('base64'),
+        format: 'wav',
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('surfaces the numeric Seed Speech error envelope on a 401', async () => {
+      const fetchMock = asrFetch(
+        { code: 45000010, message: 'Invalid X-Api-Key' },
+        401,
+      )
+      await expect(
+        generateTranscription({
+          adapter: adapterWith(fetchMock),
+          audio: 'https://example.com/a.mp3',
+          debug: false,
+        }),
+      ).rejects.toThrow(
+        'BytePlus Seed Speech transcription failed (401 45000010): Invalid X-Api-Key',
+      )
+    })
+
+    it('fails when a 200 response carries no transcript', async () => {
+      const fetchMock = asrFetch({ code: 45000151, message: 'Audio too long' })
+      await expect(
+        generateTranscription({
+          adapter: adapterWith(fetchMock),
+          audio: 'https://example.com/a.mp3',
+          debug: false,
+        }),
+      ).rejects.toThrow(
+        'BytePlus Seed Speech transcription failed (200 45000151): Audio too long',
+      )
+    })
+  })
+
+  describe('headers', () => {
+    it('merges configured default headers into the request', async () => {
+      const fetchMock = asrFetch()
+      await generateTranscription({
+        adapter: adapterWith(fetchMock, { 'X-Test-Id': 'abc' }),
+        audio: 'https://example.com/a.mp3',
+      })
+      expect(lastRequest(fetchMock).headers.get('x-test-id')).toBe('abc')
+    })
+
+    it('does not let default headers clobber the auth or resource headers', async () => {
+      const fetchMock = asrFetch()
+      await generateTranscription({
+        adapter: adapterWith(fetchMock, {
+          'X-Api-Key': 'attacker-key',
+          'X-Api-Resource-Id': 'volc.wrong.model',
+          'Content-Type': 'text/plain',
+        }),
+        audio: 'https://example.com/a.mp3',
+      })
+      const { headers } = lastRequest(fetchMock)
+      expect(headers.get('x-api-key')).toBe('voice-key')
+      expect(headers.get('x-api-resource-id')).toBe('volc.seedasr.auc_turbo')
+      expect(headers.get('content-type')).toBe('application/json')
+    })
+  })
+
+  describe('warnings for options the endpoint cannot honour', () => {
+    it('warns that prompt is ignored', async () => {
+      const logger = captureLogger()
+      await generateTranscription({
+        adapter: adapterWith(asrFetch()),
+        audio: 'https://example.com/a.mp3',
+        prompt: 'guitar shop vocabulary',
+        debug: { logger },
+      })
+      expect(
+        logger.warnings.some((w) => w.includes('`prompt` option is ignored')),
+      ).toBe(true)
+    })
+
+    it('warns that a non-json responseFormat is ignored', async () => {
+      const logger = captureLogger()
+      await generateTranscription({
+        adapter: adapterWith(asrFetch()),
+        audio: 'https://example.com/a.mp3',
+        responseFormat: 'srt',
+        debug: { logger },
+      })
+      expect(
+        logger.warnings.some(
+          (w) => w.includes('always returns JSON') && w.includes('"srt"'),
+        ),
+      ).toBe(true)
+    })
+
+    it('stays quiet for responseFormat json', async () => {
+      const logger = captureLogger()
+      await generateTranscription({
+        adapter: adapterWith(asrFetch()),
+        audio: 'https://example.com/a.mp3',
+        responseFormat: 'json',
+        debug: { logger },
+      })
+      expect(logger.warnings).toHaveLength(0)
+    })
+  })
+
+  describe('response mapping edges', () => {
+    it('skips utterances with no timings', async () => {
+      const mapped = mapRecognizeResponse(
+        {
+          result: {
+            text: 'partial',
+            utterances: [
+              { text: 'no timings' },
+              { text: 'timed', start_time: 0, end_time: 500 },
+            ],
+          },
+        },
+        'partial',
+      )
+      expect(mapped.segments).toEqual([
+        { id: 0, start: 0, end: 0.5, text: 'timed' },
+      ])
+    })
+
+    it('omits segments, words and usage entirely when nothing is timed', async () => {
+      const mapped = mapRecognizeResponse(
+        { result: { text: 'bare', utterances: [{ text: 'bare' }] } },
+        'bare',
+      )
+      expect(mapped.segments).toBeUndefined()
+      expect(mapped.words).toBeUndefined()
+      expect(mapped.usage).toBeUndefined()
+      expect(mapped.duration).toBeUndefined()
+    })
+
+    it('surfaces per-word confidence for callers that narrow the type', async () => {
+      const result = await generateTranscription({
+        adapter: adapterWith(
+          asrFetch({
+            result: {
+              text: 'hi',
+              utterances: [
+                {
+                  text: 'hi',
+                  start_time: 0,
+                  end_time: 500,
+                  words: [
+                    {
+                      text: 'hi',
+                      start_time: 0,
+                      end_time: 500,
+                      confidence: 0.98,
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+        ),
+        audio: 'https://example.com/a.mp3',
+      })
+      const words = result.words as Array<BytePlusTranscriptionWord> | undefined
+      expect(words?.[0]?.confidence).toBe(0.98)
+    })
+  })
+
+  it('keeps non-JSON error bodies diagnosable', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementation(() =>
+        Promise.resolve(new Response('<html>502</html>', { status: 502 })),
+      )
+    await expect(
+      generateTranscription({
+        adapter: adapterWith(fetchMock),
+        audio: 'https://example.com/a.mp3',
+        debug: false,
+      }),
+    ).rejects.toThrow('<html>502</html>')
+  })
+
+  it('createBytePlusTranscription wires the explicit key through', async () => {
+    const fetchMock = asrFetch()
+    const adapter = createBytePlusTranscription('seed-asr', 'explicit-key', {
+      baseURL: BASE_URL,
+      fetch: fetchMock,
+    })
+    await generateTranscription({
+      adapter,
+      audio: 'https://example.com/a.mp3',
+    })
+    expect(lastRequest(fetchMock).headers.get('x-api-key')).toBe('explicit-key')
+  })
+})

--- a/packages/ai-byteplus/tests/tts.test.ts
+++ b/packages/ai-byteplus/tests/tts.test.ts
@@ -451,6 +451,58 @@ describe('BytePlusTTSAdapter', () => {
       expect(result.audio).toBe('QUJD')
     })
 
+    // Only the *error* envelope was verified live; the success envelope is
+    // docs-derived. A string-typed code must not slip through as success —
+    // `readStringField` already renders both forms in the error message, so
+    // requiring a number here would have returned a failed 200 as valid audio.
+    it('rejects a 200 whose non-zero code arrives as a string', async () => {
+      const fetchMock = ttsFetch({
+        code: '45000010',
+        message: 'Invalid X-Api-Key',
+        audio: 'QUJD',
+        duration: 1.5,
+      })
+      await expect(
+        generateSpeech({
+          adapter: adapterWith(fetchMock),
+          text: 'hi',
+          debug: false,
+        }),
+      ).rejects.toThrow(/45000010/)
+    })
+
+    it('accepts a 200 whose success code arrives as the string "0"', async () => {
+      const fetchMock = ttsFetch({ code: '0', audio: 'QUJD', duration: 1.5 })
+      const result = await generateSpeech({
+        adapter: adapterWith(fetchMock),
+        text: 'hi',
+      })
+      expect(result.audio).toBe('QUJD')
+    })
+
+    it('accepts a 200 that omits code entirely', async () => {
+      const fetchMock = ttsFetch({ audio: 'QUJD', duration: 1.5 })
+      const result = await generateSpeech({
+        adapter: adapterWith(fetchMock),
+        text: 'hi',
+      })
+      expect(result.audio).toBe('QUJD')
+    })
+
+    // An empty string is a *well-formed* success envelope carrying nothing to
+    // play, so it needs its own message — reusing the envelope-error phrasing
+    // ("failed (200)") gives no hint that the adapter is the one rejecting it.
+    it('rejects a success envelope whose audio is an empty string', async () => {
+      const fetchMock = ttsFetch({ code: 0, audio: '', duration: 1.5 })
+      await expect(
+        generateSpeech({
+          adapter: adapterWith(fetchMock),
+          text: 'hi',
+          debug: false,
+        }),
+      ).rejects.toThrow(/success response with no audio/)
+    })
+
     it('fails when a 200 response carries no audio', async () => {
       const fetchMock = ttsFetch({ code: 45000151, message: 'Quota exceeded' })
       await expect(

--- a/packages/ai-byteplus/tests/tts.test.ts
+++ b/packages/ai-byteplus/tests/tts.test.ts
@@ -424,6 +424,33 @@ describe('BytePlusTTSAdapter', () => {
       )
     })
 
+    it('rejects a 200 carrying a non-zero code even when audio is present', async () => {
+      const fetchMock = ttsFetch({
+        code: 45000010,
+        message: 'Invalid X-Api-Key',
+        audio: 'QUJD',
+        duration: 1.5,
+      })
+      await expect(
+        generateSpeech({
+          adapter: adapterWith(fetchMock),
+          text: 'hi',
+          debug: false,
+        }),
+      ).rejects.toThrow(
+        'BytePlus Seed Speech text-to-speech failed (200 45000010): Invalid X-Api-Key',
+      )
+    })
+
+    it('accepts a 200 that reports code 0', async () => {
+      const fetchMock = ttsFetch({ code: 0, audio: 'QUJD', duration: 1.5 })
+      const result = await generateSpeech({
+        adapter: adapterWith(fetchMock),
+        text: 'hi',
+      })
+      expect(result.audio).toBe('QUJD')
+    })
+
     it('fails when a 200 response carries no audio', async () => {
       const fetchMock = ttsFetch({ code: 45000151, message: 'Quota exceeded' })
       await expect(

--- a/packages/ai-byteplus/tests/tts.test.ts
+++ b/packages/ai-byteplus/tests/tts.test.ts
@@ -88,12 +88,16 @@ describe('BytePlusTTSAdapter', () => {
     // Seed Speech uses X-Api-Key, never an Ark-style bearer token.
     expect(headers.get('authorization')).toBeNull()
 
+    // `text_prompt` (not `text`) and the voice inside `references` are both
+    // load-bearing: a top-level `speaker` is silently ignored by the server,
+    // and `text` belongs to the /tts/unidirectional endpoint.
     expect(body).toEqual({
       model: 'seed-audio-1.0',
       text_prompt: 'welcome to the guitar store',
-      speaker: 'en_female_stokie_uranus_bigtts',
-      audio_config: { format: 'mp3' },
+      references: [{ speaker: 'en_female_stokie_uranus_bigtts' }],
+      audio_config: { format: 'mp3', sample_rate: 24000 },
     })
+    expect(body.speaker).toBeUndefined()
 
     expect(result.model).toBe('seed-audio-1.0')
     expect(result.audio).toBe('QUJD')
@@ -101,6 +105,18 @@ describe('BytePlusTTSAdapter', () => {
     expect(result.contentType).toBe('audio/mpeg')
     expect(result.duration).toBe(1.5)
     expect(result.id).toMatch(/^byteplus-/)
+  })
+
+  it('sends a per-request X-Api-Request-Id', async () => {
+    const fetchMock = ttsFetch()
+    await generateSpeech({ adapter: adapterWith(fetchMock), text: 'hi' })
+    const first = lastRequest(fetchMock).headers.get('x-api-request-id')
+    expect(first).toBeTruthy()
+
+    await generateSpeech({ adapter: adapterWith(fetchMock), text: 'hi' })
+    expect(lastRequest(fetchMock).headers.get('x-api-request-id')).not.toBe(
+      first,
+    )
   })
 
   it('sends TTSOptions.voice as speaker and lets modelOptions.speaker win', async () => {
@@ -113,7 +129,9 @@ describe('BytePlusTTSAdapter', () => {
       text: 'hi',
       voice: 'test-voice-from-options',
     })
-    expect(lastRequest(fetchMock).body.speaker).toBe('test-voice-from-options')
+    expect(lastRequest(fetchMock).body.references).toEqual([
+      { speaker: 'test-voice-from-options' },
+    ])
 
     await generateSpeech({
       adapter: adapterWith(fetchMock),
@@ -121,9 +139,34 @@ describe('BytePlusTTSAdapter', () => {
       voice: 'test-voice-from-options',
       modelOptions: { speaker: 'test-voice-from-model-options' },
     })
-    expect(lastRequest(fetchMock).body.speaker).toBe(
-      'test-voice-from-model-options',
-    )
+    expect(lastRequest(fetchMock).body.references).toEqual([
+      { speaker: 'test-voice-from-model-options' },
+    ])
+  })
+
+  it('lets an explicit references array replace the speaker entry', async () => {
+    const fetchMock = ttsFetch()
+    await generateSpeech({
+      adapter: adapterWith(fetchMock),
+      text: 'say it like @Audio1',
+      voice: 'test-voice-from-options',
+      modelOptions: {
+        references: [{ audio_url: 'https://example.com/clip.wav' }],
+      },
+    })
+    expect(lastRequest(fetchMock).body.references).toEqual([
+      { audio_url: 'https://example.com/clip.wav' },
+    ])
+  })
+
+  it('forwards watermark when set', async () => {
+    const fetchMock = ttsFetch()
+    await generateSpeech({
+      adapter: adapterWith(fetchMock),
+      text: 'hi',
+      modelOptions: { watermark: true },
+    })
+    expect(lastRequest(fetchMock).body.watermark).toBe(true)
   })
 
   describe('format mapping', () => {
@@ -186,6 +229,14 @@ describe('BytePlusTTSAdapter', () => {
       })
       expect(lastRequest(fetchMock).body.audio_config.sample_rate).toBe(48000)
       expect(result.contentType).toBe('audio/L16;rate=48000')
+    })
+
+    it('always sends an explicit sample_rate rather than trusting the server default', async () => {
+      // The documented default (40000) is not a value the endpoint accepts,
+      // so omitting the field is never safe.
+      const fetchMock = ttsFetch()
+      await generateSpeech({ adapter: adapterWith(fetchMock), text: 'hi' })
+      expect(lastRequest(fetchMock).body.audio_config.sample_rate).toBe(24000)
     })
   })
 
@@ -258,12 +309,17 @@ describe('BytePlusTTSAdapter', () => {
     })
   })
 
-  it('forwards pitch, loudness and subtitle options', async () => {
+  it('forwards pitch, loudness and subtitle options inside audio_config', async () => {
+    const subtitle = {
+      sentences: [{ text: 'hi', start_time: 0, end_time: 200 }],
+      words: [{ text: 'hi', start_time: 0, end_time: 200 }],
+    }
     const fetchMock = ttsFetch({
       audio: 'QUJD',
       duration: 2,
+      original_duration: 2,
       url: 'https://voice.test/out.mp3',
-      subtitle: [{ text: 'hi', start_time: 0, end_time: 200 }],
+      subtitle,
     })
     const result: BytePlusTTSResult = await generateSpeech({
       adapter: adapterWith(fetchMock),
@@ -278,40 +334,52 @@ describe('BytePlusTTSAdapter', () => {
     const { body } = lastRequest(fetchMock)
     expect(body.audio_config.pitch_rate).toBe(-3)
     expect(body.audio_config.loudness_rate).toBe(20)
-    expect(body.enable_subtitle).toBe(true)
+    // enable_subtitle is the sixth member of audio_config, not a top-level
+    // field — at the top level the server ignores it.
+    expect(body.audio_config.enable_subtitle).toBe(true)
+    expect(body.enable_subtitle).toBeUndefined()
 
-    expect(result.subtitle).toEqual([
-      { text: 'hi', start_time: 0, end_time: 200 },
-    ])
+    // Subtitle timings stay in milliseconds while the durations are seconds.
+    expect(result.subtitle).toEqual(subtitle)
     expect(result.url).toBe('https://voice.test/out.mp3')
   })
 
-  describe('duration normalisation', () => {
-    it('passes through values within the 120s output cap as seconds', async () => {
-      const fetchMock = ttsFetch({ audio: 'QUJD', duration: 12 })
-      const result = await generateSpeech({
-        adapter: adapterWith(fetchMock),
-        text: 'hi',
-      })
-      expect(result.duration).toBe(12)
-    })
-
-    it('treats values above the cap as milliseconds', async () => {
+  describe('durations', () => {
+    it('reports duration and original_duration as seconds', async () => {
       const fetchMock = ttsFetch({
         audio: 'QUJD',
-        duration: BYTEPLUS_TTS_MAX_OUTPUT_SECONDS * 1000,
+        duration: 12.5,
+        original_duration: 10,
       })
-      const result = await generateSpeech({
+      const result: BytePlusTTSResult = await generateSpeech({
         adapter: adapterWith(fetchMock),
         text: 'hi',
       })
-      expect(result.duration).toBe(BYTEPLUS_TTS_MAX_OUTPUT_SECONDS)
+      expect(result.duration).toBe(12.5)
+      expect(result.originalDuration).toBe(10)
+    })
+
+    it('passes a slowed clip longer than the 120s cap straight through', async () => {
+      // A 120s (billed) clip at speech_rate -50 plays for 240s. Rescaling it
+      // as if it were milliseconds — which an earlier heuristic did — would
+      // corrupt it to 0.24s.
+      const fetchMock = ttsFetch({
+        audio: 'QUJD',
+        duration: BYTEPLUS_TTS_MAX_OUTPUT_SECONDS * 2,
+        original_duration: BYTEPLUS_TTS_MAX_OUTPUT_SECONDS,
+      })
+      const result: BytePlusTTSResult = await generateSpeech({
+        adapter: adapterWith(fetchMock),
+        text: 'hi',
+        speed: 0.5,
+      })
+      expect(result.duration).toBe(240)
+      expect(result.originalDuration).toBe(BYTEPLUS_TTS_MAX_OUTPUT_SECONDS)
     })
 
     it.each([
-      [BYTEPLUS_TTS_MAX_OUTPUT_SECONDS, BYTEPLUS_TTS_MAX_OUTPUT_SECONDS],
-      // Just over the cap flips to the millisecond reading, by design.
-      [BYTEPLUS_TTS_MAX_OUTPUT_SECONDS + 1, 0.121],
+      [12.5, 12.5],
+      [BYTEPLUS_TTS_MAX_OUTPUT_SECONDS + 1, 121],
       [0, undefined],
       [-5, undefined],
       [Number.NaN, undefined],
@@ -320,24 +388,8 @@ describe('BytePlusTTSAdapter', () => {
       expect(toDurationSeconds(raw)).toBe(expected)
     })
 
-    it('warns when the millisecond branch fires', async () => {
-      const logger = captureLogger()
-      await generateSpeech({
-        adapter: adapterWith(ttsFetch({ audio: 'QUJD', duration: 3200 })),
-        text: 'hi',
-        debug: { logger },
-      })
-      expect(
-        logger.warnings.some(
-          (w) =>
-            w.includes('duration=3200') &&
-            w.includes('reading it as milliseconds'),
-        ),
-      ).toBe(true)
-    })
-
     it('coerces string durations and drops unusable ones', async () => {
-      const stringDuration = ttsFetch({ audio: 'QUJD', duration: '3200' })
+      const stringDuration = ttsFetch({ audio: 'QUJD', duration: '3.2' })
       expect(
         (
           await generateSpeech({

--- a/packages/ai-byteplus/tests/tts.test.ts
+++ b/packages/ai-byteplus/tests/tts.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, it, vi } from 'vitest'
+import { generateSpeech } from '@tanstack/ai'
+import {
+  BYTEPLUS_TTS_MAX_OUTPUT_SECONDS,
+  BytePlusTTSAdapter,
+  createBytePlusSpeech,
+  toDurationSeconds,
+  toSpeechRate,
+} from '../src/adapters/tts'
+import type { Logger } from '@tanstack/ai'
+import type { BytePlusTTSResult } from '../src/audio/tts-provider-options'
+
+const BASE_URL = 'https://voice.test'
+
+/**
+ * Captures what the adapter routes through `logger.warn`. Passed as
+ * `debug: { logger }`, which turns every category on — including the `errors`
+ * category that gates `warn`.
+ */
+function captureLogger(): Logger & { warnings: Array<string> } {
+  const warnings: Array<string> = []
+  return {
+    warnings,
+    debug: () => {},
+    info: () => {},
+    warn: (message: string) => {
+      warnings.push(message)
+    },
+    error: () => {},
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+// A fresh `Response` per call — a `Response` body can only be read once, so a
+// shared instance breaks any test that fetches twice.
+function ttsFetch(
+  body: unknown = { audio: 'QUJD', duration: 1.5 },
+  status = 200,
+) {
+  return vi
+    .fn<typeof fetch>()
+    .mockImplementation(() => Promise.resolve(jsonResponse(body, status)))
+}
+
+function adapterWith(
+  fetchImpl: typeof fetch,
+  defaultHeaders?: Record<string, string>,
+) {
+  return new BytePlusTTSAdapter('seed-audio-1.0', {
+    apiKey: 'voice-key',
+    baseURL: BASE_URL,
+    fetch: fetchImpl,
+    ...(defaultHeaders && { defaultHeaders }),
+  })
+}
+
+function lastRequest(fetchMock: ReturnType<typeof ttsFetch>) {
+  const call = fetchMock.mock.calls.at(-1)
+  if (!call) throw new Error('fetch was not called')
+  const [url, init] = call
+  return {
+    url: String(url),
+    init: init as RequestInit,
+    headers: new Headers(init?.headers),
+    body: JSON.parse(String(init?.body)),
+  }
+}
+
+describe('BytePlusTTSAdapter', () => {
+  it('posts to /api/v3/tts/create with the Seed Speech key and default speaker', async () => {
+    const fetchMock = ttsFetch()
+    const result: BytePlusTTSResult = await generateSpeech({
+      adapter: adapterWith(fetchMock),
+      text: 'welcome to the guitar store',
+    })
+
+    const { url, init, headers, body } = lastRequest(fetchMock)
+    expect(url).toBe(`${BASE_URL}/api/v3/tts/create`)
+    expect(init.method).toBe('POST')
+    expect(headers.get('x-api-key')).toBe('voice-key')
+    expect(headers.get('content-type')).toBe('application/json')
+    // Seed Speech uses X-Api-Key, never an Ark-style bearer token.
+    expect(headers.get('authorization')).toBeNull()
+
+    expect(body).toEqual({
+      model: 'seed-audio-1.0',
+      text_prompt: 'welcome to the guitar store',
+      speaker: 'en_female_stokie_uranus_bigtts',
+      audio_config: { format: 'mp3' },
+    })
+
+    expect(result.model).toBe('seed-audio-1.0')
+    expect(result.audio).toBe('QUJD')
+    expect(result.format).toBe('mp3')
+    expect(result.contentType).toBe('audio/mpeg')
+    expect(result.duration).toBe(1.5)
+    expect(result.id).toMatch(/^byteplus-/)
+  })
+
+  it('sends TTSOptions.voice as speaker and lets modelOptions.speaker win', async () => {
+    // Deliberately synthetic ids — the adapter passes `speaker` through
+    // verbatim, and inventing plausible-looking BytePlus voice ids in a test
+    // is how they end up copied into docs as if they were real.
+    const fetchMock = ttsFetch()
+    await generateSpeech({
+      adapter: adapterWith(fetchMock),
+      text: 'hi',
+      voice: 'test-voice-from-options',
+    })
+    expect(lastRequest(fetchMock).body.speaker).toBe('test-voice-from-options')
+
+    await generateSpeech({
+      adapter: adapterWith(fetchMock),
+      text: 'hi',
+      voice: 'test-voice-from-options',
+      modelOptions: { speaker: 'test-voice-from-model-options' },
+    })
+    expect(lastRequest(fetchMock).body.speaker).toBe(
+      'test-voice-from-model-options',
+    )
+  })
+
+  describe('format mapping', () => {
+    it.each([
+      ['mp3', 'mp3', 'audio/mpeg'],
+      ['wav', 'wav', 'audio/wav'],
+      ['pcm', 'pcm', 'audio/L16;rate=24000'],
+      ['opus', 'ogg_opus', 'audio/ogg;codecs=opus'],
+    ] as const)('maps %s to %s', async (requested, wireFormat, contentType) => {
+      const fetchMock = ttsFetch()
+      const result = await generateSpeech({
+        adapter: adapterWith(fetchMock),
+        text: 'hi',
+        format: requested,
+      })
+      expect(lastRequest(fetchMock).body.audio_config.format).toBe(wireFormat)
+      expect(result.format).toBe(wireFormat)
+      expect(result.contentType).toBe(contentType)
+    })
+
+    it.each(['aac', 'flac'] as const)(
+      'falls back to mp3 for unsupported format %s and warns',
+      async (requested) => {
+        const fetchMock = ttsFetch()
+        const logger = captureLogger()
+        const result = await generateSpeech({
+          adapter: adapterWith(fetchMock),
+          text: 'hi',
+          format: requested,
+          debug: { logger },
+        })
+        expect(lastRequest(fetchMock).body.audio_config.format).toBe('mp3')
+        expect(result.format).toBe('mp3')
+        expect(
+          logger.warnings.some(
+            (w) => w.includes(requested) && w.includes('falling back to mp3'),
+          ),
+        ).toBe(true)
+      },
+    )
+
+    it('lets modelOptions.format override the generic format', async () => {
+      const fetchMock = ttsFetch()
+      await generateSpeech({
+        adapter: adapterWith(fetchMock),
+        text: 'hi',
+        format: 'mp3',
+        modelOptions: { format: 'ogg_opus' },
+      })
+      expect(lastRequest(fetchMock).body.audio_config.format).toBe('ogg_opus')
+    })
+
+    it('reports the caller sample rate in the pcm content type', async () => {
+      const fetchMock = ttsFetch()
+      const result = await generateSpeech({
+        adapter: adapterWith(fetchMock),
+        text: 'hi',
+        format: 'pcm',
+        modelOptions: { sample_rate: 48000 },
+      })
+      expect(lastRequest(fetchMock).body.audio_config.sample_rate).toBe(48000)
+      expect(result.contentType).toBe('audio/L16;rate=48000')
+    })
+  })
+
+  describe('speed → speech_rate', () => {
+    it.each([
+      [0.25, -50],
+      [0.5, -50],
+      [0.75, -25],
+      [1, 0],
+      [1.5, 50],
+      [2, 100],
+      [4, 100],
+    ])('maps speed %s to speech_rate %s', (speed, expected) => {
+      expect(toSpeechRate(speed)).toBe(expected)
+    })
+
+    it('forwards the derived speech_rate on the request', async () => {
+      const fetchMock = ttsFetch()
+      await generateSpeech({
+        adapter: adapterWith(fetchMock),
+        text: 'hi',
+        speed: 1.25,
+      })
+      expect(lastRequest(fetchMock).body.audio_config.speech_rate).toBe(25)
+    })
+
+    it('omits speech_rate when no speed is given', async () => {
+      const fetchMock = ttsFetch()
+      await generateSpeech({ adapter: adapterWith(fetchMock), text: 'hi' })
+      expect(
+        lastRequest(fetchMock).body.audio_config.speech_rate,
+      ).toBeUndefined()
+    })
+
+    it('warns when the speed clamps outside the documented 0.5×–2× range', async () => {
+      const logger = captureLogger()
+      await generateSpeech({
+        adapter: adapterWith(ttsFetch()),
+        text: 'hi',
+        speed: 4,
+        debug: { logger },
+      })
+      expect(
+        logger.warnings.some(
+          (w) => w.includes('4×') && w.includes('clamping speech_rate'),
+        ),
+      ).toBe(true)
+    })
+
+    it('does not warn for a speed inside the documented range', async () => {
+      const logger = captureLogger()
+      await generateSpeech({
+        adapter: adapterWith(ttsFetch()),
+        text: 'hi',
+        speed: 1.5,
+        debug: { logger },
+      })
+      expect(logger.warnings).toHaveLength(0)
+    })
+
+    it('lets an explicit modelOptions.speech_rate win over speed', async () => {
+      const fetchMock = ttsFetch()
+      await generateSpeech({
+        adapter: adapterWith(fetchMock),
+        text: 'hi',
+        speed: 2,
+        modelOptions: { speech_rate: -10 },
+      })
+      expect(lastRequest(fetchMock).body.audio_config.speech_rate).toBe(-10)
+    })
+  })
+
+  it('forwards pitch, loudness and subtitle options', async () => {
+    const fetchMock = ttsFetch({
+      audio: 'QUJD',
+      duration: 2,
+      url: 'https://voice.test/out.mp3',
+      subtitle: [{ text: 'hi', start_time: 0, end_time: 200 }],
+    })
+    const result: BytePlusTTSResult = await generateSpeech({
+      adapter: adapterWith(fetchMock),
+      text: 'hi',
+      modelOptions: {
+        pitch_rate: -3,
+        loudness_rate: 20,
+        enable_subtitle: true,
+      },
+    })
+
+    const { body } = lastRequest(fetchMock)
+    expect(body.audio_config.pitch_rate).toBe(-3)
+    expect(body.audio_config.loudness_rate).toBe(20)
+    expect(body.enable_subtitle).toBe(true)
+
+    expect(result.subtitle).toEqual([
+      { text: 'hi', start_time: 0, end_time: 200 },
+    ])
+    expect(result.url).toBe('https://voice.test/out.mp3')
+  })
+
+  describe('duration normalisation', () => {
+    it('passes through values within the 120s output cap as seconds', async () => {
+      const fetchMock = ttsFetch({ audio: 'QUJD', duration: 12 })
+      const result = await generateSpeech({
+        adapter: adapterWith(fetchMock),
+        text: 'hi',
+      })
+      expect(result.duration).toBe(12)
+    })
+
+    it('treats values above the cap as milliseconds', async () => {
+      const fetchMock = ttsFetch({
+        audio: 'QUJD',
+        duration: BYTEPLUS_TTS_MAX_OUTPUT_SECONDS * 1000,
+      })
+      const result = await generateSpeech({
+        adapter: adapterWith(fetchMock),
+        text: 'hi',
+      })
+      expect(result.duration).toBe(BYTEPLUS_TTS_MAX_OUTPUT_SECONDS)
+    })
+
+    it.each([
+      [BYTEPLUS_TTS_MAX_OUTPUT_SECONDS, BYTEPLUS_TTS_MAX_OUTPUT_SECONDS],
+      // Just over the cap flips to the millisecond reading, by design.
+      [BYTEPLUS_TTS_MAX_OUTPUT_SECONDS + 1, 0.121],
+      [0, undefined],
+      [-5, undefined],
+      [Number.NaN, undefined],
+      [undefined, undefined],
+    ])('toDurationSeconds(%s) is %s', (raw, expected) => {
+      expect(toDurationSeconds(raw)).toBe(expected)
+    })
+
+    it('warns when the millisecond branch fires', async () => {
+      const logger = captureLogger()
+      await generateSpeech({
+        adapter: adapterWith(ttsFetch({ audio: 'QUJD', duration: 3200 })),
+        text: 'hi',
+        debug: { logger },
+      })
+      expect(
+        logger.warnings.some(
+          (w) =>
+            w.includes('duration=3200') &&
+            w.includes('reading it as milliseconds'),
+        ),
+      ).toBe(true)
+    })
+
+    it('coerces string durations and drops unusable ones', async () => {
+      const stringDuration = ttsFetch({ audio: 'QUJD', duration: '3200' })
+      expect(
+        (
+          await generateSpeech({
+            adapter: adapterWith(stringDuration),
+            text: 'hi',
+          })
+        ).duration,
+      ).toBe(3.2)
+
+      const missing = ttsFetch({ audio: 'QUJD' })
+      expect(
+        (await generateSpeech({ adapter: adapterWith(missing), text: 'hi' }))
+          .duration,
+      ).toBeUndefined()
+    })
+  })
+
+  describe('errors', () => {
+    it('surfaces the numeric Seed Speech error envelope on a 401', async () => {
+      const fetchMock = ttsFetch(
+        { code: 45000010, message: 'Invalid X-Api-Key' },
+        401,
+      )
+      await expect(
+        generateSpeech({
+          adapter: adapterWith(fetchMock),
+          text: 'hi',
+          debug: false,
+        }),
+      ).rejects.toThrow(
+        'BytePlus Seed Speech text-to-speech failed (401 45000010): Invalid X-Api-Key',
+      )
+    })
+
+    it('fails when a 200 response carries no audio', async () => {
+      const fetchMock = ttsFetch({ code: 45000151, message: 'Quota exceeded' })
+      await expect(
+        generateSpeech({
+          adapter: adapterWith(fetchMock),
+          text: 'hi',
+          debug: false,
+        }),
+      ).rejects.toThrow(
+        'BytePlus Seed Speech text-to-speech failed (200 45000151): Quota exceeded',
+      )
+    })
+
+    it('keeps non-JSON error bodies diagnosable', async () => {
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response('<html>502</html>', { status: 502 }))
+      await expect(
+        generateSpeech({
+          adapter: adapterWith(fetchMock),
+          text: 'hi',
+          debug: false,
+        }),
+      ).rejects.toThrow('<html>502</html>')
+    })
+  })
+
+  it('merges configured default headers into the request', async () => {
+    const fetchMock = ttsFetch()
+    await generateSpeech({
+      adapter: adapterWith(fetchMock, { 'X-Test-Id': 'abc' }),
+      text: 'hi',
+    })
+    expect(lastRequest(fetchMock).headers.get('x-test-id')).toBe('abc')
+  })
+
+  it('createBytePlusSpeech wires the explicit key through', async () => {
+    const fetchMock = ttsFetch()
+    const adapter = createBytePlusSpeech('seed-audio-1.0', 'explicit-key', {
+      baseURL: BASE_URL,
+      fetch: fetchMock,
+    })
+    await generateSpeech({ adapter, text: 'hi' })
+    expect(lastRequest(fetchMock).headers.get('x-api-key')).toBe('explicit-key')
+  })
+})

--- a/packages/ai-byteplus/tests/video.test.ts
+++ b/packages/ai-byteplus/tests/video.test.ts
@@ -229,6 +229,67 @@ describe('createVideoJob', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it('keeps Authorization when defaultHeaders tries to override it', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = createBytePlusVideo(
+      'seedance-1-0-pro-250528',
+      'ark-test-key',
+      {
+        fetch: fetchMock,
+        defaultHeaders: { Authorization: 'Bearer not-the-real-key' },
+      },
+    )
+
+    await adapter.createVideoJob(createOptions())
+
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+      Authorization: 'Bearer ark-test-key',
+    })
+  })
+
+  // Live-probed 2026-07-31 and contradicting the BytePlus docs, which list
+  // this model as 480p/720p. Guards the cell most likely to be "corrected"
+  // back by someone reading the docs.
+  it('accepts 1080p on seedance-1-0-pro-fast-251015', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-fast-251015')
+
+    await adapter.createVideoJob(createOptions({ size: '16:9_1080p' }))
+
+    expect(sentRequest(fetchMock).resolution).toBe('1080p')
+  })
+
+  // No Seedance model has a 2K tier, including the 2.0 flagship whose docs
+  // advertise "up to 4K". The cast mimics a caller who trusted the docs.
+  it('rejects a 2k resolution on every model', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({ size: '16:9_2k' as '16:9_1080p' }),
+      ),
+    ).rejects.toThrow(/resolution "2k" is not supported/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('validates a resolution that modelOptions introduced', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    // 4k is exclusive to the 2.0 flagship; overriding a valid size with it
+    // must fail locally rather than reaching Ark.
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-5-pro-251215')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          size: '16:9_720p',
+          modelOptions: { resolution: '4k' as '1080p' },
+        }),
+      ),
+    ).rejects.toThrow(/resolution "4k" is not supported.*480p, 720p, 1080p/s)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('rejects a malformed size template', async () => {
     const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
     const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
@@ -551,6 +612,68 @@ describe('createVideoJob content roles', () => {
         }),
       ),
     ).rejects.toThrow(/does not support a closing frame/)
+  })
+
+  // The per-model modality map makes these compile errors; the casts stand in
+  // for JS callers and for a prompt built from untyped data.
+  it('rejects video prompt parts on a 1.x model', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-5-pro-251215')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          prompt: [
+            {
+              type: 'video',
+              source: { type: 'url', value: 'https://x/v.mp4' },
+            },
+          ] as Array<MediaPromptPart>,
+        }),
+      ),
+    ).rejects.toThrow(/does not accept video prompt parts/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects audio prompt parts on a 1.x model', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          prompt: [
+            {
+              type: 'audio',
+              source: { type: 'url', value: 'https://x/a.mp3' },
+            },
+          ] as Array<MediaPromptPart>,
+        }),
+      ),
+    ).rejects.toThrow(/does not accept audio prompt parts/)
+  })
+
+  // The create schema says maxItems: 5, but Ark accepted 7 live, so the
+  // adapter passes long prompts through rather than rejecting what the API
+  // would have taken.
+  it('does not cap the content array locally', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await adapter.createVideoJob(
+      createOptions({
+        prompt: [
+          { type: 'text', content: 'blend these' },
+          imagePart('https://example.com/1.jpg', 'reference'),
+          imagePart('https://example.com/2.jpg', 'reference'),
+          imagePart('https://example.com/3.jpg', 'reference'),
+          imagePart('https://example.com/4.jpg', 'reference'),
+          imagePart('https://example.com/5.jpg', 'reference'),
+        ],
+      }),
+    )
+
+    expect(sentRequest(fetchMock).content).toHaveLength(6)
   })
 
   it('rejects mask and control roles Seedance has no channel for', async () => {

--- a/packages/ai-byteplus/tests/video.test.ts
+++ b/packages/ai-byteplus/tests/video.test.ts
@@ -145,6 +145,37 @@ describe('createVideoJob', () => {
     })
   })
 
+  it('merges configured defaultHeaders into the request', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = createBytePlusVideo(
+      'seedance-1-0-pro-250528',
+      'ark-test-key',
+      { fetch: fetchMock, defaultHeaders: { 'X-Test-Id': 'video-1' } },
+    )
+
+    await adapter.createVideoJob(createOptions())
+
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+      Authorization: 'Bearer ark-test-key',
+      'X-Test-Id': 'video-1',
+    })
+  })
+
+  it('honours a custom baseURL, trailing slashes and all', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = createBytePlusVideo(
+      'seedance-1-0-pro-250528',
+      'ark-test-key',
+      { fetch: fetchMock, baseURL: 'https://proxy.example.com/api/v3//' },
+    )
+
+    await adapter.createVideoJob(createOptions())
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://proxy.example.com/api/v3/contents/generations/tasks',
+    )
+  })
+
   it('splits the size template into ratio and resolution', async () => {
     const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
     const adapter = adapterWithFetch(fetchMock, 'seedance-1-5-pro-251215')
@@ -419,6 +450,58 @@ describe('createVideoJob content roles', () => {
         }),
       ),
     ).rejects.toThrow(/cannot be combined with reference media/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('reports the mode mix, not the audio rule, for a frame plus audio', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          prompt: [
+            imagePart('https://example.com/open.jpg', 'start_frame'),
+            {
+              type: 'audio',
+              source: { type: 'url', value: 'https://x/a.mp3' },
+            },
+          ],
+        }),
+      ),
+      // Advising the caller to add another reference would still fail — the
+      // real defect is the frame/reference mix.
+    ).rejects.toThrow(/cannot be combined with reference media/)
+  })
+
+  it('rejects more than one opening frame', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          prompt: [
+            imagePart('https://example.com/a.jpg'),
+            imagePart('https://example.com/b.jpg', 'start_frame'),
+          ],
+        }),
+      ),
+    ).rejects.toThrow(/at most one opening frame; received 2/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a closing frame with no opening frame', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-5-pro-251215')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          prompt: [imagePart('https://example.com/close.jpg', 'end_frame')],
+        }),
+      ),
+    ).rejects.toThrow(/closing frame needs an opening frame/)
     expect(fetchMock).not.toHaveBeenCalled()
   })
 

--- a/packages/ai-byteplus/tests/video.test.ts
+++ b/packages/ai-byteplus/tests/video.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
 import {
   BytePlusVideoAdapter,
   byteplusVideo,
   createBytePlusVideo,
 } from '../src/adapters/video'
+import { isKnownBytePlusVideoModel } from '../src/model-meta'
+import type {
+  BytePlusVideoSize,
+  ResolveBytePlusVideoSize,
+} from '../src/model-meta'
 import type {
   BytePlusVideoCreateRequest,
   BytePlusVideoTask,
@@ -890,6 +895,158 @@ describe('getVideoUrl', () => {
     await expect(adapter.getVideoUrl(JOB_ID)).rejects.toThrow(
       `Video job not found: ${JOB_ID}`,
     )
+  })
+})
+
+// Seedance 2.5 was announced 2026-07-31 as a consumer product with the Ark
+// API "available soon"; no 2.5 id resolves on the data plane yet. Rather than
+// ship a guessed id, the factories accept any string so the real id works the
+// day BytePlus publishes it. These cover that path.
+describe('unknown model ids', () => {
+  const FUTURE = 'dreamina-seedance-2-5-260901'
+
+  it('accepts a bare string through the factories', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = createBytePlusVideo(FUTURE, 'ark-test-key', {
+      fetch: fetchMock,
+    })
+
+    expect(adapter.model).toBe(FUTURE)
+    expect(await adapter.createVideoJob(createOptions())).toEqual({
+      jobId: JOB_ID,
+      model: FUTURE,
+    })
+  })
+
+  it('passes resolutions and ratios through without the per-model table', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = createBytePlusVideo(FUTURE, 'ark-test-key', {
+      fetch: fetchMock,
+    })
+
+    // '8k' and '32:9' exist on no model today; a future model may have both.
+    await adapter.createVideoJob(createOptions({ size: '32:9_8K' }))
+
+    expect(sentRequest(fetchMock)).toMatchObject({
+      ratio: '32:9',
+      resolution: '8k',
+    })
+  })
+
+  it('sends an unknown model duration verbatim rather than clamping it', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = createBytePlusVideo(FUTURE, 'ark-test-key', {
+      fetch: fetchMock,
+    })
+
+    // 20s is outside every range shipping today; clamping to 15 would corrupt
+    // a legitimate request for a model with a longer ceiling.
+    await adapter.createVideoJob(createOptions({ duration: 20 }))
+
+    expect(sentRequest(fetchMock).duration).toBe(20)
+  })
+
+  it('passes provider options through ungated', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = createBytePlusVideo(FUTURE, 'ark-test-key', {
+      fetch: fetchMock,
+    })
+
+    // draft is 1.5-pro-only and priority is 2.0-only today; on an unknown
+    // model neither is second-guessed.
+    await adapter.createVideoJob(
+      createOptions({ modelOptions: { draft: true, priority: 3 } }),
+    )
+
+    expect(sentRequest(fetchMock)).toMatchObject({ draft: true, priority: 3 })
+  })
+
+  it('stands down the media-shape guards', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = createBytePlusVideo(FUTURE, 'ark-test-key', {
+      fetch: fetchMock,
+    })
+
+    // Frame + reference is mutually exclusive on every model today. If 2.5
+    // relaxes it, blocking the request locally would defeat the escape hatch.
+    await adapter.createVideoJob(
+      createOptions({
+        prompt: [
+          imagePart('https://example.com/open.jpg', 'start_frame'),
+          imagePart('https://example.com/ref.jpg', 'reference'),
+        ],
+      }),
+    )
+
+    expect(sentRequest(fetchMock).content).toEqual([
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/open.jpg' },
+        role: 'first_frame',
+      },
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/ref.jpg' },
+        role: 'reference_image',
+      },
+    ])
+  })
+
+  it('still rejects roles the wire format cannot carry on any model', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = createBytePlusVideo(FUTURE, 'ark-test-key', {
+      fetch: fetchMock,
+    })
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          prompt: [imagePart('https://example.com/m.png', 'mask')],
+        }),
+      ),
+    ).rejects.toThrow(/has no 'mask' image input/)
+  })
+
+  it('reports the union of known ranges as its duration hint', () => {
+    const adapter = createBytePlusVideo(FUTURE, 'ark-test-key')
+
+    expect(adapter.availableDurations()).toEqual({
+      kind: 'range',
+      min: 2,
+      max: 15,
+      step: 1,
+      unit: 'seconds',
+    })
+  })
+
+  it('knows which ids it has metadata for', () => {
+    expect(isKnownBytePlusVideoModel('seedance-1-5-pro-251215')).toBe(true)
+    expect(isKnownBytePlusVideoModel(FUTURE)).toBe(false)
+  })
+})
+
+describe('model id typing', () => {
+  it('accepts a bare string while keeping known ids narrowed', () => {
+    // A plain string compiles through both factories — the escape hatch's
+    // whole point. `toBeCallableWith` checks the signature without running
+    // byteplusVideo, which would need ARK_API_KEY.
+    expectTypeOf(byteplusVideo).toBeCallableWith('dreamina-seedance-2-5-260901')
+    const adapter = createBytePlusVideo('dreamina-seedance-2-5-260901', 'k')
+    expectTypeOf(adapter.model).toEqualTypeOf<'dreamina-seedance-2-5-260901'>()
+
+    // Known ids keep their probe-verified size union, so a tier the model
+    // does not offer stays a compile error.
+    expectTypeOf<
+      ResolveBytePlusVideoSize<'dreamina-seedance-2-0-fast-260128'>
+    >().toEqualTypeOf<BytePlusVideoSize<'480p' | '720p'>>()
+    expectTypeOf<
+      ResolveBytePlusVideoSize<'dreamina-seedance-2-0-260128'>
+    >().toEqualTypeOf<BytePlusVideoSize<'480p' | '720p' | '1080p' | '4k'>>()
+
+    // An unknown id widens instead.
+    expectTypeOf<ResolveBytePlusVideoSize<'anything-else'>>().toEqualTypeOf<
+      BytePlusVideoSize | (string & {})
+    >()
   })
 })
 

--- a/packages/ai-byteplus/tests/video.test.ts
+++ b/packages/ai-byteplus/tests/video.test.ts
@@ -1,0 +1,718 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import {
+  BytePlusVideoAdapter,
+  byteplusVideo,
+  createBytePlusVideo,
+} from '../src/adapters/video'
+import type {
+  BytePlusVideoCreateRequest,
+  BytePlusVideoTask,
+} from '../src/video/wire-types'
+import type { BytePlusVideoModel } from '../src/model-meta'
+import type { MediaPromptPart, VideoGenerationOptions } from '@tanstack/ai'
+import type { BytePlusVideoProviderOptions } from '../src/video/video-provider-options'
+
+const logger = resolveDebugOption(false)
+
+const VIDEO_URL =
+  'https://ark-content-generation-v2-ap-southeast-1.tos-ap-southeast-1.volces.com/seedance/x.mp4'
+
+/** Task id shape returned by a live `flex` create call (2026-07-31). */
+const JOB_ID = 'cgt-batch-20260731174311-zmz5s'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * A `vi.fn` fetch stub with the real fetch parameter list, so call assertions
+ * (`mock.calls[0]`) stay typed as `[input, init?]`.
+ */
+function mockFetch(handler: () => Response) {
+  return vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+    handler(),
+  )
+}
+
+function adapterWithFetch<TModel extends BytePlusVideoModel>(
+  fetchMock: ReturnType<typeof mockFetch>,
+  model: TModel,
+) {
+  return createBytePlusVideo(model, 'ark-test-key', { fetch: fetchMock })
+}
+
+/** Reads the JSON body the adapter sent on its first request. */
+function sentRequest(
+  fetchMock: ReturnType<typeof mockFetch>,
+): BytePlusVideoCreateRequest {
+  return JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))
+}
+
+function createOptions(
+  overrides: Partial<
+    VideoGenerationOptions<BytePlusVideoProviderOptions, string, number>
+  > = {},
+): VideoGenerationOptions<BytePlusVideoProviderOptions, any, any> {
+  return {
+    model: 'seedance-1-0-pro-fast-251015',
+    prompt: 'a guitar being played in a store',
+    logger,
+    ...overrides,
+  }
+}
+
+function imagePart(url: string, role?: string): MediaPromptPart {
+  return {
+    type: 'image',
+    source: { type: 'url', value: url },
+    ...(role && { metadata: { role: role as 'start_frame' } }),
+  }
+}
+
+/** A succeeded task as documented by the Get action's response example. */
+function succeededTask(overrides: Partial<BytePlusVideoTask> = {}) {
+  return {
+    id: JOB_ID,
+    model: 'seedance-1-0-pro-fast-251015',
+    status: 'succeeded',
+    created_at: 1_718_049_470,
+    updated_at: 1_718_053_070,
+    content: { video_url: VIDEO_URL },
+    usage: { completion_tokens: 35800, total_tokens: 35800 },
+    ...overrides,
+  } satisfies BytePlusVideoTask
+}
+
+describe('factories', () => {
+  it('creates an adapter with the provided API key', () => {
+    const adapter = createBytePlusVideo(
+      'seedance-1-0-pro-fast-251015',
+      'ark-test-key',
+    )
+    expect(adapter).toBeInstanceOf(BytePlusVideoAdapter)
+    expect(adapter.kind).toBe('video')
+    expect(adapter.name).toBe('byteplus')
+    expect(adapter.model).toBe('seedance-1-0-pro-fast-251015')
+  })
+
+  it('byteplusVideo reads ARK_API_KEY from the environment', () => {
+    vi.stubEnv('ARK_API_KEY', 'env-key')
+    try {
+      expect(byteplusVideo('dreamina-seedance-2-0-260128')).toBeInstanceOf(
+        BytePlusVideoAdapter,
+      )
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('byteplusVideo names ARK_API_KEY when it is missing', () => {
+    vi.stubEnv('ARK_API_KEY', '')
+    vi.stubEnv('BYTEPLUS_API_KEY', '')
+    try {
+      expect(() => byteplusVideo('seedance-1-5-pro-251215')).toThrow(
+        /ARK_API_KEY/,
+      )
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+})
+
+describe('createVideoJob', () => {
+  it('posts to the Seedance task endpoint with Ark auth', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-fast-251015')
+
+    const result = await adapter.createVideoJob(createOptions())
+
+    expect(result).toEqual({
+      jobId: JOB_ID,
+      model: 'seedance-1-0-pro-fast-251015',
+    })
+    const [url, init] = fetchMock.mock.calls[0] ?? []
+    expect(url).toBe(
+      'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks',
+    )
+    expect(init?.method).toBe('POST')
+    expect(init?.headers).toMatchObject({
+      Authorization: 'Bearer ark-test-key',
+      'Content-Type': 'application/json',
+    })
+  })
+
+  it('splits the size template into ratio and resolution', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-5-pro-251215')
+
+    await adapter.createVideoJob(
+      createOptions({ size: '21:9_1080p', duration: 6 }),
+    )
+
+    expect(sentRequest(fetchMock)).toMatchObject({
+      model: 'seedance-1-5-pro-251215',
+      ratio: '21:9',
+      resolution: '1080p',
+      duration: 6,
+      content: [{ type: 'text', text: 'a guitar being played in a store' }],
+    })
+  })
+
+  it('accepts a bare ratio with no resolution suffix', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await adapter.createVideoJob(createOptions({ size: 'adaptive' }))
+
+    const request = sentRequest(fetchMock)
+    expect(request.ratio).toBe('adaptive')
+    expect(request.resolution).toBeUndefined()
+  })
+
+  it('lowercases the resolution, which the API matches case-insensitively', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await adapter.createVideoJob(
+      createOptions({ size: '16:9_4K' as '16:9_4k' }),
+    )
+
+    expect(sentRequest(fetchMock).resolution).toBe('4k')
+  })
+
+  it('rejects a resolution the model does not offer', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    // 4k is exclusive to the 2.0 flagship (live-probed).
+    const adapter = adapterWithFetch(
+      fetchMock,
+      'dreamina-seedance-2-0-fast-260128',
+    )
+
+    await expect(
+      adapter.createVideoJob(createOptions({ size: '16:9_4k' as '16:9_720p' })),
+    ).rejects.toThrow(/resolution "4k" is not supported.*480p, 720p/s)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed size template', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
+
+    await expect(
+      adapter.createVideoJob(createOptions({ size: '720p' as '16:9' })),
+    ).rejects.toThrow(/is not supported by model/)
+  })
+
+  it('snaps the generic duration into the model range', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-fast-251015')
+
+    await adapter.createVideoJob(createOptions({ duration: 99 }))
+
+    expect(sentRequest(fetchMock).duration).toBe(12)
+  })
+
+  it('lets modelOptions override the derived fields', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-5-pro-251215')
+
+    await adapter.createVideoJob(
+      createOptions({
+        size: '16:9_720p',
+        duration: 5,
+        modelOptions: {
+          resolution: '1080p',
+          // -1 (model picks the length) is only reachable through
+          // modelOptions, which is why it is not snapped.
+          duration: -1,
+          service_tier: 'flex',
+          draft: true,
+        },
+      }),
+    )
+
+    expect(sentRequest(fetchMock)).toMatchObject({
+      ratio: '16:9',
+      resolution: '1080p',
+      duration: -1,
+      service_tier: 'flex',
+      draft: true,
+    })
+  })
+
+  it('surfaces an Ark error envelope', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse(
+        {
+          error: {
+            code: 'InvalidParameter',
+            message: 'the parameter duration is not valid',
+            type: 'BadRequest',
+          },
+        },
+        400,
+      ),
+    )
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
+
+    await expect(adapter.createVideoJob(createOptions())).rejects.toThrow(
+      /video task creation failed \(400 InvalidParameter\): the parameter duration is not valid/,
+    )
+  })
+
+  it('fails when the response carries no task id', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({}))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
+
+    await expect(adapter.createVideoJob(createOptions())).rejects.toThrow(
+      /returned no task id/,
+    )
+  })
+})
+
+describe('createVideoJob content roles', () => {
+  it('sends an un-roled image as the opening frame', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-fast-251015')
+
+    await adapter.createVideoJob(
+      createOptions({
+        prompt: [
+          { type: 'text', content: 'the guitarist starts playing' },
+          imagePart('https://example.com/shop.jpg'),
+        ],
+      }),
+    )
+
+    expect(sentRequest(fetchMock).content).toEqual([
+      { type: 'text', text: 'the guitarist starts playing' },
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/shop.jpg' },
+        role: 'first_frame',
+      },
+    ])
+  })
+
+  it('maps start_frame and end_frame onto first_frame and last_frame', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-5-pro-251215')
+
+    await adapter.createVideoJob(
+      createOptions({
+        prompt: [
+          imagePart('https://example.com/open.jpg', 'start_frame'),
+          imagePart('https://example.com/close.jpg', 'end_frame'),
+        ],
+      }),
+    )
+
+    expect(sentRequest(fetchMock).content).toEqual([
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/open.jpg' },
+        role: 'first_frame',
+      },
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/close.jpg' },
+        role: 'last_frame',
+      },
+    ])
+  })
+
+  it('maps reference and character images onto reference_image', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await adapter.createVideoJob(
+      createOptions({
+        prompt: [
+          imagePart('https://example.com/a.jpg', 'reference'),
+          imagePart('https://example.com/b.jpg', 'character'),
+        ],
+      }),
+    )
+
+    expect(sentRequest(fetchMock).content).toEqual([
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/a.jpg' },
+        role: 'reference_image',
+      },
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/b.jpg' },
+        role: 'reference_image',
+      },
+    ])
+  })
+
+  it('maps video and audio parts onto reference_video and reference_audio', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await adapter.createVideoJob(
+      createOptions({
+        prompt: [
+          { type: 'text', content: 'match this camera move' },
+          { type: 'video', source: { type: 'url', value: 'https://x/v.mp4' } },
+          { type: 'audio', source: { type: 'url', value: 'https://x/a.mp3' } },
+        ],
+      }),
+    )
+
+    expect(sentRequest(fetchMock).content).toEqual([
+      { type: 'text', text: 'match this camera move' },
+      {
+        type: 'video_url',
+        video_url: { url: 'https://x/v.mp4' },
+        role: 'reference_video',
+      },
+      {
+        type: 'audio_url',
+        audio_url: { url: 'https://x/a.mp3' },
+        role: 'reference_audio',
+      },
+    ])
+  })
+
+  it('sends base64 image sources as data URIs', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
+
+    await adapter.createVideoJob(
+      createOptions({
+        prompt: [
+          {
+            type: 'image',
+            source: { type: 'data', value: 'AAAA', mimeType: 'image/PNG' },
+          },
+        ],
+      }),
+    )
+
+    expect(sentRequest(fetchMock).content).toEqual([
+      {
+        type: 'image_url',
+        image_url: { url: 'data:image/png;base64,AAAA' },
+        role: 'first_frame',
+      },
+    ])
+  })
+
+  it('rejects mixing frame roles with reference roles', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          prompt: [
+            imagePart('https://example.com/open.jpg', 'start_frame'),
+            imagePart('https://example.com/ref.jpg', 'reference'),
+          ],
+        }),
+      ),
+    ).rejects.toThrow(/cannot be combined with reference media/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a reference audio that is the only reference input', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          prompt: [
+            { type: 'text', content: 'use this score' },
+            {
+              type: 'audio',
+              source: { type: 'url', value: 'https://x/a.mp3' },
+            },
+          ],
+        }),
+      ),
+    ).rejects.toThrow(/cannot be the only reference/)
+  })
+
+  it('rejects reference images on a model without reference mode', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-5-pro-251215')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          prompt: [imagePart('https://example.com/ref.jpg', 'reference')],
+        }),
+      ),
+    ).rejects.toThrow(/does not support reference images/)
+  })
+
+  it('rejects a closing frame on seedance-1-0-pro-fast', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-fast-251015')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          prompt: [
+            imagePart('https://example.com/open.jpg', 'start_frame'),
+            imagePart('https://example.com/close.jpg', 'end_frame'),
+          ],
+        }),
+      ),
+    ).rejects.toThrow(/does not support a closing frame/)
+  })
+
+  it('rejects mask and control roles Seedance has no channel for', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await expect(
+      adapter.createVideoJob(
+        createOptions({
+          prompt: [imagePart('https://example.com/m.png', 'mask')],
+        }),
+      ),
+    ).rejects.toThrow(/has no 'mask' image input/)
+  })
+
+  it('rejects an empty prompt', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({ id: JOB_ID }))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
+
+    await expect(
+      adapter.createVideoJob(createOptions({ prompt: [] })),
+    ).rejects.toThrow(/must carry text or at least one media input/)
+  })
+})
+
+describe('getVideoStatus', () => {
+  it.each([
+    ['queued', 'pending'],
+    ['running', 'processing'],
+    ['succeeded', 'completed'],
+    ['failed', 'failed'],
+    ['expired', 'failed'],
+    ['cancelled', 'failed'],
+  ] as const)('maps %s to %s', async (apiStatus, expected) => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse({ id: JOB_ID, status: apiStatus }),
+    )
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-fast-251015')
+
+    const status = await adapter.getVideoStatus(JOB_ID)
+
+    expect(status.status).toBe(expected)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      `https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks/${JOB_ID}`,
+    )
+  })
+
+  it('surfaces the error code and message of a failed task', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        id: JOB_ID,
+        status: 'failed',
+        error: {
+          code: 'OutputVideoSensitiveContentDetected',
+          message: 'The request failed because the output video may contain…',
+        },
+      }),
+    )
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-fast-251015')
+
+    expect(await adapter.getVideoStatus(JOB_ID)).toEqual({
+      jobId: JOB_ID,
+      status: 'failed',
+      error:
+        'OutputVideoSensitiveContentDetected: The request failed because the output video may contain…',
+    })
+  })
+
+  it('explains an expired task, which carries no error block', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse({ id: JOB_ID, status: 'expired' }),
+    )
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-5-pro-251215')
+
+    const status = await adapter.getVideoStatus(JOB_ID)
+
+    expect(status.error).toMatch(/expired before it finished/)
+  })
+
+  it('reports a 404 as a failed job rather than throwing', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse(
+        { error: { code: 'NotFound', message: 'task not found' } },
+        404,
+      ),
+    )
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
+
+    expect(await adapter.getVideoStatus(JOB_ID)).toEqual({
+      jobId: JOB_ID,
+      status: 'failed',
+      error: 'Job not found',
+    })
+  })
+
+  it('propagates non-404 lookup failures', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse(
+        {
+          error: {
+            code: 'RateLimitExceeded.FoundationModelRPMExceeded',
+            message: 'RPM exceeded',
+          },
+        },
+        429,
+      ),
+    )
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
+
+    await expect(adapter.getVideoStatus(JOB_ID)).rejects.toThrow(
+      /429 RateLimitExceeded.FoundationModelRPMExceeded/,
+    )
+  })
+})
+
+describe('getVideoUrl', () => {
+  it('returns the URL, its 24h expiry and usage', async () => {
+    const task = succeededTask()
+    const fetchMock = mockFetch(() => jsonResponse(task))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-fast-251015')
+
+    const result = await adapter.getVideoUrl(JOB_ID)
+
+    expect(result.url).toBe(VIDEO_URL)
+    // Anchored on updated_at (when the output appeared), not created_at.
+    expect(result.expiresAt).toEqual(
+      new Date((task.updated_at + 24 * 60 * 60) * 1000),
+    )
+    expect(result.usage).toEqual({
+      promptTokens: 0,
+      completionTokens: 35800,
+      totalTokens: 35800,
+      unitsBilled: 35800,
+    })
+  })
+
+  it('falls back to created_at when the task has no updated_at', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        id: JOB_ID,
+        status: 'succeeded',
+        created_at: 1_718_049_470,
+        content: { video_url: VIDEO_URL },
+      }),
+    )
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-fast-251015')
+
+    const result = await adapter.getVideoUrl(JOB_ID)
+
+    expect(result.expiresAt).toEqual(
+      new Date((1_718_049_470 + 24 * 60 * 60) * 1000),
+    )
+  })
+
+  it('coerces usage counts the schema types as strings', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse(
+        succeededTask({
+          usage: { completion_tokens: '35800', total_tokens: '35800' },
+        }),
+      ),
+    )
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-5-pro-251215')
+
+    expect((await adapter.getVideoUrl(JOB_ID)).usage).toMatchObject({
+      completionTokens: 35800,
+      totalTokens: 35800,
+      unitsBilled: 35800,
+    })
+  })
+
+  it('omits usage when the task reports none', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse(succeededTask({ usage: undefined })),
+    )
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-5-pro-251215')
+
+    expect((await adapter.getVideoUrl(JOB_ID)).usage).toBeUndefined()
+  })
+
+  it('throws with the failure detail when the task failed', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse({
+        id: JOB_ID,
+        status: 'failed',
+        error: {
+          code: 'InputImageSensitiveContentDetected',
+          message: 'input image may contain sensitive information',
+        },
+      }),
+    )
+    const adapter = adapterWithFetch(fetchMock, 'dreamina-seedance-2-0-260128')
+
+    await expect(adapter.getVideoUrl(JOB_ID)).rejects.toThrow(
+      /Video generation failed: InputImageSensitiveContentDetected: input image may contain sensitive information/,
+    )
+  })
+
+  it('throws while the task is still running', async () => {
+    const fetchMock = mockFetch(() =>
+      jsonResponse({ id: JOB_ID, status: 'running' }),
+    )
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
+
+    await expect(adapter.getVideoUrl(JOB_ID)).rejects.toThrow(
+      /not ready for download/,
+    )
+  })
+
+  it('throws a job-not-found error on 404', async () => {
+    const fetchMock = mockFetch(() => jsonResponse({}, 404))
+    const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
+
+    await expect(adapter.getVideoUrl(JOB_ID)).rejects.toThrow(
+      `Video job not found: ${JOB_ID}`,
+    )
+  })
+})
+
+describe('durations', () => {
+  it.each([
+    ['dreamina-seedance-2-0-260128', 4, 15],
+    ['dreamina-seedance-2-0-fast-260128', 4, 15],
+    ['dreamina-seedance-2-0-mini-260615', 4, 15],
+    ['seedance-1-5-pro-251215', 4, 12],
+    ['seedance-1-0-pro-250528', 2, 12],
+    ['seedance-1-0-pro-fast-251015', 2, 12],
+  ] as const)('reports the %s range as %i–%i seconds', (model, min, max) => {
+    const adapter = createBytePlusVideo(model, 'ark-test-key')
+
+    expect(adapter.availableDurations()).toEqual({
+      kind: 'range',
+      min,
+      max,
+      step: 1,
+      unit: 'seconds',
+    })
+  })
+
+  it('snaps below, above and between the range', () => {
+    const adapter = createBytePlusVideo('seedance-1-5-pro-251215', 'k')
+
+    expect(adapter.snapDuration(1)).toBe(4)
+    expect(adapter.snapDuration(6.4)).toBe(6)
+    expect(adapter.snapDuration(6.6)).toBe(7)
+    expect(adapter.snapDuration(30)).toBe(12)
+  })
+})

--- a/packages/ai-byteplus/tests/video.test.ts
+++ b/packages/ai-byteplus/tests/video.test.ts
@@ -726,6 +726,96 @@ describe('getVideoStatus', () => {
     )
   })
 
+  // Core's poll loop treats `processing` as "keep waiting", so a status it
+  // can't map must not answer `processing` — that turns a malformed or
+  // newly-added terminal state into a silent poll to `maxDuration` and a
+  // generic timeout, with what Ark actually sent never reaching the caller.
+  it.each([
+    ['a status Ark adds later', { id: JOB_ID, status: 'rejected' }],
+    ['a task with no status at all', { id: JOB_ID }],
+  ])('throws naming %s', async (_label, body) => {
+    const adapter = adapterWithFetch(
+      mockFetch(() => jsonResponse(body)),
+      'seedance-1-0-pro-fast-251015',
+    )
+
+    await expect(adapter.getVideoStatus(JOB_ID)).rejects.toThrow(
+      /unrecognized Seedance task status/,
+    )
+  })
+
+  it('names the offending status value in the error', async () => {
+    const adapter = adapterWithFetch(
+      mockFetch(() => jsonResponse({ id: JOB_ID, status: 'rejected' })),
+      'seedance-1-0-pro-fast-251015',
+    )
+
+    await expect(adapter.getVideoStatus(JOB_ID)).rejects.toThrow(/"rejected"/)
+  })
+
+  // `readJsonBody` returns `undefined` for an empty body and the raw text for
+  // a non-JSON one — both documented failure modes of these hosts (an HTML
+  // error page from a proxy). Casting either to a task hides the body.
+  it.each([
+    ['an empty body', new Response('', { status: 200 })],
+    [
+      'an HTML error page served with 200',
+      new Response('<html><body>502 Bad Gateway</body></html>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    ],
+  ])('throws with the body in hand for %s', async (_label, response) => {
+    const adapter = adapterWithFetch(
+      mockFetch(() => response),
+      'seedance-1-0-pro-fast-251015',
+    )
+
+    await expect(adapter.getVideoStatus(JOB_ID)).rejects.toThrow(
+      /non-object body/,
+    )
+  })
+
+  it('carries the raw HTML into the error so the failure stays diagnosable', async () => {
+    const adapter = adapterWithFetch(
+      mockFetch(
+        () =>
+          new Response('<html><body>502 Bad Gateway</body></html>', {
+            status: 200,
+            headers: { 'Content-Type': 'text/html' },
+          }),
+      ),
+      'seedance-1-0-pro-fast-251015',
+    )
+
+    await expect(adapter.getVideoStatus(JOB_ID)).rejects.toThrow(
+      /502 Bad Gateway/,
+    )
+  })
+
+  // Core does `throw new Error(statusResult.error || 'Video generation
+  // failed')`, so a failure with no `error` block must still carry something
+  // identifying or the caller gets an unattributable error.
+  it('describes a failed task that carries no error block', async () => {
+    const adapter = adapterWithFetch(
+      mockFetch(() =>
+        jsonResponse({
+          id: JOB_ID,
+          status: 'failed',
+          model: 'seedance-1-0-pro-fast-251015',
+        }),
+      ),
+      'seedance-1-0-pro-fast-251015',
+    )
+
+    const status = await adapter.getVideoStatus(JOB_ID)
+
+    expect(status.status).toBe('failed')
+    expect(status.error).toContain(JOB_ID)
+    expect(status.error).toContain('seedance-1-0-pro-fast-251015')
+    expect(status.error).toContain('no error detail')
+  })
+
   it('surfaces the error code and message of a failed task', async () => {
     const fetchMock = mockFetch(() =>
       jsonResponse({
@@ -767,11 +857,14 @@ describe('getVideoStatus', () => {
     )
     const adapter = adapterWithFetch(fetchMock, 'seedance-1-0-pro-250528')
 
-    expect(await adapter.getVideoStatus(JOB_ID)).toEqual({
-      jobId: JOB_ID,
-      status: 'failed',
-      error: 'Job not found',
-    })
+    const result = await adapter.getVideoStatus(JOB_ID)
+    expect(result).toMatchObject({ jobId: JOB_ID, status: 'failed' })
+    // Ark's own code/message is kept: a 404 from a wrong baseURL or a proxy in
+    // front of the API is not an expired job id, and collapsing both to a bare
+    // "Job not found" points the caller at the wrong cause.
+    expect(result.error).toContain(JOB_ID)
+    expect(result.error).toContain('NotFound')
+    expect(result.error).toContain('task not found')
   })
 
   it('propagates non-404 lookup failures', async () => {

--- a/packages/ai-byteplus/tsconfig.json
+++ b/packages/ai-byteplus/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ai-byteplus/vite.config.ts
+++ b/packages/ai-byteplus/vite.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import { tanstackViteConfig } from '@tanstack/vite-config'
+import packageJson from './package.json'
+
+const config = defineConfig({
+  test: {
+    name: packageJson.name,
+    dir: './',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        'tests/',
+        '**/*.test.ts',
+        '**/*.config.ts',
+        '**/types.ts',
+      ],
+      include: ['src/**/*.ts'],
+    },
+  },
+})
+
+export default mergeConfig(
+  config,
+  tanstackViteConfig({
+    entry: ['./src/index.ts'],
+    srcDir: './src',
+    cjs: false,
+  }),
+)

--- a/packages/ai/skills/ai-core/adapter-configuration/SKILL.md
+++ b/packages/ai/skills/ai-core/adapter-configuration/SKILL.md
@@ -3,13 +3,16 @@ name: ai-core/adapter-configuration
 description: >
   Provider adapter selection and configuration: openaiText, anthropicText,
   geminiText, ollamaText, grokText, groqText, openRouterText, bedrockText,
-  openaiCompatible. Per-model type safety with modelOptions, reasoning/thinking configuration,
+  byteplusText, openaiCompatible. Per-model type safety with modelOptions,
+  reasoning/thinking configuration,
   runtime adapter switching, extendAdapter() for custom models, createModel().
   Generic OpenAI-compatible providers (DeepSeek, Together, Fireworks, etc.) via
   openaiCompatible({ baseURL, apiKey, models }) from @tanstack/ai-openai/compatible.
   API key env vars: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY/GEMINI_API_KEY,
   XAI_API_KEY, GROQ_API_KEY, OPENROUTER_API_KEY, OLLAMA_HOST,
-  BEDROCK_API_KEY (or AWS_BEARER_TOKEN_BEDROCK).
+  BEDROCK_API_KEY (or AWS_BEARER_TOKEN_BEDROCK). BytePlus needs TWO keys:
+  ARK_API_KEY (ModelArk — chat/video/image) and BYTEPLUS_VOICE_API_KEY
+  (Seed Speech — TTS/transcription); neither is a fallback for the other.
 type: sub-skill
 library: tanstack-ai
 library_version: '0.10.0'
@@ -80,7 +83,14 @@ The text adapter is the primary one for chat/completions:
 | OpenRouter        | `@tanstack/ai-openrouter`        | `openRouterText`                            | `OPENROUTER_API_KEY`                              |
 | Ollama            | `@tanstack/ai-ollama`            | `ollamaText`                                | `OLLAMA_HOST` (default: `http://localhost:11434`) |
 | Bedrock           | `@tanstack/ai-bedrock`           | `bedrockText`                               | `BEDROCK_API_KEY` or `AWS_BEARER_TOKEN_BEDROCK`   |
+| BytePlus          | `@tanstack/ai-byteplus`          | `byteplusText`                              | `ARK_API_KEY` (falls back to `BYTEPLUS_API_KEY`)  |
 | OpenAI-compatible | `@tanstack/ai-openai/compatible` | `openaiCompatible` / `openaiCompatibleText` | provider-specific (passed via `apiKey`)           |
+
+> **BytePlus uses two keys.** `byteplusText` / `byteplusVideo` /
+> `byteplusImage` read `ARK_API_KEY` (ModelArk, `Authorization: Bearer`), but
+> `byteplusSpeech` / `byteplusTranscription` are a separate product and read
+> **`BYTEPLUS_VOICE_API_KEY`** (Seed Speech, `X-Api-Key`). Ark keys are also
+> region-isolated — the default base URL is the ap-southeast endpoint.
 
 ```typescript
 // Each factory takes model as first arg, optional config as second
@@ -92,6 +102,7 @@ import { groqText } from '@tanstack/ai-groq'
 import { openRouterText } from '@tanstack/ai-openrouter'
 import { ollamaText } from '@tanstack/ai-ollama'
 import { bedrockText } from '@tanstack/ai-bedrock'
+import { byteplusText } from '@tanstack/ai-byteplus'
 
 // Model string is passed to the factory, NOT to chat()
 const adapter = openaiText('gpt-5.2')
@@ -102,6 +113,7 @@ const adapter5 = groqText('llama-3.3-70b-versatile')
 const adapter6 = openRouterText('anthropic/claude-sonnet-4')
 const adapter7 = ollamaText('llama3.3')
 const adapter8 = bedrockText('us.anthropic.claude-3-7-sonnet-20250219-v1:0')
+const adapter9 = byteplusText('seed-2-0-lite-260428')
 
 // Optional: pass explicit API key
 const adapterWithKey = openaiText('gpt-5.2', {
@@ -283,15 +295,16 @@ chat({
 
 Per-provider sampling keys (all live inside `modelOptions`):
 
-| Provider          | Temperature   | Nucleus | Max output tokens                   |
-| ----------------- | ------------- | ------- | ----------------------------------- |
-| OpenAI            | `temperature` | `top_p` | `max_output_tokens`                 |
-| Anthropic         | `temperature` | `top_p` | `max_tokens`                        |
-| Gemini            | `temperature` | `topP`  | `maxOutputTokens`                   |
-| Grok (xAI)        | `temperature` | `top_p` | `max_tokens`                        |
-| Groq              | `temperature` | `top_p` | `max_completion_tokens`             |
-| OpenRouter (chat) | `temperature` | `topP`  | `maxCompletionTokens`               |
-| Ollama            | `temperature` | `top_p` | `num_predict` (nested in `options`) |
+| Provider          | Temperature   | Nucleus | Max output tokens                         |
+| ----------------- | ------------- | ------- | ----------------------------------------- |
+| OpenAI            | `temperature` | `top_p` | `max_output_tokens`                       |
+| Anthropic         | `temperature` | `top_p` | `max_tokens`                              |
+| Gemini            | `temperature` | `topP`  | `maxOutputTokens`                         |
+| Grok (xAI)        | `temperature` | `top_p` | `max_tokens`                              |
+| Groq              | `temperature` | `top_p` | `max_completion_tokens`                   |
+| OpenRouter (chat) | `temperature` | `topP`  | `maxCompletionTokens`                     |
+| Ollama            | `temperature` | `top_p` | `num_predict` (nested in `options`)       |
+| BytePlus          | `temperature` | `top_p` | `max_tokens` (or `max_completion_tokens`) |
 
 `temperature` is the one key every provider names identically; token limits and
 some sampling options use provider-native names. Ollama nests all sampling under
@@ -324,19 +337,28 @@ runs.
 
 Current per-adapter status (#605):
 
-| Adapter                                      | Returns                                                                                           |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `openaiText` / `openaiChatCompletions`       | `true` (all supported models)                                                                     |
-| `anthropicText`                              | `true` for Claude 4.5+ (gated by `ANTHROPIC_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise |
-| `geminiText`                                 | `true` for Gemini 3.x (gated by `GEMINI_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise     |
-| `grokText`                                   | `true` for Grok 4 family (gated by `GROK_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise    |
-| `groqText`                                   | `false` (Groq API rejects schema + tools + stream)                                                |
-| `openRouterText` / `openRouterResponsesText` | `false` (per-call resolution is a follow-up)                                                      |
-| `ollamaText`                                 | `false` (constrained-decoding vs tool-call grammar conflict)                                      |
+| Adapter                                      | Returns                                                                                               |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `openaiText` / `openaiChatCompletions`       | `true` (all supported models)                                                                         |
+| `anthropicText`                              | `true` for Claude 4.5+ (gated by `ANTHROPIC_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise     |
+| `geminiText`                                 | `true` for Gemini 3.x (gated by `GEMINI_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise         |
+| `grokText`                                   | `true` for Grok 4 family (gated by `GROK_COMBINED_TOOLS_AND_SCHEMA_MODELS`), `false` otherwise        |
+| `groqText`                                   | `false` (Groq API rejects schema + tools + stream)                                                    |
+| `openRouterText` / `openRouterResponsesText` | `false` (per-call resolution is a follow-up)                                                          |
+| `ollamaText`                                 | `false` (constrained-decoding vs tool-call grammar conflict)                                          |
+| `byteplusText`                               | Per model — `true` only for the 10 ids in `BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS`, `false` otherwise |
 
 Subclasses can override to narrow the capability. When extending an
 adapter for a custom model that doesn't support the combination, return
 `false` explicitly.
+
+> **BytePlus has no JSON-mode fallback.** On the 8 chat models outside
+> `BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS`, Ark rejects `json_schema` _and_
+> `json_object`, so `false` here does not buy a degraded path — it only keeps
+> `response_format` out of the streaming chat request. `structuredOutput()`
+> throws and `structuredOutputStream()` emits `RUN_ERROR` on those models.
+> Note `seed-2-0-lite-260428` (the obvious default) is one of them; use
+> `seed-2-0-lite-260228` or `dola-seed-2-1-turbo-260628` for typed output.
 
 ### 6. OpenAI-Compatible Providers
 
@@ -443,6 +465,7 @@ Detailed per-adapter reference files:
 - [Grok Adapter](references/grok-adapter.md)
 - [Groq Adapter](references/groq-adapter.md)
 - [OpenRouter Adapter](references/openrouter-adapter.md)
+- [BytePlus Adapter](references/byteplus-adapter.md)
 
 ## Tension
 

--- a/packages/ai/skills/ai-core/adapter-configuration/references/byteplus-adapter.md
+++ b/packages/ai/skills/ai-core/adapter-configuration/references/byteplus-adapter.md
@@ -1,0 +1,148 @@
+# BytePlus Adapter Reference
+
+## Package
+
+```
+@tanstack/ai-byteplus
+```
+
+## Adapter Factories
+
+| Factory                 | Type          | Description                |
+| ----------------------- | ------------- | -------------------------- |
+| `byteplusText`          | Text/Chat     | ModelArk chat completions  |
+| `byteplusVideo`         | Video         | Seedance async task API    |
+| `byteplusImage`         | Image         | Seedream image generation  |
+| `byteplusSpeech`        | TTS           | Seed Speech text-to-speech |
+| `byteplusTranscription` | Transcription | Seed Speech ASR            |
+
+Each has a `createBytePlus*(model, apiKey, config?)` sibling that takes an
+explicit key instead of reading the environment.
+
+## Import
+
+```typescript
+import {
+  byteplusText,
+  byteplusVideo,
+  byteplusImage,
+} from '@tanstack/ai-byteplus'
+import { byteplusSpeech, byteplusTranscription } from '@tanstack/ai-byteplus'
+```
+
+## Key Chat Models
+
+| Model                        | Context | Notes                                                              |
+| ---------------------------- | ------- | ------------------------------------------------------------------ |
+| `dola-seed-2-1-turbo-260628` | 256K    | Flagship; text/image/video in; structured output; thinking summary |
+| `seed-2-0-lite-260428`       | 256K    | Good default; audio in; **no** structured output                   |
+| `seed-2-0-mini-260428`       | 256K    | Smallest 2.0; audio in; **no** structured output                   |
+| `seed-2-0-pro-260328`        | 256K    | Structured output; thinking summary                                |
+| `seed-2-0-lite-260228`       | 256K    | Structured output — use instead of `-260428` for typed output      |
+| `seed-1-6-flash-250715`      | 256K    | Fast/cheap; structured output                                      |
+| `glm-5-2-260617`             | 1024K   | Structured output; `reasoning_effort` incl. `none`/`xhigh`/`max`   |
+| `deepseek-v4-pro-260425`     | 1024K   | 384K output; no structured output                                  |
+| `deepseek-v3-2-251201`       | 128K    | Reasoning defaults **off**; no structured output                   |
+| `gpt-oss-120b-250805`        | 128K    | Only model accepting `thinking: { type: 'auto' }`                  |
+
+`BYTEPLUS_CHAT_MODELS` is the full list of 18 (also
+`seed-2-0-mini-260215`, `seed-2-0-code-preview-260328`, `seed-1-8-251228`,
+`seed-1-6-250915`, `seed-1-6-250615`, `seed-1-6-flash-250615`,
+`glm-4-7-251222`, `deepseek-v4-flash-260425`).
+
+Media models: `BYTEPLUS_VIDEO_MODELS` (Seedance —
+`dreamina-seedance-2-0-260128` / `-fast-260128` / `-mini-260615`,
+`seedance-1-5-pro-251215`, `seedance-1-0-pro-250528`,
+`seedance-1-0-pro-fast-251015`), `BYTEPLUS_IMAGE_MODELS` (Seedream —
+`dola-seedream-5-0-pro-260628`, `seedream-5-0-260128`,
+`seedream-5-0-lite-260128`, `seedream-4-5-251128`, `seedream-4-0-250828`),
+`BYTEPLUS_TTS_MODELS` (`seed-audio-1.0`) and
+`BYTEPLUS_TRANSCRIPTION_MODELS` (`seed-asr`).
+
+## Provider-Specific modelOptions
+
+```typescript
+chat({
+  adapter: byteplusText('dola-seed-2-1-turbo-260628'),
+  messages,
+  modelOptions: {
+    // Ark-only
+    thinking: { type: 'enabled' }, // 'enabled' | 'disabled' | 'auto' ('auto': gpt-oss-120b only)
+    reasoning_effort: 'medium', // 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+    repetition_penalty: 1.1,
+    service_tier: 'default', // 'default' | 'flex' (flex = cheaper offline batch queue)
+    // Sampling (OpenAI-compatible names)
+    temperature: 0.7,
+    top_p: 0.9,
+    top_k: 40,
+    frequency_penalty: 0.5,
+    presence_penalty: 0.5,
+    seed: 42,
+    stop: ['\n\n'],
+    // Token limits — mutually exclusive
+    max_tokens: 2048,
+    // max_completion_tokens: 2048,
+    // Tool calling
+    tool_choice: 'auto',
+    parallel_tool_calls: true,
+    // Logging / attribution
+    logprobs: true,
+    top_logprobs: 5,
+    user: 'user-123',
+  },
+})
+```
+
+`response_format` is deliberately **not** a provider option — the chat
+activity owns it via `outputSchema`.
+
+## Environment Variables
+
+```
+ARK_API_KEY              # chat, video, image (falls back to BYTEPLUS_API_KEY)
+BYTEPLUS_VOICE_API_KEY   # TTS + transcription — a DIFFERENT product key
+```
+
+## Gotchas
+
+- **Two products, two keys.** ModelArk uses `Authorization: Bearer $ARK_API_KEY`
+  at `ark.ap-southeast.bytepluses.com`; Seed Speech uses
+  `X-Api-Key: $BYTEPLUS_VOICE_API_KEY` at `voice.ap-southeast-1.bytepluses.com`.
+  An Ark key on the voice host fails with `45000010 Invalid X-Api-Key`.
+- **Ark keys are region-isolated.** The default base URL is ap-southeast; the EU
+  endpoint serves chat and image only (no Seedance). Override with
+  `config.baseURL`.
+- **Structured output is per model and fails loud.** Only the 10 ids in
+  `BYTEPLUS_STRUCTURED_OUTPUT_CHAT_MODELS` accept `json_schema`; the other 8
+  reject `json_object` too, so there is no JSON-mode fallback. `glm-4-7-251222`
+  is excluded deliberately — it accepts the schema with `200` and then answers
+  in prose. `seed-2-0-lite-260428` is _not_ on the list.
+- **`reasoning_effort` + `thinking: { type: 'disabled' }` is a 400.** So is
+  sending both `max_tokens` and `max_completion_tokens`.
+- **`reasoning_effort` values are gated per model.** `minimal` / `low` /
+  `medium` / `high` are general; `none` and `xhigh` are accepted only by
+  `glm-5-2-260617`; `max` only by `glm-5-2-260617` and the two
+  `deepseek-v4-*-260425` models. `thinking: { type: 'auto' }` is
+  `gpt-oss-120b-250805` only.
+- **Reasoning is on by default** on every model except `deepseek-v3-2-251201`.
+- **`encrypted_content` round-trip.** The four thinking-summary models
+  (`dola-seed-2-1-turbo-260628`, `seed-2-0-lite-260428`,
+  `seed-2-0-mini-260428`, `seed-2-0-pro-260328`) emit an opaque signature over
+  the reasoning trace that BytePlus asks for back on the next turn. The adapter
+  round-trips it automatically over the same seam Anthropic thinking signatures
+  use: it is captured onto `STEP_FINISHED.signature`, which lands on the
+  thinking part as `ModelMessage.thinking[].signature` and is echoed back on the
+  following request. Code that persists and replays history by hand must **keep
+  the thinking part's `signature`** — not "message metadata", which is a
+  different field and carries nothing here. Losing it costs a reasoning-cache
+  hit, not the request: a live probe confirmed Ark accepts a turn whose
+  assistant message omits `encrypted_content`. A structured-output turn doesn't
+  capture the blob at all, for the same reason.
+- **Model ids are dated and retired aggressively.** Only ids verified against a
+  live request are exported; the published BytePlus lists include dead ones.
+  Bare ids mostly don't resolve — the `dola-` prefix is required on
+  `dola-seed-2-1-turbo-260628` and the `dreamina-` prefix on the Seedance 2.0
+  family, but adding `dola-` to an older id 404s.
+- **Media option applicability is per model and enforced server-side** — Ark
+  400s on an inapplicable Seedance field instead of ignoring it. See the
+  media-generation skill.

--- a/packages/ai/skills/ai-core/media-generation/SKILL.md
+++ b/packages/ai/skills/ai-core/media-generation/SKILL.md
@@ -2,11 +2,11 @@
 name: ai-core/media-generation
 description: >
   Image, audio, video, speech (TTS), and transcription generation using
-  activity-specific adapters: generateImage() with openaiImage/geminiImage,
+  activity-specific adapters: generateImage() with openaiImage/geminiImage/byteplusImage,
   generateAudio() with geminiAudio/falAudio, generateVideo() with async
-  polling (openaiVideo/geminiVideo/grokVideo/falVideo, per-model typed
-  durations), generateSpeech() with openaiSpeech, generateTranscription()
-  with openaiTranscription. React hooks: useGenerateImage, useGenerateAudio,
+  polling (openaiVideo/geminiVideo/grokVideo/falVideo/byteplusVideo, per-model typed
+  durations), generateSpeech() with openaiSpeech/byteplusSpeech, generateTranscription()
+  with openaiTranscription/byteplusTranscription. React hooks: useGenerateImage, useGenerateAudio,
   useGenerateSpeech, useTranscription, useGenerateVideo.
   TanStack Start server function integration with toServerSentEventsResponse.
 type: sub-skill
@@ -150,8 +150,16 @@ function ImageGenerator() {
 ### 1. Image Generation
 
 Supported adapters: `openaiImage` (dall-e-2, dall-e-3, gpt-image-1,
-gpt-image-1-mini, gpt-image-2) and `geminiImage` (gemini-3.1-flash-image-preview,
-gemini-3.1-flash-lite-image, imagen-4.0-generate-001, etc.).
+gpt-image-1-mini, gpt-image-2), `geminiImage` (gemini-3.1-flash-image-preview,
+gemini-3.1-flash-lite-image, imagen-4.0-generate-001, etc.) and `byteplusImage`
+(Seedream — `seedream-4-0-250828`, `seedream-4-5-251128`, the 5.0 family).
+
+> **Seedream quirks:** `watermark` defaults to **`true`** (pass
+> `modelOptions: { watermark: false }` for a clean image), `size` is a token
+> (`'1K'` | `'2K'` | `'4K'`) **or** explicit `'2048x2048'` pixels but never a
+> mix, and `numberOfImages` is an **upper bound** — Seedream has no `n`, so it
+> maps onto group-image mode and the model may return fewer. Reads
+> `ARK_API_KEY`.
 
 ```typescript
 import { generateImage } from '@tanstack/ai'
@@ -333,7 +341,19 @@ const { generate, result, isLoading } = useGenerateAudio({
 
 ### 3. Text-to-Speech
 
-Adapter: `openaiSpeech` (tts-1, tts-1-hd, gpt-4o-audio-preview).
+Adapters: `openaiSpeech` (tts-1, tts-1-hd, gpt-4o-audio-preview) and
+`byteplusSpeech` (`seed-audio-1.0`).
+
+> **BytePlus Seed Speech is a separate product from ModelArk** — it reads
+> **`BYTEPLUS_VOICE_API_KEY`**, not `ARK_API_KEY`, and an Ark key there fails
+> with `45000010 Invalid X-Api-Key`. Output is capped at **120 seconds**.
+> There is no top-level `speaker` field — `voice` is sent as
+> `references: [{ speaker }]`, and `modelOptions.references` **replaces** that
+> array rather than merging, so passing `references` for voice cloning silently
+> drops `voice`. Voice ids ending `_uranus_bigtts` are TTS 2.0,
+> `_mars_bigtts` / `_moon_bigtts` are TTS 1.0, and `*_emo_v2_*` are the 1.0
+> voices that accept emotion tags. Formats: `wav`, `mp3`, `pcm`, `ogg_opus`;
+> `watermark` is also available on `modelOptions`.
 
 ```typescript
 import { generateSpeech } from '@tanstack/ai'
@@ -367,8 +387,10 @@ const { generate, result, isLoading } = useGenerateSpeech({
 
 ### 4. Audio Transcription
 
-Adapter: `openaiTranscription` (whisper-1, gpt-4o-transcribe,
-gpt-4o-mini-transcribe, gpt-4o-transcribe-diarize).
+Adapters: `openaiTranscription` (whisper-1, gpt-4o-transcribe,
+gpt-4o-mini-transcribe, gpt-4o-transcribe-diarize) and `byteplusTranscription`
+(`seed-asr` — synchronous, no polling; audio up to 2 hours / 100 MB; also reads
+**`BYTEPLUS_VOICE_API_KEY`**).
 
 > **Capturing audio in the browser:** Use `useAudioRecorder` from `@tanstack/ai-react` to record directly in the browser, then pass the recording as the `audio` input to `generate()`, or use `recording.part` as a prompt part in chat/generation calls. No transcoding or extra dependencies required — the recorder returns the native browser format (`audio/webm` or `audio/mp4`). For transcription, wrap it as a `data:` URL so the provider gets the real content type; passing raw `recording.base64` makes the adapter assume `audio/mpeg` and mislabel the webm/mp4 bytes.
 >
@@ -517,7 +539,20 @@ durations 4/8/12s, single `input_reference` image prompt part), `grokVideo(...)`
 (`grok-imagine-video` does text-to-video + image-to-video; `grok-imagine-video-1.5` is
 image-to-video only — needs an `image` prompt part as the starting frame, text-only throws;
 aspect-ratio size template like `'16:9_720p'`, integer durations 1-15s, reports
-`usage.unitsBilled` seconds and exact `usage.cost`), and `falVideo(...)` (hosted models, see cost tracking below).
+`usage.unitsBilled` seconds and exact `usage.cost`), `byteplusVideo(...)` (Seedance —
+aspect-ratio size template like `'16:9_720p'`, durations 4-15s on the 2.0 family,
+4-12s on 1.5-pro, 2-12s on the 1.0-pro models; reads `ARK_API_KEY`), and
+`falVideo(...)` (hosted models, see cost tracking below).
+
+> **Seedance option applicability is per model and enforced server-side** —
+> Ark returns a 400 for an inapplicable field rather than ignoring it.
+> `service_tier` / `camera_fixed` are Seedance 1.x only, `frames` is
+> 1-0-pro + 1-0-pro-fast only, `draft` is 1-5-pro only, `priority` is the 2.0
+> family only, and `duration: -1` works on 2.0 + 1-5-pro. There is no 2K tier
+> on any model and `4k` exists only on `dreamina-seedance-2-0-260128`.
+> **Video URLs expire 24 hours after the task completes** (task record kept 7
+> days). Seedance is also reachable via `falVideo` — `byteplusVideo` is the
+> direct-to-BytePlus path.
 
 Client hook with job tracking:
 

--- a/packages/ai/src/logger/types.ts
+++ b/packages/ai/src/logger/types.ts
@@ -29,7 +29,7 @@ export interface Logger {
  */
 export interface DebugCategories {
   /**
-   * Raw chunks/frames received from a provider SDK (OpenAI, Anthropic, Gemini, Ollama, Grok, Groq, OpenRouter, fal, ElevenLabs). Emitted inside every streaming adapter's chunk loop.
+   * Raw chunks/frames received from a provider SDK (OpenAI, Anthropic, Gemini, Ollama, Grok, Groq, OpenRouter, fal, ElevenLabs, BytePlus). Emitted inside every streaming adapter's chunk loop.
    */
   provider?: boolean
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,7 +357,7 @@ importers:
         version: 17.2.3
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -514,7 +514,7 @@ importers:
         version: 15.0.12
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       puppeteer:
         specifier: ^24.34.0
         version: 24.39.1(supports-color@7.2.0)(typescript@5.9.3)
@@ -608,7 +608,7 @@ importers:
         version: 0.10.0
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -804,7 +804,7 @@ importers:
         version: 0.561.0(react@19.2.3)
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -896,6 +896,9 @@ importers:
       '@tanstack/ai-grok':
         specifier: workspace:*
         version: link:../../packages/ai-grok
+      '@tanstack/ai-react':
+        specifier: workspace:*
+        version: link:../../packages/ai-react
       '@tanstack/react-router':
         specifier: ^1.158.4
         version: 1.159.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -910,7 +913,7 @@ importers:
         version: 0.561.0(react@19.2.3)
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -1044,7 +1047,7 @@ importers:
         version: 0.561.0(react@19.2.3)
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1141,7 +1144,7 @@ importers:
         version: link:../../packages/ai-solid-ui
       '@tanstack/nitro-v2-vite-plugin':
         specifier: ^1.155.0
-        version: 1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/router-plugin':
         specifier: ^1.158.4
         version: 1.159.5(@tanstack/react-router@1.159.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -1744,10 +1747,10 @@ importers:
         version: 27.3.0(postcss@8.5.19)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.28.1)(solid-js@1.9.10)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))
+        version: 2.2.0(esbuild@0.28.1)(solid-js@1.9.10)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))
       vite:
         specifier: ^8.1.4
         version: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -1968,10 +1971,10 @@ importers:
         version: 15.0.4
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.6.1)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.6.1)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       vite:
         specifier: ^8.1.4
-        version: 8.1.4(@types/node@24.10.3)(esbuild@0.27.7)(jiti@2.6.1)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
       zod:
         specifier: ^4.2.0
         version: 4.3.6
@@ -1983,7 +1986,7 @@ importers:
         version: link:../ai-event-client
       ioredis:
         specifier: '>=5.0.0'
-        version: 5.9.2
+        version: 5.9.2(supports-color@7.2.0)
     devDependencies:
       '@honcho-ai/sdk':
         specifier: ^2.1.1
@@ -1999,7 +2002,7 @@ importers:
         version: 4.0.14(supports-color@7.2.0)(vitest@4.1.10)
       ioredis-mock:
         specifier: ^8.9.0
-        version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.9.2))(ioredis@5.9.2)
+        version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.9.2(supports-color@7.2.0)))(ioredis@5.9.2(supports-color@7.2.0))
       redis:
         specifier: ^4.7.0
         version: 4.7.1
@@ -2812,7 +2815,7 @@ importers:
         version: link:../../packages/ai-react-ui
       '@tanstack/nitro-v2-vite-plugin':
         specifier: ^1.155.0
-        version: 1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/react-ai-devtools':
         specifier: workspace:*
         version: link:../../packages/react-ai-devtools
@@ -2827,7 +2830,7 @@ importers:
         version: 1.159.5(crossws@0.4.6(srvx@0.11.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start':
         specifier: ^1.120.20
-        version: 1.120.20(8a86bcf9ed90298a1c326f85f2b149b3)
+        version: 1.120.20(ad5aa143b5402ea1fab6b2d0538871c6)
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -20943,19 +20946,11 @@ snapshots:
   '@prisma/client-runtime-utils@7.9.0':
     optional: true
 
-  '@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.9.0
     optionalDependencies:
       prisma: 7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
-      typescript: 5.9.3
-    optional: true
-
-  '@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)':
-    dependencies:
-      '@prisma/client-runtime-utils': 7.9.0
-    optionalDependencies:
-      prisma: 7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       typescript: 5.9.3
     optional: true
 
@@ -22953,45 +22948,9 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@tanstack/nitro-v2-vite-plugin@1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/nitro-v2-vite-plugin@1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
-      pathe: 2.0.3
-      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - better-sqlite3
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - mysql2
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - supports-color
-      - uploadthing
-      - xml2js
-
-  '@tanstack/nitro-v2-vite-plugin@1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
+      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
       pathe: 2.0.3
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -23126,9 +23085,9 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-plugin@1.131.50(2737dc8ad1bbc72babeed4d28efb8f90)':
+  '@tanstack/react-start-plugin@1.131.50(acd959054103106c0a9bad82aa502122)':
     dependencies:
-      '@tanstack/start-plugin-core': 1.131.50(654162e66e5a9cff1a2932da21908c03)
+      '@tanstack/start-plugin-core': 1.131.50(18cacbf56349ba96e495ac9a4b1f347f)
       '@vitejs/plugin-react': 4.7.0(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       pathe: 2.0.3
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -23168,11 +23127,11 @@ snapshots:
       - webpack
       - xml2js
 
-  '@tanstack/react-start-router-manifest@1.120.19(61710034f5693f0d4629ffde97945be3)':
+  '@tanstack/react-start-router-manifest@1.120.19(89eee2ca08d25747ea346b710d88e83e)':
     dependencies:
       '@tanstack/router-core': 1.159.4
       tiny-invariant: 1.3.3
-      vinxi: 0.5.3(61710034f5693f0d4629ffde97945be3)
+      vinxi: 0.5.3(89eee2ca08d25747ea346b710d88e83e)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -23643,11 +23602,11 @@ snapshots:
       '@tanstack/store': 0.8.0
       solid-js: 1.9.10
 
-  '@tanstack/start-api-routes@1.120.19(7575f2d5e0bec14d376a64f34c2be7ae)':
+  '@tanstack/start-api-routes@1.120.19(4180420749541f7634d0ea935ae88706)':
     dependencies:
       '@tanstack/router-core': 1.159.4
       '@tanstack/start-server-core': 1.159.4(crossws@0.4.6(srvx@0.11.17))
-      vinxi: 0.5.3(61710034f5693f0d4629ffde97945be3)
+      vinxi: 0.5.3(89eee2ca08d25747ea346b710d88e83e)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -23719,21 +23678,21 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/start-config@1.120.20(8a86bcf9ed90298a1c326f85f2b149b3)':
+  '@tanstack/start-config@1.120.20(ad5aa143b5402ea1fab6b2d0538871c6)':
     dependencies:
       '@tanstack/react-router': 1.159.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/react-start-plugin': 1.131.50(2737dc8ad1bbc72babeed4d28efb8f90)
+      '@tanstack/react-start-plugin': 1.131.50(acd959054103106c0a9bad82aa502122)
       '@tanstack/router-generator': 1.159.4
       '@tanstack/router-plugin': 1.159.5(@tanstack/react-router@1.159.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/server-functions-plugin': 1.141.0(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start-server-functions-handler': 1.120.19(crossws@0.4.6(srvx@0.11.17))
       '@vitejs/plugin-react': 4.7.0(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       import-meta-resolve: 4.2.0
-      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
+      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
       ofetch: 1.5.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vinxi: 0.5.3(61710034f5693f0d4629ffde97945be3)
+      vinxi: 0.5.3(89eee2ca08d25747ea346b710d88e83e)
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -23787,7 +23746,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.154.7': {}
 
-  '@tanstack/start-plugin-core@1.131.50(654162e66e5a9cff1a2932da21908c03)':
+  '@tanstack/start-plugin-core@1.131.50(18cacbf56349ba96e495ac9a4b1f347f)':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.29.0
@@ -23803,7 +23762,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.12
       cheerio: 1.1.2
       h3: 1.13.0
-      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
+      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
       pathe: 2.0.3
       ufo: 1.6.3
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -24027,13 +23986,13 @@ snapshots:
     dependencies:
       '@tanstack/router-core': 1.159.4
 
-  '@tanstack/start@1.120.20(8a86bcf9ed90298a1c326f85f2b149b3)':
+  '@tanstack/start@1.120.20(ad5aa143b5402ea1fab6b2d0538871c6)':
     dependencies:
       '@tanstack/react-start-client': 1.141.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/react-start-router-manifest': 1.120.19(61710034f5693f0d4629ffde97945be3)
+      '@tanstack/react-start-router-manifest': 1.120.19(89eee2ca08d25747ea346b710d88e83e)
       '@tanstack/react-start-server': 1.141.1(crossws@0.4.6(srvx@0.11.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/start-api-routes': 1.120.19(7575f2d5e0bec14d376a64f34c2be7ae)
-      '@tanstack/start-config': 1.120.20(8a86bcf9ed90298a1c326f85f2b149b3)
+      '@tanstack/start-api-routes': 1.120.19(4180420749541f7634d0ea935ae88706)
+      '@tanstack/start-config': 1.120.20(ad5aa143b5402ea1fab6b2d0538871c6)
       '@tanstack/start-server-functions-client': 1.131.50(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start-server-functions-handler': 1.120.19(crossws@0.4.6(srvx@0.11.17))
       '@tanstack/start-server-functions-server': 1.131.2(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -24318,9 +24277,9 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/ioredis-mock@8.2.7(ioredis@5.9.2)':
+  '@types/ioredis-mock@8.2.7(ioredis@5.9.2(supports-color@7.2.0))':
     dependencies:
-      ioredis: 5.9.2
+      ioredis: 5.9.2(supports-color@7.2.0)
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -26226,25 +26185,18 @@ snapshots:
 
   dayjs@1.11.19: {}
 
-  db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3):
+  db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3):
+    optionalDependencies:
+      '@electric-sql/pglite': 0.4.3
+      better-sqlite3: 12.11.1
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
+      mysql2: 3.15.3
+
+  db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3):
     optionalDependencies:
       '@electric-sql/pglite': 0.4.3
       better-sqlite3: 12.11.1
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
-      mysql2: 3.15.3
-
-  db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3):
-    optionalDependencies:
-      '@electric-sql/pglite': 0.4.3
-      better-sqlite3: 12.11.1
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
-      mysql2: 3.15.3
-
-  db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3):
-    optionalDependencies:
-      '@electric-sql/pglite': 0.4.3
-      better-sqlite3: 12.11.1
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
       mysql2: 3.15.3
 
   de-indent@1.0.2: {}
@@ -26450,35 +26402,23 @@ snapshots:
       '@cloudflare/workers-types': 4.20260317.1
       '@electric-sql/pglite': 0.4.3
       '@opentelemetry/api': 1.9.1
-      '@prisma/client': 7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client': 7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
       better-sqlite3: 12.11.1
       mysql2: 3.15.3
       postgres: 3.4.7
       prisma: 7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
     optional: true
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260317.1
       '@electric-sql/pglite': 0.4.3
       '@opentelemetry/api': 1.9.1
-      '@prisma/client': 7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client': 7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
       better-sqlite3: 12.11.1
       mysql2: 3.15.3
       postgres: 3.4.7
       prisma: 7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
-    optional: true
-
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)):
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20260317.1
-      '@electric-sql/pglite': 0.4.3
-      '@opentelemetry/api': 1.9.1
-      '@prisma/client': 7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
-      better-sqlite3: 12.11.1
-      mysql2: 3.15.3
-      postgres: 3.4.7
-      prisma: 7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
     optional: true
 
   dts-resolver@2.1.3(oxc-resolver@11.21.3):
@@ -27966,17 +27906,17 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.9.2))(ioredis@5.9.2):
+  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.9.2(supports-color@7.2.0)))(ioredis@5.9.2(supports-color@7.2.0)):
     dependencies:
       '@ioredis/as-callback': 3.0.0
       '@ioredis/commands': 1.5.0
-      '@types/ioredis-mock': 8.2.7(ioredis@5.9.2)
+      '@types/ioredis-mock': 8.2.7(ioredis@5.9.2(supports-color@7.2.0))
       fengari: 0.1.5
       fengari-interop: 0.1.4(fengari@0.1.5)
-      ioredis: 5.9.2
+      ioredis: 5.9.2(supports-color@7.2.0)
       semver: 7.8.4
 
-  ioredis@5.9.2:
+  ioredis@5.9.2(supports-color@7.2.0):
     dependencies:
       '@ioredis/commands': 1.5.0
       cluster-key-slot: 1.1.2
@@ -29611,11 +29551,11 @@ snapshots:
       rollup: 4.60.1
       tailwindcss: 4.1.18
 
-  nitro@3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0):
+  nitro@3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.6(srvx@0.11.17)
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       env-runner: 0.1.14(miniflare@4.20260617.1)(wrangler@4.103.0)
       h3: 2.0.1-rc.22(crossws@0.4.6(srvx@0.11.17))
       hookable: 6.1.1
@@ -29626,7 +29566,7 @@ snapshots:
       rolldown: 1.1.5
       srvx: 0.11.17
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.2.3
       giget: 2.0.0
@@ -29665,11 +29605,11 @@ snapshots:
       - uploadthing
       - wrangler
 
-  nitro@3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0):
+  nitro@3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.6(srvx@0.11.17)
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       env-runner: 0.1.14(miniflare@4.20260617.1)(wrangler@4.103.0)
       h3: 2.0.1-rc.22(crossws@0.4.6(srvx@0.11.17))
       hookable: 6.1.1
@@ -29680,7 +29620,7 @@ snapshots:
       rolldown: 1.1.5
       srvx: 0.11.17
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.2.3
       giget: 2.0.0
@@ -29740,7 +29680,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -29753,7 +29693,7 @@ snapshots:
       h3: 1.15.5
       hookable: 5.5.3
       httpxy: 0.1.7
-      ioredis: 5.9.2
+      ioredis: 5.9.2(supports-color@7.2.0)
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
@@ -29821,7 +29761,7 @@ snapshots:
       - supports-color
       - uploadthing
 
-  nitropack@2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5):
+  nitropack@2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.1)
@@ -29842,7 +29782,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -29855,7 +29795,7 @@ snapshots:
       h3: 1.15.5
       hookable: 5.5.3
       httpxy: 0.1.7
-      ioredis: 5.9.2
+      ioredis: 5.9.2(supports-color@7.2.0)
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
@@ -29888,109 +29828,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 5.6.0
       unplugin-utils: 0.3.1
-      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2)
-      untyped: 2.0.0
-      unwasm: 0.5.3
-      youch: 4.1.0-beta.13
-      youch-core: 0.3.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - better-sqlite3
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - mysql2
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - supports-color
-      - uploadthing
-
-  nitropack@2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.2
-      '@rollup/plugin-alias': 6.0.0(rollup@4.60.1)
-      '@rollup/plugin-commonjs': 29.0.0(rollup@4.60.1)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.60.1)
-      '@rollup/plugin-json': 6.1.0(rollup@4.60.1)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.1)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.60.1)
-      '@vercel/nft': 1.3.0(rollup@4.60.1)
-      archiver: 7.0.1
-      c12: 3.3.3(magicast@0.5.2)
-      chokidar: 5.0.0
-      citty: 0.1.6
-      compatx: 0.2.0
-      confbox: 0.2.2
-      consola: 3.4.2
-      cookie-es: 2.0.1
-      croner: 9.1.0
-      crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
-      defu: 6.1.4
-      destr: 2.0.5
-      dot-prop: 10.1.0
-      esbuild: 0.27.7
-      escape-string-regexp: 5.0.0
-      etag: 1.8.1
-      exsolve: 1.0.8
-      globby: 16.1.0
-      gzip-size: 7.0.0
-      h3: 1.15.5
-      hookable: 5.5.3
-      httpxy: 0.1.7
-      ioredis: 5.9.2
-      jiti: 2.7.0
-      klona: 2.0.6
-      knitwork: 1.3.0
-      listhen: 1.9.0
-      magic-string: 0.30.21
-      magicast: 0.5.2
-      mime: 4.1.0
-      mlly: 1.8.0
-      node-fetch-native: 1.6.7
-      node-mock-http: 1.0.4
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.0.0
-      pkg-types: 2.3.0
-      pretty-bytes: 7.1.0
-      radix3: 1.1.2
-      rollup: 4.60.1
-      rollup-plugin-visualizer: 6.0.5(rolldown@1.1.5)(rollup@4.60.1)
-      scule: 1.3.0
-      semver: 7.8.4
-      serve-placeholder: 2.0.2
-      serve-static: 2.2.1
-      source-map: 0.7.6
-      std-env: 3.10.0
-      ufo: 1.6.3
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unenv: 2.0.0-rc.24
-      unimport: 5.6.0
-      unplugin-utils: 0.3.1
-      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2)
+      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.0-beta.13
@@ -30806,25 +30644,6 @@ snapshots:
       react-is: 18.3.1
 
   prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
-    dependencies:
-      '@prisma/config': 7.9.0(magicast@0.5.2)
-      '@prisma/dev': 0.24.14(typescript@5.9.3)
-      '@prisma/engines': 7.9.0
-      '@prisma/studio-core': 0.33.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      mysql2: 3.15.3
-      postgres: 3.4.7
-    optionalDependencies:
-      better-sqlite3: 12.11.1
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - magicast
-      - react
-      - react-dom
-    optional: true
-
-  prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@prisma/config': 7.9.0(magicast@0.5.2)
       '@prisma/dev': 0.24.14(typescript@5.9.3)
@@ -32581,16 +32400,16 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup-preset-solid@2.2.0(esbuild@0.28.1)(solid-js@1.9.10)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)):
+  tsup-preset-solid@2.2.0(esbuild@0.28.1)(solid-js@1.9.10)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)):
     dependencies:
       esbuild-plugin-solid: 0.5.0(esbuild@0.28.1)(solid-js@1.9.10)
-      tsup: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      tsup: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - solid-js
       - supports-color
 
-  tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.6.1)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0):
+  tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.6.1)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -32619,7 +32438,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0):
+  tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -32933,10 +32752,10 @@ snapshots:
       ufo: 1.6.3
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
-      ioredis: 5.9.2
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      ioredis: 5.9.2(supports-color@7.2.0)
 
-  unstorage@1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2):
+  unstorage@1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -32948,29 +32767,14 @@ snapshots:
       ufo: 1.6.3
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
-      ioredis: 5.9.2
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      ioredis: 5.9.2(supports-color@7.2.0)
 
-  unstorage@1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2):
-    dependencies:
-      anymatch: 3.1.3
-      chokidar: 5.0.0
-      destr: 2.0.5
-      h3: 1.15.5
-      lru-cache: 11.2.4
-      node-fetch-native: 1.6.7
-      ofetch: 1.5.1
-      ufo: 1.6.3
-    optionalDependencies:
-      aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
-      ioredis: 5.9.2
-
-  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       aws4fetch: 1.0.20
       chokidar: 5.0.0
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       ofetch: 2.0.0-alpha.3
 
   untun@0.1.3:
@@ -33076,7 +32880,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vinxi@0.5.3(61710034f5693f0d4629ffde97945be3):
+  vinxi@0.5.3(89eee2ca08d25747ea346b710d88e83e):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.0)
@@ -33098,7 +32902,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.8
-      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
+      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
       node-fetch-native: 1.6.7
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -33109,7 +32913,7 @@ snapshots:
       ufo: 1.6.1
       unctx: 2.4.1
       unenv: 1.10.0
-      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2)
+      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2)
       vite: 6.4.2(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -33301,7 +33105,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@8.1.4(@types/node@24.10.3)(esbuild@0.27.7)(jiti@2.6.1)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0):
+  vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -33310,7 +33114,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.10.3
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.6.1
       less: 4.6.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,7 +357,7 @@ importers:
         version: 17.2.3
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -514,7 +514,7 @@ importers:
         version: 15.0.12
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       puppeteer:
         specifier: ^24.34.0
         version: 24.39.1(supports-color@7.2.0)(typescript@5.9.3)
@@ -608,7 +608,7 @@ importers:
         version: 0.10.0
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -694,6 +694,9 @@ importers:
       '@tanstack/ai-bedrock':
         specifier: workspace:*
         version: link:../../packages/ai-bedrock
+      '@tanstack/ai-byteplus':
+        specifier: workspace:*
+        version: link:../../packages/ai-byteplus
       '@tanstack/ai-claude-code':
         specifier: workspace:*
         version: link:../../packages/ai-claude-code
@@ -801,7 +804,7 @@ importers:
         version: 0.561.0(react@19.2.3)
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -881,6 +884,9 @@ importers:
       '@tanstack/ai':
         specifier: workspace:*
         version: link:../../packages/ai
+      '@tanstack/ai-byteplus':
+        specifier: workspace:*
+        version: link:../../packages/ai-byteplus
       '@tanstack/ai-fal':
         specifier: workspace:*
         version: link:../../packages/ai-fal
@@ -904,7 +910,7 @@ importers:
         version: 0.561.0(react@19.2.3)
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -1038,7 +1044,7 @@ importers:
         version: 0.561.0(react@19.2.3)
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
+        version: 3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1135,7 +1141,7 @@ importers:
         version: link:../../packages/ai-solid-ui
       '@tanstack/nitro-v2-vite-plugin':
         specifier: ^1.155.0
-        version: 1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/router-plugin':
         specifier: ^1.158.4
         version: 1.159.5(@tanstack/react-router@1.159.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -1257,13 +1263,13 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.3.1
-        version: 3.3.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 3.3.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))
       '@sveltejs/kit':
         specifier: ^2.15.10
-        version: 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.1.1
-        version: 5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -1436,10 +1442,10 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: ^2.6.2
-        version: 2.6.3(@angular/build@21.2.15(8fad83f643b8ab70eeb3183426533450))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 2.6.3(@angular/build@21.2.15(9b25d723ebc5560eb21fc2f98d972433))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@angular/build':
         specifier: ^21.2.0
-        version: 21.2.15(8fad83f643b8ab70eeb3183426533450)
+        version: 21.2.15(9b25d723ebc5560eb21fc2f98d972433)
       '@angular/common':
         specifier: ^21.2.0
         version: 21.2.17(@angular/core@21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
@@ -1472,7 +1478,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(@vitest/coverage-v8@4.0.14)(happy-dom@20.0.11)(jsdom@27.3.0(postcss@8.5.19))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(happy-dom@20.0.11)(jsdom@27.3.0(postcss@8.5.19))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       zod:
         specifier: ^4.2.0
         version: 4.3.6
@@ -1738,10 +1744,10 @@ importers:
         version: 27.3.0(postcss@8.5.19)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.6.1)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.28.1)(solid-js@1.9.10)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.6.1)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))
+        version: 2.2.0(esbuild@0.28.1)(solid-js@1.9.10)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))
       vite:
         specifier: ^8.1.4
         version: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -1965,7 +1971,7 @@ importers:
         version: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.6.1)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       vite:
         specifier: ^8.1.4
-        version: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.1.4(@types/node@24.10.3)(esbuild@0.27.7)(jiti@2.6.1)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
       zod:
         specifier: ^4.2.0
         version: 4.3.6
@@ -2418,7 +2424,7 @@ importers:
         version: 2.5.7(svelte@5.45.10)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.1.1
-        version: 5.1.1(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/ai':
         specifier: workspace:*
         version: link:../ai
@@ -2638,6 +2644,9 @@ importers:
       '@tanstack/ai-bedrock':
         specifier: workspace:*
         version: link:../../packages/ai-bedrock
+      '@tanstack/ai-byteplus':
+        specifier: workspace:*
+        version: link:../../packages/ai-byteplus
       '@tanstack/ai-claude-code':
         specifier: workspace:*
         version: link:../../packages/ai-claude-code
@@ -2803,7 +2812,7 @@ importers:
         version: link:../../packages/ai-react-ui
       '@tanstack/nitro-v2-vite-plugin':
         specifier: ^1.155.0
-        version: 1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/react-ai-devtools':
         specifier: workspace:*
         version: link:../../packages/react-ai-devtools
@@ -2818,7 +2827,7 @@ importers:
         version: 1.159.5(crossws@0.4.6(srvx@0.11.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start':
         specifier: ^1.120.20
-        version: 1.120.20(ad5aa143b5402ea1fab6b2d0538871c6)
+        version: 1.120.20(8a86bcf9ed90298a1c326f85f2b149b3)
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -16775,7 +16784,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@analogjs/vite-plugin-angular@2.6.3(@angular/build@21.2.15(8fad83f643b8ab70eeb3183426533450))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@analogjs/vite-plugin-angular@2.6.3(@angular/build@21.2.15(9b25d723ebc5560eb21fc2f98d972433))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       magic-string: 0.30.21
       obug: 2.1.1
@@ -16784,8 +16793,8 @@ snapshots:
       ts-morph: 21.0.1
       typescript: 5.9.3
     optionalDependencies:
-      '@angular/build': 21.2.15(8fad83f643b8ab70eeb3183426533450)
-      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+      '@angular/build': 21.2.15(9b25d723ebc5560eb21fc2f98d972433)
+      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -16865,7 +16874,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.2.15(8fad83f643b8ab70eeb3183426533450)':
+  '@angular/build@21.2.15(9b25d723ebc5560eb21fc2f98d972433)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.15(chokidar@5.0.0)
@@ -16906,7 +16915,7 @@ snapshots:
       ng-packagr: 21.2.5(@angular/compiler-cli@21.2.17(@angular/compiler@21.2.17)(typescript@5.9.3))(tailwindcss@4.1.18)(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.19
       tailwindcss: 4.1.18
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(@vitest/coverage-v8@4.0.14)(happy-dom@20.0.11)(jsdom@27.3.0(postcss@8.5.19))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(happy-dom@20.0.11)(jsdom@27.3.0(postcss@8.5.19))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -19855,7 +19864,7 @@ snapshots:
 
   '@mcp-ui/client@7.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@modelcontextprotocol/ext-apps': 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.2.1))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
+      '@modelcontextprotocol/ext-apps': 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -19912,9 +19921,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.2.1))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)':
+  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.2.1)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       '@standard-schema/spec': 1.1.0
       zod: 3.25.76
     optionalDependencies:
@@ -20934,11 +20943,19 @@ snapshots:
   '@prisma/client-runtime-utils@7.9.0':
     optional: true
 
-  '@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.9.0
     optionalDependencies:
       prisma: 7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      typescript: 5.9.3
+    optional: true
+
+  '@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)':
+    dependencies:
+      '@prisma/client-runtime-utils': 7.9.0
+    optionalDependencies:
+      prisma: 7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       typescript: 5.9.3
     optional: true
 
@@ -22556,16 +22573,16 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
-      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       import-meta-resolve: 4.2.0
 
-  '@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -22592,40 +22609,27 @@ snapshots:
       svelte2tsx: 0.7.45(@typescript/typescript6@6.0.2)(svelte@5.45.10)
       typescript: '@typescript/typescript6@6.0.2'
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
-      debug: 4.4.3(supports-color@7.2.0)
-      svelte: 5.45.10
-      vite: 7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       debug: 4.4.3(supports-color@7.2.0)
       svelte: 5.45.10
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       debug: 4.4.3(supports-color@7.2.0)
-      deepmerge: 4.3.1
-      kleur: 4.1.5
-      magic-string: 0.30.21
       svelte: 5.45.10
       vite: 7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.1(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       debug: 4.4.3(supports-color@7.2.0)
       deepmerge: 4.3.1
       kleur: 4.1.5
@@ -22633,6 +22637,19 @@ snapshots:
       svelte: 5.45.10
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
       vitefu: 1.1.1(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      debug: 4.4.3(supports-color@7.2.0)
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      svelte: 5.45.10
+      vite: 7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.1(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -22936,9 +22953,45 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@tanstack/nitro-v2-vite-plugin@1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/nitro-v2-vite-plugin@1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
+      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
+      pathe: 2.0.3
+      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - better-sqlite3
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - mysql2
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - supports-color
+      - uploadthing
+      - xml2js
+
+  '@tanstack/nitro-v2-vite-plugin@1.155.0(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
       pathe: 2.0.3
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -23073,9 +23126,9 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-plugin@1.131.50(acd959054103106c0a9bad82aa502122)':
+  '@tanstack/react-start-plugin@1.131.50(2737dc8ad1bbc72babeed4d28efb8f90)':
     dependencies:
-      '@tanstack/start-plugin-core': 1.131.50(18cacbf56349ba96e495ac9a4b1f347f)
+      '@tanstack/start-plugin-core': 1.131.50(654162e66e5a9cff1a2932da21908c03)
       '@vitejs/plugin-react': 4.7.0(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       pathe: 2.0.3
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -23115,11 +23168,11 @@ snapshots:
       - webpack
       - xml2js
 
-  '@tanstack/react-start-router-manifest@1.120.19(89eee2ca08d25747ea346b710d88e83e)':
+  '@tanstack/react-start-router-manifest@1.120.19(61710034f5693f0d4629ffde97945be3)':
     dependencies:
       '@tanstack/router-core': 1.159.4
       tiny-invariant: 1.3.3
-      vinxi: 0.5.3(89eee2ca08d25747ea346b710d88e83e)
+      vinxi: 0.5.3(61710034f5693f0d4629ffde97945be3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -23590,11 +23643,11 @@ snapshots:
       '@tanstack/store': 0.8.0
       solid-js: 1.9.10
 
-  '@tanstack/start-api-routes@1.120.19(4180420749541f7634d0ea935ae88706)':
+  '@tanstack/start-api-routes@1.120.19(7575f2d5e0bec14d376a64f34c2be7ae)':
     dependencies:
       '@tanstack/router-core': 1.159.4
       '@tanstack/start-server-core': 1.159.4(crossws@0.4.6(srvx@0.11.17))
-      vinxi: 0.5.3(89eee2ca08d25747ea346b710d88e83e)
+      vinxi: 0.5.3(61710034f5693f0d4629ffde97945be3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -23666,21 +23719,21 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/start-config@1.120.20(ad5aa143b5402ea1fab6b2d0538871c6)':
+  '@tanstack/start-config@1.120.20(8a86bcf9ed90298a1c326f85f2b149b3)':
     dependencies:
       '@tanstack/react-router': 1.159.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/react-start-plugin': 1.131.50(acd959054103106c0a9bad82aa502122)
+      '@tanstack/react-start-plugin': 1.131.50(2737dc8ad1bbc72babeed4d28efb8f90)
       '@tanstack/router-generator': 1.159.4
       '@tanstack/router-plugin': 1.159.5(@tanstack/react-router@1.159.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/server-functions-plugin': 1.141.0(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start-server-functions-handler': 1.120.19(crossws@0.4.6(srvx@0.11.17))
       '@vitejs/plugin-react': 4.7.0(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       import-meta-resolve: 4.2.0
-      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
+      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
       ofetch: 1.5.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vinxi: 0.5.3(89eee2ca08d25747ea346b710d88e83e)
+      vinxi: 0.5.3(61710034f5693f0d4629ffde97945be3)
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -23734,7 +23787,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.154.7': {}
 
-  '@tanstack/start-plugin-core@1.131.50(18cacbf56349ba96e495ac9a4b1f347f)':
+  '@tanstack/start-plugin-core@1.131.50(654162e66e5a9cff1a2932da21908c03)':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.29.0
@@ -23750,7 +23803,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.12
       cheerio: 1.1.2
       h3: 1.13.0
-      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
+      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
       pathe: 2.0.3
       ufo: 1.6.3
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -23974,13 +24027,13 @@ snapshots:
     dependencies:
       '@tanstack/router-core': 1.159.4
 
-  '@tanstack/start@1.120.20(ad5aa143b5402ea1fab6b2d0538871c6)':
+  '@tanstack/start@1.120.20(8a86bcf9ed90298a1c326f85f2b149b3)':
     dependencies:
       '@tanstack/react-start-client': 1.141.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/react-start-router-manifest': 1.120.19(89eee2ca08d25747ea346b710d88e83e)
+      '@tanstack/react-start-router-manifest': 1.120.19(61710034f5693f0d4629ffde97945be3)
       '@tanstack/react-start-server': 1.141.1(crossws@0.4.6(srvx@0.11.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/start-api-routes': 1.120.19(4180420749541f7634d0ea935ae88706)
-      '@tanstack/start-config': 1.120.20(ad5aa143b5402ea1fab6b2d0538871c6)
+      '@tanstack/start-api-routes': 1.120.19(7575f2d5e0bec14d376a64f34c2be7ae)
+      '@tanstack/start-config': 1.120.20(8a86bcf9ed90298a1c326f85f2b149b3)
       '@tanstack/start-server-functions-client': 1.131.50(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start-server-functions-handler': 1.120.19(crossws@0.4.6(srvx@0.11.17))
       '@tanstack/start-server-functions-server': 1.131.2(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -24814,6 +24867,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.0.14':
     dependencies:
@@ -26165,18 +26226,25 @@ snapshots:
 
   dayjs@1.11.19: {}
 
-  db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3):
-    optionalDependencies:
-      '@electric-sql/pglite': 0.4.3
-      better-sqlite3: 12.11.1
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
-      mysql2: 3.15.3
-
-  db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3):
+  db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3):
     optionalDependencies:
       '@electric-sql/pglite': 0.4.3
       better-sqlite3: 12.11.1
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
+      mysql2: 3.15.3
+
+  db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3):
+    optionalDependencies:
+      '@electric-sql/pglite': 0.4.3
+      better-sqlite3: 12.11.1
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
+      mysql2: 3.15.3
+
+  db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3):
+    optionalDependencies:
+      '@electric-sql/pglite': 0.4.3
+      better-sqlite3: 12.11.1
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
       mysql2: 3.15.3
 
   de-indent@1.0.2: {}
@@ -26382,23 +26450,35 @@ snapshots:
       '@cloudflare/workers-types': 4.20260317.1
       '@electric-sql/pglite': 0.4.3
       '@opentelemetry/api': 1.9.1
-      '@prisma/client': 7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client': 7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
       better-sqlite3: 12.11.1
       mysql2: 3.15.3
       postgres: 3.4.7
       prisma: 7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
     optional: true
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260317.1
       '@electric-sql/pglite': 0.4.3
       '@opentelemetry/api': 1.9.1
-      '@prisma/client': 7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client': 7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
       better-sqlite3: 12.11.1
       mysql2: 3.15.3
       postgres: 3.4.7
       prisma: 7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+    optional: true
+
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)):
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260317.1
+      '@electric-sql/pglite': 0.4.3
+      '@opentelemetry/api': 1.9.1
+      '@prisma/client': 7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+      better-sqlite3: 12.11.1
+      mysql2: 3.15.3
+      postgres: 3.4.7
+      prisma: 7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
     optional: true
 
   dts-resolver@2.1.3(oxc-resolver@11.21.3):
@@ -29531,11 +29611,11 @@ snapshots:
       rollup: 4.60.1
       tailwindcss: 4.1.18
 
-  nitro@3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0):
+  nitro@3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.6(srvx@0.11.17)
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       env-runner: 0.1.14(miniflare@4.20260617.1)(wrangler@4.103.0)
       h3: 2.0.1-rc.22(crossws@0.4.6(srvx@0.11.17))
       hookable: 6.1.1
@@ -29546,7 +29626,7 @@ snapshots:
       rolldown: 1.1.5
       srvx: 0.11.17
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.2.3
       giget: 2.0.0
@@ -29585,11 +29665,11 @@ snapshots:
       - uploadthing
       - wrangler
 
-  nitro@3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0):
+  nitro@3.0.260610-beta(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(chokidar@5.0.0)(dotenv@17.2.3)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(giget@2.0.0)(jiti@2.7.0)(miniflare@4.20260617.1)(mysql2@3.15.3)(rollup@4.60.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.103.0):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.6(srvx@0.11.17)
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       env-runner: 0.1.14(miniflare@4.20260617.1)(wrangler@4.103.0)
       h3: 2.0.1-rc.22(crossws@0.4.6(srvx@0.11.17))
       hookable: 6.1.1
@@ -29600,7 +29680,7 @@ snapshots:
       rolldown: 1.1.5
       srvx: 0.11.17
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.2.3
       giget: 2.0.0
@@ -29660,7 +29740,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -29741,7 +29821,7 @@ snapshots:
       - supports-color
       - uploadthing
 
-  nitropack@2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5):
+  nitropack@2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.1)
@@ -29762,7 +29842,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -29808,7 +29888,109 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 5.6.0
       unplugin-utils: 0.3.1
-      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2)
+      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2)
+      untyped: 2.0.0
+      unwasm: 0.5.3
+      youch: 4.1.0-beta.13
+      youch-core: 0.3.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - better-sqlite3
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - mysql2
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - supports-color
+      - uploadthing
+
+  nitropack@2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@rollup/plugin-alias': 6.0.0(rollup@4.60.1)
+      '@rollup/plugin-commonjs': 29.0.0(rollup@4.60.1)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.60.1)
+      '@rollup/plugin-json': 6.1.0(rollup@4.60.1)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.1)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.60.1)
+      '@vercel/nft': 1.3.0(rollup@4.60.1)
+      archiver: 7.0.1
+      c12: 3.3.3(magicast@0.5.2)
+      chokidar: 5.0.0
+      citty: 0.1.6
+      compatx: 0.2.0
+      confbox: 0.2.2
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      croner: 9.1.0
+      crossws: 0.3.5
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      defu: 6.1.4
+      destr: 2.0.5
+      dot-prop: 10.1.0
+      esbuild: 0.27.7
+      escape-string-regexp: 5.0.0
+      etag: 1.8.1
+      exsolve: 1.0.8
+      globby: 16.1.0
+      gzip-size: 7.0.0
+      h3: 1.15.5
+      hookable: 5.5.3
+      httpxy: 0.1.7
+      ioredis: 5.9.2
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      listhen: 1.9.0
+      magic-string: 0.30.21
+      magicast: 0.5.2
+      mime: 4.1.0
+      mlly: 1.8.0
+      node-fetch-native: 1.6.7
+      node-mock-http: 1.0.4
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.0.0
+      pkg-types: 2.3.0
+      pretty-bytes: 7.1.0
+      radix3: 1.1.2
+      rollup: 4.60.1
+      rollup-plugin-visualizer: 6.0.5(rolldown@1.1.5)(rollup@4.60.1)
+      scule: 1.3.0
+      semver: 7.8.4
+      serve-placeholder: 2.0.2
+      serve-static: 2.2.1
+      source-map: 0.7.6
+      std-env: 3.10.0
+      ufo: 1.6.3
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unenv: 2.0.0-rc.24
+      unimport: 5.6.0
+      unplugin-utils: 0.3.1
+      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.0-beta.13
@@ -30555,6 +30737,15 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.7.0
+      postcss: 8.5.19
+      tsx: 4.21.0
+      yaml: 2.9.0
+
   postcss-media-query-parser@0.2.3: {}
 
   postcss-safe-parser@7.0.1(postcss@8.5.19):
@@ -30615,6 +30806,25 @@ snapshots:
       react-is: 18.3.1
 
   prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+    dependencies:
+      '@prisma/config': 7.9.0(magicast@0.5.2)
+      '@prisma/dev': 0.24.14(typescript@5.9.3)
+      '@prisma/engines': 7.9.0
+      '@prisma/studio-core': 0.33.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      mysql2: 3.15.3
+      postgres: 3.4.7
+    optionalDependencies:
+      better-sqlite3: 12.11.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - magicast
+      - react
+      - react-dom
+    optional: true
+
+  prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@prisma/config': 7.9.0(magicast@0.5.2)
       '@prisma/dev': 0.24.14(typescript@5.9.3)
@@ -32371,10 +32581,10 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup-preset-solid@2.2.0(esbuild@0.28.1)(solid-js@1.9.10)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.6.1)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)):
+  tsup-preset-solid@2.2.0(esbuild@0.28.1)(solid-js@1.9.10)(tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)):
     dependencies:
       esbuild-plugin-solid: 0.5.0(esbuild@0.28.1)(solid-js@1.9.10)
-      tsup: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.6.1)(postcss@8.5.19)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      tsup: 8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - solid-js
@@ -32409,10 +32619,39 @@ snapshots:
       - tsx
       - yaml
 
+  tsup@8.5.1(@microsoft/api-extractor@7.47.7(@types/node@24.10.3))(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3(supports-color@7.2.0)
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.19)(tsx@4.21.0)(yaml@2.9.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.47.7(@types/node@24.10.3)
+      postcss: 8.5.19
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.7
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -32694,10 +32933,10 @@ snapshots:
       ufo: 1.6.3
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       ioredis: 5.9.2
 
-  unstorage@1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2):
+  unstorage@1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -32709,14 +32948,29 @@ snapshots:
       ufo: 1.6.3
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       ioredis: 5.9.2
 
-  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3):
+  unstorage@1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.5
+      lru-cache: 11.2.4
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.3
+    optionalDependencies:
+      aws4fetch: 1.0.20
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      ioredis: 5.9.2
+
+  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       aws4fetch: 1.0.20
       chokidar: 5.0.0
-      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
       ofetch: 2.0.0-alpha.3
 
   untun@0.1.3:
@@ -32822,7 +33076,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vinxi@0.5.3(89eee2ca08d25747ea346b710d88e83e):
+  vinxi@0.5.3(61710034f5693f0d4629ffde97945be3):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.0)
@@ -32844,7 +33098,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.8
-      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
+      nitropack: 2.13.1(@electric-sql/pglite@0.4.3)(aws4fetch@1.0.20)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)(rolldown@1.1.5)
       node-fetch-native: 1.6.7
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -32855,7 +33109,7 @@ snapshots:
       ufo: 1.6.1
       unctx: 2.4.1
       unenv: 1.10.0
-      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2)
+      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2)
       vite: 6.4.2(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -33047,7 +33301,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0):
+  vite@8.1.4(@types/node@24.10.3)(esbuild@0.27.7)(jiti@2.6.1)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -33056,7 +33310,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.10.3
-      esbuild: 0.28.1
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
       less: 4.6.6
@@ -33083,6 +33337,24 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
+  vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.10.3
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      less: 4.6.6
+      sass: 1.97.3
+      terser: 5.44.1
+      tsx: 4.21.0
+      yaml: 2.9.0
+
   vitefu@1.1.1(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -33105,7 +33377,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
@@ -33136,7 +33408,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
@@ -33166,7 +33438,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
@@ -33182,6 +33454,36 @@ snapshots:
     transitivePeerDependencies:
       - msw
     optional: true
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(happy-dom@20.0.11)(jsdom@27.3.0(postcss@8.5.19))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.10.3
+      happy-dom: 20.0.11
+      jsdom: 27.3.0(postcss@8.5.19)
+    transitivePeerDependencies:
+      - msw
 
   vlq@1.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1266,13 +1266,13 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.3.1
-        version: 3.3.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 3.3.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))
       '@sveltejs/kit':
         specifier: ^2.15.10
-        version: 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.1.1
-        version: 5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -1445,10 +1445,10 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: ^2.6.2
-        version: 2.6.3(@angular/build@21.2.15(9b25d723ebc5560eb21fc2f98d972433))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 2.6.3(@angular/build@21.2.15(8fad83f643b8ab70eeb3183426533450))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@angular/build':
         specifier: ^21.2.0
-        version: 21.2.15(9b25d723ebc5560eb21fc2f98d972433)
+        version: 21.2.15(8fad83f643b8ab70eeb3183426533450)
       '@angular/common':
         specifier: ^21.2.0
         version: 21.2.17(@angular/core@21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
@@ -1481,7 +1481,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(happy-dom@20.0.11)(jsdom@27.3.0(postcss@8.5.19))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(@vitest/coverage-v8@4.0.14)(happy-dom@20.0.11)(jsdom@27.3.0(postcss@8.5.19))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       zod:
         specifier: ^4.2.0
         version: 4.3.6
@@ -1547,9 +1547,6 @@ importers:
 
   packages/ai-byteplus:
     dependencies:
-      '@tanstack/ai':
-        specifier: workspace:^
-        version: link:../ai
       '@tanstack/ai-utils':
         specifier: workspace:*
         version: link:../ai-utils
@@ -1563,6 +1560,9 @@ importers:
         specifier: ^4.0.0
         version: 4.3.6
     devDependencies:
+      '@tanstack/ai':
+        specifier: workspace:*
+        version: link:../ai
       '@vitest/coverage-v8':
         specifier: 4.0.14
         version: 4.0.14(supports-color@7.2.0)(vitest@4.1.10)
@@ -1986,7 +1986,7 @@ importers:
         version: link:../ai-event-client
       ioredis:
         specifier: '>=5.0.0'
-        version: 5.9.2(supports-color@7.2.0)
+        version: 5.9.2
     devDependencies:
       '@honcho-ai/sdk':
         specifier: ^2.1.1
@@ -2002,7 +2002,7 @@ importers:
         version: 4.0.14(supports-color@7.2.0)(vitest@4.1.10)
       ioredis-mock:
         specifier: ^8.9.0
-        version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.9.2(supports-color@7.2.0)))(ioredis@5.9.2(supports-color@7.2.0))
+        version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.9.2))(ioredis@5.9.2)
       redis:
         specifier: ^4.7.0
         version: 4.7.1
@@ -2427,7 +2427,7 @@ importers:
         version: 2.5.7(svelte@5.45.10)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.1.1
-        version: 5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.1(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/ai':
         specifier: workspace:*
         version: link:../ai
@@ -16787,7 +16787,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@analogjs/vite-plugin-angular@2.6.3(@angular/build@21.2.15(9b25d723ebc5560eb21fc2f98d972433))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@analogjs/vite-plugin-angular@2.6.3(@angular/build@21.2.15(8fad83f643b8ab70eeb3183426533450))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       magic-string: 0.30.21
       obug: 2.1.1
@@ -16796,8 +16796,8 @@ snapshots:
       ts-morph: 21.0.1
       typescript: 5.9.3
     optionalDependencies:
-      '@angular/build': 21.2.15(9b25d723ebc5560eb21fc2f98d972433)
-      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+      '@angular/build': 21.2.15(8fad83f643b8ab70eeb3183426533450)
+      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -16877,7 +16877,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.2.15(9b25d723ebc5560eb21fc2f98d972433)':
+  '@angular/build@21.2.15(8fad83f643b8ab70eeb3183426533450)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.15(chokidar@5.0.0)
@@ -16918,7 +16918,7 @@ snapshots:
       ng-packagr: 21.2.5(@angular/compiler-cli@21.2.17(@angular/compiler@21.2.17)(typescript@5.9.3))(tailwindcss@4.1.18)(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.19
       tailwindcss: 4.1.18
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(happy-dom@20.0.11)(jsdom@27.3.0(postcss@8.5.19))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(@vitest/coverage-v8@4.0.14)(happy-dom@20.0.11)(jsdom@27.3.0(postcss@8.5.19))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -19867,7 +19867,7 @@ snapshots:
 
   '@mcp-ui/client@7.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@modelcontextprotocol/ext-apps': 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
+      '@modelcontextprotocol/ext-apps': 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.2.1))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -19924,9 +19924,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)':
+  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.2.1))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.2.1)
       '@standard-schema/spec': 1.1.0
       zod: 3.25.76
     optionalDependencies:
@@ -22568,16 +22568,16 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
-      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       import-meta-resolve: 4.2.0
 
-  '@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -22604,40 +22604,27 @@ snapshots:
       svelte2tsx: 0.7.45(@typescript/typescript6@6.0.2)(svelte@5.45.10)
       typescript: '@typescript/typescript6@6.0.2'
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
-      debug: 4.4.3(supports-color@7.2.0)
-      svelte: 5.45.10
-      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       debug: 4.4.3(supports-color@7.2.0)
       svelte: 5.45.10
       vite: 7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(supports-color@7.2.0)(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       debug: 4.4.3(supports-color@7.2.0)
-      deepmerge: 4.3.1
-      kleur: 4.1.5
-      magic-string: 0.30.21
       svelte: 5.45.10
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.1(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(supports-color@7.2.0)(svelte@5.45.10)(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       debug: 4.4.3(supports-color@7.2.0)
       deepmerge: 4.3.1
       kleur: 4.1.5
@@ -22645,6 +22632,19 @@ snapshots:
       svelte: 5.45.10
       vite: 7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
       vitefu: 1.1.1(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.45.10)(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      debug: 4.4.3(supports-color@7.2.0)
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      svelte: 5.45.10
+      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.1(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -24277,9 +24277,9 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/ioredis-mock@8.2.7(ioredis@5.9.2(supports-color@7.2.0))':
+  '@types/ioredis-mock@8.2.7(ioredis@5.9.2)':
     dependencies:
-      ioredis: 5.9.2(supports-color@7.2.0)
+      ioredis: 5.9.2
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -24826,14 +24826,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
-
-  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.0.14':
     dependencies:
@@ -27906,17 +27898,17 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.9.2(supports-color@7.2.0)))(ioredis@5.9.2(supports-color@7.2.0)):
+  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.9.2))(ioredis@5.9.2):
     dependencies:
       '@ioredis/as-callback': 3.0.0
       '@ioredis/commands': 1.5.0
-      '@types/ioredis-mock': 8.2.7(ioredis@5.9.2(supports-color@7.2.0))
+      '@types/ioredis-mock': 8.2.7(ioredis@5.9.2)
       fengari: 0.1.5
       fengari-interop: 0.1.4(fengari@0.1.5)
-      ioredis: 5.9.2(supports-color@7.2.0)
+      ioredis: 5.9.2
       semver: 7.8.4
 
-  ioredis@5.9.2(supports-color@7.2.0):
+  ioredis@5.9.2:
     dependencies:
       '@ioredis/commands': 1.5.0
       cluster-key-slot: 1.1.2
@@ -29693,7 +29685,7 @@ snapshots:
       h3: 1.15.5
       hookable: 5.5.3
       httpxy: 0.1.7
-      ioredis: 5.9.2(supports-color@7.2.0)
+      ioredis: 5.9.2
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
@@ -29795,7 +29787,7 @@ snapshots:
       h3: 1.15.5
       hookable: 5.5.3
       httpxy: 0.1.7
-      ioredis: 5.9.2(supports-color@7.2.0)
+      ioredis: 5.9.2
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
@@ -32753,7 +32745,7 @@ snapshots:
     optionalDependencies:
       aws4fetch: 1.0.20
       db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
-      ioredis: 5.9.2(supports-color@7.2.0)
+      ioredis: 5.9.2
 
   unstorage@1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.2):
     dependencies:
@@ -32768,7 +32760,7 @@ snapshots:
     optionalDependencies:
       aws4fetch: 1.0.20
       db0: 0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3)
-      ioredis: 5.9.2(supports-color@7.2.0)
+      ioredis: 5.9.2
 
   unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.4.3)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.9.0(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.9.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)))(mysql2@3.15.3))(ofetch@2.0.0-alpha.3):
     optionalDependencies:
@@ -33141,24 +33133,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.5
-      postcss: 8.5.19
-      rolldown: 1.1.5
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.10.3
-      esbuild: 0.28.1
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      less: 4.6.6
-      sass: 1.97.3
-      terser: 5.44.1
-      tsx: 4.21.0
-      yaml: 2.9.0
-
   vitefu@1.1.1(vite@7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 7.3.3(@types/node@24.10.3)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -33258,36 +33232,6 @@ snapshots:
     transitivePeerDependencies:
       - msw
     optional: true
-
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.3)(happy-dom@20.0.11)(jsdom@27.3.0(postcss@8.5.19))(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 24.10.3
-      happy-dom: 20.0.11
-      jsdom: 27.3.0(postcss@8.5.19)
-    transitivePeerDependencies:
-      - msw
 
   vlq@1.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1544,6 +1544,9 @@ importers:
       '@tanstack/ai-utils':
         specifier: workspace:*
         version: link:../ai-utils
+      '@tanstack/openai-base':
+        specifier: workspace:*
+        version: link:../openai-base
       openai:
         specifier: ^6.41.0
         version: 6.41.0(ws@8.21.0)(zod@4.3.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1536,6 +1536,28 @@ importers:
         specifier: ^8.1.4
         version: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
 
+  packages/ai-byteplus:
+    dependencies:
+      '@tanstack/ai':
+        specifier: workspace:^
+        version: link:../ai
+      '@tanstack/ai-utils':
+        specifier: workspace:*
+        version: link:../ai-utils
+      openai:
+        specifier: ^6.41.0
+        version: 6.41.0(ws@8.21.0)(zod@4.3.6)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: 4.0.14
+        version: 4.0.14(supports-color@7.2.0)(vitest@4.1.10)
+      vite:
+        specifier: ^8.1.4
+        version: 8.1.4(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+
   packages/ai-claude-code:
     devDependencies:
       '@tanstack/ai':

--- a/scripts/sync-provider-models.ts
+++ b/scripts/sync-provider-models.ts
@@ -9,6 +9,28 @@
  *
  * Usage:
  *   pnpm tsx scripts/sync-provider-models.ts
+ *
+ * ## Providers deliberately NOT synced
+ *
+ * The sync is only safe when the provider's own model ids can be derived from
+ * OpenRouter's. Adding an entry to `PROVIDER_MAP` for a provider where that
+ * doesn't hold generates ids that 404 at request time, which is worse than no
+ * automation. These are excluded on purpose:
+ *
+ * - **byteplus** (`@tanstack/ai-byteplus`) — OpenRouter lists the same models
+ *   under undated slugs (`bytedance-seed/seed-1.6`), but BytePlus Ark
+ *   addresses them by *date-suffixed* id (`seed-1-6-250615`), and the suffix
+ *   is not derivable from anything OpenRouter publishes. Ark's own `GET
+ *   /models` is the catalog, and it is not exhaustive. On top of that the
+ *   package's capability tables are live-probe-verified specifically because
+ *   the published metadata is wrong in both directions, so a metadata-driven
+ *   sync would overwrite probed facts with worse ones. Use `/gap-analysis
+ *   byteplus` instead; the probe recipe is in that package's `model-meta.ts`.
+ * - **fal**, **elevenlabs** — media-only providers whose endpoint ids are not
+ *   OpenRouter models at all. fal image fields have their own generator
+ *   (`scripts/generate-fal-image-field-map.ts`).
+ * - **bedrock** — ids are AWS-region-qualified; see
+ *   `scripts/fetch-bedrock-models.ts`.
  */
 
 import { execFileSync } from 'node:child_process'

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -4,7 +4,7 @@ End-to-end tests for TanStack AI using Playwright and [aimock](https://github.co
 
 **Architecture:** Playwright drives a TanStack Start app (`testing/e2e/`) which routes requests through provider adapters pointing at aimock. Fixtures define mock responses. No real API keys needed. All scenarios (including tool execution flows) use aimock fixtures. Tests run in parallel with per-test `X-Test-Id` isolation.
 
-**Providers tested:** openai, anthropic, gemini, ollama, groq, grok, openrouter, bedrock, bedrock-responses
+**Providers tested:** openai, anthropic, gemini, ollama, groq, grok, openrouter, openrouter-responses, bedrock, bedrock-responses, openai-compatible, mistral, byteplus, elevenlabs
 
 > **Claude Code (`@tanstack/ai-claude-code`) is excluded from the standard matrix.** It's a harness adapter that spawns the Claude Code runtime as a subprocess, so aimock's per-test `X-Test-Id` header isolation can't be injected into its requests. It's covered by unit tests in the package plus a gated live smoke test in `tests/claude-code.spec.ts` — run it with `CLAUDE_CODE_E2E=1` and an `ANTHROPIC_API_KEY` (or a local `claude login`).
 
@@ -223,6 +223,23 @@ The default `bedrock-converse` adapter (introduced later) uses `@aws-sdk/client-
 
 **Follow-up:** a Bedrock/Converse provider will be added to aimock to close this gap and enable full E2E coverage of the Converse path.
 
+### BytePlus (Ark) path handling and record-mode gap
+
+BytePlus splits across two products, and the E2E wiring reflects that split:
+
+- **Ark** (chat, Seedream image, Seedance video) serves everything under `/api/v3`, so the chat, image and video adapters get `baseURL: <mock>/api/v3`.
+- **Seed Speech** (TTS, ASR) is a separate host with a separate key, and its adapters append `/api/v3/...` themselves — so they get the bare `<mock>` base.
+
+Chat and image need **no mock changes**. aimock's compat-path normalizer rewrites any non-`/v1/`, non-`/v2/` path ending in a known OpenAI suffix to `/v1/<suffix>`, so `/api/v3/chat/completions` and `/api/v3/images/generations` land on the native handlers and the provider-agnostic fixtures apply unchanged. Seedream's request body differs from OpenAI's (`size` as a `1K`/`2K` token, no `n`, `watermark`), but aimock's image handler only reads `model` and `prompt` and answers with the `{ created, data: [...] }` envelope Seedream also returns.
+
+Three endpoints have no aimock equivalent and are mounted in `global-setup.ts`, all on the `/api/v3` prefix — each returns `false` for paths it doesn't own so chat and image still fall through:
+
+- `byteplusSeedanceMount()` — `POST`/`GET /contents/generations/tasks[/{id}]`
+- `byteplusTTSMount()` — `POST /tts/create`
+- `byteplusASRMount()` — `POST /auc/bigmodel/recognize/flash`
+
+**Record-mode gap:** aimock's `RecordProviderKey` union has no `byteplus` entry, so `pnpm record` can't proxy `ark.ap-southeast.bytepluses.com` or the Seed Speech host to capture real fixtures — the same situation as the Bedrock Converse gap above. Chat features reuse the existing provider-agnostic fixtures (aimock matches on message content, not provider); the media endpoints are served by the hand-written mounts listed above. Update those mounts by hand if the wire shapes change, and cross-check against the adapter unit tests in `packages/ai-byteplus/tests/`.
+
 **SDK baseURL notes:**
 
 - OpenAI, Grok: `LLMOCK_OPENAI` (with `/v1`) + `defaultHeaders`
@@ -231,6 +248,7 @@ The default `bedrock-converse` adapter (introduced later) uses `@aws-sdk/client-
 - Gemini: `httpOptions: { baseUrl: LLMOCK_BASE, headers }`
 - Ollama: `{ host: LLMOCK_BASE, headers }` (config object)
 - OpenRouter: `serverURL` with `?testId=` query param (SDK doesn't support headers)
+- BytePlus: `LLMOCK_BASE + /api/v3` + `defaultHeaders` for Ark (chat, image, video); bare `LLMOCK_BASE` + `defaultHeaders` for Seed Speech (TTS, ASR)
 
 ## 7. Adding a Tool Test Scenario
 

--- a/testing/e2e/global-setup.ts
+++ b/testing/e2e/global-setup.ts
@@ -104,6 +104,19 @@ export default async function globalSetup() {
   // `usage` survives onto `RUN_FINISHED.usage` on the fallback path.
   mock.mount('/anthropic-structured-usage', anthropicStructuredUsageMount())
 
+  // BytePlus. Ark (chat, Seedream image, Seedance video) serves its whole data
+  // plane under /api/v3, and Seed Speech (TTS/ASR) mounts its own endpoints at
+  // the same prefix on a different host — which collapses onto one prefix here
+  // because every adapter points at this single mock. Chat and image are NOT
+  // handled by these mounts: aimock's compat-path normalizer rewrites
+  // `/api/v3/chat/completions` and `/api/v3/images/generations` to their /v1
+  // equivalents, so each mount returns false for anything it doesn't own and
+  // those two fall through to the native handlers. Mounts are matched by raw
+  // pathname *before* that normalization, so ordering here is safe.
+  mock.mount('/api/v3', byteplusSeedanceMount())
+  mock.mount('/api/v3', byteplusTTSMount())
+  mock.mount('/api/v3', byteplusASRMount())
+
   await mock.start()
   console.log(`[aimock] started on port 4010`)
   ;(globalThis as any).__aimock = mock
@@ -499,6 +512,385 @@ function geminiOmniVideoMount(): Mountable {
       }
 
       return false
+    },
+  }
+}
+
+/**
+ * Fake audio payloads keyed by Seed Speech's `audio_config.format`.
+ *
+ * The TTS adapter labels its result from the format it *requested*
+ * (`getContentType`), and it always sends `audio_config.format` explicitly —
+ * defaulting to `mp3` when the caller names no format. So the mount has to
+ * answer in whichever container the request asked for, or the adapter builds a
+ * mislabeled `data:` URI (mp3 bytes announced as `audio/wav`, say).
+ *
+ * Each payload is only as real as it needs to be: the specs assert that the
+ * `<audio>` element renders, not that it plays. `ogg_opus` is not exercised by
+ * any spec today — its magic bytes are a placeholder so an unexpected format
+ * still yields a plausible container rather than a silent mismatch.
+ */
+const FAKE_AUDIO_BY_FORMAT: Record<string, Buffer> = {
+  mp3: FAKE_MP3_BYTES,
+  wav: buildSilentWav(),
+  pcm: FAKE_PCM_BYTES,
+  ogg_opus: Buffer.from('OggS'),
+}
+
+/**
+ * Minimal RIFF/WAV container: a 44-byte header describing 16-bit mono PCM at
+ * 24 kHz, followed by silence.
+ */
+function buildSilentWav(): Buffer {
+  const samples = Buffer.alloc(64)
+  const header = Buffer.alloc(44)
+  header.write('RIFF', 0, 'ascii')
+  header.writeUInt32LE(36 + samples.length, 4)
+  header.write('WAVE', 8, 'ascii')
+  header.write('fmt ', 12, 'ascii')
+  header.writeUInt32LE(16, 16) // PCM chunk size
+  header.writeUInt16LE(1, 20) // format: PCM
+  header.writeUInt16LE(1, 22) // channels
+  header.writeUInt32LE(24000, 24) // sample rate
+  header.writeUInt32LE(24000 * 2, 28) // byte rate
+  header.writeUInt16LE(2, 32) // block align
+  header.writeUInt16LE(16, 34) // bits per sample
+  header.write('data', 36, 'ascii')
+  header.writeUInt32LE(samples.length, 40)
+  return Buffer.concat([header, samples])
+}
+
+/**
+ * Reads a mounted request body as a JSON object, or `undefined` when the body
+ * is absent, malformed, or not an object.
+ *
+ * The three BytePlus mounts below **validate** what the adapters send instead
+ * of draining it, which deliberately deviates from the `drainBody` house style
+ * every other mount in this file uses. The reason: BytePlus is the only
+ * provider in this suite with neither aimock fixtures nor record mode
+ * (aimock's `RecordProviderKey` union has no `byteplus` entry), so nothing
+ * else pins the request wire shape. With a canned 200, an adapter regression —
+ * a dropped `text_prompt`, a `speaker` that stopped nesting under
+ * `references`, an empty Seedance `content[]` — would still be answered
+ * successfully and the spec would pass green. A 400 turns that into a failing
+ * spec, which is the whole point of these mounts existing.
+ */
+async function readJsonRequestBody(
+  req: http.IncomingMessage,
+): Promise<Record<string, unknown> | undefined> {
+  const raw = await readBody(req)
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return undefined
+    return parsed as Record<string, unknown>
+  } catch {
+    return undefined
+  }
+}
+
+/** Narrow an arbitrary JSON value to an object so nested fields can be read. */
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined
+  }
+  return value as Record<string, unknown>
+}
+
+/**
+ * Rejects with Ark's error envelope — `{ error: { code, message } }` with a
+ * dotted string code. Matching the real envelope means `bytePlusArkError`
+ * renders the reason into the thrown message, so a validation failure shows up
+ * in the spec output as the actual missing field.
+ */
+function rejectArkRequest(res: http.ServerResponse, message: string): true {
+  res.statusCode = 400
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify({ error: { code: 'InvalidParameter', message } }))
+  return true
+}
+
+/**
+ * Rejects with Seed Speech's error envelope — a flat numeric `code` plus
+ * `message`, which is what `bytePlusVoiceError` parses.
+ */
+function rejectVoiceRequest(res: http.ServerResponse, message: string): true {
+  res.statusCode = 400
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify({ code: 45000001, message }))
+  return true
+}
+
+/**
+ * Mounts BytePlus Seedance's asynchronous video task API:
+ *
+ * - `POST /api/v3/contents/generations/tasks` — submits the job, returns `{ id }`.
+ * - `GET  /api/v3/contents/generations/tasks/{id}` — polls it.
+ *
+ * aimock's native `/v1/videos` handling models OpenAI's job API, not Ark's, so
+ * this is hand-mocked. Every poll answers `succeeded`, matching the openai
+ * `onVideo` fixture and `geminiVeoMount` — the `fetcher` transport's
+ * `generateVideoFn` calls `getVideoJobStatus` exactly once after creating the
+ * job, so a mock that reports `running` first has no second poll to recover on.
+ * The queued/running branches of the adapter's status map are unit-tested.
+ *
+ * The success body mirrors a captured live task (see the Phase 0 probe notes):
+ * `content.video_url` plus `usage.completion_tokens`, `seed`, `resolution`,
+ * `ratio`, `duration`, the lowercase `framespersecond`, and `output_format`.
+ * `updated_at` matters — `getVideoUrl` anchors its 24-hour `expiresAt` to it.
+ * The `model` is echoed back from the submitted task rather than hardcoded, so
+ * the poll response can't drift from what the adapter actually asked for.
+ *
+ * The create request is validated (see `readJsonRequestBody`): Ark requires a
+ * string `model` and a non-empty `content[]`, and answers `MissingParameter`
+ * without them — a live-probed behaviour worth preserving here, since an
+ * adapter that stopped building `content[]` would otherwise still get a job id.
+ *
+ * Anything that isn't a task path returns false so Ark's OpenAI-compatible
+ * chat and Seedream image requests reach aimock's native handlers.
+ */
+function byteplusSeedanceMount(): Mountable {
+  const VIDEO_URL = 'https://example.com/guitar-store.mp4'
+  const TASKS_PATH = '/contents/generations/tasks'
+  // Model per submitted task id, so the poll can echo what was requested.
+  const jobModels = new Map<string, string>()
+  let nextTaskId = 0
+
+  return {
+    async handleRequest(
+      req: http.IncomingMessage,
+      res: http.ServerResponse,
+      // aimock strips the mount prefix ('/api/v3'), so pathname looks like
+      // '/contents/generations/tasks' or '/contents/generations/tasks/{id}'.
+      pathname: string,
+    ): Promise<boolean> {
+      if (pathname === TASKS_PATH && req.method === 'POST') {
+        const body = await readJsonRequestBody(req)
+        if (!body) {
+          return rejectArkRequest(res, 'Malformed JSON body.')
+        }
+        if (typeof body.model !== 'string' || body.model.length === 0) {
+          return rejectArkRequest(res, 'MissingParameter: model.')
+        }
+        if (!Array.isArray(body.content) || body.content.length === 0) {
+          return rejectArkRequest(
+            res,
+            'MissingParameter: content must be a non-empty array.',
+          )
+        }
+
+        const id = `cgt-e2e-${++nextTaskId}`
+        jobModels.set(id, body.model)
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ id }))
+        return true
+      }
+
+      const pollMatch = pathname.match(
+        /^\/contents\/generations\/tasks\/([^/]+)$/,
+      )
+      if (pollMatch && req.method === 'GET') {
+        const jobId = pollMatch[1]!
+        const nowSeconds = Math.floor(Date.now() / 1000)
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'application/json')
+        res.end(
+          JSON.stringify({
+            id: jobId,
+            model: jobModels.get(jobId),
+            status: 'succeeded',
+            created_at: nowSeconds - 30,
+            updated_at: nowSeconds,
+            content: { video_url: VIDEO_URL },
+            usage: { completion_tokens: 39285, total_tokens: 39285 },
+            seed: 1234567890,
+            resolution: '480p',
+            ratio: '16:9',
+            duration: 5,
+            framespersecond: 24,
+            output_format: 'mp4',
+            service_tier: 'default',
+          }),
+        )
+        return true
+      }
+
+      // Not a Seedance path — fall through to aimock's compat-path
+      // normalization (Ark chat + Seedream image live under the same prefix).
+      return false
+    },
+  }
+}
+
+/**
+ * Mounts Seed Speech's synchronous TTS endpoint,
+ * `POST /api/v3/tts/create`.
+ *
+ * The request is validated against the decoded wire schema (see
+ * `readJsonRequestBody` for why these mounts validate at all). Three fields
+ * pin the shapes most likely to regress silently:
+ *
+ * - `text_prompt` — the synthesis field. There is no request-side `text`; that
+ *   belongs to the *other* endpoint (`/tts/unidirectional`), so a rename to
+ *   `text` is exactly the kind of drift worth catching.
+ * - `references[0].speaker` — the voice nests inside `references[]`. A
+ *   top-level `speaker` is ignored by the real server, which would otherwise
+ *   look like success here.
+ * - `audio_config.format` — always sent explicitly by the adapter.
+ *
+ * The response echoes that requested format's container (see
+ * `FAKE_AUDIO_BY_FORMAT`), because the adapter derives its result's content
+ * type from what it asked for, not from anything in this payload.
+ *
+ * The envelope is the documented one: a numeric `code` (0 on success), base64
+ * `audio`, `duration` / `original_duration` in **seconds**, and a temporary
+ * `url`. Note that a non-zero `code` can arrive on an HTTP 200 — the adapter
+ * rejects `code !== 0`, so this must send 0 for the success path to hold.
+ * `subtitle` is omitted: the adapter only asks for it via `enable_subtitle`,
+ * which this feature doesn't set.
+ */
+function byteplusTTSMount(): Mountable {
+  return {
+    async handleRequest(
+      req: http.IncomingMessage,
+      res: http.ServerResponse,
+      pathname: string,
+    ): Promise<boolean> {
+      if (pathname !== '/tts/create' || req.method !== 'POST') return false
+
+      const body = await readJsonRequestBody(req)
+      if (!body) {
+        return rejectVoiceRequest(res, 'Malformed JSON body.')
+      }
+      if (typeof body.text_prompt !== 'string' || !body.text_prompt) {
+        return rejectVoiceRequest(
+          res,
+          'Missing text_prompt (note: the synthesis field is text_prompt, not text).',
+        )
+      }
+      const references = Array.isArray(body.references)
+        ? body.references
+        : undefined
+      const speaker = asRecord(references?.[0])?.speaker
+      if (typeof speaker !== 'string' || !speaker) {
+        return rejectVoiceRequest(
+          res,
+          'Missing references[0].speaker (the voice nests inside references[], not at the top level).',
+        )
+      }
+      const audioConfig = asRecord(body.audio_config)
+      const format = audioConfig?.format
+      if (typeof format !== 'string' || !(format in FAKE_AUDIO_BY_FORMAT)) {
+        return rejectVoiceRequest(
+          res,
+          `Missing or unsupported audio_config.format: ${String(format)}.`,
+        )
+      }
+
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.end(
+        JSON.stringify({
+          code: 0,
+          message: 'Success',
+          audio: FAKE_AUDIO_BY_FORMAT[format]!.toString('base64'),
+          duration: 2.4,
+          original_duration: 2.4,
+          url: `https://example.com/welcome-to-the-guitar-store.${format}`,
+          // Timings only come back when the caller opted in. No spec sets
+          // `enable_subtitle` today; this keeps the branch honest if one does.
+          // Subtitle times are MILLISECONDS even though `duration` above is
+          // seconds — the endpoint genuinely mixes units, so don't "fix" it.
+          ...(audioConfig?.enable_subtitle === true && {
+            subtitle: {
+              sentences: [
+                {
+                  text: 'welcome to the guitar store',
+                  start_time: 0,
+                  end_time: 2400,
+                },
+              ],
+            },
+          }),
+        }),
+      )
+      return true
+    },
+  }
+}
+
+/**
+ * Mounts Seed Speech's synchronous ASR endpoint,
+ * `POST /api/v3/auc/bigmodel/recognize/flash`.
+ *
+ * The transcript matches the other providers' transcription mocks so
+ * `transcription.spec.ts` asserts the same "Fender Stratocaster" text for
+ * every provider. Wire timings are **milliseconds** (the adapter converts
+ * them to seconds), and the payload uses the nested `result` spelling rather
+ * than the flat aliases.
+ *
+ * The request is validated for an `audio.url` or `audio.data` (see
+ * `readJsonRequestBody`): the endpoint takes the clip one way or the other,
+ * and an adapter that sent neither would otherwise still get a transcript back
+ * and pass.
+ */
+function byteplusASRMount(): Mountable {
+  return {
+    async handleRequest(
+      req: http.IncomingMessage,
+      res: http.ServerResponse,
+      pathname: string,
+    ): Promise<boolean> {
+      if (
+        pathname !== '/auc/bigmodel/recognize/flash' ||
+        req.method !== 'POST'
+      ) {
+        return false
+      }
+
+      const body = await readJsonRequestBody(req)
+      if (!body) {
+        return rejectVoiceRequest(res, 'Malformed JSON body.')
+      }
+      const audio = asRecord(body.audio)
+      const hasUrl = typeof audio?.url === 'string' && audio.url.length > 0
+      const hasData = typeof audio?.data === 'string' && audio.data.length > 0
+      if (!hasUrl && !hasData) {
+        return rejectVoiceRequest(
+          res,
+          'Missing audio: exactly one of audio.url or audio.data is required.',
+        )
+      }
+
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.end(
+        JSON.stringify({
+          audio_info: { duration: 2400 },
+          result: {
+            text: 'I would like to buy a Fender Stratocaster please',
+            utterances: [
+              {
+                text: 'I would like to buy a Fender Stratocaster please',
+                start_time: 0,
+                end_time: 2400,
+                words: [
+                  { text: 'I', start_time: 0, end_time: 100 },
+                  { text: 'would', start_time: 100, end_time: 300 },
+                  { text: 'like', start_time: 300, end_time: 500 },
+                  { text: 'to', start_time: 500, end_time: 600 },
+                  { text: 'buy', start_time: 600, end_time: 800 },
+                  { text: 'a', start_time: 800, end_time: 900 },
+                  { text: 'Fender', start_time: 900, end_time: 1300 },
+                  { text: 'Stratocaster', start_time: 1300, end_time: 2000 },
+                  { text: 'please', start_time: 2000, end_time: 2400 },
+                ],
+              },
+            ],
+          },
+        }),
+      )
+      return true
     },
   }
 }

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -20,6 +20,7 @@
     "@tanstack/ai": "workspace:*",
     "@tanstack/ai-anthropic": "workspace:*",
     "@tanstack/ai-bedrock": "workspace:*",
+    "@tanstack/ai-byteplus": "workspace:*",
     "@tanstack/ai-claude-code": "workspace:*",
     "@tanstack/ai-client": "workspace:*",
     "@tanstack/ai-elevenlabs": "workspace:*",

--- a/testing/e2e/src/lib/feature-support.ts
+++ b/testing/e2e/src/lib/feature-support.ts
@@ -20,6 +20,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'openai-compatible',
     'mistral',
+    'byteplus',
   ]),
   'one-shot-text': new Set([
     'openai',
@@ -33,8 +34,13 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'openai-compatible',
     'mistral',
+    'byteplus',
   ]),
-  reasoning: new Set(['openai', 'anthropic', 'gemini', 'mistral']),
+  // BytePlus streams its reasoning trace as `delta.reasoning_content`, which is
+  // exactly the field aimock's OpenAI-compatible chunk builder emits for a
+  // fixture's `reasoning` channel — so the adapter's `extractReasoning`
+  // override is exercised end-to-end against the shared fixture.
+  reasoning: new Set(['openai', 'anthropic', 'gemini', 'mistral', 'byteplus']),
   'multi-turn': new Set([
     'openai',
     'anthropic',
@@ -47,6 +53,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'openai-compatible',
     'mistral',
+    'byteplus',
   ]),
   'tool-calling': new Set([
     'openai',
@@ -60,6 +67,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'openai-compatible',
     'mistral',
+    'byteplus',
   ]),
   'parallel-tool-calls': new Set([
     'openai',
@@ -72,6 +80,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'openai-compatible',
     'mistral',
+    'byteplus',
   ]),
   // Gemini excluded: approval flow timing issues with Gemini's streaming format
   'tool-approval': new Set([
@@ -85,6 +94,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'openai-compatible',
     'mistral',
+    'byteplus',
   ]),
   // Ollama excluded: aimock doesn't support content+toolCalls for /api/chat format
   'text-tool-text': new Set([
@@ -98,6 +108,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'openai-compatible',
     'mistral',
+    'byteplus',
   ]),
   'structured-output': new Set([
     'openai',
@@ -111,6 +122,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'openai-compatible',
     'mistral',
+    'byteplus',
   ]),
   // Streaming structured output: only providers with native streaming JSON
   // schema support are listed here. Other providers fall back to the
@@ -124,6 +136,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'openai-compatible',
+    'byteplus',
   ]),
   // Multi-turn structured output: every turn produces its own typed
   // `structured-output` part on the assistant message, and historical
@@ -153,6 +166,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'openai-compatible',
+    'byteplus',
   ]),
   'agentic-structured': new Set([
     'openai',
@@ -166,6 +180,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter',
     'openai-compatible',
     'mistral',
+    'byteplus',
   ]),
   // Native-combined-mode adapters only. Each provider's default test model
   // (or per-feature override in `features.ts`) must opt into combined mode
@@ -176,6 +191,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'anthropic',
     'gemini',
     'grok',
+    'byteplus',
   ]),
   // Bedrock excluded: the default e2e model (openai.gpt-oss-120b) is text-only
   // (input: ['text'], no vision) — image input isn't supported, so the
@@ -187,6 +203,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'gemini',
     'grok',
     'openrouter',
+    'byteplus',
   ]),
   // Bedrock excluded: same text-only default e2e model as multimodal-image above.
   'multimodal-structured': new Set([
@@ -195,7 +212,12 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'gemini',
     'grok',
     'openrouter',
+    'byteplus',
   ]),
+  // byteplus excluded: @tanstack/ai-byteplus ships no summarize adapter —
+  // Ark has no summarization endpoint, and api.summarize.ts builds a
+  // dedicated `create*Summarize` adapter per provider rather than reusing the
+  // chat adapter. Add both entries here if a Seed summarize adapter lands.
   summarize: new Set([
     'openai',
     'anthropic',
@@ -219,7 +241,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'mistral',
   ]),
   // Gemini excluded: aimock doesn't mock Gemini's Imagen predict endpoint format
-  'image-gen': new Set(['openai', 'grok']),
+  'image-gen': new Set(['openai', 'grok', 'byteplus']),
   // image-to-image (image parts in the generateImage prompt). aimock 1.29
   // mocks OpenAI's multipart `/v1/images/edits` (matches on the `prompt` form
   // field, ignores the binary image/mask fields), so the OpenAI route runs
@@ -228,16 +250,32 @@ export const matrix: Record<Feature, Set<Provider>> = {
   // OpenRouter multimodal chat content parts, fal endpoint-specific input
   // fields) — their mapping is covered by unit tests. Add them here when
   // aimock support lands.
+  // byteplus excluded: Seedream edits through the same /images/generations
+  // endpoint (reference images ride an `image` array in the JSON body), so
+  // there is no `/v1/images/edits` request for this spec's journal assertion
+  // to find. The reference-image mapping is unit-tested instead.
   'image-to-image': new Set(['openai']),
+  // byteplus excluded: BytePlus has no music/audio generation product —
+  // Seed Speech is TTS + ASR only.
   'audio-gen': new Set(['gemini', 'elevenlabs']),
+  // byteplus excluded: no sound-effects endpoint (see audio-gen above).
   'sound-effects': new Set(['elevenlabs']),
-  tts: new Set(['openai', 'gemini', 'grok', 'elevenlabs']),
-  transcription: new Set(['openai', 'grok', 'groq', 'elevenlabs']),
+  tts: new Set(['openai', 'gemini', 'grok', 'elevenlabs', 'byteplus']),
+  transcription: new Set(['openai', 'grok', 'groq', 'elevenlabs', 'byteplus']),
+  // byteplus excluded: this spec asserts named-speaker segments
+  // (`agent`/`customer`), which is OpenAI's `diarized_json` shape. Seed ASR's
+  // nearest equivalent is `enable_speaker_info`, whose response shape is
+  // unverified — it couldn't be probed live without the Seed Speech voice key
+  // — and the adapter reads speaker labels defensively out of an utterance's
+  // `additions` for that reason. Revisit once the shape is confirmed.
   'transcription-diarization': new Set(['openai']),
   // Gemini Veo runs through a custom aimock mount (see geminiVeoMount in
   // global-setup.ts) — aimock 1.29 doesn't model the long-running
   // `:predictLongRunning` + operations-polling pair natively.
-  'video-gen': new Set(['openai', 'gemini']),
+  // BytePlus Seedance uses its own create→poll task API
+  // (POST/GET /api/v3/contents/generations/tasks), mounted as
+  // byteplusSeedanceMount in global-setup.ts for the same reason.
+  'video-gen': new Set(['openai', 'gemini', 'byteplus']),
   // image-to-video (image parts in the generateVideo prompt). aimock 1.29's
   // `/v1/videos` handler parses Sora's multipart upload (the SDK switches to
   // multipart when `input_reference` carries a File) and matches on the
@@ -245,14 +283,21 @@ export const matrix: Record<Feature, Set<Provider>> = {
   // endpoint-specific fields and Gemini Veo's image/lastFrame/referenceImages
   // routing remain unit-test-only (the spec's journal assertion is tied to
   // aimock's /v1/videos pipeline, which custom mounts bypass).
+  // byteplus excluded: Seedance takes its opening frame as a `first_frame`
+  // role inside the task body's `content[]`, so the spec's assertion that a
+  // multipart POST /v1/videos carried the prompt can't hold. The role mapping
+  // is unit-tested instead.
   'image-to-video': new Set(['openai']),
   // Gemini Omni Flash video generation over the Interactions API. Runs
   // through a dedicated aimock mount (see geminiOmniVideoMount in
   // global-setup.ts) — aimock handles synchronous text interactions natively
   // but not background video jobs (create → poll → inline base64 mp4).
+  // byteplus excluded: Ark has no Interactions-style API — Seedance video is
+  // the task API covered by video-gen above.
   'interactions-video': new Set(['gemini']),
   // Only Gemini currently surfaces a first-class stateful conversation API via
   // the adapter (geminiTextInteractions, behind @tanstack/ai-gemini/experimental).
+  // byteplus excluded for the same reason: Ark's chat endpoint is stateless.
   'stateful-interactions': new Set(['gemini']),
 }
 

--- a/testing/e2e/src/lib/features.ts
+++ b/testing/e2e/src/lib/features.ts
@@ -15,6 +15,19 @@ interface FeatureConfig {
   systemPrompt?: string
 }
 
+/**
+ * The byteplus model every structured-output feature overrides to.
+ *
+ * The default e2e chat model (`seed-2-0-lite-260428`, in `providers.ts`)
+ * rejects both `response_format: json_schema` and `json_object` — live-probed,
+ * and the adapter throws rather than silently degrading, so any feature that
+ * asks for a schema has to move off it. `seed-2-0-lite-260228` is the nearest
+ * sibling that accepts json_schema *and* honours it (glm-4-7 accepts it and
+ * returns prose, so acceptance alone isn't enough), and it keeps image input,
+ * which `multimodal-structured` needs.
+ */
+const BYTEPLUS_STRUCTURED_MODEL = 'seed-2-0-lite-260228'
+
 export const featureConfigs: Record<Feature, FeatureConfig> = {
   chat: {
     tools: [],
@@ -56,20 +69,24 @@ export const featureConfigs: Record<Feature, FeatureConfig> = {
   'structured-output': {
     tools: [],
     modelOptions: {},
+    modelOverrides: { byteplus: BYTEPLUS_STRUCTURED_MODEL },
   },
   'structured-output-stream': {
     tools: [],
     modelOptions: {},
+    modelOverrides: { byteplus: BYTEPLUS_STRUCTURED_MODEL },
   },
   'multi-turn-structured': {
     tools: [],
     modelOptions: {},
+    modelOverrides: { byteplus: BYTEPLUS_STRUCTURED_MODEL },
     systemPrompt:
       'You are a chef assistant that always responds with a single recipe matching the provided JSON schema. When the user asks for modifications, produce a new recipe in the same shape that reflects the change. Stay terse — short titles, short steps.',
   },
   'agentic-structured': {
     tools: [getGuitars],
     modelOptions: {},
+    modelOverrides: { byteplus: BYTEPLUS_STRUCTURED_MODEL },
   },
   // Pins #605 native-combined-mode: `outputSchema` + `tools` + `stream: true`
   // in a single chat call. Default openai (gpt-4o) and anthropic
@@ -82,6 +99,9 @@ export const featureConfigs: Record<Feature, FeatureConfig> = {
     modelOverrides: {
       gemini: 'gemini-3-flash-preview',
       grok: 'grok-build-0.1',
+      // Reports combined tools+schema support, so the engine takes the
+      // native path here too.
+      byteplus: BYTEPLUS_STRUCTURED_MODEL,
     },
   },
   'multimodal-image': {
@@ -91,6 +111,7 @@ export const featureConfigs: Record<Feature, FeatureConfig> = {
   'multimodal-structured': {
     tools: [],
     modelOptions: {},
+    modelOverrides: { byteplus: BYTEPLUS_STRUCTURED_MODEL },
   },
   summarize: {
     tools: [],

--- a/testing/e2e/src/lib/media-providers.ts
+++ b/testing/e2e/src/lib/media-providers.ts
@@ -21,6 +21,12 @@ import {
   createElevenLabsSpeech,
   createElevenLabsTranscription,
 } from '@tanstack/ai-elevenlabs'
+import {
+  createBytePlusImage,
+  createBytePlusSpeech,
+  createBytePlusTranscription,
+  createBytePlusVideo,
+} from '@tanstack/ai-byteplus'
 import type { TranscriptionResponseFormat } from '@tanstack/ai'
 import type { Feature, Provider } from '@/lib/types'
 
@@ -39,6 +45,16 @@ function llmockBase(aimockPort?: number): string {
 
 function openaiUrl(aimockPort?: number): string {
   return `${llmockBase(aimockPort)}/v1`
+}
+
+/**
+ * BytePlus Ark (chat, Seedream image, Seedance video) serves its data plane
+ * under `/api/v3`. The Seed Speech adapters (TTS/ASR) are *not* on Ark — they
+ * take the bare host and append `/api/v3/...` themselves, so they get
+ * `llmockBase()` instead.
+ */
+function bytePlusArkUrl(aimockPort?: number): string {
+  return `${llmockBase(aimockPort)}/api/v3`
 }
 
 function testHeaders(testId?: string): Record<string, string> | undefined {
@@ -77,6 +93,18 @@ export function createImageAdapter(
         baseURL: openaiUrl(aimockPort),
         defaultHeaders: headers,
       }),
+    // Seedream posts a non-OpenAI body (`size` as a 1K/2K token, no `n`,
+    // `watermark`, `sequential_image_generation`) to /images/generations, but
+    // aimock's native handler only reads `model` + `prompt` and answers with
+    // the shared `{ created, data: [{ url }] }` envelope Seedream also uses —
+    // so the Ark path needs no mount of its own.
+    // seedream-4-0-250828 deliberately: it's the one Seedream model whose
+    // response shape was captured from a live call during Phase 0.
+    byteplus: () =>
+      createBytePlusImage('seedream-4-0-250828', DUMMY_KEY, {
+        baseURL: bytePlusArkUrl(aimockPort),
+        defaultHeaders: headers,
+      }),
   }
   const factory = factories[provider]
   if (!factory) throw new Error(`No image adapter for provider: ${provider}`)
@@ -108,6 +136,14 @@ export function createTTSAdapter(
       createElevenLabsSpeech('eleven_multilingual_v2', DUMMY_KEY, {
         baseUrl: llmockBase(aimockPort),
         headers,
+      }),
+    // Seed Speech is a separate BytePlus product from Ark with its own key and
+    // its own host, so this takes the bare mock base — the adapter appends
+    // `/api/v3/tts/create`, which `byteplusTTSMount()` serves.
+    byteplus: () =>
+      createBytePlusSpeech('seed-audio-1.0', DUMMY_KEY, {
+        baseURL: llmockBase(aimockPort),
+        defaultHeaders: headers,
       }),
   }
   const factory = factories[provider]
@@ -143,6 +179,13 @@ export function createTranscriptionAdapter(
       createElevenLabsTranscription('scribe_v1', DUMMY_KEY, {
         baseUrl: llmockBase(aimockPort),
         headers,
+      }),
+    // Same Seed Speech host as the TTS adapter above; the adapter appends
+    // `/api/v3/auc/bigmodel/recognize/flash`, served by `byteplusASRMount()`.
+    byteplus: () =>
+      createBytePlusTranscription('seed-asr', DUMMY_KEY, {
+        baseURL: llmockBase(aimockPort),
+        defaultHeaders: headers,
       }),
   }
   const factory = factories[provider]
@@ -185,6 +228,13 @@ export function createVideoAdapter(
       createGeminiVideo('veo-3.1-generate-preview', DUMMY_KEY, {
         httpOptions: { baseUrl: llmockBase(aimockPort), headers },
       } as unknown as Parameters<typeof createGeminiVideo>[2]),
+    // Seedance's create→poll task API has no aimock equivalent, so it runs
+    // through `byteplusSeedanceMount()` on the Ark prefix.
+    byteplus: () =>
+      createBytePlusVideo('seedance-1-0-pro-fast-251015', DUMMY_KEY, {
+        baseURL: bytePlusArkUrl(aimockPort),
+        defaultHeaders: headers,
+      }),
   }
   const factory = factories[provider]
   if (!factory) throw new Error(`No video adapter for provider: ${provider}`)

--- a/testing/e2e/src/lib/providers.ts
+++ b/testing/e2e/src/lib/providers.ts
@@ -13,8 +13,10 @@ import {
   createOpenRouterText,
 } from '@tanstack/ai-openrouter'
 import { createMistralText } from '@tanstack/ai-mistral'
+import { createBytePlusText } from '@tanstack/ai-byteplus'
 import { HTTPClient } from '@openrouter/sdk'
 import type { AnyTextAdapter } from '@tanstack/ai'
+import type { BytePlusChatModel } from '@tanstack/ai-byteplus'
 import type { Feature, Provider } from '@/lib/types'
 
 const LLMOCK_DEFAULT_BASE = process.env.LLMOCK_URL || 'http://127.0.0.1:4010'
@@ -33,6 +35,10 @@ const defaultModels: Record<Provider, string> = {
   'openrouter-responses': 'openai/gpt-4o',
   'openai-compatible': 'gpt-4o',
   mistral: 'mistral-large-latest',
+  // Structured-output features override this in `features.ts`:
+  // seed-2-0-lite-260428 rejects both `response_format: json_schema` and
+  // `json_object` (live-probed), so it can't drive any structured feature.
+  byteplus: 'seed-2-0-lite-260428',
   // ElevenLabs has no chat/text model — the support matrix already filters
   // it out of text features, but we still need an entry to satisfy the
   // Record<Provider, …> constraint.
@@ -52,6 +58,11 @@ export function createTextAdapter(
   // Anthropic, Gemini, Ollama SDKs include their path prefixes internally
   const base = LLMOCK_DEFAULT_BASE
   const openaiUrl = `${base}/v1`
+  // BytePlus Ark's data plane lives under /api/v3. aimock's compat-path
+  // normalizer rewrites any non-/v1//v2 path ending in /chat/completions to
+  // /v1/chat/completions, so the Ark prefix reaches the native OpenAI handler
+  // untouched — see testing/e2e/README.md § "BytePlus (Ark) path handling".
+  const arkUrl = `${base}/api/v3`
 
   // X-Test-Id header for per-test sequenceIndex isolation in aimock
   const testHeaders = testId ? { 'X-Test-Id': testId } : undefined
@@ -204,6 +215,13 @@ export function createTextAdapter(
       createChatOptions({
         adapter: createMistralText(model as 'mistral-large-latest', DUMMY_KEY, {
           serverURL: base,
+          defaultHeaders: testHeaders,
+        }),
+      }),
+    byteplus: () =>
+      createChatOptions({
+        adapter: createBytePlusText(model as BytePlusChatModel, DUMMY_KEY, {
+          baseURL: arkUrl,
           defaultHeaders: testHeaders,
         }),
       }),

--- a/testing/e2e/src/lib/types.ts
+++ b/testing/e2e/src/lib/types.ts
@@ -13,6 +13,7 @@ export type Provider =
   | 'openrouter-responses'
   | 'openai-compatible'
   | 'mistral'
+  | 'byteplus'
   | 'elevenlabs'
 
 export type Feature =
@@ -58,6 +59,7 @@ export const ALL_PROVIDERS: Provider[] = [
   'openrouter-responses',
   'openai-compatible',
   'mistral',
+  'byteplus',
   'elevenlabs',
 ]
 

--- a/testing/e2e/tests/test-matrix.ts
+++ b/testing/e2e/tests/test-matrix.ts
@@ -26,6 +26,7 @@ export const providers: Provider[] = [
   'openrouter-responses',
   'openai-compatible',
   'mistral',
+  'byteplus',
   'elevenlabs',
 ]
 

--- a/testing/react-native-smoke/scripts/assert-import-surface.ts
+++ b/testing/react-native-smoke/scripts/assert-import-surface.ts
@@ -37,7 +37,7 @@ const forbiddenPackages = new Set([
 ])
 
 const providerPackagePattern =
-  /^@tanstack\/ai-(anthropic|elevenlabs|fal|gemini|grok|groq|ollama|openai|openrouter)(?:\/|$)/
+  /^@tanstack\/ai-(anthropic|byteplus|elevenlabs|fal|gemini|grok|groq|ollama|openai|openrouter)(?:\/|$)/
 
 const forbiddenPackagePrefixes = ['@vue/']
 const builtins = new Set(


### PR DESCRIPTION
## 🎯 Changes

Adds **`@tanstack/ai-byteplus`** — direct BytePlus provider adapters:

- **Chat** (`byteplusText`): Ark's OpenAI-compatible API with 18 live-verified models (Seed 2.x/1.x, GLM, DeepSeek V4/V3.2, gpt-oss). Supports `thinking`/`reasoning_content`, `encrypted_content` round-trip through the thinking-signature seam (works in the server agent loop — live-verified), and per-model structured-output gating (10 models honour `json_schema`; Ark has no `json_object` fallback, and `glm-4-7` *accepts-but-ignores* schemas, so unsupported models fail loud instead of 400ing or parsing prose).
- **Seedance video** (`byteplusVideo`): async task lifecycle (create → poll → URL with 24h expiry anchored at completion), first/last-frame + reference-media roles with mode-exclusivity validation, per-model duration/resolution matrices (all live-probed — e.g. no 2K tier exists anywhere, 4K only on the 2.0 flagship, `flex` tier verified end-to-end). Unknown model ids are accepted un-gated (day-one support for new releases — see Seedance 2.5 below).
- **Seedream image** (`byteplusImage`): size tokens or WxH, editing refs, group-image mode (`numberOfImages` is an upper bound — documented), per-image failure surfacing.
- **Seed Speech TTS + ASR** (`byteplusSpeech`/`byteplusTranscription`): separate voice host + `X-Api-Key` (env `BYTEPLUS_VOICE_API_KEY` — *not* the Ark key). Wire schema decoded from the official docs (`text_prompt`, `references[{speaker}]`, `audio_config`); flagged live-probe items remain pending a voice key.

Also: e2e integration (31 byteplus specs; custom aimock mounts that *validate* request wire shapes so schema drift fails tests), `docs/adapters/byteplus.md` (15 kiira-clean snippets) + provider-enumerating docs/skills updates, example wiring, and a **Seedance Studio** page in `examples/ts-react-media` with capability-gated per-model controls and an advanced custom-model mode.

**Seedance 2.5**: the Ark id `dreamina-seedance-2-5-260628` exists but is activation-gated per account (`ModelNotOpen`); it's deliberately absent from the typed tables until capabilities are probeable, and usable today via the open model parameter / Studio custom-model field.

Notes: Seedance is also reachable via `@tanstack/ai-fal`; this package is the deliberate direct path. Model metadata was live-verified against the real API on 2026-07-31 (aimock has no byteplus record mode — gap documented in `testing/e2e/README.md`). `packages/ai-grok`'s README carries the same pre-existing `generate()` sample bug fixed here for byteplus; left for a follow-up.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BytePlus support for chat, reasoning, image generation, video generation, text-to-speech, and transcription.
  * Added Seedance Studio for configuring, monitoring, previewing, and downloading video jobs.
  * Added BytePlus provider options to chat, media-generation, and audio examples.
  * Added support for separate ModelArk and Seed Speech credentials.

* **Documentation**
  * Added setup guides, model details, API key requirements, regional endpoint guidance, usage limits, and expiration notes.

* **Tests**
  * Added comprehensive unit and end-to-end coverage for BytePlus capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->