### PR TITLE
docs: add README header banners to the framework adapter packages

### DIFF
--- a/packages/ai-solid/README.md
+++ b/packages/ai-solid/README.md
@@ -1,3 +1,20 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?framework=solid&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png?framework=solid"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png?framework=solid"
+      alt="TanStack Solid AI"
+      width="900"
+    />
+  </picture>
+</div>
 # @tanstack/ai-react
 
 React hooks for building AI chat interfaces with TanStack AI.

--- a/packages/ai-svelte/README.md
+++ b/packages/ai-svelte/README.md
@@ -1,3 +1,20 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?framework=svelte&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png?framework=svelte"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png?framework=svelte"
+      alt="TanStack Svelte AI"
+      width="900"
+    />
+  </picture>
+</div>
 # @tanstack/ai-svelte
 
 Svelte bindings for TanStack AI.


### PR DESCRIPTION
Follow-up to #1043, which is already merged.

That PR swapped the README banners that **already existed** for the
`/api/readme/` endpoint. It did not add banners to packages that never had
one, which left an inconsistency: sibling framework adapters in this repo now
look different from each other purely because of which PNG happened to be
committed before.

This adds the banner to the public framework adapter packages that were
missed: `@tanstack/ai-solid`, `@tanstack/ai-svelte`.

## Scope

Only packages a user installs directly. Internal packages are deliberately
left banner-free - a branded header on plumbing nobody browses is noise:

- build/tooling packages (vite, rspack and cli plugins)
- `*-core` packages and internal client/server split packages
- storage and persistence backends

## Verification

Every URL added here was requested against the live endpoint and returned
`200 image/png` at 1800x450. Light and dark are served through `<picture>`,
with the trailing `<img>` left as the light variant so renderers that ignore
`<picture>` (npm, most editors) still show a banner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added responsive, centered TanStack AI banner images to the Solid and Svelte README files.
  * Banners automatically adapt to light and dark themes and include fallback imagery and descriptive alt text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->