### PR TITLE
refactor(ai): remove zod from the dependency graph

### DIFF
--- a/.changeset/ag-ui-core-zod-free.md
+++ b/.changeset/ag-ui-core-zod-free.md
@@ -1,0 +1,25 @@
+---
+'@tanstack/ai': minor
+---
+
+Remove zod from `@tanstack/ai`'s dependency graph entirely.
+
+`@ag-ui/core` is bumped to `0.1.1-canary.beta.0`, which drops zod from its
+runtime dependencies and declares it as an optional peer instead. Previously
+every `@tanstack/ai` install pulled zod in transitively through it.
+
+`chatParamsFromRequest` / `chatParamsFromRequestBody` were the only zod
+consumers in this package — they validated request bodies with AG-UI's
+`RunAgentInputSchema`. They now validate the same `RunAgentInput` contract
+structurally, so `@tanstack/ai` ships with no schema-validation runtime at all
+and neither requires nor suggests zod.
+
+No API change: both helpers keep their signatures, still reject non-conforming
+bodies with a migration-pointing `AGUIError` (`chatParamsFromRequest` still
+throws a 400 `Response`), and still carry TanStack's canonical `parts` field
+through on messages. Validation errors now name the offending field —
+`messages[1].content must be a string` instead of a zod issue dump.
+
+zod remains fully supported for defining tools; it is simply no longer
+installed on your behalf. If you relied on getting zod transitively without
+declaring it, add it explicitly: `npm install zod`.

--- a/docs/comparison/vercel-ai-sdk.md
+++ b/docs/comparison/vercel-ai-sdk.md
@@ -379,9 +379,10 @@ const logger: ChatMiddleware = {
     console.log(`[${ctx.requestId}] Chat started`)
   },
   onChunk: (ctx, chunk) => {
-    // Transform, expand, or drop chunks
-    if ('delta' in chunk && 'messageId' in chunk) {
-      return { ...chunk, delta: chunk.delta!.replace(/\b\d{3}-\d{2}-\d{4}\b/g, '[REDACTED]') }
+    // Transform, expand, or drop chunks. `type` is the discriminant, so it
+    // narrows `chunk` to the matching event and types `delta` as `string`.
+    if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
+      return { ...chunk, delta: chunk.delta.replace(/\b\d{3}-\d{2}-\d{4}\b/g, '[REDACTED]') }
     }
   },
   onBeforeToolCall: (ctx, hookCtx) => {

--- a/docs/config.json
+++ b/docs/config.json
@@ -660,7 +660,7 @@
           "label": "AG-UI Client Compliance",
           "to": "migration/ag-ui-compliance",
           "addedAt": "2026-05-16",
-          "updatedAt": "2026-07-08"
+          "updatedAt": "2026-07-31"
         },
         {
           "label": "Sampling → modelOptions",

--- a/docs/migration/ag-ui-compliance.md
+++ b/docs/migration/ag-ui-compliance.md
@@ -363,7 +363,37 @@ Pure AG-UI `RunAgentInput` payloads (no TanStack `parts` field) work end-to-end:
 
 ## `@ag-ui/core` bump
 
-`@tanstack/ai` now depends on `@ag-ui/core@^0.0.52`. If your code imports types from `@tanstack/ai` that re-export AG-UI types, you may need minor type adjustments — see the changeset for specifics.
+`@tanstack/ai` now depends on `@ag-ui/core@0.1.1-canary.beta.0`. If your code imports types from `@tanstack/ai` that re-export AG-UI types, you may need minor type adjustments — see the changeset for specifics.
+
+### zod is no longer installed for you
+
+`@ag-ui/core` used to list `zod` as a runtime dependency, so every
+`@tanstack/ai` install pulled zod in transitively. As of `0.1.x` it declares zod
+as an optional peer instead, and `@tanstack/ai` no longer uses zod anywhere —
+the package now ships with no schema-validation runtime at all.
+
+`chatParamsFromRequest` / `chatParamsFromRequestBody` were the only zod
+consumers: they validated the request body with AG-UI's `RunAgentInputSchema`.
+They now validate the same `RunAgentInput` contract structurally. Their
+signatures, their thrown types (`AGUIError`, and a 400 `Response` from
+`chatParamsFromRequest`), and the `parts` passthrough on messages are all
+unchanged. The one visible difference is friendlier failures — the error names
+the offending field, e.g.:
+
+```
+Request body is not a valid AG-UI RunAgentInput. ... Validation errors: messages[1].content must be a string
+```
+
+zod is still fully supported for defining tools; it is just no longer installed
+on your behalf. If your project used zod without declaring it — relying on the
+transitive copy — add it explicitly:
+
+```bash
+npm install zod
+```
+
+If you define tools with a different Standard Schema library (ArkType, Valibot),
+you can now drop zod entirely.
 
 ## Out of scope (existing behavior preserved)
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -89,7 +89,7 @@
     "tanstack-intent"
   ],
   "dependencies": {
-    "@ag-ui/core": "^0.0.57",
+    "@ag-ui/core": "0.1.1-canary.beta.0",
     "@standard-schema/spec": "^1.1.0",
     "@tanstack/ai-event-client": "workspace:*",
     "@tanstack/ai-utils": "workspace:*",

--- a/packages/ai/src/utilities/chat-params.ts
+++ b/packages/ai/src/utilities/chat-params.ts
@@ -1,5 +1,10 @@
-import { AGUIError, RunAgentInputSchema } from '@ag-ui/core'
-import type { Context as AGUIContext } from '@ag-ui/core'
+import { AGUIError } from '@ag-ui/core'
+import type {
+  Context as AGUIContext,
+  Message as AGUIMessage,
+  ResumeEntry as AGUIResumeEntry,
+  Role as AGUIRole,
+} from '@ag-ui/core'
 import type {
   AnyTool,
   JSONSchema,
@@ -30,6 +35,162 @@ function isValidParts(value: unknown): value is Array<{ type: string }> {
 }
 
 /**
+ * Keyed by `AGUIRole` so a role added upstream fails to compile here until it
+ * is handled, rather than silently falling through as an unknown role.
+ */
+const AGUI_ROLES: Record<AGUIRole, true> = {
+  developer: true,
+  system: true,
+  assistant: true,
+  user: true,
+  tool: true,
+  activity: true,
+  reasoning: true,
+}
+
+function isAGUIRole(value: unknown): value is AGUIRole {
+  return typeof value === 'string' && value in AGUI_ROLES
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Reject the request body, pointing at the migration guide. Mirrors the
+ * message the previous `RunAgentInputSchema.safeParse` failure produced.
+ */
+function invalidBody(reason: string): never {
+  throw new AGUIError(
+    `Request body is not a valid AG-UI RunAgentInput. ` +
+      `If you're upgrading from a previous @tanstack/ai-client release, ` +
+      `see docs/migration/ag-ui-compliance.md. ` +
+      `Validation errors: ${reason}`,
+  )
+}
+
+function requireString(value: unknown, at: string): string {
+  if (typeof value !== 'string') invalidBody(`${at} must be a string`)
+  return value
+}
+
+function requireArray(value: unknown, at: string): Array<unknown> {
+  if (!Array.isArray(value)) invalidBody(`${at} must be an array`)
+  return value
+}
+
+/**
+ * Assert one AG-UI `Message`, discriminating on `role` exactly as the upstream
+ * `MessageSchema` discriminated union does. The record view is retained on the
+ * asserted type so callers can still inspect non-AG-UI extras like `parts`.
+ */
+function assertAGUIMessage(
+  value: Record<string, unknown>,
+  at: string,
+): asserts value is Record<string, unknown> & AGUIMessage {
+  requireString(value.id, `${at}.id`)
+
+  const role = value.role
+  if (!isAGUIRole(role)) {
+    invalidBody(
+      `${at}.role must be one of ${Object.keys(AGUI_ROLES).join(' | ')}`,
+    )
+  }
+
+  switch (role) {
+    case 'assistant':
+      // Both optional: a tool-calling turn carries no text content.
+      if (value.content !== undefined) {
+        requireString(value.content, `${at}.content`)
+      }
+      if (value.toolCalls !== undefined) {
+        requireArray(value.toolCalls, `${at}.toolCalls`)
+      }
+      break
+    case 'user':
+      if (typeof value.content !== 'string' && !Array.isArray(value.content)) {
+        invalidBody(
+          `${at}.content must be a string or an array of content parts`,
+        )
+      }
+      break
+    case 'tool':
+      requireString(value.content, `${at}.content`)
+      requireString(value.toolCallId, `${at}.toolCallId`)
+      break
+    case 'activity':
+      requireString(value.activityType, `${at}.activityType`)
+      if (!isRecord(value.content)) {
+        invalidBody(`${at}.content must be an object`)
+      }
+      break
+    case 'developer':
+    case 'system':
+    case 'reasoning':
+      requireString(value.content, `${at}.content`)
+      break
+  }
+}
+
+function validateMessage(value: unknown, index: number): AGUIMessage {
+  const at = `messages[${index}]`
+  if (!isRecord(value)) invalidBody(`${at} must be an object`)
+  assertAGUIMessage(value, at)
+
+  // `parts` is TanStack's canonical extra, carried through so the UIMessage
+  // path inside `chat()` can use it. Keep it only when it holds recognized
+  // part types — the previous schema-based path dropped `parts` during parse
+  // and re-attached it from the raw body behind this same check.
+  if ('parts' in value && !isValidParts(value.parts)) {
+    const withoutParts = { ...value }
+    Reflect.deleteProperty(withoutParts, 'parts')
+    return withoutParts
+  }
+  return value
+}
+
+function validateTool(
+  value: unknown,
+  index: number,
+): { name: string; description: string; parameters: JSONSchema } {
+  const at = `tools[${index}]`
+  if (!isRecord(value)) invalidBody(`${at} must be an object`)
+  return {
+    name: requireString(value.name, `${at}.name`),
+    description: requireString(value.description, `${at}.description`),
+    // Upstream `ToolSchema` types this as optional `any`; it reaches the
+    // provider as a raw JSON Schema either way.
+    parameters: value.parameters as JSONSchema,
+  }
+}
+
+function validateContext(value: unknown, index: number): AGUIContext {
+  const at = `context[${index}]`
+  if (!isRecord(value)) invalidBody(`${at} must be an object`)
+  return {
+    description: requireString(value.description, `${at}.description`),
+    value: requireString(value.value, `${at}.value`),
+  }
+}
+
+function validateResumeEntry(value: unknown, index: number): AGUIResumeEntry {
+  const at = `resume[${index}]`
+  if (!isRecord(value)) invalidBody(`${at} must be an object`)
+  const status = value.status
+  if (status !== 'resolved' && status !== 'cancelled') {
+    invalidBody(`${at}.status must be "resolved" or "cancelled"`)
+  }
+  const entry: AGUIResumeEntry = {
+    interruptId: requireString(value.interruptId, `${at}.interruptId`),
+    status,
+  }
+  // Omit the key entirely when absent, matching the optional-field shape the
+  // schema produced.
+  if (value.payload !== undefined) entry.payload = value.payload
+  return entry
+}
+
+/**
  * Parse and validate an HTTP request body as an AG-UI `RunAgentInput`.
  *
  * Returns a spread-friendly object whose `messages` field is suitable for
@@ -37,11 +198,14 @@ function isValidParts(value: unknown): value is Array<{ type: string }> {
  * `convertMessagesToModelMessages` handles AG-UI fan-out dedup and
  * reasoning/activity/developer-role normalization internally.
  *
+ * Validated structurally against the AG-UI `RunAgentInput` contract without a
+ * schema library, so this package pulls in no validation runtime of its own.
+ *
  * @throws An error with a migration-pointing message when the body does
- *   not conform to AG-UI `RunAgentInputSchema`. Surface this as a
+ *   not conform to AG-UI `RunAgentInput`. Surface this as a
  *   400 Bad Request to the client.
  */
-export function chatParamsFromRequestBody(body: unknown): Promise<{
+export async function chatParamsFromRequestBody(body: unknown): Promise<{
   messages: Array<UIMessage | ModelMessage>
   threadId: string
   runId: string
@@ -57,55 +221,41 @@ export function chatParamsFromRequestBody(body: unknown): Promise<{
   context: Array<AGUIContext>
   aguiContext: Array<AGUIContext>
 }> {
-  const parseResult = RunAgentInputSchema.safeParse(body)
-  if (!parseResult.success) {
-    return Promise.reject(
-      new AGUIError(
-        `Request body is not a valid AG-UI RunAgentInput. ` +
-          `If you're upgrading from a previous @tanstack/ai-client release, ` +
-          `see docs/migration/ag-ui-compliance.md. ` +
-          `Validation errors: ${parseResult.error.message}`,
-      ),
-    )
+  if (!isRecord(body)) invalidBody('body must be a JSON object')
+
+  const threadId = requireString(body.threadId, 'threadId')
+  const runId = requireString(body.runId, 'runId')
+  const parentRunId =
+    body.parentRunId === undefined
+      ? undefined
+      : requireString(body.parentRunId, 'parentRunId')
+
+  const messages = requireArray(body.messages, 'messages').map(validateMessage)
+  const tools = requireArray(body.tools, 'tools').map(validateTool)
+  const aguiContext = requireArray(body.context, 'context').map(validateContext)
+  const resume =
+    body.resume === undefined
+      ? undefined
+      : requireArray(body.resume, 'resume').map(validateResumeEntry)
+
+  if (body.forwardedProps !== undefined && !isRecord(body.forwardedProps)) {
+    invalidBody('forwardedProps must be an object')
   }
 
-  const parsed = parseResult.data
-  const aguiContext = parsed.context
-
-  // AG-UI Zod uses `.strip()` so extra fields like `parts` on messages are
-  // dropped during parse. We re-attach them from the original body so the
-  // existing UIMessage path inside `chat()` can use them directly.
-  const rawMessages =
-    (body as { messages?: Array<Record<string, unknown>> }).messages ?? []
-  const messages = parsed.messages.map((m, i) => {
-    const raw = rawMessages[i]
-    if (
-      raw &&
-      typeof raw === 'object' &&
-      'parts' in raw &&
-      isValidParts(raw.parts)
-    ) {
-      return { ...m, parts: raw.parts } as UIMessage | ModelMessage
-    }
-    return m as ModelMessage
-  })
-
-  return Promise.resolve({
-    messages,
-    threadId: parsed.threadId,
-    runId: parsed.runId,
-    parentRunId: parsed.parentRunId,
-    tools: parsed.tools as Array<{
-      name: string
-      description: string
-      parameters: JSONSchema
-    }>,
-    forwardedProps: (parsed.forwardedProps ?? {}) as Record<string, unknown>,
-    state: parsed.state,
-    resume: parsed.resume,
+  return {
+    // Unknown top-level fields (e.g. a legacy `cursor`) are dropped by
+    // construction: only the fields below are copied onto the result.
+    messages: messages as Array<UIMessage | ModelMessage>,
+    threadId,
+    runId,
+    parentRunId,
+    tools,
+    forwardedProps: (body.forwardedProps ?? {}) as Record<string, unknown>,
+    state: body.state,
+    resume: resume as Array<RunAgentResumeItem> | undefined,
     context: aguiContext,
     aguiContext,
-  })
+  }
 }
 
 /**

--- a/packages/ai/tests/chat-params.test.ts
+++ b/packages/ai/tests/chat-params.test.ts
@@ -91,6 +91,218 @@ describe('chatParamsFromRequestBody', () => {
   })
 })
 
+// The AG-UI `RunAgentInput` contract is validated structurally rather than by a
+// schema library, so the accept/reject boundary is covered explicitly here.
+describe('chatParamsFromRequestBody — RunAgentInput validation', () => {
+  const base = {
+    threadId: 'thread-1',
+    runId: 'run-1',
+    tools: [],
+    context: [],
+  }
+  const withMessages = (messages: Array<unknown>) => ({ ...base, messages })
+
+  it.each([
+    ['a non-object body', 'not-an-object'],
+    ['a null body', null],
+    ['an array body', []],
+  ])('rejects %s', async (_label, body) => {
+    await expect(chatParamsFromRequestBody(body)).rejects.toThrow(/AG-UI/i)
+  })
+
+  it.each([
+    ['tools', { ...base, tools: undefined, messages: [] }],
+    ['context', { ...base, context: undefined, messages: [] }],
+  ])('rejects a missing required `%s` array', async (_label, body) => {
+    await expect(chatParamsFromRequestBody(body)).rejects.toThrow(/AG-UI/i)
+  })
+
+  it('rejects a non-array `messages`', async () => {
+    await expect(
+      chatParamsFromRequestBody({ ...base, messages: {} }),
+    ).rejects.toThrow(/messages must be an array/)
+  })
+
+  it('reports the offending index and field in the error', async () => {
+    await expect(
+      chatParamsFromRequestBody(
+        withMessages([
+          { id: 'm1', role: 'user', content: 'ok' },
+          { id: 'm2', role: 'user' },
+        ]),
+      ),
+    ).rejects.toThrow(/messages\[1\]\.content/)
+  })
+
+  it('rejects an unknown role', async () => {
+    await expect(
+      chatParamsFromRequestBody(
+        withMessages([{ id: 'm1', role: 'wizard', content: 'hi' }]),
+      ),
+    ).rejects.toThrow(/messages\[0\]\.role/)
+  })
+
+  it('rejects a message without a string id', async () => {
+    await expect(
+      chatParamsFromRequestBody(
+        withMessages([{ id: 7, role: 'user', content: 'hi' }]),
+      ),
+    ).rejects.toThrow(/messages\[0\]\.id/)
+  })
+
+  it.each(['developer', 'system', 'reasoning', 'user'] as const)(
+    'requires string content on a %s message',
+    async (role) => {
+      await expect(
+        chatParamsFromRequestBody(withMessages([{ id: 'm1', role }])),
+      ).rejects.toThrow(/messages\[0\]\.content/)
+    },
+  )
+
+  it('accepts an assistant message with no content (tool-calling turn)', async () => {
+    const result = await chatParamsFromRequestBody(
+      withMessages([
+        {
+          id: 'm1',
+          role: 'assistant',
+          toolCalls: [
+            {
+              id: 'tc1',
+              type: 'function',
+              function: { name: 'greet', arguments: '{}' },
+            },
+          ],
+        },
+      ]),
+    )
+    expect(result.messages).toHaveLength(1)
+  })
+
+  it('accepts multimodal user content as an array', async () => {
+    const result = await chatParamsFromRequestBody(
+      withMessages([
+        {
+          id: 'm1',
+          role: 'user',
+          content: [{ type: 'text', text: 'describe this' }],
+        },
+      ]),
+    )
+    expect(result.messages).toHaveLength(1)
+  })
+
+  it('requires toolCallId on a tool message', async () => {
+    await expect(
+      chatParamsFromRequestBody(
+        withMessages([{ id: 'm1', role: 'tool', content: 'result' }]),
+      ),
+    ).rejects.toThrow(/messages\[0\]\.toolCallId/)
+  })
+
+  it('requires activityType and object content on an activity message', async () => {
+    await expect(
+      chatParamsFromRequestBody(
+        withMessages([{ id: 'm1', role: 'activity', content: {} }]),
+      ),
+    ).rejects.toThrow(/messages\[0\]\.activityType/)
+
+    await expect(
+      chatParamsFromRequestBody(
+        withMessages([
+          { id: 'm1', role: 'activity', activityType: 'search', content: 'no' },
+        ]),
+      ),
+    ).rejects.toThrow(/messages\[0\]\.content/)
+  })
+
+  it('drops `parts` that contain unrecognized part types', async () => {
+    const result = await chatParamsFromRequestBody(
+      withMessages([
+        {
+          id: 'm1',
+          role: 'user',
+          content: 'hi',
+          parts: [{ type: 'not-a-real-part' }],
+        },
+      ]),
+    )
+    expect('parts' in result.messages[0]!).toBe(false)
+  })
+
+  it('rejects a malformed tool declaration', async () => {
+    await expect(
+      chatParamsFromRequestBody({
+        ...base,
+        messages: [],
+        tools: [{ name: 'greet' }],
+      }),
+    ).rejects.toThrow(/tools\[0\]\.description/)
+  })
+
+  it('rejects a malformed context entry', async () => {
+    await expect(
+      chatParamsFromRequestBody({
+        ...base,
+        messages: [],
+        context: [{ description: 'user tz', value: 5 }],
+      }),
+    ).rejects.toThrow(/context\[0\]\.value/)
+  })
+
+  it('rejects an unknown resume status', async () => {
+    await expect(
+      chatParamsFromRequestBody({
+        ...base,
+        messages: [],
+        resume: [{ interruptId: 'i1', status: 'maybe' }],
+      }),
+    ).rejects.toThrow(/resume\[0\]\.status/)
+  })
+
+  it('omits `payload` on resume entries that carry none', async () => {
+    const result = await chatParamsFromRequestBody({
+      ...base,
+      messages: [],
+      resume: [{ interruptId: 'i1', status: 'cancelled' }],
+    })
+    expect(result.resume).toEqual([{ interruptId: 'i1', status: 'cancelled' }])
+    expect('payload' in result.resume![0]!).toBe(false)
+  })
+
+  it('defaults forwardedProps to {} and rejects a non-object one', async () => {
+    const result = await chatParamsFromRequestBody(withMessages([]))
+    expect(result.forwardedProps).toEqual({})
+
+    await expect(
+      chatParamsFromRequestBody({
+        ...withMessages([]),
+        forwardedProps: 'nope',
+      }),
+    ).rejects.toThrow(/forwardedProps/)
+  })
+
+  it('passes `state` through untouched without validating it', async () => {
+    const state = { nested: { count: 1 } }
+    const result = await chatParamsFromRequestBody({
+      ...withMessages([]),
+      state,
+    })
+    expect(result.state).toEqual(state)
+  })
+
+  it('accepts an optional parentRunId and rejects a non-string one', async () => {
+    const result = await chatParamsFromRequestBody({
+      ...withMessages([]),
+      parentRunId: 'parent-1',
+    })
+    expect(result.parentRunId).toBe('parent-1')
+
+    await expect(
+      chatParamsFromRequestBody({ ...withMessages([]), parentRunId: 3 }),
+    ).rejects.toThrow(/parentRunId/)
+  })
+})
+
 describe('chatParamsFromRequest', () => {
   const validBody = {
     threadId: 'thread-1',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1378,8 +1378,8 @@ importers:
   packages/ai:
     dependencies:
       '@ag-ui/core':
-        specifier: ^0.0.57
-        version: 0.0.57
+        specifier: 0.1.1-canary.beta.0
+        version: 0.1.1-canary.beta.0(zod@4.2.1)
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
@@ -2892,8 +2892,13 @@ packages:
   '@acemir/cssom@0.9.29':
     resolution: {integrity: sha512-G90x0VW+9nW4dFajtjCoT+NM0scAfH9Mb08IcjgFHYbfiL/lU04dTF9JuVOi3/OH+DJCQdcIseSXkdCB9Ky6JA==}
 
-  '@ag-ui/core@0.0.57':
-    resolution: {integrity: sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==}
+  '@ag-ui/core@0.1.1-canary.beta.0':
+    resolution: {integrity: sha512-zcP3RH5p3HJTZ0kyQxNOL1blnVFTDpaShitR7UMS/thwFdl48V6CAG+WQBcYEu/dfa8mKonRez88N0Ok+nEI+w==}
+    peerDependencies:
+      zod: ^3.25.18 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@agentclientprotocol/sdk@0.25.1':
     resolution: {integrity: sha512-jx2rF3bdpGwZ75Q/meyEDLLbYmbtxk82Uh9hDCdxDvcEedBnNSF5hZAnL/kJR5VNz56JqwOmqnAqasC84MwwkQ==}
@@ -16722,9 +16727,9 @@ snapshots:
 
   '@acemir/cssom@0.9.29': {}
 
-  '@ag-ui/core@0.0.57':
-    dependencies:
-      zod: 3.25.76
+  '@ag-ui/core@0.1.1-canary.beta.0(zod@4.2.1)':
+    optionalDependencies:
+      zod: 4.2.1
 
   '@agentclientprotocol/sdk@0.25.1(zod@4.3.6)':
     dependencies:


### PR DESCRIPTION
## 🎯 Changes

`@tanstack/ai` no longer pulls zod into consumers' dependency graphs.

**Why it was there.** `@ag-ui/core` listed `zod` as a runtime dependency, so every `@tanstack/ai` install got zod transitively. `0.1.1-canary.beta.0` is the only published version of `@ag-ui/core` that declares zod as an *optional peer* instead — all 59 others, including `0.0.57` (`latest`), `0.0.58-canary.beta.0` and `0.0.59-canary.*`, hard-depend on it.

**Why the bump alone isn't enough.** `chatParamsFromRequest` / `chatParamsFromRequestBody` were the only zod consumers in this package — they validated request bodies with AG-UI's `RunAgentInputSchema`, which the canary moved to the `@ag-ui/core/schemas` subpath. Because that module is re-exported from the package root, importing the subpath (statically *or* lazily) keeps zod on the critical path for anyone doing `import { chat } from '@tanstack/ai'`: a static import makes zod mandatory for every consumer, and an optional peer would let them install without it and crash at import time.

So both helpers now validate the same `RunAgentInput` contract structurally, transcribed from the upstream schema definitions — `tools`/`context` stay required arrays, `parentRunId`/`state`/`forwardedProps`/`resume` optional, messages discriminate on `role` per variant (`assistant` content optional, `user` content string-or-array, `tool` requires `toolCallId`, `activity` requires `activityType` + object content). The role switch is exhaustive rather than `default`-cased, and the role list is keyed `Record<AGUIRole, true>` so a role added upstream fails to compile until it's handled (verified: removing one yields `TS2741`).

**Result:** `@tanstack/ai` ships with no schema-validation runtime at all. Verified by importing the built entry under a resolver hook that blocks `zod` and `@ag-ui/core/schemas` — the root imports fine (98 exports) and request parsing still succeeds.

### No API change

Both helpers keep their signatures, still reject non-conforming bodies with `AGUIError` (`chatParamsFromRequest` still throws a 400 `Response` with the original attached as `cause`), and still carry TanStack's canonical `parts` through on messages. Validation failures now name the offending field — `messages[1].content must be a string` instead of a zod issue dump.

zod remains fully supported for defining tools; it's simply no longer installed on your behalf. Projects that used zod *without declaring it*, relying on the transitive copy, need to add it — called out in the changeset and the migration guide.

### Two deliberate behavior notes

- **`forwardedProps` is now validated as an object.** Upstream typed it `z.any()`, so a non-object previously passed through and violated the declared `Record<string, unknown>` return type. Happy to relax this if the looser contract was intentional.
- **Unknown fields on individual messages now pass through** instead of being stripped by `z.object`, which is more forward-compatible with newer AG-UI message fields. Unknown *top-level* fields are still dropped by construction, so the `cursor` behavior is unchanged and its test still passes.

### Drive-by doc fix

The canary replaced zod-inferred event types with hand-written interfaces, which changes narrowing on the `AGUIEvent` union (`StreamChunk = AGUIEvent`). A middleware snippet in `docs/comparison/vercel-ai-sdk.md` used `'delta' in chunk`, which no longer filters the union — every member is retained and intersected with `Record<'delta', unknown>`, typing `delta` as `unknown` (hence `{}` after `!`). It now discriminates on `type`, the real discriminant, which narrows `delta` to `string` with no non-null assertion. Treated as a correction, so its `updatedAt` isn't bumped; the migration guide's is.

### Tests

25 new cases in `chat-params.test.ts` covering the accept/reject boundary this PR now owns: role validation, per-variant required fields, malformed tool/context/resume entries, `parts` dropping, `state` passthrough, optional `parentRunId`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

Ran the `test:pr` target set directly rather than through the Nx wrapper — in a git worktree on this machine Nx dies with `EISDIR: illegal operation on a directory, lstat 'F:'` and reports phantom successes (it printed "Successfully ran target build for 50 projects" while writing no `dist` at all). Results:

- `test:lib` — 1335 passed (71 files)
- `test:types` — clean for `packages/ai`; 51 projects via Nx
- `test:kiira` — 876/876 snippets, 133 files, 0 errors
- `test:oxlint` — exit 0
- `test:sherif` — no issues
- `test:docs` — no broken links
- `test:build` (publint) — all good
- `build` — all packages, via `pnpm -r`
- E2E — 386 passed, 12 flaky (TTS/image/video provider tests, unrelated), 0 failed

`test:knip` exits 1 on 13 pre-existing config hints (a `packages/react-ai` workspace entry, stale `ignore`/`ignoreDependencies` paths); `knip --no-config-hints` exits 0 and none of the hints relate to this change. Left alone as unrelated config drift.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

One caveat worth an explicit decision: this pins a **canary** (`0.1.1-canary.beta.0`) as an exact version, since `^` on a prerelease doesn't range as you'd expect. It's the only release with zod as a peer, so going zod-free today means shipping against the canary. If you'd rather wait for a stable `0.1.x`, the structural-validation half of this PR stands on its own and can land against `0.0.57`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structural validation for agent requests with clearer errors identifying invalid fields.
  * Preserved supported request formats while filtering malformed content and unknown fields.
* **Bug Fixes**
  * Improved handling of messages, tools, context, resume data, and forwarded properties.
  * Updated middleware event handling for more reliable text content processing.
* **Documentation**
  * Added migration guidance for the optional Zod integration.
  * Updated AG-UI compatibility documentation and dependency information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->