### PR TITLE
feat(ai-gemini): add gemini-3.6-flash and gemini-3.5-flash-lite

### DIFF
--- a/.changeset/gemini-3-6-flash-3-5-flash-lite.md
+++ b/.changeset/gemini-3-6-flash-3-5-flash-lite.md
@@ -4,4 +4,4 @@
 
 Add Gemini 3.6 Flash (`gemini-3.6-flash`) and Gemini 3.5 Flash-Lite (`gemini-3.5-flash-lite`) chat models.
 
-Both are stable GA text models with full multimodal input, thinking, structured output, batch/caching, and the native combined tools + `responseSchema` path. Tool surface includes code execution, file search, Google Search, Google Maps, URL context, and Computer Use (Preview).
+Both are stable GA text models with full multimodal input, thinking, structured output, batch/caching, and the native combined tools + `responseSchema` path. Tool surface includes code execution, file search, Google Search, Google Maps, and URL context. Computer Use (Preview) is listed for 3.6 Flash (and corrected onto existing 3.5 Flash); 3.5 Flash-Lite does not support Computer Use.

--- a/.changeset/gemini-3-6-flash-3-5-flash-lite.md
+++ b/.changeset/gemini-3-6-flash-3-5-flash-lite.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-gemini': minor
+---
+
+Add Gemini 3.6 Flash (`gemini-3.6-flash`) and Gemini 3.5 Flash-Lite (`gemini-3.5-flash-lite`) chat models.
+
+Both are stable GA text models with full multimodal input, thinking, structured output, batch/caching, and the native combined tools + `responseSchema` path. Tool surface includes code execution, file search, Google Search, Google Maps, URL context, and Computer Use (Preview).

--- a/examples/ts-react-chat/src/lib/model-selection.ts
+++ b/examples/ts-react-chat/src/lib/model-selection.ts
@@ -57,6 +57,21 @@ export const MODEL_OPTIONS: Array<ModelOption> = [
   // Gemini (stateless `geminiText`)
   {
     provider: 'gemini',
+    model: 'gemini-3.6-flash',
+    label: 'Gemini - 3.6 Flash',
+  },
+  {
+    provider: 'gemini',
+    model: 'gemini-3.5-flash',
+    label: 'Gemini - 3.5 Flash',
+  },
+  {
+    provider: 'gemini',
+    model: 'gemini-3.5-flash-lite',
+    label: 'Gemini - 3.5 Flash Lite',
+  },
+  {
+    provider: 'gemini',
     model: 'gemini-3.1-pro-preview',
     label: 'Gemini - 3.1 Pro Preview',
   },
@@ -79,13 +94,23 @@ export const MODEL_OPTIONS: Array<ModelOption> = [
   // Gemini Interactions (stateful, experimental — `@tanstack/ai-gemini/experimental`)
   {
     provider: 'gemini-interactions',
-    model: 'gemini-3.1-pro-preview',
-    label: 'Gemini Interactions - 3.1 Pro Preview (experimental)',
+    model: 'gemini-3.6-flash',
+    label: 'Gemini Interactions - 3.6 Flash (experimental)',
   },
   {
     provider: 'gemini-interactions',
     model: 'gemini-3.5-flash',
     label: 'Gemini Interactions - 3.5 Flash (experimental)',
+  },
+  {
+    provider: 'gemini-interactions',
+    model: 'gemini-3.5-flash-lite',
+    label: 'Gemini Interactions - 3.5 Flash Lite (experimental)',
+  },
+  {
+    provider: 'gemini-interactions',
+    model: 'gemini-3.1-pro-preview',
+    label: 'Gemini Interactions - 3.1 Pro Preview (experimental)',
   },
   {
     provider: 'gemini-interactions',

--- a/examples/ts-react-chat/src/routes/api.structured-output.ts
+++ b/examples/ts-react-chat/src/routes/api.structured-output.ts
@@ -160,10 +160,10 @@ function adapterFor(provider: Provider, model?: string): AnyTextAdapter {
       // for the combination and falls back to the engine's legacy
       // finalization path.
       //
-      // Default is `gemini-3.5-flash`: the newest *stable* (non-preview)
+      // Default is `gemini-3.6-flash`: the newest *stable* (non-preview)
       // 3.x id, matching the dropdown's first entry. The previous default
       // (`gemini-3-pro-preview`) was retired by Google and now 404s.
-      return geminiText((baseModel || 'gemini-3.5-flash') as 'gemini-3.5-flash')
+      return geminiText((baseModel || 'gemini-3.6-flash') as 'gemini-3.6-flash')
     case 'grok':
       return grokText((model || 'grok-build-0.1') as 'grok-build-0.1')
     case 'groq':

--- a/examples/ts-react-chat/src/routes/generations.structured-output.tsx
+++ b/examples/ts-react-chat/src/routes/generations.structured-output.tsx
@@ -80,7 +80,9 @@ const PROVIDER_MODELS: Record<
   // keys on the exact string, so any drift here silently breaks
   // combined-mode routing.
   gemini: [
+    { value: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash' },
     { value: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
+    { value: 'gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite' },
     { value: 'gemini-3-flash-preview', label: 'Gemini 3 Flash (Preview)' },
     { value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro (Preview)' },
     { value: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },

--- a/packages/ai-gemini/src/model-meta.ts
+++ b/packages/ai-gemini/src/model-meta.ts
@@ -743,6 +743,48 @@ const GEMINI_OMNI_FLASH_PREVIEW = {
     GeminiCachedContentOptions
 >
 
+const GEMINI_3_6_FLASH = {
+  name: 'gemini-3.6-flash',
+  max_input_tokens: 1_048_576,
+  max_output_tokens: 65_536,
+  knowledge_cutoff: '2025-01-01',
+  supports: {
+    input: ['text', 'image', 'video', 'audio', 'document'],
+    output: ['text'],
+    capabilities: [
+      'batch_api',
+      'caching',
+      'function_calling',
+      'structured_output',
+      'thinking',
+    ],
+    tools: [
+      'code_execution',
+      'file_search',
+      'google_search',
+      'google_maps',
+      'url_context',
+      'computer_use',
+    ],
+  },
+  pricing: {
+    input: {
+      normal: 1.5,
+      cached: 0.15,
+    },
+    output: {
+      normal: 7.5,
+    },
+  },
+} as const satisfies ModelMeta<
+  GeminiToolConfigOptions &
+    GeminiSafetyOptions &
+    GeminiCommonConfigOptions &
+    GeminiCachedContentOptions &
+    GeminiStructuredOutputOptions &
+    GeminiThinkingOptions
+>
+
 const GEMINI_3_5_FLASH = {
   name: 'gemini-3.5-flash',
   max_input_tokens: 1_048_576,
@@ -777,8 +819,52 @@ const GEMINI_3_5_FLASH = {
     GeminiThinkingOptions
 >
 
+const GEMINI_3_5_FLASH_LITE = {
+  name: 'gemini-3.5-flash-lite',
+  max_input_tokens: 1_048_576,
+  max_output_tokens: 65_536,
+  knowledge_cutoff: '2025-01-01',
+  supports: {
+    input: ['text', 'image', 'video', 'audio', 'document'],
+    output: ['text'],
+    capabilities: [
+      'batch_api',
+      'caching',
+      'function_calling',
+      'structured_output',
+      'thinking',
+    ],
+    tools: [
+      'code_execution',
+      'file_search',
+      'google_search',
+      'google_maps',
+      'url_context',
+      'computer_use',
+    ],
+  },
+  pricing: {
+    input: {
+      normal: 0.3,
+      cached: 0.03,
+    },
+    output: {
+      normal: 2.5,
+    },
+  },
+} as const satisfies ModelMeta<
+  GeminiToolConfigOptions &
+    GeminiSafetyOptions &
+    GeminiCommonConfigOptions &
+    GeminiCachedContentOptions &
+    GeminiStructuredOutputOptions &
+    GeminiThinkingOptions
+>
+
 export const GEMINI_MODELS = [
+  GEMINI_3_6_FLASH.name,
   GEMINI_3_5_FLASH.name,
+  GEMINI_3_5_FLASH_LITE.name,
   GEMINI_3_1_PRO.name,
   GEMINI_3_FLASH.name,
   GEMINI_3_1_FLASH_LITE.name,
@@ -796,11 +882,13 @@ export const GEMINI_MODELS = [
  * brittle and keeps the engine's legacy finalization fallback.
  */
 export const GEMINI_COMBINED_TOOLS_AND_SCHEMA_MODELS = new Set<string>([
+  GEMINI_3_6_FLASH.name,
+  GEMINI_3_5_FLASH.name,
+  GEMINI_3_5_FLASH_LITE.name,
   GEMINI_3_1_PRO.name,
   GEMINI_3_FLASH.name,
   GEMINI_3_1_FLASH_LITE.name,
   GEMINI_3_1_FLASH_LITE_PREVIEW.name,
-  GEMINI_3_5_FLASH.name,
 ])
 
 export type GeminiModels = (typeof GEMINI_MODELS)[number]
@@ -900,6 +988,24 @@ export const GEMINI_INTERACTIONS_VIDEO_MODELS = [
 // Manual type map for per-model provider options
 export type GeminiChatModelProviderOptionsByName = {
   // Models with thinking and structured output support
+  [GEMINI_3_6_FLASH.name]: GeminiToolConfigOptions &
+    GeminiSafetyOptions &
+    GeminiCommonConfigOptions &
+    GeminiCachedContentOptions &
+    GeminiStructuredOutputOptions &
+    GeminiThinkingOptions
+  [GEMINI_3_5_FLASH.name]: GeminiToolConfigOptions &
+    GeminiSafetyOptions &
+    GeminiCommonConfigOptions &
+    GeminiCachedContentOptions &
+    GeminiStructuredOutputOptions &
+    GeminiThinkingOptions
+  [GEMINI_3_5_FLASH_LITE.name]: GeminiToolConfigOptions &
+    GeminiSafetyOptions &
+    GeminiCommonConfigOptions &
+    GeminiCachedContentOptions &
+    GeminiStructuredOutputOptions &
+    GeminiThinkingOptions
   [GEMINI_3_1_PRO.name]: GeminiToolConfigOptions &
     GeminiSafetyOptions &
     GeminiCommonConfigOptions &
@@ -942,12 +1048,6 @@ export type GeminiChatModelProviderOptionsByName = {
     GeminiCachedContentOptions &
     GeminiStructuredOutputOptions &
     GeminiThinkingOptions
-  [GEMINI_3_5_FLASH.name]: GeminiToolConfigOptions &
-    GeminiSafetyOptions &
-    GeminiCommonConfigOptions &
-    GeminiCachedContentOptions &
-    GeminiStructuredOutputOptions &
-    GeminiThinkingOptions
 }
 
 /**
@@ -955,6 +1055,9 @@ export type GeminiChatModelProviderOptionsByName = {
  * Based on the 'supports.tools' arrays defined for each model.
  */
 export type GeminiChatModelToolCapabilitiesByName = {
+  [GEMINI_3_6_FLASH.name]: typeof GEMINI_3_6_FLASH.supports.tools
+  [GEMINI_3_5_FLASH.name]: typeof GEMINI_3_5_FLASH.supports.tools
+  [GEMINI_3_5_FLASH_LITE.name]: typeof GEMINI_3_5_FLASH_LITE.supports.tools
   [GEMINI_3_1_PRO.name]: typeof GEMINI_3_1_PRO.supports.tools
   [GEMINI_3_FLASH.name]: typeof GEMINI_3_FLASH.supports.tools
   [GEMINI_3_1_FLASH_LITE.name]: typeof GEMINI_3_1_FLASH_LITE.supports.tools
@@ -962,7 +1065,6 @@ export type GeminiChatModelToolCapabilitiesByName = {
   [GEMINI_2_5_PRO.name]: typeof GEMINI_2_5_PRO.supports.tools
   [GEMINI_2_5_FLASH.name]: typeof GEMINI_2_5_FLASH.supports.tools
   [GEMINI_2_5_FLASH_LITE.name]: typeof GEMINI_2_5_FLASH_LITE.supports.tools
-  [GEMINI_3_5_FLASH.name]: typeof GEMINI_3_5_FLASH.supports.tools
 }
 
 /**
@@ -980,13 +1082,15 @@ export type GeminiChatModelToolCapabilitiesByName = {
  */
 export type GeminiModelInputModalitiesByName = {
   // Models with full multimodal support (text, image, audio, video, document)
+  [GEMINI_3_6_FLASH.name]: typeof GEMINI_3_6_FLASH.supports.input
+  [GEMINI_3_5_FLASH.name]: typeof GEMINI_3_5_FLASH.supports.input
+  [GEMINI_3_5_FLASH_LITE.name]: typeof GEMINI_3_5_FLASH_LITE.supports.input
   [GEMINI_3_1_PRO.name]: typeof GEMINI_3_1_PRO.supports.input
   [GEMINI_3_FLASH.name]: typeof GEMINI_3_FLASH.supports.input
   [GEMINI_3_1_FLASH_LITE.name]: typeof GEMINI_3_1_FLASH_LITE.supports.input
   [GEMINI_3_1_FLASH_LITE_PREVIEW.name]: typeof GEMINI_3_1_FLASH_LITE_PREVIEW.supports.input
   [GEMINI_2_5_PRO.name]: typeof GEMINI_2_5_PRO.supports.input
   [GEMINI_2_5_FLASH_LITE.name]: typeof GEMINI_2_5_FLASH_LITE.supports.input
-  [GEMINI_3_5_FLASH.name]: typeof GEMINI_3_5_FLASH.supports.input
 
   // Models with text, image, audio, video (no document)
   [GEMINI_2_5_FLASH.name]: typeof GEMINI_2_5_FLASH.supports.input

--- a/packages/ai-gemini/src/model-meta.ts
+++ b/packages/ai-gemini/src/model-meta.ts
@@ -799,7 +799,14 @@ const GEMINI_3_5_FLASH = {
       'structured_output',
       'thinking',
     ],
-    tools: ['code_execution', 'file_search', 'google_search', 'url_context'],
+    tools: [
+      'code_execution',
+      'file_search',
+      'google_search',
+      'google_maps',
+      'url_context',
+      'computer_use',
+    ],
   },
   pricing: {
     input: {
@@ -840,7 +847,6 @@ const GEMINI_3_5_FLASH_LITE = {
       'google_search',
       'google_maps',
       'url_context',
-      'computer_use',
     ],
   },
   pricing: {

--- a/packages/ai-gemini/src/model-meta.ts
+++ b/packages/ai-gemini/src/model-meta.ts
@@ -747,7 +747,7 @@ const GEMINI_3_6_FLASH = {
   name: 'gemini-3.6-flash',
   max_input_tokens: 1_048_576,
   max_output_tokens: 65_536,
-  knowledge_cutoff: '2025-01-01',
+  knowledge_cutoff: '2026-03-01',
   supports: {
     input: ['text', 'image', 'video', 'audio', 'document'],
     output: ['text'],

--- a/packages/ai-gemini/tests/model-meta.test.ts
+++ b/packages/ai-gemini/tests/model-meta.test.ts
@@ -195,6 +195,24 @@ describe('Gemini Model Provider Options Type Assertions', () => {
       // Should have base options
       expectTypeOf<Options>().toExtend<BaseOptions>()
     })
+
+    it('gemini-3.6-flash should support thinking options', () => {
+      type Model = 'gemini-3.6-flash'
+      type Options = GeminiChatModelProviderOptionsByName[Model]
+
+      expectTypeOf<Options>().toExtend<GeminiThinkingOptions>()
+      expectTypeOf<Options>().toExtend<GeminiStructuredOutputOptions>()
+      expectTypeOf<Options>().toExtend<BaseOptions>()
+    })
+
+    it('gemini-3.5-flash-lite should support thinking options', () => {
+      type Model = 'gemini-3.5-flash-lite'
+      type Options = GeminiChatModelProviderOptionsByName[Model]
+
+      expectTypeOf<Options>().toExtend<GeminiThinkingOptions>()
+      expectTypeOf<Options>().toExtend<GeminiStructuredOutputOptions>()
+      expectTypeOf<Options>().toExtend<BaseOptions>()
+    })
   })
 
   describe('Provider options type completeness', () => {
@@ -202,6 +220,9 @@ describe('Gemini Model Provider Options Type Assertions', () => {
       // Verify the type map has all expected model keys
       type Keys = keyof GeminiChatModelProviderOptionsByName
 
+      expectTypeOf<'gemini-3.6-flash'>().toExtend<Keys>()
+      expectTypeOf<'gemini-3.5-flash'>().toExtend<Keys>()
+      expectTypeOf<'gemini-3.5-flash-lite'>().toExtend<Keys>()
       expectTypeOf<'gemini-3.1-pro-preview'>().toExtend<Keys>()
       expectTypeOf<'gemini-3-flash-preview'>().toExtend<Keys>()
       expectTypeOf<'gemini-3.1-flash-lite'>().toExtend<Keys>()
@@ -209,7 +230,6 @@ describe('Gemini Model Provider Options Type Assertions', () => {
       expectTypeOf<'gemini-2.5-pro'>().toExtend<Keys>()
       expectTypeOf<'gemini-2.5-flash'>().toExtend<Keys>()
       expectTypeOf<'gemini-2.5-flash-lite'>().toExtend<Keys>()
-      expectTypeOf<'gemini-3.5-flash'>().toExtend<Keys>()
     })
 
     it('GeminiChatModelProviderOptionsByName should NOT have entries for retired models', () => {
@@ -242,6 +262,15 @@ describe('Gemini Model Provider Options Type Assertions', () => {
 
     it('all models should have safety settings', () => {
       expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.6-flash']
+      >().toHaveProperty('safetySettings')
+      expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.5-flash']
+      >().toHaveProperty('safetySettings')
+      expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.5-flash-lite']
+      >().toHaveProperty('safetySettings')
+      expectTypeOf<
         GeminiChatModelProviderOptionsByName['gemini-3.1-pro-preview']
       >().toHaveProperty('safetySettings')
       expectTypeOf<
@@ -261,14 +290,20 @@ describe('Gemini Model Provider Options Type Assertions', () => {
       >().toHaveProperty('safetySettings')
       expectTypeOf<
         GeminiChatModelProviderOptionsByName['gemini-2.5-flash-lite']
-      >().toHaveProperty('safetySettings')
-      expectTypeOf<
-        GeminiChatModelProviderOptionsByName['gemini-3.5-flash']
       >().toHaveProperty('safetySettings')
     })
 
     it('all models should have tool config', () => {
       expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.6-flash']
+      >().toHaveProperty('toolConfig')
+      expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.5-flash']
+      >().toHaveProperty('toolConfig')
+      expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.5-flash-lite']
+      >().toHaveProperty('toolConfig')
+      expectTypeOf<
         GeminiChatModelProviderOptionsByName['gemini-3.1-pro-preview']
       >().toHaveProperty('toolConfig')
       expectTypeOf<
@@ -288,14 +323,20 @@ describe('Gemini Model Provider Options Type Assertions', () => {
       >().toHaveProperty('toolConfig')
       expectTypeOf<
         GeminiChatModelProviderOptionsByName['gemini-2.5-flash-lite']
-      >().toHaveProperty('toolConfig')
-      expectTypeOf<
-        GeminiChatModelProviderOptionsByName['gemini-3.5-flash']
       >().toHaveProperty('toolConfig')
     })
 
     it('all models should have cached content option', () => {
       expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.6-flash']
+      >().toHaveProperty('cachedContent')
+      expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.5-flash']
+      >().toHaveProperty('cachedContent')
+      expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.5-flash-lite']
+      >().toHaveProperty('cachedContent')
+      expectTypeOf<
         GeminiChatModelProviderOptionsByName['gemini-3.1-pro-preview']
       >().toHaveProperty('cachedContent')
       expectTypeOf<
@@ -315,9 +356,6 @@ describe('Gemini Model Provider Options Type Assertions', () => {
       >().toHaveProperty('cachedContent')
       expectTypeOf<
         GeminiChatModelProviderOptionsByName['gemini-2.5-flash-lite']
-      >().toHaveProperty('cachedContent')
-      expectTypeOf<
-        GeminiChatModelProviderOptionsByName['gemini-3.5-flash']
       >().toHaveProperty('cachedContent')
     })
   })
@@ -325,6 +363,15 @@ describe('Gemini Model Provider Options Type Assertions', () => {
   describe('Type discrimination between model categories', () => {
     it('models with thinking should extend GeminiThinkingOptions', () => {
       expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.6-flash']
+      >().toExtend<GeminiThinkingOptions>()
+      expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.5-flash']
+      >().toExtend<GeminiThinkingOptions>()
+      expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.5-flash-lite']
+      >().toExtend<GeminiThinkingOptions>()
+      expectTypeOf<
         GeminiChatModelProviderOptionsByName['gemini-3.1-pro-preview']
       >().toExtend<GeminiThinkingOptions>()
       expectTypeOf<
@@ -344,14 +391,20 @@ describe('Gemini Model Provider Options Type Assertions', () => {
       >().toExtend<GeminiThinkingOptions>()
       expectTypeOf<
         GeminiChatModelProviderOptionsByName['gemini-2.5-flash-lite']
-      >().toExtend<GeminiThinkingOptions>()
-      expectTypeOf<
-        GeminiChatModelProviderOptionsByName['gemini-3.5-flash']
       >().toExtend<GeminiThinkingOptions>()
     })
 
     it('all models should extend GeminiStructuredOutputOptions', () => {
       expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.6-flash']
+      >().toExtend<GeminiStructuredOutputOptions>()
+      expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.5-flash']
+      >().toExtend<GeminiStructuredOutputOptions>()
+      expectTypeOf<
+        GeminiChatModelProviderOptionsByName['gemini-3.5-flash-lite']
+      >().toExtend<GeminiStructuredOutputOptions>()
+      expectTypeOf<
         GeminiChatModelProviderOptionsByName['gemini-3.1-pro-preview']
       >().toExtend<GeminiStructuredOutputOptions>()
       expectTypeOf<
@@ -371,9 +424,6 @@ describe('Gemini Model Provider Options Type Assertions', () => {
       >().toExtend<GeminiStructuredOutputOptions>()
       expectTypeOf<
         GeminiChatModelProviderOptionsByName['gemini-2.5-flash-lite']
-      >().toExtend<GeminiStructuredOutputOptions>()
-      expectTypeOf<
-        GeminiChatModelProviderOptionsByName['gemini-3.5-flash']
       >().toExtend<GeminiStructuredOutputOptions>()
     })
   })
@@ -386,12 +436,14 @@ describe('Gemini Model Provider Options Type Assertions', () => {
  * content parts based on each Gemini model's supported input modalities.
  *
  * Models with full multimodal (text + image + audio + video + document):
+ * - gemini-3.6-flash
+ * - gemini-3.5-flash
+ * - gemini-3.5-flash-lite
  * - gemini-3.1-pro-preview
  * - gemini-3-flash-preview
  * - gemini-3.1-flash-lite (and preview)
  * - gemini-2.5-pro
  * - gemini-2.5-flash-lite
- * - gemini-3.5-flash
  *
  * Models with limited multimodal (text + image + audio + video, NO document):
  * - gemini-2.5-flash
@@ -490,6 +542,32 @@ describe('Gemini Model Input Modality Type Assertions', () => {
 
   describe('gemini-3.5-flash (full multimodal)', () => {
     type Modalities = GeminiModelInputModalitiesByName['gemini-3.5-flash']
+    type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
+
+    it('should allow all content part types', () => {
+      expectTypeOf<MessageWithContent<GeminiTextPart>>().toExtend<Message>()
+      expectTypeOf<MessageWithContent<GeminiImagePart>>().toExtend<Message>()
+      expectTypeOf<MessageWithContent<GeminiAudioPart>>().toExtend<Message>()
+      expectTypeOf<MessageWithContent<GeminiVideoPart>>().toExtend<Message>()
+      expectTypeOf<MessageWithContent<GeminiDocumentPart>>().toExtend<Message>()
+    })
+  })
+
+  describe('gemini-3.6-flash (full multimodal)', () => {
+    type Modalities = GeminiModelInputModalitiesByName['gemini-3.6-flash']
+    type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
+
+    it('should allow all content part types', () => {
+      expectTypeOf<MessageWithContent<GeminiTextPart>>().toExtend<Message>()
+      expectTypeOf<MessageWithContent<GeminiImagePart>>().toExtend<Message>()
+      expectTypeOf<MessageWithContent<GeminiAudioPart>>().toExtend<Message>()
+      expectTypeOf<MessageWithContent<GeminiVideoPart>>().toExtend<Message>()
+      expectTypeOf<MessageWithContent<GeminiDocumentPart>>().toExtend<Message>()
+    })
+  })
+
+  describe('gemini-3.5-flash-lite (full multimodal)', () => {
+    type Modalities = GeminiModelInputModalitiesByName['gemini-3.5-flash-lite']
     type Message = ConstrainedModelMessage<MakeInputModalitiesTypes<Modalities>>
 
     it('should allow all content part types', () => {

--- a/packages/ai-gemini/tests/tools-per-model-type-safety.test.ts
+++ b/packages/ai-gemini/tests/tools-per-model-type-safety.test.ts
@@ -99,4 +99,40 @@ describe('Gemini per-model tool gating', () => {
       googleSearchRetrievalTool(),
     ])
   })
+
+  it('gemini-3.6-flash accepts code_execution, file_search, google_search, google_maps, url_context, computer_use', () => {
+    const adapter = geminiText('gemini-3.6-flash')
+    typedTools(adapter, [
+      userTool,
+      codeExecutionTool(),
+      fileSearchTool({ fileSearchStoreNames: [] }),
+      googleSearchTool(),
+      googleMapsTool(),
+      urlContextTool(),
+      computerUseTool({
+        environment: Environment.ENVIRONMENT_BROWSER,
+        excludedPredefinedFunctions: [],
+      }),
+      // @ts-expect-error - gemini-3.6-flash does not support google_search_retrieval
+      googleSearchRetrievalTool(),
+    ])
+  })
+
+  it('gemini-3.5-flash-lite accepts code_execution, file_search, google_search, google_maps, url_context, computer_use', () => {
+    const adapter = geminiText('gemini-3.5-flash-lite')
+    typedTools(adapter, [
+      userTool,
+      codeExecutionTool(),
+      fileSearchTool({ fileSearchStoreNames: [] }),
+      googleSearchTool(),
+      googleMapsTool(),
+      urlContextTool(),
+      computerUseTool({
+        environment: Environment.ENVIRONMENT_BROWSER,
+        excludedPredefinedFunctions: [],
+      }),
+      // @ts-expect-error - gemini-3.5-flash-lite does not support google_search_retrieval
+      googleSearchRetrievalTool(),
+    ])
+  })
 })

--- a/packages/ai-gemini/tests/tools-per-model-type-safety.test.ts
+++ b/packages/ai-gemini/tests/tools-per-model-type-safety.test.ts
@@ -118,7 +118,25 @@ describe('Gemini per-model tool gating', () => {
     ])
   })
 
-  it('gemini-3.5-flash-lite accepts code_execution, file_search, google_search, google_maps, url_context, computer_use', () => {
+  it('gemini-3.5-flash accepts code_execution, file_search, google_search, google_maps, url_context, computer_use', () => {
+    const adapter = geminiText('gemini-3.5-flash')
+    typedTools(adapter, [
+      userTool,
+      codeExecutionTool(),
+      fileSearchTool({ fileSearchStoreNames: [] }),
+      googleSearchTool(),
+      googleMapsTool(),
+      urlContextTool(),
+      computerUseTool({
+        environment: Environment.ENVIRONMENT_BROWSER,
+        excludedPredefinedFunctions: [],
+      }),
+      // @ts-expect-error - gemini-3.5-flash does not support google_search_retrieval
+      googleSearchRetrievalTool(),
+    ])
+  })
+
+  it('gemini-3.5-flash-lite accepts code_execution, file_search, google_search, google_maps, url_context but rejects computer_use', () => {
     const adapter = geminiText('gemini-3.5-flash-lite')
     typedTools(adapter, [
       userTool,
@@ -127,6 +145,7 @@ describe('Gemini per-model tool gating', () => {
       googleSearchTool(),
       googleMapsTool(),
       urlContextTool(),
+      // @ts-expect-error - gemini-3.5-flash-lite does not support computer_use
       computerUseTool({
         environment: Environment.ENVIRONMENT_BROWSER,
         excludedPredefinedFunctions: [],


### PR DESCRIPTION
## 🎯 Changes

Google GA'd `gemini-3.6-flash` and `gemini-3.5-flash-lite`; only `gemini-3.5-flash` was already in `@tanstack/ai-gemini`. Without meta entries the new IDs are absent from `GEMINI_MODELS`, the combined tools+schema allow-list, and the per-model type maps that gate provider options, tools, and input modalities.

This PR adds both stable chat models, puts them on the combined tools+schema path, and corrects adjacent 3.5 Flash tool metadata against the official model cards:

| Model | In / out tokens | $/1M in · cached · out | Tools (notable) |
| --- | --- | --- | --- |
| `gemini-3.6-flash` *(new)* | 1,048,576 / 65,536 | $1.50 · $0.15 · $7.50 | + `google_maps`, `computer_use` |
| `gemini-3.5-flash-lite` *(new)* | 1,048,576 / 65,536 | $0.30 · $0.03 · $2.50 | + `google_maps`; **no** `computer_use` |
| `gemini-3.5-flash` *(existing, fixed)* | unchanged limits/pricing | unchanged | was missing `google_maps` + `computer_use` |

No cyber-only / image / TTS / video variants. No removals. `gemini-3.5-pro` is not GA on the checked Gemini API model pages.

**Files to review (7, +308 / −31):**

| File | Why |
| --- | --- |
| `packages/ai-gemini/src/model-meta.ts` *(start here)* | New consts, `GEMINI_MODELS`, combined-tools set, all three type maps, 3.5 Flash tool fix |
| `packages/ai-gemini/tests/tools-per-model-type-safety.test.ts` | Tool accept/reject cases for 3.6, 3.5 Flash, 3.5 Flash-Lite |
| `packages/ai-gemini/tests/model-meta.test.ts` | Provider-options + modality type coverage |
| `examples/ts-react-chat/...` | Dropdowns + structured-output default → `gemini-3.6-flash` |
| `.changeset/gemini-3-6-flash-3-5-flash-lite.md` | minor on `@tanstack/ai-gemini` |

**Sources:** [models index](https://ai.google.dev/gemini-api/docs/models) · [3.6 Flash](https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash) · [3.5 Flash-Lite](https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite) · [latest-model](https://ai.google.dev/gemini-api/docs/latest-model) · [pricing](https://ai.google.dev/gemini-api/docs/pricing)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.
  - Scoped equivalent: `pnpm --filter @tanstack/ai-gemini test:types` · `test:lib` (244 pass) · `test:oxlint` (0 errors)

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gemini 3.6 Flash and Gemini 3.5 Flash-Lite chat models.
  * Added multimodal input, structured output, thinking, caching, batch processing, and expanded tool integrations.
  * Added the new models to model selectors and structured-output examples.
  * Expanded Gemini 3.5 Flash support for Google Maps and computer-use tools.

* **Documentation**
  * Documented model capabilities, supported tools, and feature limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->