### PR TITLE
fix: forward usage from non-stream structuredOutput() (#1076)

### DIFF
--- a/.changeset/openrouter-structured-usage.md
+++ b/.changeset/openrouter-structured-usage.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/ai-openrouter': patch
+'@tanstack/openai-base': patch
+'@tanstack/ai-mistral': patch
+'@tanstack/ai-bedrock': patch
+---
+
+fix: populate StructuredOutputResult.usage from non-stream structuredOutput()
+
+Adapters that already returned tokens/cost on streaming structured paths were dropping response.usage on the non-stream structuredOutput() method. OpenRouter now forwards tokens and cost; openai-base, Mistral, and Bedrock Converse do the same for tokens so fallbackStructuredOutputStream and middleware can observe usage.

--- a/packages/ai-bedrock/src/adapters/converse-text.ts
+++ b/packages/ai-bedrock/src/adapters/converse-text.ts
@@ -261,9 +261,17 @@ export class BedrockConverseTextAdapter<
           `${this.name}.structuredOutput: response contained no forced-tool output`,
         )
       }
+      const usage = res.usage
       return {
         data: structured,
         rawText: JSON.stringify(structured),
+        ...(usage && {
+          usage: {
+            promptTokens: usage.inputTokens ?? 0,
+            completionTokens: usage.outputTokens ?? 0,
+            totalTokens: usage.totalTokens ?? 0,
+          },
+        }),
       }
     } catch (error: unknown) {
       chatOptions.logger.errors(`${this.name}.structuredOutput fatal`, {

--- a/packages/ai-mistral/src/adapters/text.ts
+++ b/packages/ai-mistral/src/adapters/text.ts
@@ -271,9 +271,17 @@ export class MistralTextAdapter<
       )
     }
 
+    const usage = response.usage
     return {
       data: transformNullsToUndefined(parsed),
       rawText: textContent,
+      ...(usage && {
+        usage: {
+          promptTokens: usage.promptTokens ?? 0,
+          completionTokens: usage.completionTokens ?? 0,
+          totalTokens: usage.totalTokens ?? 0,
+        },
+      }),
     }
   }
 

--- a/packages/ai-openrouter/src/adapters/responses-text.ts
+++ b/packages/ai-openrouter/src/adapters/responses-text.ts
@@ -262,9 +262,27 @@ export class OpenRouterResponsesTextAdapter<
       // OpenRouter override: pass nulls through unchanged.
       const transformed = this.transformStructuredOutput(parsed)
 
+      // Responses API reports usage as inputTokens/outputTokens (not the
+      // chat-completions promptTokens/completionTokens shape). Map to
+      // TokenUsage and attach OpenRouter cost when present — same contract
+      // as structuredOutputStream / processStreamChunks.
+      const usage = response.usage
+      const hasUsage =
+        usage != null &&
+        (usage.inputTokens != null ||
+          usage.outputTokens != null ||
+          usage.totalTokens != null)
       return {
         data: transformed,
         rawText,
+        ...(hasUsage && {
+          usage: {
+            promptTokens: usage.inputTokens ?? 0,
+            completionTokens: usage.outputTokens ?? 0,
+            totalTokens: usage.totalTokens ?? 0,
+            ...extractUsageCost(usage),
+          },
+        }),
       }
     } catch (error: unknown) {
       chatOptions.logger.errors(`${this.name}.structuredOutput fatal`, {

--- a/packages/ai-openrouter/src/adapters/responses-text.ts
+++ b/packages/ai-openrouter/src/adapters/responses-text.ts
@@ -265,13 +265,16 @@ export class OpenRouterResponsesTextAdapter<
       // Responses API reports usage as inputTokens/outputTokens (not the
       // chat-completions promptTokens/completionTokens shape). Map to
       // TokenUsage and attach OpenRouter cost when present — same contract
-      // as structuredOutputStream / processStreamChunks.
+      // as structuredOutputStream / processStreamChunks. Cost-only usage
+      // (finite cost, no token fields) still forwards with zeroed tokens.
       const usage = response.usage
+      const cost = extractUsageCost(usage)
       const hasUsage =
         usage != null &&
         (usage.inputTokens != null ||
           usage.outputTokens != null ||
-          usage.totalTokens != null)
+          usage.totalTokens != null ||
+          cost.cost !== undefined)
       return {
         data: transformed,
         rawText,
@@ -280,7 +283,7 @@ export class OpenRouterResponsesTextAdapter<
             promptTokens: usage.inputTokens ?? 0,
             completionTokens: usage.outputTokens ?? 0,
             totalTokens: usage.totalTokens ?? 0,
-            ...extractUsageCost(usage),
+            ...cost,
           },
         }),
       }

--- a/packages/ai-openrouter/src/adapters/text.ts
+++ b/packages/ai-openrouter/src/adapters/text.ts
@@ -278,9 +278,16 @@ export class OpenRouterTextAdapter<
       // this).
       const transformed = this.transformStructuredOutput(parsed)
 
+      // Forward provider usage (tokens + OpenRouter cost) so middleware
+      // onFinish/onUsage and fallbackStructuredOutputStream see real cost.
+      // Matches the stream path and StructuredOutputResult.usage contract.
+      const baseUsage = buildOpenRouterUsage(response.usage)
       return {
         data: transformed,
         rawText,
+        ...(baseUsage && {
+          usage: { ...baseUsage, ...extractUsageCost(response.usage) },
+        }),
       }
     } catch (error: unknown) {
       // Narrow before logging: raw SDK errors can carry request metadata

--- a/packages/ai-openrouter/tests/openrouter-adapter.test.ts
+++ b/packages/ai-openrouter/tests/openrouter-adapter.test.ts
@@ -1272,6 +1272,75 @@ describe('OpenRouter structured output', () => {
     expect(params.stream).toBe(false)
   })
 
+  it('forwards response.usage tokens and cost on structuredOutput (#1076)', async () => {
+    // Regression: structuredOutput used to return only { data, rawText },
+    // dropping OpenRouter usage/cost so middleware onFinish/onUsage saw
+    // nothing after non-stream structured calls.
+    const nonStreamResponse = {
+      choices: [
+        {
+          message: {
+            content: '{"title":"Hello"}',
+          },
+        },
+      ],
+      usage: {
+        promptTokens: 12,
+        completionTokens: 4,
+        totalTokens: 16,
+        cost: 0.00042,
+        costDetails: { upstreamInferenceCost: 0.0003 },
+      },
+    }
+
+    setupMockSdkClient([], nonStreamResponse)
+    const adapter = createAdapter()
+
+    const result = await adapter.structuredOutput({
+      chatOptions: {
+        model: 'openai/gpt-4o-mini',
+        messages: [{ role: 'user', content: 'Return a short title as JSON.' }],
+        logger: testLogger,
+      },
+      outputSchema: {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: ['title'],
+      },
+    })
+
+    expect(result.data).toEqual({ title: 'Hello' })
+    expect(result.usage).toEqual({
+      promptTokens: 12,
+      completionTokens: 4,
+      totalTokens: 16,
+      cost: 0.00042,
+      costDetails: { upstreamCost: 0.0003 },
+    })
+  })
+
+  it('omits usage when the provider reports none on structuredOutput', async () => {
+    setupMockSdkClient([], {
+      choices: [{ message: { content: '{"title":"x"}' } }],
+    })
+    const adapter = createAdapter()
+
+    const result = await adapter.structuredOutput({
+      chatOptions: {
+        model: 'openai/gpt-4o-mini',
+        messages: [{ role: 'user', content: 'title' }],
+        logger: testLogger,
+      },
+      outputSchema: {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: ['title'],
+      },
+    })
+
+    expect(result.usage).toBeUndefined()
+  })
+
   it('makes schema OpenAI-strict compatible before sending', async () => {
     // Regression: upstream providers (OpenAI) reject json_schema requests with
     // strict: true unless every object sets additionalProperties: false and

--- a/packages/ai-openrouter/tests/openrouter-responses-adapter.test.ts
+++ b/packages/ai-openrouter/tests/openrouter-responses-adapter.test.ts
@@ -1276,6 +1276,54 @@ describe('OpenRouter responses adapter — structured output', () => {
     // Critical: nickname should be `null`, not `undefined`.
     expect((result.data as any).nickname).toBeNull()
   })
+
+  it('forwards response.usage tokens and cost on structuredOutput (#1076)', async () => {
+    // Regression: non-stream structuredOutput dropped Responses usage/cost,
+    // so consumers never saw TokenUsage after outputSchema finalization.
+    setupMockSdkClient([], {
+      output: [
+        {
+          type: 'message',
+          content: [
+            {
+              type: 'output_text',
+              text: JSON.stringify({ title: 'Hello' }),
+            },
+          ],
+        },
+      ],
+      usage: {
+        inputTokens: 10,
+        outputTokens: 3,
+        totalTokens: 13,
+        cost: 0.0011,
+        costDetails: { upstreamInferenceCost: 0.0009 },
+      },
+    })
+
+    const adapter = createAdapter()
+    const result = await adapter.structuredOutput({
+      chatOptions: {
+        model: 'openai/gpt-4o-mini' as any,
+        messages: [{ role: 'user', content: 'title?' }],
+        logger: testLogger,
+      },
+      outputSchema: {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: ['title'],
+      },
+    })
+
+    expect(result.data).toEqual({ title: 'Hello' })
+    expect(result.usage).toEqual({
+      promptTokens: 10,
+      completionTokens: 3,
+      totalTokens: 13,
+      cost: 0.0011,
+      costDetails: { upstreamCost: 0.0009 },
+    })
+  })
 })
 
 describe('OpenRouter responses adapter — SDK constructor wiring', () => {

--- a/packages/ai-openrouter/tests/openrouter-responses-adapter.test.ts
+++ b/packages/ai-openrouter/tests/openrouter-responses-adapter.test.ts
@@ -1324,6 +1324,51 @@ describe('OpenRouter responses adapter — structured output', () => {
       costDetails: { upstreamCost: 0.0009 },
     })
   })
+
+  it('forwards cost-only usage on structuredOutput (no token fields)', async () => {
+    // Regression: hasUsage used to require input/output/total tokens, so a
+    // usage object with only OpenRouter cost was dropped entirely.
+    setupMockSdkClient([], {
+      output: [
+        {
+          type: 'message',
+          content: [
+            {
+              type: 'output_text',
+              text: JSON.stringify({ title: 'Hello' }),
+            },
+          ],
+        },
+      ],
+      usage: {
+        cost: 0.0025,
+        costDetails: { upstreamInferenceCost: 0.002 },
+      },
+    })
+
+    const adapter = createAdapter()
+    const result = await adapter.structuredOutput({
+      chatOptions: {
+        model: 'openai/gpt-4o-mini' as any,
+        messages: [{ role: 'user', content: 'title?' }],
+        logger: testLogger,
+      },
+      outputSchema: {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: ['title'],
+      },
+    })
+
+    expect(result.data).toEqual({ title: 'Hello' })
+    expect(result.usage).toEqual({
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      cost: 0.0025,
+      costDetails: { upstreamCost: 0.002 },
+    })
+  })
 })
 
 describe('OpenRouter responses adapter — SDK constructor wiring', () => {

--- a/packages/openai-base/src/adapters/chat-completions-text.ts
+++ b/packages/openai-base/src/adapters/chat-completions-text.ts
@@ -217,9 +217,13 @@ export abstract class OpenAIBaseChatCompletionsTextAdapter<
       // from strict mode is undone by the engine, not here.
       const transformed = this.transformStructuredOutput(parsed)
 
+      // Surface usage so non-stream structured paths (and
+      // fallbackStructuredOutputStream) can forward tokens to middleware.
+      const usage = buildChatCompletionsUsage(response.usage)
       return {
         data: transformed,
         rawText,
+        ...(usage && { usage }),
       }
     } catch (error: unknown) {
       // Narrow before logging: raw SDK errors can carry request metadata

--- a/packages/openai-base/src/adapters/responses-text.ts
+++ b/packages/openai-base/src/adapters/responses-text.ts
@@ -260,9 +260,13 @@ export abstract class OpenAIBaseResponsesTextAdapter<
       // from strict mode is undone by the engine, not here.
       const transformed = this.transformStructuredOutput(parsed)
 
+      // Surface usage so non-stream structured paths (and
+      // fallbackStructuredOutputStream) can forward tokens to middleware.
+      const usage = buildResponsesUsage(response.usage)
       return {
         data: transformed,
         rawText,
+        ...(usage && { usage }),
       }
     } catch (error: unknown) {
       // Narrow before logging: raw SDK errors can carry request metadata

--- a/packages/openai-base/tests/chat-completions-text.test.ts
+++ b/packages/openai-base/tests/chat-completions-text.test.ts
@@ -791,6 +791,47 @@ describe('OpenAIBaseChatCompletionsTextAdapter', () => {
       )
     })
 
+    it('forwards response.usage on structuredOutput', async () => {
+      setupMockSdkClient([], {
+        choices: [
+          {
+            message: {
+              content: '{"name":"Alice","age":30}',
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 11,
+          completion_tokens: 5,
+          total_tokens: 16,
+        },
+      })
+
+      const adapter = new TestChatCompletionsAdapter(testConfig, 'test-model')
+
+      const result = await adapter.structuredOutput({
+        chatOptions: {
+          logger: testLogger,
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'Give me a person object' }],
+        },
+        outputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'number' },
+          },
+          required: ['name', 'age'],
+        },
+      })
+
+      expect(result.usage).toEqual({
+        promptTokens: 11,
+        completionTokens: 5,
+        totalTokens: 16,
+      })
+    })
+
     it('passes provider nulls through unchanged (engine un-widens, not the adapter)', async () => {
       const nonStreamResponse = {
         choices: [

--- a/packages/openai-base/tests/responses-text.test.ts
+++ b/packages/openai-base/tests/responses-text.test.ts
@@ -1798,6 +1798,51 @@ describe('OpenAIBaseResponsesTextAdapter', () => {
       )
     })
 
+    it('forwards response.usage on structuredOutput', async () => {
+      setupMockResponsesClient([], {
+        output: [
+          {
+            type: 'message',
+            content: [
+              {
+                type: 'output_text',
+                text: '{"name":"Alice","age":30}',
+              },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: 9,
+          output_tokens: 4,
+          total_tokens: 13,
+        },
+      })
+
+      const adapter = new TestResponsesAdapter(testConfig, 'test-model')
+
+      const result = await adapter.structuredOutput({
+        chatOptions: {
+          logger: testLogger,
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'Give me a person object' }],
+        },
+        outputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'number' },
+          },
+          required: ['name', 'age'],
+        },
+      })
+
+      expect(result.usage).toEqual({
+        promptTokens: 9,
+        completionTokens: 4,
+        totalTokens: 13,
+      })
+    })
+
     it('passes provider nulls through unchanged (engine un-widens, not the adapter)', async () => {
       const nonStreamResponse = {
         output: [


### PR DESCRIPTION
## Summary

- **OpenRouter** chat + responses `structuredOutput()` now returns `StructuredOutputResult.usage` (tokens + `cost` / `costDetails`), matching `structuredOutputStream`.
- **openai-base**, **Mistral**, and **Bedrock Converse** non-stream `structuredOutput()` also forward provider token usage when present.
- Unit tests cover OpenRouter cost forwarding and openai-base usage mapping.

Primary streaming structured-output paths already carried usage for OpenRouter; this closes the residual non-stream / fallback-adapter hole reported in #1076.

## Test plan

- [x] `pnpm --filter @tanstack/ai-openrouter test:lib`
- [x] `pnpm --filter @tanstack/openai-base test:lib`
- [x] `pnpm --filter @tanstack/ai-mistral test:lib`
- [x] `pnpm --filter @tanstack/ai-bedrock test:lib`
- [x] `test:types` / `test:oxlint` for affected packages
- [ ] CI `pnpm test:pr` on the PR

Closes #1076

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-streaming structured outputs now include token usage details across supported OpenAI, OpenRouter, Mistral, and Bedrock integrations.
  * OpenRouter structured outputs also report available cost information.
  * Usage data includes prompt, completion, and total token counts when provided by the model provider.

* **Bug Fixes**
  * Preserved responses without usage metadata without adding incomplete usage fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->