### PR TITLE
fix(scripts): sync-models array insertion breaks on single-line arrays

### DIFF
--- a/scripts/sync-provider-models.ts
+++ b/scripts/sync-provider-models.ts
@@ -475,7 +475,16 @@ function insertConstants(content: string, constants: Array<string>): string {
 
 /**
  * Add entries to an array like: export const ARRAY_NAME = [ ... ] as const
- * Uses a regex with the `s` flag (dotAll) to match across newlines.
+ *
+ * New entries are inserted immediately AFTER the opening bracket, so this
+ * only ever writes separators it owns: each inserted line carries its own
+ * trailing comma, and the existing body — multi-line with trailing commas, a
+ * short single-line array, comment lines, or nothing at all — follows
+ * unchanged. Inserting before the CLOSING bracket instead means guessing
+ * whether the last existing entry already has a comma, which is how a
+ * single-line `GROK_CHAT_MODELS` produced a syntax error (and a dead daily
+ * sync) the day grok-4.5 arrived. `pnpm format` reflows the result, so the
+ * inserted lines only need to parse, not to be pretty.
  */
 function addToArray(
   content: string,
@@ -483,13 +492,9 @@ function addToArray(
   entries: Array<string>,
   arrayRef: string,
 ): string {
-  // Match the array declaration: export const ARRAY_NAME = [...] as const
-  // Uses [\s\S]*? (non-greedy) instead of [^\]]* to handle ] inside comments
-  const pattern = new RegExp(
-    `(export const ${arrayName} = \\[\\s*[\\s\\S]*?)(\\] as const)`,
-  )
-  const match = pattern.exec(content)
-  if (!match) {
+  const open = `export const ${arrayName} = [`
+  const openIndex = content.indexOf(open)
+  if (openIndex === -1) {
     console.warn(`  Warning: Could not find array '${arrayName}' in file`)
     return content
   }
@@ -497,11 +502,8 @@ function addToArray(
   const newEntries = entries
     .map((constName) => `  ${constName}${arrayRef},`)
     .join('\n')
-  // Use replacer function to prevent $-character interpretation in replacement string
-  return content.replace(
-    pattern,
-    () => `${match[1]}\n${newEntries}\n${match[2]}`,
-  )
+  const insertAt = openIndex + open.length
+  return `${content.slice(0, insertAt)}\n${newEntries}${content.slice(insertAt)}`
 }
 
 /**


### PR DESCRIPTION
## The outage

The daily **Sync Model Metadata** workflow has failed on every run since **July 9** (last success: July 8, 08:02 UTC). Eleven new models across four providers are stranded behind it:

- `grok-4.5` (xAI)
- `gemini-3.5-flash-lite`, `gemini-3.6-flash`
- the GPT-5.6 trio (`sol` / `terra` / `luna` — being hand-added in #1040 as a workaround)
- `claude-opus-5`, `claude-opus-5-fast`

## Root cause

`addToArray` in `scripts/sync-provider-models.ts` inserted new entries just **before the closing bracket**, assuming the last existing entry ended with a trailing comma — true for every provider's long, oxfmt-multi-lined model array, but not for grok's two-entry `GROK_CHAT_MODELS`, which sat on one line:

```ts
export const GROK_CHAT_MODELS = [GROK_BUILD_0_1.name, GROK_4_3.name] as const
```

The day OpenRouter listed `grok-4.5`, the generator produced:

```ts
export const GROK_CHAT_MODELS = [GROK_BUILD_0_1.name, GROK_4_3.name
  GROK_4_5.name,
] as const
```

— a syntax error. The pipeline's closing `pnpm format` exits 2 on it, so the whole job dies **after** writing files but **before** committing, every day.

## The fix

Make the insertion **correct by construction** instead of guessing about the existing text: insert immediately **after the opening bracket**. The script then only ever writes separators it owns — each inserted line carries its own trailing comma — and the existing body (trailing commas or not, in-array section comments, or empty) follows unchanged. New models land at the top of each array, and `pnpm format` reflows the result, so the inserted lines only need to parse, not to be pretty. The function also gets simpler: the dotAll regex becomes a plain `indexOf`.

## Verification

Ran the full `pnpm generate:models` pipeline (fetch → regenerate → sync → format) with the fix:

- all 11 pending models generate; `oxfmt` passes (the previously failing step)
- `GROK_CHAT_MODELS` comes out valid; OpenAI's in-array section comments (`// Frontier models`, …) survive with the new entries above them
- `ai-grok`, `ai-gemini`, `ai-openai` **typecheck clean** with the generated entries (`grok-4.5`: 500K context, text/image/document input)

The generated model updates themselves are deliberately **not** included — the next scheduled run (or a `workflow_dispatch`) will produce them through the normal `automated/sync-models` PR flow. Two pre-existing issues will make that PR's CI red and deserve their own follow-ups (neither is caused by this change):

1. `ai-anthropic`'s `tools-per-model-type-safety.test.ts` enumerates the expected model list at the type level, so `claude-opus-5`/`-fast` need a manual test-list update — every anthropic model addition does.
2. `ai-openrouter`'s converter emits provider-option sets for some newly listed models (e.g. `prediction`) that its own `model-meta` constraint doesn't admit.

Merging #1040 first is fine — the sync script skips model ids that already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider model synchronization so new entries are added reliably to existing arrays, including single-line arrays.
  * Prevented synchronization from producing invalid syntax when updating supported provider model configurations.
  * Preserved existing configurations when the expected array is unavailable, with a warning indicating that no update was made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->