### PR TITLE
fix(ai-anthropic): forward top-level cache_control from modelOptions

### DIFF
--- a/.changeset/lucky-pans-invite.md
+++ b/.changeset/lucky-pans-invite.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-anthropic': patch
+---
+
+Forward top-level `cache_control` from `modelOptions` in the Anthropic text adapter.
+
+Anthropic's Messages API accepts `cache_control` as a request-level parameter (it auto-places the cache breakpoint on the last cacheable block), but the adapter's `modelOptions` allowlist omitted it, so any value passed was silently stripped and logged as a dropped key. Per-block caching via `systemPrompts[].metadata.cache_control` is unchanged.

--- a/packages/ai-anthropic/src/adapters/text.ts
+++ b/packages/ai-anthropic/src/adapters/text.ts
@@ -455,6 +455,7 @@ export class AnthropicTextAdapter<
     const validProviderOptions: Partial<InternalTextProviderOptions> = {}
     if (modelOptions) {
       const validKeys: Array<keyof AnthropicTextProviderOptions> = [
+        'cache_control',
         'container',
         'context_management',
         'effort',

--- a/packages/ai-anthropic/src/model-meta.ts
+++ b/packages/ai-anthropic/src/model-meta.ts
@@ -2,6 +2,7 @@ import type {
   AnthropicAdaptiveOnlyThinkingOptions,
   AnthropicAdaptiveOrDisabledThinkingOptions,
   AnthropicAdaptiveThinkingOptions,
+  AnthropicCacheControlOptions,
   AnthropicContainerOptions,
   AnthropicContextManagementOptions,
   AnthropicMCPOptions,
@@ -94,7 +95,8 @@ const CLAUDE_OPUS_4_6 = {
     ],
   },
 } as const satisfies ModelMeta<
-  AnthropicContainerOptions &
+  AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -133,7 +135,8 @@ const CLAUDE_OPUS_4_5 = {
     ],
   },
 } as const satisfies ModelMeta<
-  AnthropicContainerOptions &
+  AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -175,7 +178,8 @@ const CLAUDE_SONNET_4_6 = {
     ],
   },
 } as const satisfies ModelMeta<
-  AnthropicContainerOptions &
+  AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -214,7 +218,8 @@ const CLAUDE_SONNET_4_5 = {
     ],
   },
 } as const satisfies ModelMeta<
-  AnthropicContainerOptions &
+  AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -253,7 +258,8 @@ const CLAUDE_HAIKU_4_5 = {
     ],
   },
 } as const satisfies ModelMeta<
-  AnthropicContainerOptions &
+  AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -292,7 +298,8 @@ const CLAUDE_OPUS_4_1 = {
     ],
   },
 } as const satisfies ModelMeta<
-  AnthropicContainerOptions &
+  AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -335,7 +342,8 @@ const CLAUDE_OPUS_4_7 = {
     },
   },
 } as const satisfies ModelMeta<
-  AnthropicContainerOptions &
+  AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -378,7 +386,8 @@ const CLAUDE_OPUS_4_8 = {
     },
   },
 } as const satisfies ModelMeta<
-  AnthropicContainerOptions &
+  AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -424,7 +433,8 @@ const CLAUDE_FABLE_5 = {
     },
   },
 } as const satisfies ModelMeta<
-  AnthropicContainerOptions &
+  AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -471,7 +481,8 @@ const CLAUDE_SONNET_5 = {
     },
   },
 } as const satisfies ModelMeta<
-  AnthropicContainerOptions &
+  AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -612,7 +623,8 @@ export type AnthropicChatModel = (typeof ANTHROPIC_MODELS)[number]
 export type AnthropicChatModelProviderOptionsByName = {
   // 4.6 generation: adaptive thinking plus the deprecated budget-based
   // shape; sampling parameters still accepted.
-  [CLAUDE_OPUS_4_6.id]: AnthropicContainerOptions &
+  [CLAUDE_OPUS_4_6.id]: AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -620,7 +632,8 @@ export type AnthropicChatModelProviderOptionsByName = {
     AnthropicAdaptiveThinkingOptions &
     AnthropicToolChoiceOptions &
     AnthropicSamplingOptions
-  [CLAUDE_SONNET_4_6.id]: AnthropicContainerOptions &
+  [CLAUDE_SONNET_4_6.id]: AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -630,7 +643,8 @@ export type AnthropicChatModelProviderOptionsByName = {
     AnthropicSamplingOptions
 
   // Pre-4.6 models: budget-based extended thinking and sampling parameters.
-  [CLAUDE_OPUS_4_5.id]: AnthropicContainerOptions &
+  [CLAUDE_OPUS_4_5.id]: AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -638,7 +652,8 @@ export type AnthropicChatModelProviderOptionsByName = {
     AnthropicThinkingOptions &
     AnthropicToolChoiceOptions &
     AnthropicSamplingOptions
-  [CLAUDE_SONNET_4_5.id]: AnthropicContainerOptions &
+  [CLAUDE_SONNET_4_5.id]: AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -646,7 +661,8 @@ export type AnthropicChatModelProviderOptionsByName = {
     AnthropicThinkingOptions &
     AnthropicToolChoiceOptions &
     AnthropicSamplingOptions
-  [CLAUDE_HAIKU_4_5.id]: AnthropicContainerOptions &
+  [CLAUDE_HAIKU_4_5.id]: AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -654,7 +670,8 @@ export type AnthropicChatModelProviderOptionsByName = {
     AnthropicThinkingOptions &
     AnthropicToolChoiceOptions &
     AnthropicSamplingOptions
-  [CLAUDE_OPUS_4_1.id]: AnthropicContainerOptions &
+  [CLAUDE_OPUS_4_1.id]: AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -665,7 +682,8 @@ export type AnthropicChatModelProviderOptionsByName = {
 
   // Opus 4.7/4.8: adaptive thinking (or explicit disable), no
   // budget_tokens, no sampling parameters — see the constants above.
-  [CLAUDE_OPUS_4_7.id]: AnthropicContainerOptions &
+  [CLAUDE_OPUS_4_7.id]: AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -674,7 +692,8 @@ export type AnthropicChatModelProviderOptionsByName = {
     AnthropicToolChoiceOptions &
     AnthropicMaxTokensOptions &
     AnthropicOutputConfigOptions
-  [CLAUDE_OPUS_4_8.id]: AnthropicContainerOptions &
+  [CLAUDE_OPUS_4_8.id]: AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -686,7 +705,8 @@ export type AnthropicChatModelProviderOptionsByName = {
 
   // Claude Fable 5: thinking always on (adaptive-only config); sampling
   // parameters removed — see the CLAUDE_FABLE_5 constant above.
-  [CLAUDE_FABLE_5.id]: AnthropicContainerOptions &
+  [CLAUDE_FABLE_5.id]: AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &
@@ -698,7 +718,8 @@ export type AnthropicChatModelProviderOptionsByName = {
   // Claude Sonnet 5: adaptive thinking by default, explicit disable
   // allowed; no budget_tokens, no sampling parameters — see the
   // CLAUDE_SONNET_5 constant above.
-  [CLAUDE_SONNET_5.id]: AnthropicContainerOptions &
+  [CLAUDE_SONNET_5.id]: AnthropicCacheControlOptions &
+    AnthropicContainerOptions &
     AnthropicContextManagementOptions &
     AnthropicMCPOptions &
     AnthropicServiceTierOptions &

--- a/packages/ai-anthropic/src/text/text-provider-options.ts
+++ b/packages/ai-anthropic/src/text/text-provider-options.ts
@@ -41,6 +41,22 @@ export interface AnthropicSystemPromptMetadata {
   cache_control?: CacheControlEphemeral
 }
 
+/**
+ * Top-level prompt-caching control.
+ *
+ * Anthropic's Messages API accepts `cache_control` as a request-level
+ * parameter: it auto-places the breakpoint on the last cacheable block of the
+ * rendered prompt (`tools` → `system` → `messages`). Use this when you don't
+ * need per-block placement; for a breakpoint on a specific system prompt, use
+ * the structured `systemPrompts` form with
+ * {@link AnthropicSystemPromptMetadata} instead.
+ *
+ * @see https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+ */
+export interface AnthropicCacheControlOptions {
+  cache_control?: CacheControlEphemeral
+}
+
 export interface AnthropicContainerOptions {
   /**
    * Container identifier for reuse across requests.
@@ -288,7 +304,8 @@ Required range: x >= 0
   max_tokens?: number
 }
 
-export type ExternalTextProviderOptions = AnthropicContainerOptions &
+export type ExternalTextProviderOptions = AnthropicCacheControlOptions &
+  AnthropicContainerOptions &
   AnthropicContextManagementOptions &
   AnthropicMCPOptions &
   AnthropicServiceTierOptions &

--- a/packages/ai-anthropic/tests/anthropic-adapter.test.ts
+++ b/packages/ai-anthropic/tests/anthropic-adapter.test.ts
@@ -397,6 +397,38 @@ describe('Anthropic adapter option mapping', () => {
     expect(payload.max_tokens).toBe(2048)
   })
 
+  it('forwards top-level cache_control from modelOptions instead of dropping it', async () => {
+    mocks.betaMessagesCreate.mockResolvedValueOnce(createTextStream('ok'))
+
+    const adapter = createAdapter('claude-opus-4-1')
+
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }
+
+    for await (const _ of chat({
+      adapter,
+      messages: [{ role: 'user', content: 'Hi' }],
+      modelOptions: {
+        cache_control: { type: 'ephemeral' },
+      } satisfies AnthropicTextProviderOptions,
+      debug: { logger, errors: true },
+    })) {
+      // consume stream
+    }
+
+    const [payload] = mocks.betaMessagesCreate.mock.calls[0]!
+    expect(payload.cache_control).toEqual({ type: 'ephemeral' })
+
+    const droppedKeyError = logger.error.mock.calls.find((call) =>
+      String(call[0]).includes('dropped unknown modelOptions key'),
+    )
+    expect(droppedKeyError).toBeUndefined()
+  })
+
   it('does not warn about dropped keys when max_tokens is passed via modelOptions', async () => {
     mocks.betaMessagesCreate.mockResolvedValueOnce(createTextStream('ok'))
 


### PR DESCRIPTION
## 🎯 Changes

### The Problem

`mapCommonOptionsToAnthropic` filters `modelOptions` through an allowlist that omits `cache_control`, so any value a caller passes is silently stripped and logged as a dropped key.

### The Solution

Add `cache_control` to the allowlist, plus to `ExternalTextProviderOptions` and the per-model intersections in `model-meta.ts` — `validKeys` is typed `Array<keyof AnthropicTextProviderOptions>`, so the type has to carry the field for the entry to compile and for callers to pass it without an excess-property error. Per-block caching via `systemPrompts[].metadata.cache_control` is unchanged.

### The Reason to Merge

Anthropic's Messages API accepts `cache_control` as a request-level body param that auto-marks the last cacheable block (confirmed on `MessageCreateParamsBase` in the pinned `@anthropic-ai/sdk@0.97.1`), and prompt caching is the main cost lever on Anthropic — this is the only thing blocking callers from using it without hand-placing breakpoints.

No E2E test: `cache_control` has no observable browser behavior and aimock discards it when normalising, so this follows the boundary documented in `tests/stateful-interactions.spec.ts` — `modelOptions` wire-format translation is unit-tested. The full suite's one failure (`byteplus — agentic-structured-stream`) is an unrelated flake; it passes on an unmodified tree, and on re-runs the flaky retry lands on a different provider each time.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

Also run: `pnpm test:lib` for `@tanstack/ai-anthropic` (121 passed, including a new case asserting `cache_control` reaches `betaMessagesCreate` and logs no dropped-key error), `pnpm test:types`, `pnpm format`, and the full E2E suite (441 passed).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

Patch bump to `@tanstack/ai-anthropic`. Purely additive — a previously-stripped option now reaches the API; no existing behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
