### PR TITLE
fix(ai-client): correlate synthesized resume terminals to request run

### DIFF
--- a/.changeset/jolly-ravens-start.md
+++ b/.changeset/jolly-ravens-start.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/ai-client": patch
+'@tanstack/ai-client': patch
 ---
 
 Stamp synthesized RUN_FINISHED / RUN_ERROR with the client request runId so interrupt resume settles when the provider continuation omits a terminal event.

--- a/.changeset/jolly-ravens-start.md
+++ b/.changeset/jolly-ravens-start.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/ai-client": patch
+---
+
+Stamp synthesized RUN_FINISHED / RUN_ERROR with the client request runId so interrupt resume settles when the provider continuation omits a terminal event.

--- a/packages/ai-client/src/connection-adapters.ts
+++ b/packages/ai-client/src/connection-adapters.ts
@@ -1012,7 +1012,9 @@ export function normalizeConnectionAdapter(
 
         // If the connect stream ended cleanly without a terminal event,
         // synthesize RUN_FINISHED so request-scoped consumers can complete.
-        // Reuse the caller's threadId/runId so client-side activeRunIds tracking matches.
+        // The event payload may carry an upstream/provider runId when one was
+        // observed, but stamp the caller's request runId so getChunkRunId()
+        // correlates to activeRunIds / currentRunId (same as real stream chunks).
         if (!abortSignal?.aborted && !hasTerminalEvent) {
           const synthetic: RunFinishedEvent = {
             type: EventType.RUN_FINISHED,
@@ -1028,7 +1030,7 @@ export function normalizeConnectionAdapter(
             timestamp: Date.now(),
             finishReason: 'stop',
           }
-          push(synthetic)
+          push(synthetic, runContext?.runId)
         }
       } catch (err) {
         if (!abortSignal?.aborted && !hasTerminalEvent) {
@@ -1052,7 +1054,7 @@ export function normalizeConnectionAdapter(
               timestamp: Date.now(),
               message,
             }
-            push(synthetic)
+            push(synthetic, runContext?.runId)
           } catch {
             // fall through to rethrow the original error
           }

--- a/packages/ai-client/tests/chat-client-resume.test.ts
+++ b/packages/ai-client/tests/chat-client-resume.test.ts
@@ -72,7 +72,19 @@ async function createInterruptedClient(continuation: Script) {
         timestamp: Date.now(),
         outcome: {
           type: 'interrupt',
-          interrupts: [{ id: 'interrupt-1', reason: 'client_tool_input' }],
+          // Full legacy approval metadata (kind + toolName + input) hydrates as
+          // a public generic interrupt so resolveInterrupt() can drive resume.
+          interrupts: [
+            {
+              id: 'interrupt-1',
+              reason: 'approval_required',
+              metadata: {
+                kind: 'approval',
+                toolName: 'confirm',
+                input: {},
+              },
+            },
+          ],
         },
       },
     ],
@@ -352,7 +364,7 @@ describe('ChatClient resume', () => {
     expect(client.getPendingInterrupts()).toEqual([])
   })
 
-  it.skip('correlates a synthesized resume finish to the client request run', async () => {
+  it('correlates a synthesized resume finish to the client request run', async () => {
     const client = await createInterruptedClient([
       {
         type: EventType.RUN_STARTED,
@@ -364,12 +376,16 @@ describe('ChatClient resume', () => {
 
     resolveGenericInterrupt(client)
 
-    await vi.waitFor(() => expect(client.getInterrupts()).toEqual([]))
-    expect(client.getResumeState()).toBeNull()
-    expect(client.getSessionGenerating()).toBe(false)
+    // Wait for the full settle — interrupts are hidden while status is
+    // `submitting`, so an empty list alone is not a terminal signal.
+    await vi.waitFor(() => {
+      expect(client.getInterrupts()).toEqual([])
+      expect(client.getResumeState()).toBeNull()
+      expect(client.getSessionGenerating()).toBe(false)
+    })
   })
 
-  it.skip('correlates a synthesized resume error to the client request run', async () => {
+  it('correlates a synthesized resume error to the client request run', async () => {
     const client = await createInterruptedClient({
       chunks: [
         {
@@ -384,11 +400,11 @@ describe('ChatClient resume', () => {
 
     resolveGenericInterrupt(client)
 
-    await vi.waitFor(() =>
-      expect(client.getInterrupts()[0]?.status).toBe('error'),
-    )
-    expect(client.getResumeState()).not.toBeNull()
-    expect(client.getSessionGenerating()).toBe(false)
+    await vi.waitFor(() => {
+      expect(client.getInterrupts()[0]?.status).toBe('error')
+      expect(client.getResumeState()).not.toBeNull()
+      expect(client.getSessionGenerating()).toBe(false)
+    })
   })
 
   it('resumeInterrupts reconnects with the full current message history', async () => {


### PR DESCRIPTION
## 🎯 Changes

When interrupt resume continuation streams omit a real `RUN_FINISHED` / `RUN_ERROR`, the connect wrapper synthesizes a terminal event. Those synthesized terminals were pushed without stamping the client request `runId`, so `getChunkRunId()` fell back to the provider continuation id. That left `activeRunIds` uncleared and `sessionGenerating` stuck true after Approve appeared to succeed.

This PR stamps synthesized terminals with `runContext?.runId` (same as real stream chunks), unskips the resume correlation unit tests, and adds a patch changeset for `@tanstack/ai-client`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved interrupted conversation resumes so they complete reliably when terminal events are missing from provider responses.
  - Ensured synthesized success and error events are correctly associated with the originating request.
  - Improved handling of approval metadata during resumed interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->