### PR TITLE
fix(ai): preserve UI message IDs in model conversion

### DIFF
--- a/.changeset/fix-ui-message-id-roundtrip.md
+++ b/.changeset/fix-ui-message-id-roundtrip.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai': patch
+---
+
+Preserve stable UI message IDs when converting UI messages to model messages.

--- a/packages/ai/src/activities/chat/messages.ts
+++ b/packages/ai/src/activities/chat/messages.ts
@@ -184,6 +184,7 @@ function buildUserOrToolMessage(uiMessage: UIMessage): ModelMessage {
   }
 
   return {
+    id: uiMessage.id,
     role: uiMessage.role as 'user' | 'assistant' | 'tool',
     content: collapseContentParts(contentParts),
   }
@@ -228,6 +229,8 @@ function isToolCallIncluded(part: ToolCallPart): boolean {
  * result is emitted as a tool message.
  */
 function buildAssistantMessages(uiMessage: UIMessage): Array<ModelMessage> {
+  // A single UI message can fan out into several model messages. Keep the
+  // shared UI id on each one so persistence can retain the original identity.
   const messageList: Array<ModelMessage> = []
   let current = createSegment()
   let pendingThinking: Array<{ content: string; signature?: string }> = []
@@ -244,6 +247,7 @@ function buildAssistantMessages(uiMessage: UIMessage): Array<ModelMessage> {
 
     if (hasContent || hasToolCalls) {
       messageList.push({
+        id: uiMessage.id,
         role: 'assistant',
         content,
         ...(hasToolCalls && { toolCalls: current.toolCalls }),
@@ -288,6 +292,7 @@ function buildAssistantMessages(uiMessage: UIMessage): Array<ModelMessage> {
           !emittedToolResultIds.has(part.toolCallId)
         ) {
           messageList.push({
+            id: uiMessage.id,
             role: 'tool',
             content: part.content,
             toolCallId: part.toolCallId,
@@ -347,6 +352,7 @@ function buildAssistantMessages(uiMessage: UIMessage): Array<ModelMessage> {
     // emit the concrete output regardless of approval metadata.
     if (part.output !== undefined && !emittedToolResultIds.has(part.id)) {
       messageList.push({
+        id: uiMessage.id,
         role: 'tool',
         content: normalizeToolResult(part.output),
         toolCallId: part.id,
@@ -363,6 +369,7 @@ function buildAssistantMessages(uiMessage: UIMessage): Array<ModelMessage> {
     ) {
       const approved = part.approval.approved
       messageList.push({
+        id: uiMessage.id,
         role: 'tool',
         content: JSON.stringify({
           approved,
@@ -380,6 +387,7 @@ function buildAssistantMessages(uiMessage: UIMessage): Array<ModelMessage> {
   // If no messages were produced (e.g., empty parts), emit a minimal assistant message
   if (messageList.length === 0) {
     messageList.push({
+      id: uiMessage.id,
       role: 'assistant',
       content: null,
     })

--- a/packages/ai/tests/message-converters.test.ts
+++ b/packages/ai/tests/message-converters.test.ts
@@ -21,6 +21,7 @@ describe('Message Converters', () => {
 
       expect(result).toEqual([
         {
+          id: 'msg-1',
           role: 'user',
           content: 'Hello',
         },
@@ -41,6 +42,7 @@ describe('Message Converters', () => {
 
       expect(result).toEqual([
         {
+          id: 'msg-1',
           role: 'user',
           content: 'Hello world!',
         },
@@ -343,6 +345,62 @@ describe('Message Converters', () => {
       expect(result[1]?.role).toBe('tool')
       expect(result[1]?.toolCallId).toBe('tool-1')
       expect(result[1]?.content).toBe('{"temp": 72}')
+    })
+
+    it('should preserve the UI message id on every generated model message', () => {
+      const uiMessage: UIMessage = {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          { type: 'text', content: 'Let me check.' },
+          {
+            type: 'tool-call',
+            id: 'tc-explicit',
+            name: 'getWeather',
+            arguments: '{}',
+            state: 'input-complete',
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'tc-explicit',
+            content: '{}',
+            state: 'complete',
+          },
+          { type: 'text', content: 'I found it.' },
+          {
+            type: 'tool-call',
+            id: 'tc-output',
+            name: 'getForecast',
+            arguments: '{}',
+            state: 'complete',
+            output: { temperature: 72 },
+          },
+          {
+            type: 'tool-call',
+            id: 'tc-approval',
+            name: 'deleteForecast',
+            arguments: '{}',
+            state: 'approval-responded',
+            approval: {
+              id: 'approval-tc-approval',
+              needsApproval: true,
+              approved: false,
+            },
+          },
+        ],
+      }
+
+      const result = uiMessageToModelMessages(uiMessage)
+
+      expect(result).toHaveLength(5)
+      expect(result.every((message) => message.id === uiMessage.id)).toBe(true)
+      expect(result.map((message) => message.role)).toEqual([
+        'assistant',
+        'tool',
+        'assistant',
+        'tool',
+        'tool',
+      ])
     })
 
     it('should preserve interleaving of text, tool calls, and tool results', () => {
@@ -1132,7 +1190,7 @@ describe('Message Converters', () => {
 
       const result = convertMessagesToModelMessages(messages)
 
-      expect(result).toEqual([{ role: 'user', content: 'Hello' }])
+      expect(result).toEqual([{ id: 'msg-1', role: 'user', content: 'Hello' }])
     })
 
     it('should handle mixed UIMessage and ModelMessage array', () => {
@@ -1148,7 +1206,7 @@ describe('Message Converters', () => {
       const result = convertMessagesToModelMessages(messages)
 
       expect(result).toEqual([
-        { role: 'user', content: 'Hello' },
+        { id: 'msg-1', role: 'user', content: 'Hello' },
         { role: 'assistant', content: 'Hi there!' },
       ])
     })
@@ -1361,8 +1419,8 @@ describe('Message Converters', () => {
   describe('Round-trip symmetry: Model -> UI -> Model', () => {
     it('should round-trip simple text messages', () => {
       const original: Array<ModelMessage> = [
-        { role: 'user', content: 'Hello' },
-        { role: 'assistant', content: 'Hi there!' },
+        { id: 'user-1', role: 'user', content: 'Hello' },
+        { id: 'assistant-1', role: 'assistant', content: 'Hi there!' },
       ]
 
       const uiMessages = modelMessagesToUIMessages(original)
@@ -1374,6 +1432,7 @@ describe('Message Converters', () => {
     it('should round-trip assistant with toolCalls + tool result', () => {
       const original: Array<ModelMessage> = [
         {
+          id: 'assistant-1',
           role: 'assistant',
           content: 'Let me check.',
           toolCalls: [
@@ -1385,6 +1444,7 @@ describe('Message Converters', () => {
           ],
         },
         {
+          id: 'assistant-1',
           role: 'tool',
           content: '{"temp": 72}',
           toolCallId: 'tc-1',
@@ -1400,6 +1460,7 @@ describe('Message Converters', () => {
     it('should round-trip multimodal content array', () => {
       const original: Array<ModelMessage> = [
         {
+          id: 'user-1',
           role: 'user',
           content: [
             { type: 'text', content: 'What is this?' },
@@ -1419,8 +1480,9 @@ describe('Message Converters', () => {
 
     it('should round-trip multi-round tool conversation', () => {
       const original: Array<ModelMessage> = [
-        { role: 'user', content: 'Check guitars' },
+        { id: 'user-1', role: 'user', content: 'Check guitars' },
         {
+          id: 'assistant-1',
           role: 'assistant',
           content: 'Checking.',
           toolCalls: [
@@ -1431,8 +1493,14 @@ describe('Message Converters', () => {
             },
           ],
         },
-        { role: 'tool', content: '[{"id":7}]', toolCallId: 'tc-1' },
         {
+          id: 'assistant-1',
+          role: 'tool',
+          content: '[{"id":7}]',
+          toolCallId: 'tc-1',
+        },
+        {
+          id: 'assistant-2',
           role: 'assistant',
           content: 'Found one!',
           toolCalls: [
@@ -1444,11 +1512,16 @@ describe('Message Converters', () => {
           ],
         },
         {
+          id: 'assistant-2',
           role: 'tool',
           content: '{"recommended":true}',
           toolCallId: 'tc-2',
         },
-        { role: 'assistant', content: 'Here is my recommendation.' },
+        {
+          id: 'assistant-3',
+          role: 'assistant',
+          content: 'Here is my recommendation.',
+        },
       ]
 
       const uiMessages = modelMessagesToUIMessages(original)
@@ -1460,6 +1533,7 @@ describe('Message Converters', () => {
     it('should round-trip assistant with null content and toolCalls', () => {
       const original: Array<ModelMessage> = [
         {
+          id: 'assistant-1',
           role: 'assistant',
           content: null,
           toolCalls: [
@@ -1470,7 +1544,12 @@ describe('Message Converters', () => {
             },
           ],
         },
-        { role: 'tool', content: '{"temp":72}', toolCallId: 'tc-1' },
+        {
+          id: 'assistant-1',
+          role: 'tool',
+          content: '{"temp":72}',
+          toolCallId: 'tc-1',
+        },
       ]
 
       const uiMessages = modelMessagesToUIMessages(original)

--- a/packages/ai/tests/message-converters.test.ts
+++ b/packages/ai/tests/message-converters.test.ts
@@ -403,6 +403,18 @@ describe('Message Converters', () => {
       ])
     })
 
+    it('should preserve the UI message id on an empty assistant fallback', () => {
+      const uiMessage: UIMessage = {
+        id: 'assistant-empty',
+        role: 'assistant',
+        parts: [],
+      }
+
+      expect(uiMessageToModelMessages(uiMessage)).toEqual([
+        { id: uiMessage.id, role: 'assistant', content: null },
+      ])
+    })
+
     it('should preserve interleaving of text, tool calls, and tool results', () => {
       const uiMessage: UIMessage = {
         id: 'msg-1',

--- a/packages/ai/tests/messages.test.ts
+++ b/packages/ai/tests/messages.test.ts
@@ -163,6 +163,7 @@ describe('convertMessagesToModelMessages — AG-UI dedup pre-pass', () => {
 
     expect(convertMessagesToModelMessages(messages)).toEqual([
       {
+        id: 'assistant-approval',
         role: 'assistant',
         content: null,
         toolCalls: [

--- a/testing/e2e/src/routeTree.gen.ts
+++ b/testing/e2e/src/routeTree.gen.ts
@@ -44,6 +44,7 @@ import { Route as ApiOpenaiUsageDetailsRouteImport } from './routes/api.openai-u
 import { Route as ApiOpenaiShellSkillsWireRouteImport } from './routes/api.openai-shell-skills-wire'
 import { Route as ApiMultimodalToolResultWireRouteImport } from './routes/api.multimodal-tool-result-wire'
 import { Route as ApiMiddlewareTestRouteImport } from './routes/api.middleware-test'
+import { Route as ApiMessageIdsRouteImport } from './routes/api.message-ids'
 import { Route as ApiMcpTestRouteImport } from './routes/api.mcp-test'
 import { Route as ApiMcpStatusTestRouteImport } from './routes/api.mcp-status-test'
 import { Route as ApiMcpServerRouteImport } from './routes/api.mcp-server'
@@ -257,6 +258,11 @@ const ApiMiddlewareTestRoute = ApiMiddlewareTestRouteImport.update({
   path: '/api/middleware-test',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiMessageIdsRoute = ApiMessageIdsRouteImport.update({
+  id: '/api/message-ids',
+  path: '/api/message-ids',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiMcpTestRoute = ApiMcpTestRouteImport.update({
   id: '/api/mcp-test',
   path: '/api/mcp-test',
@@ -454,6 +460,7 @@ export interface FileRoutesByFullPath {
   '/api/mcp-server': typeof ApiMcpServerRoute
   '/api/mcp-status-test': typeof ApiMcpStatusTestRoute
   '/api/mcp-test': typeof ApiMcpTestRoute
+  '/api/message-ids': typeof ApiMessageIdsRoute
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
   '/api/multimodal-tool-result-wire': typeof ApiMultimodalToolResultWireRoute
   '/api/openai-shell-skills-wire': typeof ApiOpenaiShellSkillsWireRoute
@@ -521,6 +528,7 @@ export interface FileRoutesByTo {
   '/api/mcp-server': typeof ApiMcpServerRoute
   '/api/mcp-status-test': typeof ApiMcpStatusTestRoute
   '/api/mcp-test': typeof ApiMcpTestRoute
+  '/api/message-ids': typeof ApiMessageIdsRoute
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
   '/api/multimodal-tool-result-wire': typeof ApiMultimodalToolResultWireRoute
   '/api/openai-shell-skills-wire': typeof ApiOpenaiShellSkillsWireRoute
@@ -589,6 +597,7 @@ export interface FileRoutesById {
   '/api/mcp-server': typeof ApiMcpServerRoute
   '/api/mcp-status-test': typeof ApiMcpStatusTestRoute
   '/api/mcp-test': typeof ApiMcpTestRoute
+  '/api/message-ids': typeof ApiMessageIdsRoute
   '/api/middleware-test': typeof ApiMiddlewareTestRoute
   '/api/multimodal-tool-result-wire': typeof ApiMultimodalToolResultWireRoute
   '/api/openai-shell-skills-wire': typeof ApiOpenaiShellSkillsWireRoute
@@ -658,6 +667,7 @@ export interface FileRouteTypes {
     | '/api/mcp-server'
     | '/api/mcp-status-test'
     | '/api/mcp-test'
+    | '/api/message-ids'
     | '/api/middleware-test'
     | '/api/multimodal-tool-result-wire'
     | '/api/openai-shell-skills-wire'
@@ -725,6 +735,7 @@ export interface FileRouteTypes {
     | '/api/mcp-server'
     | '/api/mcp-status-test'
     | '/api/mcp-test'
+    | '/api/message-ids'
     | '/api/middleware-test'
     | '/api/multimodal-tool-result-wire'
     | '/api/openai-shell-skills-wire'
@@ -792,6 +803,7 @@ export interface FileRouteTypes {
     | '/api/mcp-server'
     | '/api/mcp-status-test'
     | '/api/mcp-test'
+    | '/api/message-ids'
     | '/api/middleware-test'
     | '/api/multimodal-tool-result-wire'
     | '/api/openai-shell-skills-wire'
@@ -860,6 +872,7 @@ export interface RootRouteChildren {
   ApiMcpServerRoute: typeof ApiMcpServerRoute
   ApiMcpStatusTestRoute: typeof ApiMcpStatusTestRoute
   ApiMcpTestRoute: typeof ApiMcpTestRoute
+  ApiMessageIdsRoute: typeof ApiMessageIdsRoute
   ApiMiddlewareTestRoute: typeof ApiMiddlewareTestRoute
   ApiMultimodalToolResultWireRoute: typeof ApiMultimodalToolResultWireRoute
   ApiOpenaiShellSkillsWireRoute: typeof ApiOpenaiShellSkillsWireRoute
@@ -1125,6 +1138,13 @@ declare module '@tanstack/react-router' {
       path: '/api/middleware-test'
       fullPath: '/api/middleware-test'
       preLoaderRoute: typeof ApiMiddlewareTestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/message-ids': {
+      id: '/api/message-ids'
+      path: '/api/message-ids'
+      fullPath: '/api/message-ids'
+      preLoaderRoute: typeof ApiMessageIdsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/mcp-test': {
@@ -1441,6 +1461,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiMcpServerRoute: ApiMcpServerRoute,
   ApiMcpStatusTestRoute: ApiMcpStatusTestRoute,
   ApiMcpTestRoute: ApiMcpTestRoute,
+  ApiMessageIdsRoute: ApiMessageIdsRoute,
   ApiMiddlewareTestRoute: ApiMiddlewareTestRoute,
   ApiMultimodalToolResultWireRoute: ApiMultimodalToolResultWireRoute,
   ApiOpenaiShellSkillsWireRoute: ApiOpenaiShellSkillsWireRoute,

--- a/testing/e2e/src/routes/api.message-ids.ts
+++ b/testing/e2e/src/routes/api.message-ids.ts
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { convertMessagesToModelMessages } from '@tanstack/ai'
+import type { ModelMessage, UIMessage } from '@tanstack/ai'
+
+/**
+ * Provider-free harness for the UIMessage -> ModelMessage identity contract.
+ * The route keeps this regression at the public server boundary without
+ * starting a provider request or requiring an API key.
+ */
+export const Route = createFileRoute('/api/message-ids')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const body = (await request.json()) as {
+          messages: Array<UIMessage | ModelMessage>
+        }
+
+        return Response.json(convertMessagesToModelMessages(body.messages))
+      },
+    },
+  },
+})

--- a/testing/e2e/src/routes/api.message-ids.ts
+++ b/testing/e2e/src/routes/api.message-ids.ts
@@ -1,6 +1,110 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { convertMessagesToModelMessages } from '@tanstack/ai'
-import type { ModelMessage, UIMessage } from '@tanstack/ai'
+import { z } from 'zod'
+import type { UIMessage } from '@tanstack/ai'
+
+const sourceSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('data'),
+    value: z.string(),
+    mimeType: z.string(),
+  }),
+  z.object({
+    type: z.literal('url'),
+    value: z.string(),
+    mimeType: z.string().optional(),
+  }),
+])
+
+const contentPartSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('text'),
+    content: z.string(),
+    metadata: z.unknown().optional(),
+  }),
+  ...(['image', 'audio', 'video', 'document'] as const).map((type) =>
+    z.object({
+      type: z.literal(type),
+      source: sourceSchema,
+      metadata: z.unknown().optional(),
+    }),
+  ),
+])
+
+const messagePartSchema = z.discriminatedUnion('type', [
+  ...contentPartSchema.options,
+  z.object({
+    type: z.literal('tool-call'),
+    id: z.string(),
+    name: z.string(),
+    arguments: z.string(),
+    input: z.unknown().optional(),
+    state: z.enum([
+      'awaiting-input',
+      'input-streaming',
+      'input-complete',
+      'approval-requested',
+      'approval-responded',
+      'complete',
+      'error',
+    ]),
+    approval: z
+      .object({
+        id: z.string(),
+        needsApproval: z.boolean(),
+        approved: z.boolean().optional(),
+      })
+      .optional(),
+    output: z.unknown().optional(),
+    metadata: z.unknown().optional(),
+  }),
+  z.object({
+    type: z.literal('tool-result'),
+    toolCallId: z.string(),
+    content: z.union([z.string(), z.array(contentPartSchema)]),
+    state: z.enum(['streaming', 'complete', 'error']),
+    error: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('thinking'),
+    content: z.string(),
+    stepId: z.string().optional(),
+    signature: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('structured-output'),
+    status: z.enum(['streaming', 'complete', 'error']),
+    partial: z.unknown().optional(),
+    data: z.unknown().optional(),
+    raw: z.string(),
+    reasoning: z.string().optional(),
+    errorMessage: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('ui-resource'),
+    resource: z.object({
+      uri: z.string(),
+      mimeType: z.string(),
+      text: z.string().optional(),
+      blob: z.string().optional(),
+    }),
+    serverId: z.string().optional(),
+    toolCallId: z.string(),
+    toolName: z.string(),
+    meta: z.record(z.string(), z.unknown()).optional(),
+  }),
+])
+
+const requestBodySchema: z.ZodType<{ messages: Array<UIMessage> }> = z.object({
+  messages: z.array(
+    z.object({
+      id: z.string(),
+      role: z.enum(['system', 'user', 'assistant']),
+      parts: z.array(messagePartSchema),
+      createdAt: z.coerce.date().optional(),
+    }),
+  ),
+})
 
 /**
  * Provider-free harness for the UIMessage -> ModelMessage identity contract.
@@ -11,11 +115,21 @@ export const Route = createFileRoute('/api/message-ids')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        const body = (await request.json()) as {
-          messages: Array<UIMessage | ModelMessage>
+        let body: unknown
+        try {
+          body = await request.json()
+        } catch {
+          return new Response('Invalid JSON request body', { status: 400 })
         }
 
-        return Response.json(convertMessagesToModelMessages(body.messages))
+        const parsed = requestBodySchema.safeParse(body)
+        if (!parsed.success) {
+          return new Response('Invalid message data', { status: 400 })
+        }
+
+        return Response.json(
+          convertMessagesToModelMessages(parsed.data.messages),
+        )
       },
     },
   },

--- a/testing/e2e/tests/chat.spec.ts
+++ b/testing/e2e/tests/chat.spec.ts
@@ -53,6 +53,67 @@ for (const provider of providersFor('chat')) {
   })
 }
 
+test('preserves UI message IDs at the server conversion boundary', async ({
+  request,
+}) => {
+  const response = await request.post('/api/message-ids', {
+    data: {
+      messages: [
+        {
+          id: 'user-1',
+          role: 'user',
+          parts: [{ type: 'text', content: 'Hello' }],
+        },
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            { type: 'text', content: 'Let me check.' },
+            {
+              type: 'tool-call',
+              id: 'tool-1',
+              name: 'getWeather',
+              arguments: '{}',
+              state: 'input-complete',
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'tool-1',
+              content: '{"temp":72}',
+              state: 'complete',
+            },
+          ],
+        },
+      ],
+    },
+  })
+
+  expect(response.ok()).toBe(true)
+  const modelMessages = await response.json()
+
+  expect(modelMessages).toEqual([
+    { id: 'user-1', role: 'user', content: 'Hello' },
+    {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'Let me check.',
+      toolCalls: [
+        {
+          id: 'tool-1',
+          type: 'function',
+          function: { name: 'getWeather', arguments: '{}' },
+        },
+      ],
+    },
+    {
+      id: 'assistant-1',
+      role: 'tool',
+      content: '{"temp":72}',
+      toolCallId: 'tool-1',
+    },
+  ])
+})
+
 test.describe('openai chat persistence', () => {
   test('persists chat messages across browser reload with localStorage', async ({
     page,

--- a/testing/e2e/tests/chat.spec.ts
+++ b/testing/e2e/tests/chat.spec.ts
@@ -7,6 +7,9 @@ import {
 } from './helpers'
 import { providersFor } from './test-matrix'
 
+// The server conversion test in this spec does not call a provider HTTP
+// endpoint, so it intentionally does not configure aimock.
+
 for (const provider of providersFor('chat')) {
   test.describe(`${provider} — chat`, () => {
     test('sends a message and receives a streaming response', async ({
@@ -112,6 +115,35 @@ test('preserves UI message IDs at the server conversion boundary', async ({
       toolCallId: 'tool-1',
     },
   ])
+})
+
+test('rejects malformed JSON at the server conversion boundary', async ({
+  request,
+}) => {
+  const response = await request.post('/api/message-ids', {
+    data: '{',
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+  expect(response.status()).toBe(400)
+})
+
+test('rejects invalid message parts at the server conversion boundary', async ({
+  request,
+}) => {
+  const response = await request.post('/api/message-ids', {
+    data: {
+      messages: [
+        {
+          id: 'user-1',
+          role: 'user',
+          parts: [{ type: 'text', content: 42 }],
+        },
+      ],
+    },
+  })
+
+  expect(response.status()).toBe(400)
 })
 
 test.describe('openai chat persistence', () => {


### PR DESCRIPTION
## Summary

- Preserve `UIMessage.id` on every `ModelMessage` emitted by UI-to-model conversion, including assistant segments and derived tool results.
- Add unit coverage and a provider-free chat-boundary E2E regression.
- Add a patch changeset for `@tanstack/ai`.

Fixes #1063

## Test plan

- `pnpm --filter @tanstack/ai test:lib --run` — 80 files, 1451 tests passed.
- `pnpm --filter @tanstack/ai test:types` — passed.
- `pnpm --filter @tanstack/ai test:oxlint` — passed with existing warnings only.
- `pnpm --filter @tanstack/ai test:build` — passed.
- `pnpm --filter @tanstack/ai-e2e test:e2e -- --grep "preserves UI message IDs"` — passed.
- `pnpm test:dts` — passed.
- `pnpm test:pr` — all 73 Nx target groups reported success; the wrapper exits with the existing Windows Nx `EISDIR: illegal operation on a directory, lstat 'D:'` cleanup error.
- The full E2E suite was attempted; browser-launch tests were blocked by the missing Playwright `chromium_headless_shell-1200` binary, while request-only tests ran.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved stable message IDs when converting UI messages to model messages.
  * Maintained IDs across text, tool calls, tool results, client outputs, approvals, and multi-part assistant messages.
  * Improved round-trip consistency for segmented and empty messages.
  * Added clearer handling for malformed or invalid message data.

* **Tests**
  * Expanded coverage for message ID preservation and text- and tool-based conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->