### PR TITLE
fix: enforce onComplete requirement in audio recorder overloads

### DIFF
--- a/.changeset/soft-teams-work.md
+++ b/.changeset/soft-teams-work.md
@@ -1,9 +1,9 @@
 ---
-"@tanstack/ai-angular": patch
-"@tanstack/ai-svelte": patch
-"@tanstack/ai-react": patch
-"@tanstack/ai-solid": patch
-"@tanstack/ai-vue": patch
+'@tanstack/ai-angular': patch
+'@tanstack/ai-svelte': patch
+'@tanstack/ai-react': patch
+'@tanstack/ai-solid': patch
+'@tanstack/ai-vue': patch
 ---
 
 Fix audio-recorder transforming overloads so options without `onComplete`

--- a/.changeset/soft-teams-work.md
+++ b/.changeset/soft-teams-work.md
@@ -1,0 +1,14 @@
+---
+"@tanstack/ai-angular": patch
+"@tanstack/ai-svelte": patch
+"@tanstack/ai-react": patch
+"@tanstack/ai-solid": patch
+"@tanstack/ai-vue": patch
+---
+
+Fix audio-recorder transforming overloads so options without `onComplete`
+(e.g. `{ onError }`) keep `AudioRecording` instead of collapsing
+`recording`/`stop()` to `unknown` (issue #1001).
+
+The transforming overload now requires `onComplete`, matching the fix already
+landed in the Octane port (#1000). Runtime behavior is unchanged.

--- a/packages/ai-angular/src/inject-audio-recorder.ts
+++ b/packages/ai-angular/src/inject-audio-recorder.ts
@@ -44,10 +44,18 @@ export interface InjectAudioRecorderResult<TOutput> {
  * failure (and `stop()` rejects with `Recording cancelled` if `cancel()` runs
  * while a stop is in flight, e.g. on destroy) — handle one channel, not both.
  */
+// The transforming overload requires `onComplete`. Without that constraint an
+// options object carrying only unrelated keys (`injectAudioRecorder({ onError })`)
+// still matches it, `TOnComplete` infers as `unknown`, and `recording`/`stop()`
+// collapse to `unknown` — so passing any option would silently cost you the
+// `AudioRecording` type. Requiring it here sends those calls to the second
+// overload instead (issue #1001).
 export function injectAudioRecorder<
   TOnComplete extends (recording: AudioRecording) => unknown,
 >(
-  options: InjectAudioRecorderOptions<TOnComplete>,
+  options: InjectAudioRecorderOptions<TOnComplete> & {
+    onComplete: TOnComplete
+  },
 ): InjectAudioRecorderResult<InferAudioRecordingOutput<TOnComplete>>
 export function injectAudioRecorder(
   options?: InjectAudioRecorderOptions<undefined>,

--- a/packages/ai-angular/tests/inject-audio-recorder-types.test.ts
+++ b/packages/ai-angular/tests/inject-audio-recorder-types.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Type-level tests for `injectAudioRecorder` overload selection (issue #1001).
+ * Scenario functions are never executed (the injectable requires an injection
+ * context at runtime), so `expectTypeOf` runs as a no-op and `tsc`
+ * (`test:types`) is what validates them.
+ */
+import { describe, expectTypeOf, it } from 'vitest'
+import { injectAudioRecorder } from '../src/inject-audio-recorder'
+import type { AudioRecording } from '@tanstack/ai-client'
+
+describe('injectAudioRecorder type inference (issue #1001)', () => {
+  it('keeps AudioRecording when options carry no onComplete', () => {
+    function _scenario() {
+      // Only an unrelated option: must select the untransformed overload rather
+      // than inferring `TOnComplete` as `unknown` and collapsing types.
+      const { recording, stop } = injectAudioRecorder({
+        onError: (_error: Error) => {},
+      })
+
+      expectTypeOf(recording()).not.toBeUnknown()
+      expectTypeOf(recording()).toEqualTypeOf<AudioRecording | null>()
+      expectTypeOf(stop).returns.toEqualTypeOf<Promise<AudioRecording>>()
+
+      const value = recording()
+      if (value) {
+        expectTypeOf(value.base64).toBeString()
+      }
+    }
+    void _scenario
+  })
+
+  it('re-types stop()/recording() from onComplete', () => {
+    function _scenario() {
+      const { recording, stop } = injectAudioRecorder({
+        onComplete: (rec) => rec.base64,
+      })
+      expectTypeOf(recording()).toEqualTypeOf<string | null>()
+      expectTypeOf(stop).returns.toEqualTypeOf<Promise<string>>()
+    }
+    void _scenario
+  })
+
+  it('keeps AudioRecording when called with no options', () => {
+    function _scenario() {
+      const { recording, stop } = injectAudioRecorder()
+      expectTypeOf(recording()).toEqualTypeOf<AudioRecording | null>()
+      expectTypeOf(stop).returns.toEqualTypeOf<Promise<AudioRecording>>()
+    }
+    void _scenario
+  })
+})

--- a/packages/ai-react/src/use-audio-recorder.ts
+++ b/packages/ai-react/src/use-audio-recorder.ts
@@ -48,10 +48,16 @@ export interface UseAudioRecorderReturn<TOutput> {
  * sendMessage({ content: [rec.part] })
  * ```
  */
+// The transforming overload requires `onComplete`. Without that constraint an
+// options object carrying only unrelated keys (`useAudioRecorder({ onError })`)
+// still matches it, `TOnComplete` infers as `unknown`, and `recording`/`stop()`
+// collapse to `unknown` — so passing any option would silently cost you the
+// `AudioRecording` type. Requiring it here sends those calls to the second
+// overload instead (issue #1001).
 export function useAudioRecorder<
   TOnComplete extends (recording: AudioRecording) => unknown,
 >(
-  options: UseAudioRecorderOptions<TOnComplete>,
+  options: UseAudioRecorderOptions<TOnComplete> & { onComplete: TOnComplete },
 ): UseAudioRecorderReturn<InferAudioRecordingOutput<TOnComplete>>
 export function useAudioRecorder(
   options?: UseAudioRecorderOptions<undefined>,

--- a/packages/ai-react/tests/use-audio-recorder.test.tsx
+++ b/packages/ai-react/tests/use-audio-recorder.test.tsx
@@ -1,6 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 import { useAudioRecorder } from '../src/use-audio-recorder'
+import type { AudioRecording } from '@tanstack/ai-client'
 
 class FakeMediaRecorder {
   ondataavailable: ((e: { data: Blob }) => void) | null = null
@@ -149,5 +150,37 @@ describe('useAudioRecorder', () => {
     // the microphone tracks stop — a dropped cleanup would leak a live mic.
     unmount()
     expect(trackStop).toHaveBeenCalled()
+  })
+})
+
+describe('useAudioRecorder type inference (issue #1001)', () => {
+  it('keeps AudioRecording when options carry no onComplete', () => {
+    // Compile-time only: never invoked, so the recorder is never constructed.
+    const _types = () => {
+      // Only an unrelated option: must select the untransformed overload rather
+      // than inferring `TOnComplete` as `unknown` and collapsing types.
+      const { recording, stop } = useAudioRecorder({
+        onError: (_error: Error) => {},
+      })
+
+      expectTypeOf(recording).not.toBeUnknown()
+      expectTypeOf(recording).toEqualTypeOf<AudioRecording | null>()
+      expectTypeOf(stop).returns.toEqualTypeOf<Promise<AudioRecording>>()
+
+      if (recording) {
+        expectTypeOf(recording.base64).toBeString()
+      }
+
+      const withTransform = useAudioRecorder({
+        onComplete: (rec) => rec.base64,
+      })
+      expectTypeOf(withTransform.recording).toEqualTypeOf<string | null>()
+      expectTypeOf(withTransform.stop).returns.toEqualTypeOf<Promise<string>>()
+
+      const raw = useAudioRecorder()
+      expectTypeOf(raw.recording).toEqualTypeOf<AudioRecording | null>()
+      expectTypeOf(raw.stop).returns.toEqualTypeOf<Promise<AudioRecording>>()
+    }
+    expect(typeof _types).toBe('function')
   })
 })

--- a/packages/ai-react/tests/use-audio-recorder.test.tsx
+++ b/packages/ai-react/tests/use-audio-recorder.test.tsx
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 import { useAudioRecorder } from '../src/use-audio-recorder'
 import type { AudioRecording } from '@tanstack/ai-client'

--- a/packages/ai-solid/src/use-audio-recorder.ts
+++ b/packages/ai-solid/src/use-audio-recorder.ts
@@ -37,10 +37,16 @@ export interface UseAudioRecorderReturn<TOutput> {
  * failure (and `stop()` rejects with `Recording cancelled` if `cancel()` runs
  * while a stop is in flight, e.g. on unmount) — handle one channel, not both.
  */
+// The transforming overload requires `onComplete`. Without that constraint an
+// options object carrying only unrelated keys (`useAudioRecorder({ onError })`)
+// still matches it, `TOnComplete` infers as `unknown`, and `recording`/`stop()`
+// collapse to `unknown` — so passing any option would silently cost you the
+// `AudioRecording` type. Requiring it here sends those calls to the second
+// overload instead (issue #1001).
 export function useAudioRecorder<
   TOnComplete extends (recording: AudioRecording) => unknown,
 >(
-  options: UseAudioRecorderOptions<TOnComplete>,
+  options: UseAudioRecorderOptions<TOnComplete> & { onComplete: TOnComplete },
 ): UseAudioRecorderReturn<InferAudioRecordingOutput<TOnComplete>>
 export function useAudioRecorder(
   options?: UseAudioRecorderOptions<undefined>,

--- a/packages/ai-solid/tests/use-audio-recorder.test.ts
+++ b/packages/ai-solid/tests/use-audio-recorder.test.ts
@@ -121,4 +121,22 @@ describe('useAudioRecorder (solid) type inference', () => {
     }
     expect(typeof _types).toBe('function')
   })
+
+  it('keeps AudioRecording when options carry no onComplete (issue #1001)', () => {
+    const _types = () => {
+      const { recording, stop } = useAudioRecorder({
+        onError: (_error: Error) => {},
+      })
+
+      expectTypeOf(recording()).not.toBeUnknown()
+      expectTypeOf(recording()).toEqualTypeOf<AudioRecording | null>()
+      expectTypeOf(stop).returns.toEqualTypeOf<Promise<AudioRecording>>()
+
+      const value = recording()
+      if (value) {
+        expectTypeOf(value.base64).toBeString()
+      }
+    }
+    expect(typeof _types).toBe('function')
+  })
 })

--- a/packages/ai-svelte/src/create-audio-recorder.svelte.ts
+++ b/packages/ai-svelte/src/create-audio-recorder.svelte.ts
@@ -41,10 +41,18 @@ export interface CreateAudioRecorderReturn<TOutput> {
  * failure (and `stop()` rejects with `Recording cancelled` if `cancel()` runs
  * while a stop is in flight) — handle one channel, not both.
  */
+// The transforming overload requires `onComplete`. Without that constraint an
+// options object carrying only unrelated keys (`createAudioRecorder({ onError })`)
+// still matches it, `TOnComplete` infers as `unknown`, and `recording`/`stop()`
+// collapse to `unknown` — so passing any option would silently cost you the
+// `AudioRecording` type. Requiring it here sends those calls to the second
+// overload instead (issue #1001).
 export function createAudioRecorder<
   TOnComplete extends (recording: AudioRecording) => unknown,
 >(
-  options: CreateAudioRecorderOptions<TOnComplete>,
+  options: CreateAudioRecorderOptions<TOnComplete> & {
+    onComplete: TOnComplete
+  },
 ): CreateAudioRecorderReturn<InferAudioRecordingOutput<TOnComplete>>
 export function createAudioRecorder(
   options?: CreateAudioRecorderOptions<undefined>,

--- a/packages/ai-svelte/tests/create-audio-recorder.test.ts
+++ b/packages/ai-svelte/tests/create-audio-recorder.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { createAudioRecorder } from '../src/create-audio-recorder.svelte'
 import type { AudioRecording } from '@tanstack/ai-client'
 
@@ -78,5 +78,34 @@ describe('createAudioRecorder (svelte)', () => {
     await expect(recorder.start()).rejects.toThrow('Permission denied')
     expect(onError).toHaveBeenCalledWith(denied)
     expect(recorder.isRecording).toBe(false)
+  })
+})
+
+describe('createAudioRecorder type inference (issue #1001)', () => {
+  it('keeps AudioRecording when options carry no onComplete', () => {
+    const _types = () => {
+      const { recording, stop } = createAudioRecorder({
+        onError: (_error: Error) => {},
+      })
+
+      expectTypeOf(recording).not.toBeUnknown()
+      expectTypeOf(recording).toEqualTypeOf<AudioRecording | null>()
+      expectTypeOf(stop).returns.toEqualTypeOf<Promise<AudioRecording>>()
+
+      if (recording) {
+        expectTypeOf(recording.base64).toBeString()
+      }
+
+      const withTransform = createAudioRecorder({
+        onComplete: (rec) => rec.base64,
+      })
+      expectTypeOf(withTransform.recording).toEqualTypeOf<string | null>()
+      expectTypeOf(withTransform.stop).returns.toEqualTypeOf<Promise<string>>()
+
+      const raw = createAudioRecorder()
+      expectTypeOf(raw.recording).toEqualTypeOf<AudioRecording | null>()
+      expectTypeOf(raw.stop).returns.toEqualTypeOf<Promise<AudioRecording>>()
+    }
+    expect(typeof _types).toBe('function')
   })
 })

--- a/packages/ai-svelte/tests/create-audio-recorder.test.ts
+++ b/packages/ai-svelte/tests/create-audio-recorder.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from 'vitest'
 import { createAudioRecorder } from '../src/create-audio-recorder.svelte'
 import type { AudioRecording } from '@tanstack/ai-client'
 

--- a/packages/ai-vue/src/use-audio-recorder.ts
+++ b/packages/ai-vue/src/use-audio-recorder.ts
@@ -39,10 +39,16 @@ export interface UseAudioRecorderReturn<TOutput> {
  * failure (and `stop()` rejects with `Recording cancelled` if `cancel()` runs
  * while a stop is in flight, e.g. on unmount) — handle one channel, not both.
  */
+// The transforming overload requires `onComplete`. Without that constraint an
+// options object carrying only unrelated keys (`useAudioRecorder({ onError })`)
+// still matches it, `TOnComplete` infers as `unknown`, and `recording`/`stop()`
+// collapse to `unknown` — so passing any option would silently cost you the
+// `AudioRecording` type. Requiring it here sends those calls to the second
+// overload instead (issue #1001).
 export function useAudioRecorder<
   TOnComplete extends (recording: AudioRecording) => unknown,
 >(
-  options: UseAudioRecorderOptions<TOnComplete>,
+  options: UseAudioRecorderOptions<TOnComplete> & { onComplete: TOnComplete },
 ): UseAudioRecorderReturn<InferAudioRecordingOutput<TOnComplete>>
 export function useAudioRecorder(
   options?: UseAudioRecorderOptions<undefined>,

--- a/packages/ai-vue/tests/use-audio-recorder.test.ts
+++ b/packages/ai-vue/tests/use-audio-recorder.test.ts
@@ -133,4 +133,21 @@ describe('useAudioRecorder (vue) type inference', () => {
     }
     expect(typeof _types).toBe('function')
   })
+
+  it('keeps AudioRecording when options carry no onComplete (issue #1001)', () => {
+    const _types = () => {
+      const { recording, stop } = useAudioRecorder({
+        onError: (_error: Error) => {},
+      })
+
+      expectTypeOf(recording.value).not.toBeUnknown()
+      expectTypeOf(recording.value).toEqualTypeOf<AudioRecording | null>()
+      expectTypeOf(stop).returns.toEqualTypeOf<Promise<AudioRecording>>()
+
+      if (recording.value) {
+        expectTypeOf(recording.value.base64).toBeString()
+      }
+    }
+    expect(typeof _types).toBe('function')
+  })
 })


### PR DESCRIPTION
Fixes #1001

## 🎯 Changes

The transforming useAudioRecorder overload could previously match options that did not provide onComplete. For example, passing only { onError } could select the transforming overload and cause recording / stop() to be inferred as unknown.

This updates the transforming overload across React, Vue, Solid, Svelte, and Angular so that onComplete is required when that overload is selected.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed audio recorder type inference across Angular, Svelte, React, Solid, and Vue integrations.
  - Audio recordings now retain their correct types when options such as error handling are provided without a completion callback.
  - Transformed recording types continue to work correctly when an `onComplete` callback is supplied.

- **Tests**
  - Added compile-time coverage for default, transformed, and callback-based audio recorder usage across supported integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->