### PR TITLE
chore(ci): remove changeset version preview job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,18 +48,3 @@ jobs:
         run: pnpm run build:all
       - name: Publish Previews
         run: pnpx pkg-pr-new publish --pnpm './packages/*'
-  version-preview:
-    name: Version Preview
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Setup Tools
-        uses: TanStack/config/.github/setup@190f659075ff0845850e330883eb26d7ffd0671f # main
-      - name: Changeset Preview
-        uses: TanStack/config/.github/changeset-preview@190f659075ff0845850e330883eb26d7ffd0671f # main


### PR DESCRIPTION
## Summary

Removes the `version-preview` job from the PR workflow. The shared `TanStack/config` `changeset-preview` action runs `@changesets/get-release-plan` against the PR checkout, which picks up **all** pending changesets in `.changeset/` — not just the ones the PR adds. With ~50 unreleased changesets accumulated on `main`, every PR comment showed the entire backlog (30 packages "bumped", including bogus `0.x → 1.0.0` major rows despite no major changesets existing), making the preview misleading on every PR.

No test changes needed — CI-only deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the automated version preview workflow from pull request checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->