### PR TITLE
feat: add context management support and corresponding beta handling

### DIFF
--- a/.changeset/little-guests-trade.md
+++ b/.changeset/little-guests-trade.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/ai-anthropic": patch
+'@tanstack/ai-anthropic': patch
 ---
 
 Fix `modelOptions.context_management` by attaching the required

--- a/.changeset/little-guests-trade.md
+++ b/.changeset/little-guests-trade.md
@@ -1,0 +1,8 @@
+---
+"@tanstack/ai-anthropic": patch
+---
+
+Fix `modelOptions.context_management` by attaching the required
+`context-management-2025-06-27` beta. The option was typed and forwarded on the
+request body, but Anthropic rejects context editing without the beta header —
+so the feature typechecked and could not work (issue #1074).

--- a/packages/ai-anthropic/src/adapters/text.ts
+++ b/packages/ai-anthropic/src/adapters/text.ts
@@ -148,7 +148,8 @@ function buildServerToolResultBlock(
  * Computes the `betas` array for a Messages request. Unions:
  * - `interleaved-thinking-2025-05-14` when interleaved thinking is enabled,
  * - `code-execution-2025-08-25` when a `code_execution` tool is present,
- * - `skills-2025-10-02` when that tool carries skills.
+ * - `skills-2025-10-02` when that tool carries skills,
+ * - `context-management-2025-06-27` when `context_management` is set.
  * Returns `undefined` when none apply (so the call site omits `betas`).
  */
 export function computeAnthropicBetas(
@@ -159,6 +160,7 @@ export function computeAnthropicBetas(
           type?: 'enabled' | 'disabled' | 'adaptive'
           budget_tokens?: number
         }
+        context_management?: unknown | null
       }
     | undefined,
 ): Array<AnthropicBeta> | undefined {
@@ -169,6 +171,12 @@ export function computeAnthropicBetas(
     typeof modelOptions.thinking.budget_tokens === 'number' &&
     modelOptions.thinking.budget_tokens > 0
   if (useInterleavedThinking) betas.add('interleaved-thinking-2025-05-14')
+
+  // Context editing requires the beta header; the body field alone is not
+  // enough (issue #1074). `null` is a typed "unset" — do not enable the beta.
+  if (modelOptions?.context_management != null) {
+    betas.add('context-management-2025-06-27')
+  }
 
   // Code-execution beta is version-aware: select from the FIRST code_execution
   // tool's config type.

--- a/packages/ai-anthropic/tests/anthropic-adapter.test.ts
+++ b/packages/ai-anthropic/tests/anthropic-adapter.test.ts
@@ -397,6 +397,29 @@ describe('Anthropic adapter option mapping', () => {
     expect(payload.max_tokens).toBe(2048)
   })
 
+  it('forwards context_management and attaches the required beta (issue #1074)', async () => {
+    mocks.betaMessagesCreate.mockResolvedValueOnce(createTextStream('ok'))
+
+    const adapter = createAdapter('claude-opus-4-1')
+    const contextManagement = {
+      edits: [{ type: 'clear_tool_uses_20250919' as const }],
+    }
+
+    for await (const _ of chat({
+      adapter,
+      messages: [{ role: 'user', content: 'Hi' }],
+      modelOptions: {
+        context_management: contextManagement,
+      } satisfies AnthropicTextProviderOptions,
+    })) {
+      // consume stream
+    }
+
+    const [payload] = mocks.betaMessagesCreate.mock.calls[0]!
+    expect(payload.context_management).toEqual(contextManagement)
+    expect(payload.betas).toEqual(['context-management-2025-06-27'])
+  })
+
   it('forwards top-level cache_control from modelOptions instead of dropping it', async () => {
     mocks.betaMessagesCreate.mockResolvedValueOnce(createTextStream('ok'))
 

--- a/packages/ai-anthropic/tests/text.skills.test.ts
+++ b/packages/ai-anthropic/tests/text.skills.test.ts
@@ -107,6 +107,36 @@ describe('computeAnthropicBetas', () => {
     expect(computeAnthropicBetas(undefined, undefined)).toBeUndefined()
   })
 
+  it('adds context-management beta when context_management is set (issue #1074)', () => {
+    const betas = computeAnthropicBetas(undefined, {
+      context_management: {
+        edits: [{ type: 'clear_tool_uses_20250919' }],
+      },
+    })
+    expect(betas).toEqual(['context-management-2025-06-27'])
+  })
+
+  it('does not add context-management beta when context_management is null', () => {
+    expect(
+      computeAnthropicBetas(undefined, { context_management: null }),
+    ).toBeUndefined()
+  })
+
+  it('unions context-management with interleaved-thinking betas', () => {
+    const betas = computeAnthropicBetas(undefined, {
+      thinking: { type: 'enabled', budget_tokens: 2048 },
+      context_management: {
+        edits: [{ type: 'clear_thinking_20251015', keep: 'all' }],
+      },
+    })
+    expect(betas).toEqual(
+      expect.arrayContaining([
+        'interleaved-thinking-2025-05-14',
+        'context-management-2025-06-27',
+      ]),
+    )
+  })
+
   it('uses code-execution-2025-05-22 beta for legacy code_execution_20250522 tool', () => {
     const tool = codeExecutionTool({
       type: 'code_execution_20250522',


### PR DESCRIPTION
## 🎯 Changes

Fixes #1074.

`modelOptions.context_management` was typed and forwarded on the Anthropic Messages body, but `computeAnthropicBetas` never attached the required `context-management-2025-06-27` beta. Context editing therefore typechecked and could not work.

- Add `context-management-2025-06-27` when `context_management != null` (treat `null` as unset)
- Unit coverage in `computeAnthropicBetas`
- Wire-level adapter test asserting body + `betas` are both sent

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Anthropic context management settings.
  * Automatically enables the required beta capability when context management is configured.
  * Supports using context management alongside interleaved thinking.
  * Keeps the beta capability disabled when context management is explicitly turned off.

* **Bug Fixes**
  * Ensured context management settings are correctly included in Anthropic requests.

* **Documentation**
  * Documented the required beta header for context management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->