### PR TITLE
fix(ai-persistence): preserve cancelled tool resumes

### DIFF
--- a/.changeset/cancelled-client-tool-resume.md
+++ b/.changeset/cancelled-client-tool-resume.md
@@ -1,0 +1,8 @@
+---
+'@tanstack/ai-persistence': patch
+---
+
+`withPersistence` now maps cancelled client-tool and approval resume entries
+into `cancelledToolCallIds`. A resume batch that is only cancellations still
+produces a `resumeToolState`, so the engine can complete the turn instead of
+emitting another `client_tool_*` interrupt.

--- a/packages/ai-persistence/src/middleware.ts
+++ b/packages/ai-persistence/src/middleware.ts
@@ -396,6 +396,7 @@ function resumeToolStateFromPending(
 ): ChatResumeToolState | undefined {
   const approvals = new Map<string, ToolApprovalResolution>()
   const clientToolResults = new Map<string, unknown>()
+  const cancelledToolCallIds = new Set<string>()
 
   for (const interrupt of pending) {
     const entry = resumeByInterruptId.get(interrupt.interruptId)
@@ -404,6 +405,10 @@ function resumeToolStateFromPending(
     const kind = interruptKind(interrupt)
     const reason = stringField(interrupt.payload, 'reason')
     const toolCallId = stringField(interrupt.payload, 'toolCallId')
+
+    if (entry.status === 'cancelled' && toolCallId) {
+      cancelledToolCallIds.add(toolCallId)
+    }
 
     if (kind === 'approval' || reason === 'approval_required') {
       approvals.set(interrupt.interruptId, resolvedApprovalDecision(entry))
@@ -419,8 +424,14 @@ function resumeToolStateFromPending(
     }
   }
 
-  if (approvals.size === 0 && clientToolResults.size === 0) return undefined
-  return { approvals, clientToolResults }
+  if (
+    approvals.size === 0 &&
+    clientToolResults.size === 0 &&
+    cancelledToolCallIds.size === 0
+  ) {
+    return undefined
+  }
+  return { approvals, clientToolResults, cancelledToolCallIds }
 }
 
 /**

--- a/packages/ai-persistence/tests/interrupts.test.ts
+++ b/packages/ai-persistence/tests/interrupts.test.ts
@@ -87,6 +87,39 @@ const runFinished = (runId = 'r1'): StreamChunk => ({
   timestamp: 1,
 })
 
+const toolCallFinished = (runId = 'r1'): StreamChunk => ({
+  type: EventType.RUN_FINISHED,
+  runId,
+  threadId: 't1',
+  finishReason: 'tool_calls',
+  timestamp: 1,
+})
+
+const toolCallChunks = () => [
+  runStarted(),
+  toolStart(),
+  toolArgs(),
+  toolCallFinished(),
+]
+
+async function persistClientToolTurn(
+  persistence: ReturnType<typeof memoryPersistence>,
+  tools: Array<Tool>,
+) {
+  const first = mockAdapter([toolCallChunks()])
+  await collect(
+    chat({
+      adapter: first.adapter,
+      messages: [{ role: 'user', content: 'hi' }],
+      tools,
+      runId: 'r1',
+      threadId: 't1',
+      middleware: [withPersistence(persistence)],
+    }) as AsyncIterable<StreamChunk>,
+  )
+  return first
+}
+
 const clientTool = (name: string): Tool => ({
   name,
   description: `${name} client tool`,
@@ -144,20 +177,7 @@ describe('interrupt persistence', () => {
   it('does not persist duplicate records before terminal interrupt outcome', async () => {
     const persistence = memoryPersistence()
     const create = vi.spyOn(persistence.stores.interrupts!, 'create')
-    const { adapter } = mockAdapter([
-      [
-        runStarted(),
-        toolStart(),
-        toolArgs(),
-        {
-          type: EventType.RUN_FINISHED,
-          runId: 'r1',
-          threadId: 't1',
-          finishReason: 'tool_calls',
-          timestamp: 1,
-        },
-      ],
-    ])
+    const { adapter } = mockAdapter([toolCallChunks()])
 
     await collect(
       chat({
@@ -260,29 +280,9 @@ describe('interrupt persistence', () => {
   // interrupt. Feeding the client output then drives exactly one model call.
   it('applies persisted approval and client-tool resume decisions with empty client messages', async () => {
     const persistence = memoryPersistence()
-    const toolCallChunks = () => [
-      runStarted(),
-      toolStart(),
-      toolArgs(),
-      {
-        type: EventType.RUN_FINISHED,
-        runId: 'r1',
-        threadId: 't1',
-        finishReason: 'tool_calls',
-        timestamp: 1,
-      } as StreamChunk,
-    ]
-    const first = mockAdapter([toolCallChunks()])
-    await collect(
-      chat({
-        adapter: first.adapter,
-        messages: [{ role: 'user', content: 'hi' }],
-        tools: [approvalClientTool('clientSearch')],
-        runId: 'r1',
-        threadId: 't1',
-        middleware: [withPersistence(persistence)],
-      }) as AsyncIterable<StreamChunk>,
-    )
+    await persistClientToolTurn(persistence, [
+      approvalClientTool('clientSearch'),
+    ])
 
     const approvalInterrupt = await persistence.stores.interrupts!.get(
       'approval_tool-call-1',
@@ -370,6 +370,65 @@ describe('interrupt persistence', () => {
     expect(finalChunks).toContainEqual(
       expect.objectContaining({ delta: 'done' }),
     )
+    expect(await persistence.stores.interrupts!.listPending('t1')).toEqual([])
+  })
+
+  // Issue #1088: cancelling a hydrated client-tool interrupt under
+  // withPersistence must complete the turn. Persistence clears `config.resume`
+  // and must therefore put the cancelled toolCallId on `cancelledToolCallIds`.
+  // Otherwise the engine treats the stored tool call as unhandled and emits
+  // another `client_tool_*` interrupt instead of an output-error.
+  it('completes a cancelled client-tool resume from persisted state with empty client messages', async () => {
+    const persistence = memoryPersistence()
+    await persistClientToolTurn(persistence, [clientTool('clientSearch')])
+
+    const pending = await persistence.stores.interrupts!.get(
+      'client_tool_tool-call-1',
+    )
+    expect(pending?.status).toBe('pending')
+
+    const afterCancel = mockAdapter([
+      [runStarted(), text('cancelled-and-done'), runFinished('r1')],
+    ])
+    const chunks = await collect(
+      chat({
+        adapter: afterCancel.adapter,
+        messages: [],
+        tools: [clientTool('clientSearch')],
+        runId: 'r1',
+        threadId: 't1',
+        resume: [
+          {
+            interruptId: 'client_tool_tool-call-1',
+            status: 'cancelled',
+          },
+        ],
+        middleware: [withPersistence(persistence)],
+      }) as AsyncIterable<StreamChunk>,
+    )
+
+    expect(afterCancel.calls).toHaveLength(1)
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: EventType.TOOL_CALL_RESULT,
+        toolCallId: 'tool-call-1',
+        content: JSON.stringify({ error: 'Tool execution cancelled' }),
+      }),
+    )
+    expect(
+      chunks.find(
+        (chunk) =>
+          chunk.type === EventType.RUN_FINISHED &&
+          chunk.outcome?.type === 'interrupt',
+      ),
+    ).toBeUndefined()
+    expect(chunks).toContainEqual(
+      expect.objectContaining({ delta: 'cancelled-and-done' }),
+    )
+    expect(
+      (await persistence.stores.interrupts!.get('client_tool_tool-call-1'))
+        ?.status,
+    ).toBe('cancelled')
     expect(await persistence.stores.interrupts!.listPending('t1')).toEqual([])
   })
 

--- a/packages/ai-persistence/tests/interrupts.test.ts
+++ b/packages/ai-persistence/tests/interrupts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { EventType, chat } from '@tanstack/ai'
+import { EventType, chat, defineChatMiddleware } from '@tanstack/ai'
 import type { AnyTextAdapter, StreamChunk, Tool } from '@tanstack/ai'
 import { memoryPersistence } from '../src/memory'
 import { withPersistence } from '../src/middleware'
@@ -775,6 +775,13 @@ describe('interrupt persistence', () => {
     })
 
     const run = mockAdapter([[runStarted(), text('ok'), runFinished('r1')]])
+    const resumeStates: Array<ReadonlySet<string> | undefined> = []
+    const observeResumeState = defineChatMiddleware({
+      name: 'observe-resume-state',
+      onConfig(_ctx, config) {
+        resumeStates.push(config.resumeToolState?.cancelledToolCallIds)
+      },
+    })
     await collect(
       chat({
         adapter: run.adapter,
@@ -782,7 +789,7 @@ describe('interrupt persistence', () => {
         runId: 'r1',
         threadId: 't1',
         resume: [{ interruptId: 'approval-1', status: 'cancelled' }],
-        middleware: [withPersistence(persistence)],
+        middleware: [withPersistence(persistence), observeResumeState],
       }) as AsyncIterable<StreamChunk>,
     )
 
@@ -790,6 +797,7 @@ describe('interrupt persistence', () => {
       run.calls[0] as { approvals?: ReadonlyMap<string, boolean> }
     ).approvals
     expect(approvals?.get('approval-1')).toBe(false)
+    expect(resumeStates[0]?.has('tc1')).toBe(true)
     expect(
       (await persistence.stores.interrupts!.get('approval-1'))?.status,
     ).toBe('cancelled')
@@ -806,6 +814,13 @@ describe('interrupt persistence', () => {
     })
 
     const run = mockAdapter([[runStarted(), text('ok'), runFinished('r1')]])
+    const resumeStates: Array<ReadonlySet<string> | undefined> = []
+    const observeResumeState = defineChatMiddleware({
+      name: 'observe-resume-state',
+      onConfig(_ctx, config) {
+        resumeStates.push(config.resumeToolState?.cancelledToolCallIds)
+      },
+    })
     await collect(
       chat({
         adapter: run.adapter,
@@ -819,7 +834,7 @@ describe('interrupt persistence', () => {
             payload: { answer: 99 },
           },
         ],
-        middleware: [withPersistence(persistence)],
+        middleware: [withPersistence(persistence), observeResumeState],
       }) as AsyncIterable<StreamChunk>,
     )
 
@@ -829,6 +844,7 @@ describe('interrupt persistence', () => {
       run.calls[0] as { clientToolResults?: ReadonlyMap<string, unknown> }
     ).clientToolResults
     expect(clientToolResults?.get('tc1')).toBeUndefined()
+    expect(resumeStates[0]?.has('tc1')).toBe(true)
     expect((await persistence.stores.interrupts!.get('client-1'))?.status).toBe(
       'cancelled',
     )


### PR DESCRIPTION
## Summary
- Preserve cancelled approval and client-tool IDs in persisted resume state.
- Keep cancellation-only resumes non-empty so the chat engine consumes them.
- Add regression coverage for both cancellation paths.

Fixes #1088

## Validation
- vitest run packages/ai-persistence/tests: 172 passed
- tsc -p packages/ai-persistence/tsconfig.json --noEmit: passed
- oxlint packages/ai-persistence/src --type-aware: passed
- vite build in packages/ai-persistence: passed
- publint --strict: passed
- git diff --check: passed

The repository Playwright/Chromium install was blocked during Windows extraction, so the E2E suite was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled tool interruptions are now preserved when conversations are resumed.
  * Cancelled approval and client-tool calls are accurately tracked during resume.
  * Cancelled client-tool operations now return a cancellation error, complete the run, and clear pending interruptions.
  * Cancellation-only resume requests no longer trigger another client-tool interruption.
  * Approval-denial behavior continues to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->