### PR TITLE
feat(ai-openai): add GPT-5.6 Sol, Terra, and Luna models

### DIFF
--- a/.changeset/openai-gpt-5-6-models.md
+++ b/.changeset/openai-gpt-5-6-models.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-openai': minor
+---
+
+Add OpenAI GPT-5.6 family models: `gpt-5.6` (alias → Sol), `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.

--- a/examples/ts-react-chat/src/lib/model-selection.ts
+++ b/examples/ts-react-chat/src/lib/model-selection.ts
@@ -17,6 +17,15 @@ export interface ModelOption {
 
 export const MODEL_OPTIONS: Array<ModelOption> = [
   // OpenAI
+  { provider: 'openai', model: 'gpt-5.6', label: 'OpenAI - GPT-5.6' },
+  { provider: 'openai', model: 'gpt-5.6-sol', label: 'OpenAI - GPT-5.6 Sol' },
+  {
+    provider: 'openai',
+    model: 'gpt-5.6-terra',
+    label: 'OpenAI - GPT-5.6 Terra',
+  },
+  { provider: 'openai', model: 'gpt-5.6-luna', label: 'OpenAI - GPT-5.6 Luna' },
+  { provider: 'openai', model: 'gpt-5.5', label: 'OpenAI - GPT-5.5' },
   { provider: 'openai', model: 'gpt-5.2', label: 'OpenAI - GPT-5.2' },
   { provider: 'openai', model: 'gpt-5.2-pro', label: 'OpenAI - GPT-5.2 Pro' },
   { provider: 'openai', model: 'gpt-5.1', label: 'OpenAI - GPT-5.1' },

--- a/examples/ts-svelte-chat/src/lib/model-selection.ts
+++ b/examples/ts-svelte-chat/src/lib/model-selection.ts
@@ -16,6 +16,7 @@ export const MODEL_OPTIONS: Array<ModelOption> = [
     label: 'OpenAI - GPT-5.6 Terra',
   },
   { provider: 'openai', model: 'gpt-5.6-luna', label: 'OpenAI - GPT-5.6 Luna' },
+  { provider: 'openai', model: 'gpt-5.5', label: 'OpenAI - GPT-5.5' },
   { provider: 'openai', model: 'gpt-4o', label: 'OpenAI - GPT-4o' },
   { provider: 'openai', model: 'gpt-4o-mini', label: 'OpenAI - GPT-4o Mini' },
   { provider: 'openai', model: 'gpt-5', label: 'OpenAI - GPT-5' },

--- a/examples/ts-svelte-chat/src/lib/model-selection.ts
+++ b/examples/ts-svelte-chat/src/lib/model-selection.ts
@@ -8,6 +8,14 @@ export interface ModelOption {
 
 export const MODEL_OPTIONS: Array<ModelOption> = [
   // OpenAI
+  { provider: 'openai', model: 'gpt-5.6', label: 'OpenAI - GPT-5.6' },
+  { provider: 'openai', model: 'gpt-5.6-sol', label: 'OpenAI - GPT-5.6 Sol' },
+  {
+    provider: 'openai',
+    model: 'gpt-5.6-terra',
+    label: 'OpenAI - GPT-5.6 Terra',
+  },
+  { provider: 'openai', model: 'gpt-5.6-luna', label: 'OpenAI - GPT-5.6 Luna' },
   { provider: 'openai', model: 'gpt-4o', label: 'OpenAI - GPT-4o' },
   { provider: 'openai', model: 'gpt-4o-mini', label: 'OpenAI - GPT-4o Mini' },
   { provider: 'openai', model: 'gpt-5', label: 'OpenAI - GPT-5' },

--- a/examples/ts-vue-chat/src/lib/model-selection.ts
+++ b/examples/ts-vue-chat/src/lib/model-selection.ts
@@ -16,6 +16,7 @@ export const MODEL_OPTIONS: Array<ModelOption> = [
     label: 'OpenAI - GPT-5.6 Terra',
   },
   { provider: 'openai', model: 'gpt-5.6-luna', label: 'OpenAI - GPT-5.6 Luna' },
+  { provider: 'openai', model: 'gpt-5.5', label: 'OpenAI - GPT-5.5' },
   { provider: 'openai', model: 'gpt-4o', label: 'OpenAI - GPT-4o' },
   { provider: 'openai', model: 'gpt-4o-mini', label: 'OpenAI - GPT-4o Mini' },
   { provider: 'openai', model: 'gpt-5', label: 'OpenAI - GPT-5' },

--- a/examples/ts-vue-chat/src/lib/model-selection.ts
+++ b/examples/ts-vue-chat/src/lib/model-selection.ts
@@ -8,6 +8,14 @@ export interface ModelOption {
 
 export const MODEL_OPTIONS: Array<ModelOption> = [
   // OpenAI
+  { provider: 'openai', model: 'gpt-5.6', label: 'OpenAI - GPT-5.6' },
+  { provider: 'openai', model: 'gpt-5.6-sol', label: 'OpenAI - GPT-5.6 Sol' },
+  {
+    provider: 'openai',
+    model: 'gpt-5.6-terra',
+    label: 'OpenAI - GPT-5.6 Terra',
+  },
+  { provider: 'openai', model: 'gpt-5.6-luna', label: 'OpenAI - GPT-5.6 Luna' },
   { provider: 'openai', model: 'gpt-4o', label: 'OpenAI - GPT-4o' },
   { provider: 'openai', model: 'gpt-4o-mini', label: 'OpenAI - GPT-4o Mini' },
   { provider: 'openai', model: 'gpt-5', label: 'OpenAI - GPT-5' },

--- a/packages/ai-openai/src/model-meta.ts
+++ b/packages/ai-openai/src/model-meta.ts
@@ -2043,6 +2043,190 @@ const GPT_5_4_IMAGE_2 = {
     OpenAIMetadataOptions
 >
 
+const GPT_5_6 = {
+  name: 'gpt-5.6',
+  context_window: 1_050_000,
+  max_output_tokens: 128_000,
+  knowledge_cutoff: '2026-02-16',
+  supports: {
+    input: ['image', 'text'],
+    output: ['text'],
+    endpoints: ['chat', 'chat-completions'],
+    features: [
+      'streaming',
+      'function_calling',
+      'structured_outputs',
+      'distillation',
+    ],
+    tools: [
+      'web_search',
+      'web_search_preview',
+      'file_search',
+      'image_generation',
+      'code_interpreter',
+      'mcp',
+      'computer_use',
+      'local_shell',
+      'shell',
+      'apply_patch',
+    ],
+  },
+  pricing: {
+    input: {
+      normal: 5,
+      cached: 0.5,
+    },
+    output: {
+      normal: 30,
+    },
+  },
+} as const satisfies ModelMeta<
+  OpenAIBaseOptions &
+    OpenAIReasoningOptions &
+    OpenAIStructuredOutputOptions &
+    OpenAIToolsOptions &
+    OpenAIStreamingOptions &
+    OpenAIMetadataOptions
+>
+
+const GPT_5_6_SOL = {
+  name: 'gpt-5.6-sol',
+  context_window: 1_050_000,
+  max_output_tokens: 128_000,
+  knowledge_cutoff: '2026-02-16',
+  supports: {
+    input: ['image', 'text'],
+    output: ['text'],
+    endpoints: ['chat', 'chat-completions'],
+    features: [
+      'streaming',
+      'function_calling',
+      'structured_outputs',
+      'distillation',
+    ],
+    tools: [
+      'web_search',
+      'web_search_preview',
+      'file_search',
+      'image_generation',
+      'code_interpreter',
+      'mcp',
+      'computer_use',
+      'local_shell',
+      'shell',
+      'apply_patch',
+    ],
+  },
+  pricing: {
+    input: {
+      normal: 5,
+      cached: 0.5,
+    },
+    output: {
+      normal: 30,
+    },
+  },
+} as const satisfies ModelMeta<
+  OpenAIBaseOptions &
+    OpenAIReasoningOptions &
+    OpenAIStructuredOutputOptions &
+    OpenAIToolsOptions &
+    OpenAIStreamingOptions &
+    OpenAIMetadataOptions
+>
+
+const GPT_5_6_TERRA = {
+  name: 'gpt-5.6-terra',
+  context_window: 1_050_000,
+  max_output_tokens: 128_000,
+  knowledge_cutoff: '2026-02-16',
+  supports: {
+    input: ['image', 'text'],
+    output: ['text'],
+    endpoints: ['chat', 'chat-completions'],
+    features: [
+      'streaming',
+      'function_calling',
+      'structured_outputs',
+      'distillation',
+    ],
+    tools: [
+      'web_search',
+      'web_search_preview',
+      'file_search',
+      'image_generation',
+      'code_interpreter',
+      'mcp',
+      'computer_use',
+      'local_shell',
+      'shell',
+      'apply_patch',
+    ],
+  },
+  pricing: {
+    input: {
+      normal: 2,
+      cached: 0.2,
+    },
+    output: {
+      normal: 12,
+    },
+  },
+} as const satisfies ModelMeta<
+  OpenAIBaseOptions &
+    OpenAIReasoningOptions &
+    OpenAIStructuredOutputOptions &
+    OpenAIToolsOptions &
+    OpenAIStreamingOptions &
+    OpenAIMetadataOptions
+>
+
+const GPT_5_6_LUNA = {
+  name: 'gpt-5.6-luna',
+  context_window: 1_050_000,
+  max_output_tokens: 128_000,
+  knowledge_cutoff: '2026-02-16',
+  supports: {
+    input: ['image', 'text'],
+    output: ['text'],
+    endpoints: ['chat', 'chat-completions'],
+    features: [
+      'streaming',
+      'function_calling',
+      'structured_outputs',
+      'distillation',
+    ],
+    tools: [
+      'web_search',
+      'web_search_preview',
+      'file_search',
+      'image_generation',
+      'code_interpreter',
+      'mcp',
+      'computer_use',
+      'local_shell',
+      'shell',
+      'apply_patch',
+    ],
+  },
+  pricing: {
+    input: {
+      normal: 0.2,
+      cached: 0.02,
+    },
+    output: {
+      normal: 1.2,
+    },
+  },
+} as const satisfies ModelMeta<
+  OpenAIBaseOptions &
+    OpenAIReasoningOptions &
+    OpenAIStructuredOutputOptions &
+    OpenAIToolsOptions &
+    OpenAIStreamingOptions &
+    OpenAIMetadataOptions
+>
+
 const GPT_5_5 = {
   name: 'gpt-5.5',
   context_window: 1_050_000,
@@ -2230,6 +2414,10 @@ export const OPENAI_CHAT_MODELS = [
   GPT_5_4_NANO.name,
 
   GPT_5_4_IMAGE_2.name,
+  GPT_5_6.name,
+  GPT_5_6_SOL.name,
+  GPT_5_6_TERRA.name,
+  GPT_5_6_LUNA.name,
   GPT_5_5.name,
   GPT_5_5_PRO.name,
   GPT_CHAT_LATEST.name,
@@ -2522,6 +2710,30 @@ export type OpenAIChatModelProviderOptionsByName = {
     OpenAIToolsOptions &
     OpenAIStreamingOptions &
     OpenAIMetadataOptions
+  [GPT_5_6.name]: OpenAIBaseOptions &
+    OpenAIReasoningOptions &
+    OpenAIStructuredOutputOptions &
+    OpenAIToolsOptions &
+    OpenAIStreamingOptions &
+    OpenAIMetadataOptions
+  [GPT_5_6_SOL.name]: OpenAIBaseOptions &
+    OpenAIReasoningOptions &
+    OpenAIStructuredOutputOptions &
+    OpenAIToolsOptions &
+    OpenAIStreamingOptions &
+    OpenAIMetadataOptions
+  [GPT_5_6_TERRA.name]: OpenAIBaseOptions &
+    OpenAIReasoningOptions &
+    OpenAIStructuredOutputOptions &
+    OpenAIToolsOptions &
+    OpenAIStreamingOptions &
+    OpenAIMetadataOptions
+  [GPT_5_6_LUNA.name]: OpenAIBaseOptions &
+    OpenAIReasoningOptions &
+    OpenAIStructuredOutputOptions &
+    OpenAIToolsOptions &
+    OpenAIStreamingOptions &
+    OpenAIMetadataOptions
   [GPT_5_5.name]: OpenAIBaseOptions &
     OpenAIReasoningOptions &
     OpenAIStructuredOutputOptions &
@@ -2646,6 +2858,10 @@ export type OpenAIModelInputModalitiesByName = {
   [GPT_5_4_MINI.name]: typeof GPT_5_4_MINI.supports.input
   [GPT_5_4_NANO.name]: typeof GPT_5_4_NANO.supports.input
   [GPT_5_4_IMAGE_2.name]: typeof GPT_5_4_IMAGE_2.supports.input
+  [GPT_5_6.name]: typeof GPT_5_6.supports.input
+  [GPT_5_6_SOL.name]: typeof GPT_5_6_SOL.supports.input
+  [GPT_5_6_TERRA.name]: typeof GPT_5_6_TERRA.supports.input
+  [GPT_5_6_LUNA.name]: typeof GPT_5_6_LUNA.supports.input
   [GPT_5_5.name]: typeof GPT_5_5.supports.input
   [GPT_5_5_PRO.name]: typeof GPT_5_5_PRO.supports.input
   [GPT_CHAT_LATEST.name]: typeof GPT_CHAT_LATEST.supports.input

--- a/packages/ai-openai/src/model-meta.ts
+++ b/packages/ai-openai/src/model-meta.ts
@@ -2410,16 +2410,16 @@ export const OPENAI_CHAT_MODELS = [
   O1.name,
   O1_PRO.name,
 
-  GPT_5_4_MINI.name,
-  GPT_5_4_NANO.name,
-
-  GPT_5_4_IMAGE_2.name,
+  // GPT-5.6 / 5.5 / 5.4 extended family
   GPT_5_6.name,
   GPT_5_6_SOL.name,
   GPT_5_6_TERRA.name,
   GPT_5_6_LUNA.name,
   GPT_5_5.name,
   GPT_5_5_PRO.name,
+  GPT_5_4_MINI.name,
+  GPT_5_4_NANO.name,
+  GPT_5_4_IMAGE_2.name,
   GPT_CHAT_LATEST.name,
 ] as const
 
@@ -2800,6 +2800,14 @@ export type OpenAIChatModelToolCapabilitiesByName = {
   [O1_PRO.name]: typeof O1_PRO.supports.tools
   [GPT_5_4_MINI.name]: typeof GPT_5_4_MINI.supports.tools
   [GPT_5_4_NANO.name]: typeof GPT_5_4_NANO.supports.tools
+  [GPT_5_4_IMAGE_2.name]: typeof GPT_5_4_IMAGE_2.supports.tools
+  [GPT_5_6.name]: typeof GPT_5_6.supports.tools
+  [GPT_5_6_SOL.name]: typeof GPT_5_6_SOL.supports.tools
+  [GPT_5_6_TERRA.name]: typeof GPT_5_6_TERRA.supports.tools
+  [GPT_5_6_LUNA.name]: typeof GPT_5_6_LUNA.supports.tools
+  [GPT_5_5.name]: typeof GPT_5_5.supports.tools
+  [GPT_5_5_PRO.name]: typeof GPT_5_5_PRO.supports.tools
+  [GPT_CHAT_LATEST.name]: typeof GPT_CHAT_LATEST.supports.tools
 }
 
 /**

--- a/packages/ai-openai/tests/model-meta.test.ts
+++ b/packages/ai-openai/tests/model-meta.test.ts
@@ -121,6 +121,46 @@ describe('OpenAI Chat Model Provider Options Type Assertions', () => {
       expectTypeOf<Options>().toExtend<OpenAIStreamingOptions>()
       expectTypeOf<Options>().toExtend<BaseOptions>()
     })
+
+    it('gpt-5.6 should support all features', () => {
+      type Options = OpenAIChatModelProviderOptionsByName['gpt-5.6']
+
+      expectTypeOf<Options>().toExtend<OpenAIReasoningOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIStructuredOutputOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIToolsOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIStreamingOptions>()
+      expectTypeOf<Options>().toExtend<BaseOptions>()
+    })
+
+    it('gpt-5.6-sol should support all features', () => {
+      type Options = OpenAIChatModelProviderOptionsByName['gpt-5.6-sol']
+
+      expectTypeOf<Options>().toExtend<OpenAIReasoningOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIStructuredOutputOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIToolsOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIStreamingOptions>()
+      expectTypeOf<Options>().toExtend<BaseOptions>()
+    })
+
+    it('gpt-5.6-terra should support all features', () => {
+      type Options = OpenAIChatModelProviderOptionsByName['gpt-5.6-terra']
+
+      expectTypeOf<Options>().toExtend<OpenAIReasoningOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIStructuredOutputOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIToolsOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIStreamingOptions>()
+      expectTypeOf<Options>().toExtend<BaseOptions>()
+    })
+
+    it('gpt-5.6-luna should support all features', () => {
+      type Options = OpenAIChatModelProviderOptionsByName['gpt-5.6-luna']
+
+      expectTypeOf<Options>().toExtend<OpenAIReasoningOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIStructuredOutputOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIToolsOptions>()
+      expectTypeOf<Options>().toExtend<OpenAIStreamingOptions>()
+      expectTypeOf<Options>().toExtend<BaseOptions>()
+    })
   })
 
   describe('Models WITH reasoning AND structured output AND tools (gpt-5-mini/nano)', () => {
@@ -475,6 +515,10 @@ describe('OpenAI Chat Model Provider Options Type Assertions', () => {
       expectTypeOf<'gpt-5.1-codex'>().toExtend<Keys>()
       expectTypeOf<'gpt-5'>().toExtend<Keys>()
       expectTypeOf<'gpt-5-pro'>().toExtend<Keys>()
+      expectTypeOf<'gpt-5.6'>().toExtend<Keys>()
+      expectTypeOf<'gpt-5.6-sol'>().toExtend<Keys>()
+      expectTypeOf<'gpt-5.6-terra'>().toExtend<Keys>()
+      expectTypeOf<'gpt-5.6-luna'>().toExtend<Keys>()
 
       // Standard models (structured output + tools, no reasoning)
       expectTypeOf<'gpt-5-mini'>().toExtend<Keys>()

--- a/packages/ai-openai/tests/model-sampling-support.test.ts
+++ b/packages/ai-openai/tests/model-sampling-support.test.ts
@@ -17,6 +17,10 @@ describe('openAIModelRejectsSamplingParams', () => {
       'gpt-5.2-pro',
       'gpt-5.5',
       'gpt-5.5-pro',
+      'gpt-5.6',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
       'gpt-5.1-codex-mini',
       'codex-mini-latest',
     ]) {

--- a/packages/ai-openai/tests/tools-per-model-type-safety.test.ts
+++ b/packages/ai-openai/tests/tools-per-model-type-safety.test.ts
@@ -47,9 +47,9 @@ const userTool = toolDefinition({
 describe('OpenAI per-model tool gating', () => {
   // One literal `it` per model so `openaiText('<id>')` is checked against that
   // model's tool capabilities alone — not a union of every row in a table.
-  function assertFullToolSuperset<TAdapter extends ReturnType<typeof openaiText>>(
-    adapter: TAdapter,
-  ) {
+  function assertFullToolSuperset<
+    TAdapter extends ReturnType<typeof openaiText>,
+  >(adapter: TAdapter) {
     typedTools(adapter, [
       userTool,
       webSearchTool({ type: 'web_search' }),

--- a/packages/ai-openai/tests/tools-per-model-type-safety.test.ts
+++ b/packages/ai-openai/tests/tools-per-model-type-safety.test.ts
@@ -73,6 +73,41 @@ describe('OpenAI per-model tool gating', () => {
     ])
   })
 
+  it.each([
+    'gpt-5.6',
+    'gpt-5.6-sol',
+    'gpt-5.6-terra',
+    'gpt-5.6-luna',
+    'gpt-5.5',
+    'gpt-5.5-pro',
+  ] as const)('%s accepts the full tool superset', (model) => {
+    const adapter = openaiText(model)
+    typedTools(adapter, [
+      userTool,
+      webSearchTool({ type: 'web_search' }),
+      webSearchPreviewTool({ type: 'web_search_preview' }),
+      fileSearchTool({ type: 'file_search', vector_store_ids: ['vs_123'] }),
+      imageGenerationTool({}),
+      codeInterpreterTool({
+        type: 'code_interpreter',
+        container: { type: 'auto' },
+      }),
+      mcpTool({
+        server_label: 'my-server',
+        server_url: 'https://example.com/mcp',
+      }),
+      computerUseTool({
+        type: 'computer_use_preview',
+        display_height: 768,
+        display_width: 1024,
+        environment: 'linux',
+      }),
+      localShellTool(),
+      shellTool(),
+      applyPatchTool(),
+    ])
+  })
+
   it('gpt-3.5-turbo rejects every provider tool; user-defined tool is still accepted', () => {
     const adapter = openaiText('gpt-3.5-turbo')
     typedTools(adapter, [

--- a/packages/ai-openai/tests/tools-per-model-type-safety.test.ts
+++ b/packages/ai-openai/tests/tools-per-model-type-safety.test.ts
@@ -45,8 +45,11 @@ const userTool = toolDefinition({
 }).server(async ({ msg }) => msg)
 
 describe('OpenAI per-model tool gating', () => {
-  it('gpt-5.2 accepts the full tool superset', () => {
-    const adapter = openaiText('gpt-5.2')
+  // One literal `it` per model so `openaiText('<id>')` is checked against that
+  // model's tool capabilities alone — not a union of every row in a table.
+  function assertFullToolSuperset<TAdapter extends ReturnType<typeof openaiText>>(
+    adapter: TAdapter,
+  ) {
     typedTools(adapter, [
       userTool,
       webSearchTool({ type: 'web_search' }),
@@ -71,41 +74,34 @@ describe('OpenAI per-model tool gating', () => {
       shellTool(),
       applyPatchTool(),
     ])
+  }
+
+  it('gpt-5.2 accepts the full tool superset', () => {
+    assertFullToolSuperset(openaiText('gpt-5.2'))
   })
 
-  it.each([
-    'gpt-5.6',
-    'gpt-5.6-sol',
-    'gpt-5.6-terra',
-    'gpt-5.6-luna',
-    'gpt-5.5',
-    'gpt-5.5-pro',
-  ] as const)('%s accepts the full tool superset', (model) => {
-    const adapter = openaiText(model)
-    typedTools(adapter, [
-      userTool,
-      webSearchTool({ type: 'web_search' }),
-      webSearchPreviewTool({ type: 'web_search_preview' }),
-      fileSearchTool({ type: 'file_search', vector_store_ids: ['vs_123'] }),
-      imageGenerationTool({}),
-      codeInterpreterTool({
-        type: 'code_interpreter',
-        container: { type: 'auto' },
-      }),
-      mcpTool({
-        server_label: 'my-server',
-        server_url: 'https://example.com/mcp',
-      }),
-      computerUseTool({
-        type: 'computer_use_preview',
-        display_height: 768,
-        display_width: 1024,
-        environment: 'linux',
-      }),
-      localShellTool(),
-      shellTool(),
-      applyPatchTool(),
-    ])
+  it('gpt-5.6 accepts the full tool superset', () => {
+    assertFullToolSuperset(openaiText('gpt-5.6'))
+  })
+
+  it('gpt-5.6-sol accepts the full tool superset', () => {
+    assertFullToolSuperset(openaiText('gpt-5.6-sol'))
+  })
+
+  it('gpt-5.6-terra accepts the full tool superset', () => {
+    assertFullToolSuperset(openaiText('gpt-5.6-terra'))
+  })
+
+  it('gpt-5.6-luna accepts the full tool superset', () => {
+    assertFullToolSuperset(openaiText('gpt-5.6-luna'))
+  })
+
+  it('gpt-5.5 accepts the full tool superset', () => {
+    assertFullToolSuperset(openaiText('gpt-5.5'))
+  })
+
+  it('gpt-5.5-pro accepts the full tool superset', () => {
+    assertFullToolSuperset(openaiText('gpt-5.5-pro'))
   })
 
   it('gpt-3.5-turbo rejects every provider tool; user-defined tool is still accepted', () => {


### PR DESCRIPTION
## 🎯 Changes

OpenAI shipped the GPT-5.6 family (`gpt-5.6` / `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) and `@tanstack/ai-openai` had no model-meta entries for them. Adapters already accept any string at runtime, but without meta the IDs are missing from `OPENAI_CHAT_MODELS`, provider-options typing, input-modality maps, and — critically — `OpenAIChatModelToolCapabilitiesByName` (missing keys resolve to `readonly []`, so typed provider tools are rejected).

This PR adds the four IDs with pricing/context/tools from the OpenAI model pages, wires every type map (including tool capabilities for the new models **and** the pre-existing holes on `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4-image-2`, `gpt-chat-latest`), and surfaces them in the chat example dropdowns.

| Model | Role | Context | Max out | $/1M in · cached · out | Cutoff |
| --- | --- | ---: | ---: | --- | --- |
| `gpt-5.6` | Alias → Sol | 1,050,000 | 128,000 | $5 / $0.50 / $30 | 2026-02-16 |
| `gpt-5.6-sol` | Frontier | 1,050,000 | 128,000 | $5 / $0.50 / $30 | 2026-02-16 |
| `gpt-5.6-terra` | Balanced | 1,050,000 | 128,000 | $2 / $0.20 / $12 | 2026-02-16 |
| `gpt-5.6-luna` | Cost-sensitive | 1,050,000 | 128,000 | $0.20 / $0.02 / $1.20 | 2026-02-16 |

**Files to review (8, +340 / −3):**

| File | Why |
| --- | --- |
| `packages/ai-openai/src/model-meta.ts` *(start here)* | Model consts, `OPENAI_CHAT_MODELS`, provider-options / modalities / **tool-capabilities** maps |
| `packages/ai-openai/tests/tools-per-model-type-safety.test.ts` | Full tool-superset cases for 5.6 + 5.5 (catches the map hole) |
| `packages/ai-openai/tests/model-meta.test.ts` | Provider-options type coverage |
| `packages/ai-openai/tests/model-sampling-support.test.ts` | Confirms sampling strip via existing `gpt-5*` rule |
| `examples/ts-*/src/lib/model-selection.ts` | Dropdown entries only |
| `.changeset/openai-gpt-5-6-models.md` | minor on `@tanstack/ai-openai` |

**Sources:** [gpt-5.6-sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol) · [terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra) · [luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna) · [pricing](https://developers.openai.com/api/docs/pricing)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.
  - Scoped equivalent: `pnpm --filter @tanstack/ai-openai test:types` · `test:lib` (252 pass) · `test:oxlint` (0 errors)

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the GPT-5.6 model family, including standard, Sol, Terra, and Luna variants.
  * Added the new models to chat model selection across React, Svelte, and Vue examples.
  * Added model capabilities for reasoning, structured output, tools, streaming, and supported input types.
  * Included GPT-5.5 in the example model selections.

* **Tests**
  * Expanded coverage for model capabilities, sampling restrictions, and tool compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->