### PR TITLE
fix: make default Daytona + Grok/Codex sandbox runs work

### DIFF
--- a/.changeset/daytona-headless-edges.md
+++ b/.changeset/daytona-headless-edges.md
@@ -1,6 +1,6 @@
 ---
 '@tanstack/ai-sandbox': patch
-'@tanstack/ai-sandbox-daytona': patch
+'@tanstack/ai-sandbox-daytona': minor
 '@tanstack/ai-grok-build': patch
 '@tanstack/ai-codex': patch
 '@tanstack/ai-acp': patch

--- a/.changeset/daytona-headless-edges.md
+++ b/.changeset/daytona-headless-edges.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/ai-sandbox': patch
+'@tanstack/ai-sandbox-daytona': patch
+'@tanstack/ai-grok-build': patch
+'@tanstack/ai-codex': patch
+'@tanstack/ai-acp': patch
+'@tanstack/ai-claude-code': patch
+---
+
+fix: make default Daytona + Grok/Codex sandbox runs work without extra wrappers
+
+Headless Grok and Codex stay permissive when policy is deny-only plus default allow. Daytona remaps `/workspace`, starts stopped sandboxes on resume, keeps secrets out of create-time envVars and command strings, and uses native fs/git plus session stdin. Nested skills project by name. Durable Grok journals when durability is wired.

--- a/docs/adapters/codex.md
+++ b/docs/adapters/codex.md
@@ -53,7 +53,7 @@ const stream = chat({
 | Option                 | Description                                                                                                                                  |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cwd`                  | Working directory for the harness session. Defaults to `process.cwd()`.                                                                       |
-| `sandboxMode`          | Codex sandbox: `'read-only'` (harness default), `'workspace-write'`, or `'danger-full-access'`. This is the safety boundary on a server.       |
+| `sandboxMode`          | Codex sandbox: `'read-only'`, `'workspace-write'`, or `'danger-full-access'`. Default is `'workspace-write'` on local-process and Docker. Default is `'danger-full-access'` on Daytona and Cloudflare, because those providers cannot create a nested bubblewrap namespace. Isolation is then the outer VM plus `defineSandboxPolicy`. |
 | `approvalPolicy`       | Codex approval policy. Defaults to `'never'` — headless runs have no approval UI, so anything else can stall a turn.                           |
 | `modelReasoningEffort` | `'minimal'` \| `'low'` \| `'medium'` \| `'high'` \| `'xhigh'`.                                                                                 |
 | `skipGitRepoCheck`     | Skip the harness's git-repo safety check. Defaults to `true` (server adapters routinely point at scratch directories).                         |

--- a/docs/adapters/grok-build.md
+++ b/docs/adapters/grok-build.md
@@ -105,6 +105,7 @@ Adapter config (second argument to `grokBuildText`):
 | `grokExecutable` | Path/name of the `grok` executable inside the sandbox. Defaults to `grok`.  |
 | `env`            | Extra environment variables for the `grok` process inside the sandbox.      |
 | `emitDiff`       | Emit a `file.changed` CUSTOM event with the working-tree `git diff` after the run. Defaults to `true`. |
+| `protocol`       | Harness wire protocol: `'acp'` or `'streaming-json'`. Defaults to `'acp'`. A durable sandbox run with no protocol set uses `'streaming-json'` so the run can journal. |
 | `extraArgs`      | Extra raw CLI flags appended verbatim (advanced).                           |
 
 Per-call overrides go through `modelOptions`:
@@ -114,6 +115,7 @@ Per-call overrides go through `modelOptions`:
 | `sessionId`     | Resume an existing Grok Build session (see below).           |
 | `cwd`           | Per-call override of the harness working directory.          |
 | `maxTurns`      | Per-call cap on the number of harness turns.                 |
+| `protocol`      | Per-call override of the harness wire protocol.              |
 
 ## Stateful Sessions
 
@@ -165,6 +167,23 @@ Two kinds of tools flow through this adapter:
 tools inside a live process and can't pause across an HTTP round-trip. A tool
 without a server `execute()` (or marked `needsApproval`) fails fast; run those
 with a regular provider adapter.
+
+## Durable runs
+
+A durable sandbox run (you pass `runs` and `durability` to `withSandbox`)
+journals the agent output so a later request can take the run over. ACP does
+not journal. When durability is wired and you do not set `protocol`, the
+adapter uses `'streaming-json'`.
+
+Set `protocol: 'acp'` only when you want ACP on that call. A fresh ACP run
+with durability wired logs a warning. An attach against ACP throws
+`DurableAttachNotSupportedError`.
+
+## Headless NDJSON flags
+
+On the `'streaming-json'` path with auto-approve, the adapter adds
+`--always-approve --no-plan --no-auto-update`. Those flags keep Plan Mode and
+the CLI update check from blocking a headless run.
 
 ## Limitations
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -521,7 +521,7 @@
           "label": "Providers",
           "to": "sandbox/providers",
           "addedAt": "2026-06-29",
-          "updatedAt": "2026-08-04"
+          "updatedAt": "2026-08-12"
         },
         {
           "label": "Harnesses",
@@ -533,7 +533,7 @@
           "label": "Workspace",
           "to": "sandbox/workspace",
           "addedAt": "2026-06-29",
-          "updatedAt": "2026-08-04"
+          "updatedAt": "2026-08-12"
         },
         {
           "label": "Tools",
@@ -545,13 +545,13 @@
           "label": "Policy",
           "to": "sandbox/policy",
           "addedAt": "2026-06-29",
-          "updatedAt": "2026-08-04"
+          "updatedAt": "2026-08-12"
         },
         {
           "label": "Lifecycle & Snapshots",
           "to": "sandbox/lifecycle",
           "addedAt": "2026-06-29",
-          "updatedAt": "2026-08-04"
+          "updatedAt": "2026-08-12"
         },
         {
           "label": "Instance Durability",
@@ -596,7 +596,7 @@
           "label": "Provisioning",
           "to": "sandbox/provisioning",
           "addedAt": "2026-06-29",
-          "updatedAt": "2026-08-04"
+          "updatedAt": "2026-08-12"
         },
         {
           "label": "Observability",
@@ -859,7 +859,7 @@
           "label": "Codex",
           "to": "adapters/codex",
           "addedAt": "2026-06-12",
-          "updatedAt": "2026-06-30"
+          "updatedAt": "2026-08-12"
         },
         {
           "label": "OpenCode",
@@ -870,7 +870,8 @@
         {
           "label": "Grok Build",
           "to": "adapters/grok-build",
-          "addedAt": "2026-06-29"
+          "addedAt": "2026-06-29",
+          "updatedAt": "2026-08-12"
         },
         {
           "label": "ACP-Compatible",

--- a/docs/sandbox/lifecycle.md
+++ b/docs/sandbox/lifecycle.md
@@ -36,7 +36,7 @@ const sandbox = defineSandbox({
 | ------------------- | ------------------------------------------------------------------------------------------- |
 | `reuse`             | `'thread'` keeps one sandbox per `threadId`; `'none'` provisions a fresh sandbox per run.    |
 | `snapshot`          | `'after-setup'` snapshots the workspace once bootstrap finishes, on snapshot-capable providers. |
-| `keepAlive`         | Duration hint (e.g. `'30m'`) for how long the sandbox should stay warm between runs. Nothing in `@tanstack/ai-sandbox` reads it today; it is carried for providers and host apps that implement their own idle GC. |
+| `keepAlive`         | Duration hint (e.g. `'30m'`) for how long the sandbox should stay warm between runs. Nothing in `@tanstack/ai-sandbox` reads it today. Daytona idle stop is `autoStopInterval` on `daytonaSandbox()`. Pass minutes. `0` turns auto-stop off. |
 | `destroyOnComplete` | When `false`, the sandbox survives the run so the next one can resume it.                    |
 | `snapshotMaxAge`    | Duration (e.g. `'24h'`) after which a stored snapshot is treated as stale and re-created.   |
 
@@ -58,8 +58,9 @@ destroys, exactly as an abort does. See
 
 ## Snapshot after setup
 
-When the provider supports snapshots (e.g. [Docker](./providers)), bootstrap
-automatically takes a snapshot after `setup` completes. The snapshot caches the
+When the provider supports snapshots (for example [Docker](./providers) or
+[Daytona](./providers)), bootstrap automatically takes a snapshot after
+`setup` completes. The snapshot caches the
 fully bootstrapped [workspace](./workspace) (the cloned repo with dependencies
 installed) so subsequent runs resume from it instead of re-running the setup
 steps, which dramatically reduces cold-start time.

--- a/docs/sandbox/lifecycle.md
+++ b/docs/sandbox/lifecycle.md
@@ -36,7 +36,7 @@ const sandbox = defineSandbox({
 | ------------------- | ------------------------------------------------------------------------------------------- |
 | `reuse`             | `'thread'` keeps one sandbox per `threadId`; `'none'` provisions a fresh sandbox per run.    |
 | `snapshot`          | `'after-setup'` snapshots the workspace once bootstrap finishes, on snapshot-capable providers. |
-| `keepAlive`         | Duration hint (e.g. `'30m'`) for how long the sandbox should stay warm between runs. Nothing in `@tanstack/ai-sandbox` reads it today. Daytona idle stop is `autoStopInterval` on `daytonaSandbox()`. Pass minutes. `0` turns auto-stop off. |
+| `keepAlive`         | Duration hint (e.g. `'30m'`) for how long the sandbox should stay warm between runs. Nothing in `@tanstack/ai-sandbox` reads it today; it is a hint for providers and host apps. Provider idle timers live on the [provider](./providers) config. |
 | `destroyOnComplete` | When `false`, the sandbox survives the run so the next one can resume it.                    |
 | `snapshotMaxAge`    | Duration (e.g. `'24h'`) after which a stored snapshot is treated as stale and re-created.   |
 
@@ -58,9 +58,8 @@ destroys, exactly as an abort does. See
 
 ## Snapshot after setup
 
-When the provider supports snapshots (for example [Docker](./providers) or
-[Daytona](./providers)), bootstrap automatically takes a snapshot after
-`setup` completes. The snapshot caches the
+When the provider supports snapshots (see [Providers](./providers)), bootstrap
+automatically takes a snapshot after `setup` completes. The snapshot caches the
 fully bootstrapped [workspace](./workspace) (the cloned repo with dependencies
 installed) so subsequent runs resume from it instead of re-running the setup
 steps, which dramatically reduces cold-start time.

--- a/docs/sandbox/policy.md
+++ b/docs/sandbox/policy.md
@@ -91,6 +91,9 @@ This is the broad backstop: even if a specific network command isn't in your
 `commands` lists, `network: 'ask'` still forces an approval for anything that
 reaches out.
 
+On Daytona, `network: 'deny'` also sets `networkBlockAll` when the sandbox is
+created. The sandbox then has no outbound network.
+
 ## Precedence: deny > ask > allow
 
 When more than one rule could match an action, the strictest wins. The order is
@@ -163,6 +166,20 @@ failing the run, the unsupported rule is skipped (with a warning) instead of
 throwing. Because the mapping is the adapter's job, you write the policy once
 and it behaves consistently no matter which provider or harness runs the
 sandbox.
+
+A deny-only list with `default: 'allow'` stays permissive on Grok Build and
+Codex. Those harnesses keep auto-approve. They do not enforce
+`commands.deny`. Isolation is the outer sandbox. Use Claude Code when you
+need command-level deny.
+
+## Daytona setup needs sudo
+
+The Daytona user is not root. Package installs in `setup` must run as
+`sudo -n apt-get install …`. Do not put `sudo *` in `deny` for a Daytona
+sandbox. That pattern blocks the setup commands.
+
+A Docker sandbox with `default: 'ask'` can still deny `sudo *`. The container
+often runs as root, so setup does not need sudo.
 
 ## Wiring it on
 

--- a/docs/sandbox/policy.md
+++ b/docs/sandbox/policy.md
@@ -91,8 +91,8 @@ This is the broad backstop: even if a specific network command isn't in your
 `commands` lists, `network: 'ask'` still forces an approval for anything that
 reaches out.
 
-On Daytona, `network: 'deny'` also sets `networkBlockAll` when the sandbox is
-created. The sandbox then has no outbound network.
+Some providers also enforce network at create time when `network: 'deny'`. See
+[Providers](./providers) for that mapping.
 
 ## Precedence: deny > ask > allow
 
@@ -172,14 +172,9 @@ Codex. Those harnesses keep auto-approve. They do not enforce
 `commands.deny`. Isolation is the outer sandbox. Use Claude Code when you
 need command-level deny.
 
-## Daytona setup needs sudo
-
-The Daytona user is not root. Package installs in `setup` must run as
-`sudo -n apt-get install …`. Do not put `sudo *` in `deny` for a Daytona
-sandbox. That pattern blocks the setup commands.
-
-A Docker sandbox with `default: 'ask'` can still deny `sudo *`. The container
-often runs as root, so setup does not need sudo.
+Some providers run as a non-root user, so package installs in `setup` need
+`sudo`. Do not deny `sudo *` on those providers. See [Providers](./providers)
+for the list, and [Workspace](./workspace) for how to write setup commands.
 
 ## Wiring it on
 

--- a/docs/sandbox/providers.md
+++ b/docs/sandbox/providers.md
@@ -22,7 +22,7 @@ same.
 | --- | --- | --- | --- |
 | Local process | `@tanstack/ai-sandbox-local-process` | none (host) | The fast, no-Docker dev loop. Trusted/dev use only. |
 | Docker | `@tanstack/ai-sandbox-docker` | container | Real isolation; commit-based snapshots, fork, resume-by-id. |
-| Daytona | `@tanstack/ai-sandbox-daytona` | cloud sandbox | Managed [Daytona](https://www.daytona.io/) sandboxes; port preview links, resume-by-id. Needs `DAYTONA_API_KEY`. |
+| Daytona | `@tanstack/ai-sandbox-daytona` | cloud sandbox | Managed [Daytona](https://www.daytona.io/) sandboxes; snapshots after setup, port preview links, resume-by-id. Needs `DAYTONA_API_KEY`. |
 | Vercel | `@tanstack/ai-sandbox-vercel` | microVM | Managed [Vercel Sandbox](https://vercel.com/docs/sandbox) microVMs; exposed-port domains, resume-by-id (persistent). Needs `VERCEL_TOKEN` + team/project. |
 | Sprites | `@tanstack/ai-sandbox-sprites` | stateful sandbox | Managed [Sprites](https://sprites.dev) (Fly.io) sandboxes; durable filesystem, in-place checkpoints, single proxied public-URL port, resume-by-id. Needs `SPRITES_API_KEY`. |
 
@@ -139,18 +139,79 @@ const isolated = dockerSandbox({ image: 'node:22' })
 ```ts
 import { daytonaSandbox } from '@tanstack/ai-sandbox-daytona'
 
-const daytona = daytonaSandbox({ apiKey: process.env.DAYTONA_API_KEY })
+const daytona = daytonaSandbox({
+  apiKey: process.env.DAYTONA_API_KEY,
+  snapshot: 'daytona-medium',
+  autoStopInterval: 0,
+})
 ```
 
 - **Isolation:** a managed cloud sandbox on a remote VM you do not run yourself.
-- **Auth / env:** needs `DAYTONA_API_KEY`. Harness credentials are injected as
-  workspace secrets; there is no host login to fall back on.
-- **Snapshot / resume:** no snapshots; resume-by-id reconnects to a still-running
-  sandbox (not a restored point-in-time snapshot), plus port preview links for
-  live previews.
+- **Auth / env:** needs `DAYTONA_API_KEY`. Harness credentials are workspace
+  secrets. They go onto the live handle and into each `exec` call through the
+  SDK env argument. Spawn sources a workdir env file. Secret values never
+  enter create-time `envVars` or the stored command string. Git clone auth
+  uses the native username and password arguments.
+- **Snapshot / resume:** point-in-time snapshots and restore.
+  `daytonaSandbox({ snapshot })` selects the Daytona image to create from
+  (for example `'daytona-medium'`). After `setup`, the sandbox layer takes its
+  own snapshot when `lifecycle.snapshot` is `'after-setup'` (the default on
+  this provider). That snapshot stops the sandbox, captures the filesystem,
+  then starts it again. Resume-by-id starts a `stopped` or `archived`
+  sandbox, then returns the handle. Daytona stops an idle sandbox after 15
+  minutes unless you set `autoStopInterval` (minutes; `0` turns auto-stop
+  off). Set `ephemeral: true` to delete the sandbox when it stops.
+- **Network:** `policy.capabilities.network === 'deny'` sets
+  `networkBlockAll` on create. The provider reports `networkPolicy: true`.
+- **Working directory:** the virtual root `/workspace` maps to
+  `/home/daytona/workspace` by default. Set `workdir` on `daytonaSandbox()` if
+  you need a different path. Native `sandbox.fs` and `sandbox.git` use that
+  mapped path.
+- **Stdin:** spawned processes accept stdin through
+  `sendSessionCommandInput`. `writableStdin` is `true`.
+- **Privileges:** the Daytona user is not root. Setup commands that install
+  packages must use `sudo -n`. Do not deny `sudo *` on a Daytona
+  [policy](./policy).
 - **Bridge:** the sandbox is remote, so a [bridged tool](./tools) call can't reach
   your laptop's `localhost`. In local dev, tunnel the bridge (see [tools](./tools));
   a deployed orchestrator is reachable out of the box.
+
+```ts
+import { chat } from '@tanstack/ai'
+import { grokBuildText } from '@tanstack/ai-grok-build'
+import {
+  defineSandbox,
+  defineSandboxPolicy,
+  defineWorkspace,
+  gitSkill,
+  withSandbox,
+} from '@tanstack/ai-sandbox'
+import { daytonaSandbox } from '@tanstack/ai-sandbox-daytona'
+
+const sandbox = defineSandbox({
+  id: 'daytona-agent',
+  provider: daytonaSandbox({
+    apiKey: process.env.DAYTONA_API_KEY,
+    snapshot: 'daytona-medium',
+  }),
+  workspace: defineWorkspace({
+    skills: [gitSkill({ repo: 'owner/skills-pack' })],
+  }),
+  policy: defineSandboxPolicy({
+    default: 'allow',
+    commands: { deny: ['rm -rf /'] },
+  }),
+})
+
+const stream = chat({
+  adapter: grokBuildText('grok-build'),
+  messages: [{ role: 'user', content: 'List the project files.' }],
+  middleware: [withSandbox(sandbox)],
+})
+```
+
+Grok Build and Codex do not enforce `commands.deny`. Isolation is the Daytona
+sandbox. Use Claude Code when you need command-level deny.
 
 ## Vercel
 
@@ -211,7 +272,7 @@ Providers declare what they support via `capabilities()`. The flags are:
 | `env` | Inject environment variables. |
 | `ports` | Expose/forward ports (preview URLs). |
 | `backgroundProcesses` | Keep long-running processes alive between calls. |
-| `writableStdin` | A spawned process exposes a writable host→process stdin. `true` for local-process and Docker; `false` on remote/edge providers (Daytona, Vercel, Cloudflare), where stdin-fed harnesses deliver the prompt via a file + shell redirection instead. |
+| `writableStdin` | A spawned process exposes a writable host→process stdin. `true` for local-process, Docker, and Daytona. `false` on Vercel and Cloudflare, where stdin-fed harnesses deliver the prompt via a file + shell redirection. |
 | `killableProcesses` | A spawned process can be forcibly stopped via `SpawnHandle.kill()` **and** aborted mid-flight via the `signal` passed to `spawn`. |
 | `snapshots` | Capture and restore point-in-time snapshots. |
 | `networkPolicy` | Enforce network allow/deny rules. |

--- a/docs/sandbox/providers.md
+++ b/docs/sandbox/providers.md
@@ -147,34 +147,32 @@ const daytona = daytonaSandbox({
 ```
 
 - **Isolation:** a managed cloud sandbox on a remote VM you do not run yourself.
-- **Auth / env:** needs `DAYTONA_API_KEY`. Harness credentials are workspace
-  secrets. They go onto the live handle and into each `exec` call through the
-  SDK env argument. Spawn sources a workdir env file. Secret values never
-  enter create-time `envVars` or the stored command string. Git clone auth
-  uses the native username and password arguments.
-- **Snapshot / resume:** point-in-time snapshots and restore.
-  `daytonaSandbox({ snapshot })` selects the Daytona image to create from
-  (for example `'daytona-medium'`). After `setup`, the sandbox layer takes its
-  own snapshot when `lifecycle.snapshot` is `'after-setup'` (the default on
-  this provider). That snapshot stops the sandbox, captures the filesystem,
-  then starts it again. Resume-by-id starts a `stopped` or `archived`
-  sandbox, then returns the handle. Daytona stops an idle sandbox after 15
-  minutes unless you set `autoStopInterval` (minutes; `0` turns auto-stop
-  off). Set `ephemeral: true` to delete the sandbox when it stops.
-- **Network:** `policy.capabilities.network === 'deny'` sets
-  `networkBlockAll` on create. The provider reports `networkPolicy: true`.
-- **Working directory:** the virtual root `/workspace` maps to
-  `/home/daytona/workspace` by default. Set `workdir` on `daytonaSandbox()` if
-  you need a different path. Native `sandbox.fs` and `sandbox.git` use that
-  mapped path.
-- **Stdin:** spawned processes accept stdin through
-  `sendSessionCommandInput`. `writableStdin` is `true`.
-- **Privileges:** the Daytona user is not root. Setup commands that install
-  packages must use `sudo -n`. Do not deny `sudo *` on a Daytona
-  [policy](./policy).
-- **Bridge:** the sandbox is remote, so a [bridged tool](./tools) call can't reach
-  your laptop's `localhost`. In local dev, tunnel the bridge (see [tools](./tools));
-  a deployed orchestrator is reachable out of the box.
+- **Auth / env:** needs `DAYTONA_API_KEY`. Put harness credentials in
+  [workspace secrets](./provisioning). They are applied to the live sandbox
+  at create, resume, and restore. They are not stored on the Daytona create
+  record, and they are not written into command history.
+- **Snapshot / resume:** point-in-time snapshots after setup (default when
+  `lifecycle.snapshot` is `'after-setup'`). Pass `snapshot` on
+  `daytonaSandbox()` to pick the Daytona image (for example
+  `'daytona-medium'`). Resume starts a `stopped` or `archived` sandbox, then
+  returns the handle.
+- **Idle stop:** Daytona stops an idle sandbox after 15 minutes by default.
+  Set `autoStopInterval` in minutes to change that. Pass `0` to turn auto-stop
+  off. Set `ephemeral: true` to delete the sandbox when it stops.
+- **Network:** `policy.capabilities.network: 'deny'` blocks all outbound
+  network on create.
+- **Working directory:** the portable root `/workspace` maps to
+  `/home/daytona/workspace` by default. Override with `workdir` on
+  `daytonaSandbox()` if you need another path.
+- **Stdin:** spawned processes accept host stdin (`writableStdin: true`).
+- **Privileges:** the Daytona user is not root. Package installs in `setup`
+  must use `sudo -n` (for example `sudo -n apt-get install …`). Do not put
+  `sudo *` in a [policy](./policy) deny list for this provider.
+- **Bridge:** the sandbox is remote, so a [bridged tool](./tools) call cannot
+  reach your laptop's `localhost`. In local dev, tunnel the bridge (see
+  [tools](./tools)). A deployed orchestrator is reachable without a tunnel.
+
+Default headless path on Daytona:
 
 ```ts
 import { chat } from '@tanstack/ai'
@@ -211,7 +209,7 @@ const stream = chat({
 ```
 
 Grok Build and Codex do not enforce `commands.deny`. Isolation is the Daytona
-sandbox. Use Claude Code when you need command-level deny.
+VM. Use Claude Code when you need command-level deny.
 
 ## Vercel
 

--- a/docs/sandbox/providers.md
+++ b/docs/sandbox/providers.md
@@ -199,7 +199,6 @@ const sandbox = defineSandbox({
   }),
   policy: defineSandboxPolicy({
     default: 'allow',
-    commands: { deny: ['rm -rf /'] },
   }),
 })
 
@@ -210,8 +209,8 @@ const stream = chat({
 })
 ```
 
-Grok Build and Codex do not enforce `commands.deny`. Isolation is the Daytona
-VM. Use Claude Code when you need command-level deny.
+Headless Grok Build and Codex stay on auto-approve with `default: 'allow'`.
+Isolation is the Daytona VM. Use Claude Code when you need command-level deny.
 
 ## Vercel
 

--- a/docs/sandbox/providers.md
+++ b/docs/sandbox/providers.md
@@ -182,6 +182,7 @@ import {
   defineSandboxPolicy,
   defineWorkspace,
   gitSkill,
+  githubRepo,
   withSandbox,
 } from '@tanstack/ai-sandbox'
 import { daytonaSandbox } from '@tanstack/ai-sandbox-daytona'
@@ -193,6 +194,7 @@ const sandbox = defineSandbox({
     snapshot: 'daytona-medium',
   }),
   workspace: defineWorkspace({
+    source: githubRepo({ repo: 'owner/app' }),
     skills: [gitSkill({ repo: 'owner/skills-pack' })],
   }),
   policy: defineSandboxPolicy({

--- a/docs/sandbox/provisioning.md
+++ b/docs/sandbox/provisioning.md
@@ -64,8 +64,9 @@ defineWorkspace({
 })
 ```
 
-`secrets` is [declared on the workspace](./workspace), and the values are
-injected into the sandbox env at create/resume time.
+`secrets` is [declared on the workspace](./workspace). `ensure()` puts the
+values onto the live handle at create, resume, and snapshot restore. They
+never stay on the Daytona sandbox record as create-time `envVars`.
 
 ### Why the values never leak
 
@@ -175,7 +176,12 @@ defineWorkspace({
 
 `gitSkill` takes an optional `into` field, an **absolute path inside the
 sandbox**, controlling where the repo is cloned. It defaults to
-`.tanstack-skills/<repo-basename>`:
+`.tanstack-skills/<repo-basename>`. Bootstrap creates the parent directory
+before the clone.
+
+Paths that start with `/workspace` map to the provider workdir. On Daytona
+that workdir is `/home/daytona/workspace` by default. You can keep the
+portable `/workspace/...` path in `into`.
 
 ```ts
 import { createSecrets, defineWorkspace, gitSkill, githubRepo } from '@tanstack/ai-sandbox'
@@ -205,6 +211,11 @@ format:
 | Claude Code | `.mcp.json`              |
 | Codex       | `.codex/config.toml`     |
 | OpenCode    | `opencode.json`          |
+
+Each projector walks the cloned repo for folders that contain `SKILL.md`. A
+nested pack (`skills/foo/SKILL.md`) is linked under the skill name `foo`. A
+flat clone with `SKILL.md` at the root uses the clone name. You do not write
+`ln -s` by hand.
 
 A concept a given CLI lacks (for example, `plugins` on Codex) **emits a
 warning and is silently skipped** rather than throwing. The same applies to

--- a/docs/sandbox/provisioning.md
+++ b/docs/sandbox/provisioning.md
@@ -64,9 +64,10 @@ defineWorkspace({
 })
 ```
 
-`secrets` is [declared on the workspace](./workspace). `ensure()` puts the
-values onto the live handle at create, resume, and snapshot restore. They
-never stay on the Daytona sandbox record as create-time `envVars`.
+`secrets` is [declared on the workspace](./workspace). At create, resume, and
+snapshot restore, the sandbox layer resolves them onto the live handle env.
+Providers never write those values into snapshots, the sandbox store, or the
+event log.
 
 ### Why the values never leak
 
@@ -78,7 +79,7 @@ non-enumerable:
 - `Object.keys(secrets)`, spreads, and `JSON.stringify(secrets)` never expose
   the values.
 - The values are **never written to snapshots, the sandbox store, or the event
-  log**. They are resolved only at the moment the sandbox env is built.
+  log**. They are resolved only when the live sandbox env is built.
 
 This is what makes the workspace definition safe to hash, persist, and replay
 for resume bookkeeping without ever persisting a credential.
@@ -179,9 +180,9 @@ sandbox**, controlling where the repo is cloned. It defaults to
 `.tanstack-skills/<repo-basename>`. Bootstrap creates the parent directory
 before the clone.
 
-Paths that start with `/workspace` map to the provider workdir. On Daytona
-that workdir is `/home/daytona/workspace` by default. You can keep the
-portable `/workspace/...` path in `into`.
+Paths that start with `/workspace` use the portable workspace root. The
+provider maps that root onto its real workdir. Keep `/workspace/...` in
+`into` unless you have a reason to pin a provider-specific path.
 
 ```ts
 import { createSecrets, defineWorkspace, gitSkill, githubRepo } from '@tanstack/ai-sandbox'

--- a/docs/sandbox/workspace.md
+++ b/docs/sandbox/workspace.md
@@ -170,8 +170,10 @@ subshell (like the Grok CLI installer, `(curl … || curl …) | bash`) is not a
 valid argument to another command, and `sh` then fails at parse time with
 `syntax error: unexpected "("` (exit `2`) without running anything.
 
-Some providers run as a non-root user. Package installs on those providers
-need `sudo` in `setup`. See [Providers](./providers) and [Policy](./policy).
+Some providers run as a non-root user. Workspace-local installs such as
+`pnpm install` do not need sudo. System or global package installs on those
+providers need non-interactive `sudo -n` in `setup`. See
+[Providers](./providers) and [Policy](./policy).
 
 ## Scripts
 

--- a/docs/sandbox/workspace.md
+++ b/docs/sandbox/workspace.md
@@ -170,9 +170,8 @@ subshell (like the Grok CLI installer, `(curl … || curl …) | bash`) is not a
 valid argument to another command, and `sh` then fails at parse time with
 `syntax error: unexpected "("` (exit `2`) without running anything.
 
-On [Daytona](./providers) the user is not root. Write a package install as
-`sudo -n apt-get install …`. Do not deny `sudo *` on that provider. See
-[Policy](./policy).
+Some providers run as a non-root user. Package installs on those providers
+need `sudo` in `setup`. See [Providers](./providers) and [Policy](./policy).
 
 ## Scripts
 

--- a/docs/sandbox/workspace.md
+++ b/docs/sandbox/workspace.md
@@ -170,6 +170,10 @@ subshell (like the Grok CLI installer, `(curl … || curl …) | bash`) is not a
 valid argument to another command, and `sh` then fails at parse time with
 `syntax error: unexpected "("` (exit `2`) without running anything.
 
+On [Daytona](./providers) the user is not root. Write a package install as
+`sudo -n apt-get install …`. Do not deny `sudo *` on that provider. See
+[Policy](./policy).
+
 ## Scripts
 
 `scripts` is a map of named commands the agent and user can invoke by name,

--- a/packages/ai-acp/package.json
+++ b/packages/ai-acp/package.json
@@ -38,8 +38,8 @@
     "lint:fix": "oxlint src --type-aware --fix",
     "test:build": "publint --strict",
     "test:oxlint": "oxlint src --type-aware",
-    "test:lib": "vitest",
-    "test:lib:dev": "pnpm test:lib --watch",
+    "test:lib": "vitest run --testTimeout=30000",
+    "test:lib:dev": "vitest --watch",
     "test:types": "tsc"
   },
   "dependencies": {

--- a/packages/ai-acp/src/adapters/projection.ts
+++ b/packages/ai-acp/src/adapters/projection.ts
@@ -17,7 +17,11 @@
  * `fileSkill` and `instructions` are already written by the provider-agnostic
  * bootstrap (into the workspace root + `AGENTS.md`), so they need no projection.
  */
-import { isSecretRef, resolveGitSkillDir } from '@tanstack/ai-sandbox'
+import {
+  discoverSkillDirs,
+  isSecretRef,
+  resolveGitSkillDir,
+} from '@tanstack/ai-sandbox'
 import type {
   BearerRef,
   SandboxHandle,
@@ -34,11 +38,6 @@ export interface AcpMcpServer {
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
-}
-
-function basenameOf(path: string): string {
-  const segments = path.split('/').filter((segment) => segment !== '')
-  return segments[segments.length - 1] ?? path
 }
 
 /**
@@ -129,16 +128,19 @@ export async function projectAcpWorkspace(
       await handle.fs.mkdir(`${projection.root}/${skillsDir}`)
       for (const skill of gitSkills) {
         const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
-        const relSource = relativeToRoot(projection.root, source)
-        const relTarget = `${skillsDir}/${basenameOf(source)}`
-        const cp = await handle.process.exec(
-          `cp -r ${shellQuote(relSource)} ${shellQuote(relTarget)}`,
-          { cwd: projection.root },
-        )
-        if (cp.exitCode !== 0) {
-          console.warn(
-            `[${harnessName}] failed to copy gitSkill "${skill.repo}" into ${relTarget}: ${cp.stderr.trim()}`,
+        const discovered = await discoverSkillDirs(handle, source)
+        for (const { name, dir } of discovered) {
+          const relSource = relativeToRoot(projection.root, dir)
+          const relTarget = `${skillsDir}/${name}`
+          const cp = await handle.process.exec(
+            `cp -r ${shellQuote(relSource)} ${shellQuote(relTarget)}`,
+            { cwd: projection.root },
           )
+          if (cp.exitCode !== 0) {
+            console.warn(
+              `[${harnessName}] failed to copy gitSkill "${skill.repo}" into ${relTarget}: ${cp.stderr.trim()}`,
+            )
+          }
         }
       }
     }

--- a/packages/ai-acp/src/adapters/projection.ts
+++ b/packages/ai-acp/src/adapters/projection.ts
@@ -128,16 +128,14 @@ export async function projectAcpWorkspace(
       // so the shell command resolves on every provider.
       await handle.fs.mkdir(`${projection.root}/${skillsDir}`)
       for (const skill of gitSkills) {
-        // Match bootstrap's remapped clone path so discovery and shell copy
-        // use the real provider workdir (e.g. Daytona).
-        const source = resolveHarnessCwd(
-          handle,
-          skill.into ?? resolveGitSkillDir(projection.root, skill),
-        )
+        // Keep virtual `/workspace` paths for fs discovery. handle.fs remaps
+        // them. Remap only when building shell-relative paths so Daytona and
+        // local-process both resolve the same clone.
+        const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
         const discovered = await discoverSkillDirs(handle, source)
         for (const { name, dir } of discovered) {
-          const realDir = resolveHarnessCwd(handle, dir)
           const realRoot = resolveHarnessCwd(handle, projection.root)
+          const realDir = resolveHarnessCwd(handle, dir)
           const relSource = relativeToRoot(realRoot, realDir)
           const relTarget = `${skillsDir}/${name}`
           const cp = await handle.process.exec(

--- a/packages/ai-acp/src/adapters/projection.ts
+++ b/packages/ai-acp/src/adapters/projection.ts
@@ -21,6 +21,7 @@ import {
   discoverSkillDirs,
   isSecretRef,
   resolveGitSkillDir,
+  resolveHarnessCwd,
 } from '@tanstack/ai-sandbox'
 import type {
   BearerRef,
@@ -127,10 +128,17 @@ export async function projectAcpWorkspace(
       // so the shell command resolves on every provider.
       await handle.fs.mkdir(`${projection.root}/${skillsDir}`)
       for (const skill of gitSkills) {
-        const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
+        // Match bootstrap's remapped clone path so discovery and shell copy
+        // use the real provider workdir (e.g. Daytona).
+        const source = resolveHarnessCwd(
+          handle,
+          skill.into ?? resolveGitSkillDir(projection.root, skill),
+        )
         const discovered = await discoverSkillDirs(handle, source)
         for (const { name, dir } of discovered) {
-          const relSource = relativeToRoot(projection.root, dir)
+          const realDir = resolveHarnessCwd(handle, dir)
+          const realRoot = resolveHarnessCwd(handle, projection.root)
+          const relSource = relativeToRoot(realRoot, realDir)
           const relTarget = `${skillsDir}/${name}`
           const cp = await handle.process.exec(
             `cp -r ${shellQuote(relSource)} ${shellQuote(relTarget)}`,

--- a/packages/ai-acp/tests/sandbox-provisioning.test.ts
+++ b/packages/ai-acp/tests/sandbox-provisioning.test.ts
@@ -337,6 +337,47 @@ describe('workspace skill projection', () => {
     )
     await sbx.destroy()
   })
+
+  // Nested packs (skills/foo/SKILL.md) must be copied by the skill folder
+  // name, not the clone basename. Issue #1081 item 3.
+  it('copies each nested SKILL.md folder by its skill name', async () => {
+    const sbx = await provider.create({})
+    await sbx.fs.write(
+      '/workspace/.tanstack-skills/skills-pack/skills/foo/SKILL.md',
+      'foo-skill',
+    )
+    await sbx.fs.write(
+      '/workspace/.tanstack-skills/skills-pack/skills/bar/SKILL.md',
+      'bar-skill',
+    )
+
+    const projection: WorkspaceProjection = {
+      skills: [
+        gitSkill({
+          repo: 'owner/skills-pack',
+          into: '/workspace/.tanstack-skills/skills-pack',
+        }),
+      ],
+      plugins: [],
+      resolveSecret: () => '',
+      markerPath: '/workspace/.tanstack-projected-nested',
+      root: '/workspace',
+    }
+
+    await projectAcpWorkspace(sbx, projection, {
+      skillsDir: '.pi/skills',
+      harnessName: 'pi',
+    })
+
+    expect(await sbx.fs.read('/workspace/.pi/skills/foo/SKILL.md')).toBe(
+      'foo-skill',
+    )
+    expect(await sbx.fs.read('/workspace/.pi/skills/bar/SKILL.md')).toBe(
+      'bar-skill',
+    )
+    expect(await sbx.fs.exists('/workspace/.pi/skills/skills-pack')).toBe(false)
+    await sbx.destroy()
+  })
 })
 
 describe('workspaceMcpServers', () => {

--- a/packages/ai-acp/vite.config.ts
+++ b/packages/ai-acp/vite.config.ts
@@ -10,6 +10,9 @@ const config = defineConfig({
 
     globals: true,
     environment: 'node',
+    // Stdio ACP fixtures spawn a real local-process sandbox + node agent.
+    // Under Nx parallel load the default 5s budget is too tight.
+    testTimeout: 30_000,
     include: ['tests/**/*.test.ts'],
     coverage: {
       provider: 'v8',

--- a/packages/ai-acp/vite.config.ts
+++ b/packages/ai-acp/vite.config.ts
@@ -30,11 +30,12 @@ const config = defineConfig({
   },
 })
 
+// Put package test settings last so they win over the shared build config.
 export default mergeConfig(
-  config,
   tanstackViteConfig({
     entry: ['./src/index.ts'],
     srcDir: './src',
     cjs: false,
   }),
+  config,
 )

--- a/packages/ai-claude-code/src/adapters/projection.ts
+++ b/packages/ai-claude-code/src/adapters/projection.ts
@@ -24,7 +24,11 @@
  * CLI. Where claude has no clean primitive (agentSkill by bare name) we no-op
  * with a warning instead of fabricating a command.
  */
-import { isSecretRef, resolveGitSkillDir } from '@tanstack/ai-sandbox'
+import {
+  discoverSkillDirs,
+  isSecretRef,
+  resolveGitSkillDir,
+} from '@tanstack/ai-sandbox'
 import type {
   BearerRef,
   SandboxHandle,
@@ -36,12 +40,6 @@ import type {
 /** POSIX single-quote escape for embedding a value in a shell command. */
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
-}
-
-/** Last path segment of a `gitSkill` clone dir, used as the skills-dir name. */
-function basenameOf(path: string): string {
-  const segments = path.split('/').filter((segment) => segment !== '')
-  return segments[segments.length - 1] ?? path
 }
 
 /** True when `value` is a `bearer(ref)` marker created by `@tanstack/ai-sandbox`. */
@@ -136,16 +134,21 @@ async function projectGitSkills(
       madeDir = true
     }
     const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
-    const target = `${skillsDir}/${basenameOf(source)}`
-    const lnCmd = `ln -s ${shellQuote(source)} ${shellQuote(target)}`
-    const result = await handle.process.exec(lnCmd, { cwd: projection.root })
-    if (result.exitCode !== 0) {
-      const cpCmd = `cp -r ${shellQuote(source)} ${shellQuote(target)}`
-      const copied = await handle.process.exec(cpCmd, { cwd: projection.root })
-      if (copied.exitCode !== 0) {
-        console.warn(
-          `[claude-code] failed to link gitSkill "${skill.repo}" into ${target}: ${copied.stderr.trim()}`,
-        )
+    const discovered = await discoverSkillDirs(handle, source)
+    for (const { name, dir } of discovered) {
+      const target = `${skillsDir}/${name}`
+      const lnCmd = `ln -s ${shellQuote(dir)} ${shellQuote(target)}`
+      const result = await handle.process.exec(lnCmd, { cwd: projection.root })
+      if (result.exitCode !== 0) {
+        const cpCmd = `cp -r ${shellQuote(dir)} ${shellQuote(target)}`
+        const copied = await handle.process.exec(cpCmd, {
+          cwd: projection.root,
+        })
+        if (copied.exitCode !== 0) {
+          console.warn(
+            `[claude-code] failed to link gitSkill "${skill.repo}" into ${target}: ${copied.stderr.trim()}`,
+          )
+        }
       }
     }
   }

--- a/packages/ai-claude-code/src/adapters/projection.ts
+++ b/packages/ai-claude-code/src/adapters/projection.ts
@@ -28,6 +28,7 @@ import {
   discoverSkillDirs,
   isSecretRef,
   resolveGitSkillDir,
+  resolveHarnessCwd,
 } from '@tanstack/ai-sandbox'
 import type {
   BearerRef,
@@ -133,14 +134,20 @@ async function projectGitSkills(
       await handle.fs.mkdir(skillsDir)
       madeDir = true
     }
-    const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
+    // Remap `/workspace` the same way bootstrap remaps clone dirs, so shell
+    // `ln`/`cp` targets match the real provider workdir (e.g. Daytona).
+    const source = resolveHarnessCwd(
+      handle,
+      skill.into ?? resolveGitSkillDir(projection.root, skill),
+    )
     const discovered = await discoverSkillDirs(handle, source)
     for (const { name, dir } of discovered) {
-      const target = `${skillsDir}/${name}`
-      const lnCmd = `ln -s ${shellQuote(dir)} ${shellQuote(target)}`
+      const target = resolveHarnessCwd(handle, `${skillsDir}/${name}`)
+      const realDir = resolveHarnessCwd(handle, dir)
+      const lnCmd = `ln -s ${shellQuote(realDir)} ${shellQuote(target)}`
       const result = await handle.process.exec(lnCmd, { cwd: projection.root })
       if (result.exitCode !== 0) {
-        const cpCmd = `cp -r ${shellQuote(dir)} ${shellQuote(target)}`
+        const cpCmd = `cp -r ${shellQuote(realDir)} ${shellQuote(target)}`
         const copied = await handle.process.exec(cpCmd, {
           cwd: projection.root,
         })

--- a/packages/ai-claude-code/src/adapters/projection.ts
+++ b/packages/ai-claude-code/src/adapters/projection.ts
@@ -134,12 +134,9 @@ async function projectGitSkills(
       await handle.fs.mkdir(skillsDir)
       madeDir = true
     }
-    // Remap `/workspace` the same way bootstrap remaps clone dirs, so shell
-    // `ln`/`cp` targets match the real provider workdir (e.g. Daytona).
-    const source = resolveHarnessCwd(
-      handle,
-      skill.into ?? resolveGitSkillDir(projection.root, skill),
-    )
+    // Discover over virtual `/workspace` paths (handle.fs remaps). Remap only
+    // for shell `ln`/`cp`, where absolute paths must match the real workdir.
+    const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
     const discovered = await discoverSkillDirs(handle, source)
     for (const { name, dir } of discovered) {
       const target = resolveHarnessCwd(handle, `${skillsDir}/${name}`)

--- a/packages/ai-claude-code/tests/projection.test.ts
+++ b/packages/ai-claude-code/tests/projection.test.ts
@@ -38,6 +38,30 @@ interface FakeHandle {
   existing: Set<string>
 }
 
+/** Immediate children of `dir` from a flat path→content map. */
+function listChildren(
+  files: Map<string, string>,
+  dir: string,
+): Array<{ name: string; path: string; type: 'file' | 'dir' }> {
+  const prefix = dir.endsWith('/') ? dir : `${dir}/`
+  const children = new Map<
+    string,
+    { name: string; path: string; type: 'file' | 'dir' }
+  >()
+  for (const filePath of files.keys()) {
+    if (!filePath.startsWith(prefix)) continue
+    const rest = filePath.slice(prefix.length)
+    const name = rest.split('/')[0]
+    if (name === undefined || name === '') continue
+    children.set(name, {
+      name,
+      path: `${prefix}${name}`,
+      type: rest.includes('/') ? 'dir' : 'file',
+    })
+  }
+  return [...children.values()]
+}
+
 /** Build a fake handle that records writes/execs and tracks existing paths. */
 function makeFakeHandle(execResult: ExecResult): FakeHandle {
   const writes = new Map<string, string>()
@@ -57,6 +81,7 @@ function makeFakeHandle(execResult: ExecResult): FakeHandle {
         dirs.add(path)
         return Promise.resolve()
       },
+      list: (dir: string) => Promise.resolve(listChildren(writes, dir)),
     },
     process: {
       exec: (command: string, options?: { cwd?: string }) => {
@@ -214,5 +239,47 @@ describe('projectClaudeWorkspace', () => {
     expect(fake.execs.length).toBe(execsAfterFirst)
 
     warn.mockRestore()
+  })
+
+  // Nested packs (skills/foo/SKILL.md) must be linked by the skill folder
+  // name, not the clone basename. Issue #1081 item 3.
+  it('links each nested SKILL.md folder by its skill name', async () => {
+    const fake = makeFakeHandle({ stdout: '', stderr: '', exitCode: 0 })
+    const clone = resolveGitSkillDir(ROOT, {
+      kind: 'git',
+      repo: 'owner/skills-pack',
+    })
+    fake.writes.set(`${clone}/skills/foo/SKILL.md`, '# foo')
+    fake.writes.set(`${clone}/skills/bar/SKILL.md`, '# bar')
+
+    await projectClaudeWorkspace(fake.handle, {
+      skills: [gitSkill({ repo: 'owner/skills-pack' })],
+      plugins: [],
+      resolveSecret: () => '',
+      markerPath: MARKER,
+      root: ROOT,
+    })
+
+    expect(
+      fake.execs.some(
+        (e) =>
+          e.command.includes('ln -s') &&
+          e.command.includes(`${clone}/skills/foo`) &&
+          e.command.includes(`${ROOT}/.claude/skills/foo`),
+      ),
+    ).toBe(true)
+    expect(
+      fake.execs.some(
+        (e) =>
+          e.command.includes('ln -s') &&
+          e.command.includes(`${clone}/skills/bar`) &&
+          e.command.includes(`${ROOT}/.claude/skills/bar`),
+      ),
+    ).toBe(true)
+    expect(
+      fake.execs.some((e) =>
+        e.command.includes(`${ROOT}/.claude/skills/skills-pack`),
+      ),
+    ).toBe(false)
   })
 })

--- a/packages/ai-codex/src/adapters/policy-map.ts
+++ b/packages/ai-codex/src/adapters/policy-map.ts
@@ -13,10 +13,10 @@
  *   (`'allow'` → true, `'deny'` → false; unset leaves Codex's default).
  * - `approval_policy`: a fully-permissive policy (`default: 'allow'` with no
  *   `ask` rules) → `never`; a `default: 'deny'` policy → `untrusted`;
- *   anything with `ask` rules → `on-request`. A deny list alone is a hard
- *   block, not a human prompt, so it does not flip `on-request`. In `exec`
- *   mode Codex will refuse (rather than prompt for) actions that need
- *   approval.
+ *   `default: 'ask'` or any `commands.ask` rules → `on-request`. A deny list
+ *   alone is a hard block, not a human prompt, so it does not flip
+ *   `on-request`. In `exec` mode Codex will refuse (rather than prompt for)
+ *   actions that need approval.
  *
  * Returns only the knobs the policy actually constrains; the adapter merges
  * these with its own config (config/modelOptions still take precedence).
@@ -46,7 +46,7 @@ export function mapPolicyToCodexFlags(
   }
 
   const hasAsk = (policy.commands?.ask?.length ?? 0) > 0
-  if (hasAsk) {
+  if (hasAsk || policy.default === 'ask') {
     flags.approvalPolicy = 'on-request'
   } else if (policy.default === 'deny') {
     flags.approvalPolicy = 'untrusted'

--- a/packages/ai-codex/src/adapters/policy-map.ts
+++ b/packages/ai-codex/src/adapters/policy-map.ts
@@ -12,9 +12,11 @@
  * - `capabilities.network` → `sandbox_workspace_write.network_access`
  *   (`'allow'` → true, `'deny'` → false; unset leaves Codex's default).
  * - `approval_policy`: a fully-permissive policy (`default: 'allow'` with no
- *   `ask`/`deny` rules) → `never`; a `default: 'deny'` policy → `untrusted`;
- *   anything with `ask`/`deny` rules → `on-request`. In `exec` mode Codex will
- *   refuse (rather than prompt for) actions that need approval.
+ *   `ask` rules) → `never`; a `default: 'deny'` policy → `untrusted`;
+ *   anything with `ask` rules → `on-request`. A deny list alone is a hard
+ *   block, not a human prompt, so it does not flip `on-request`. In `exec`
+ *   mode Codex will refuse (rather than prompt for) actions that need
+ *   approval.
  *
  * Returns only the knobs the policy actually constrains; the adapter merges
  * these with its own config (config/modelOptions still take precedence).
@@ -43,10 +45,8 @@ export function mapPolicyToCodexFlags(
     flags.networkAccessEnabled = false
   }
 
-  const hasAskOrDeny =
-    (policy.commands?.ask?.length ?? 0) > 0 ||
-    (policy.commands?.deny?.length ?? 0) > 0
-  if (hasAskOrDeny) {
+  const hasAsk = (policy.commands?.ask?.length ?? 0) > 0
+  if (hasAsk) {
     flags.approvalPolicy = 'on-request'
   } else if (policy.default === 'deny') {
     flags.approvalPolicy = 'untrusted'

--- a/packages/ai-codex/src/adapters/projection.ts
+++ b/packages/ai-codex/src/adapters/projection.ts
@@ -175,12 +175,9 @@ async function projectGitSkills(
       await handle.fs.mkdir(skillsDir)
       madeDir = true
     }
-    // Remap `/workspace` the same way bootstrap remaps clone dirs, so shell
-    // `ln`/`cp` targets match the real provider workdir (e.g. Daytona).
-    const source = resolveHarnessCwd(
-      handle,
-      skill.into ?? resolveGitSkillDir(projection.root, skill),
-    )
+    // Discover over virtual `/workspace` paths (handle.fs remaps). Remap only
+    // for shell `ln`/`cp`, where absolute paths must match the real workdir.
+    const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
     const discovered = await discoverSkillDirs(handle, source)
     for (const { name, dir } of discovered) {
       const target = resolveHarnessCwd(handle, `${skillsDir}/${name}`)

--- a/packages/ai-codex/src/adapters/projection.ts
+++ b/packages/ai-codex/src/adapters/projection.ts
@@ -30,7 +30,11 @@
  *   - AGENTS.md is written universally by bootstrap (codex reads it natively),
  *     so it is NOT rewritten here.
  */
-import { isSecretRef, resolveGitSkillDir } from '@tanstack/ai-sandbox'
+import {
+  discoverSkillDirs,
+  isSecretRef,
+  resolveGitSkillDir,
+} from '@tanstack/ai-sandbox'
 import type {
   BearerRef,
   SandboxHandle,
@@ -42,12 +46,6 @@ import type {
 /** POSIX single-quote escape for embedding a value in a shell command. */
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
-}
-
-/** Last path segment of a `gitSkill` clone dir, used as the skills-dir name. */
-function basenameOf(path: string): string {
-  const segments = path.split('/').filter((segment) => segment !== '')
-  return segments[segments.length - 1] ?? path
 }
 
 /** True when `value` is a `bearer(ref)` marker created by `@tanstack/ai-sandbox`. */
@@ -177,16 +175,21 @@ async function projectGitSkills(
       madeDir = true
     }
     const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
-    const target = `${skillsDir}/${basenameOf(source)}`
-    const lnCmd = `ln -s ${shellQuote(source)} ${shellQuote(target)}`
-    const result = await handle.process.exec(lnCmd, { cwd: projection.root })
-    if (result.exitCode !== 0) {
-      const cpCmd = `cp -r ${shellQuote(source)} ${shellQuote(target)}`
-      const copied = await handle.process.exec(cpCmd, { cwd: projection.root })
-      if (copied.exitCode !== 0) {
-        console.warn(
-          `[codex] failed to link gitSkill "${skill.repo}" into ${target}: ${copied.stderr.trim()}`,
-        )
+    const discovered = await discoverSkillDirs(handle, source)
+    for (const { name, dir } of discovered) {
+      const target = `${skillsDir}/${name}`
+      const lnCmd = `ln -s ${shellQuote(dir)} ${shellQuote(target)}`
+      const result = await handle.process.exec(lnCmd, { cwd: projection.root })
+      if (result.exitCode !== 0) {
+        const cpCmd = `cp -r ${shellQuote(dir)} ${shellQuote(target)}`
+        const copied = await handle.process.exec(cpCmd, {
+          cwd: projection.root,
+        })
+        if (copied.exitCode !== 0) {
+          console.warn(
+            `[codex] failed to link gitSkill "${skill.repo}" into ${target}: ${copied.stderr.trim()}`,
+          )
+        }
       }
     }
   }

--- a/packages/ai-codex/src/adapters/projection.ts
+++ b/packages/ai-codex/src/adapters/projection.ts
@@ -34,6 +34,7 @@ import {
   discoverSkillDirs,
   isSecretRef,
   resolveGitSkillDir,
+  resolveHarnessCwd,
 } from '@tanstack/ai-sandbox'
 import type {
   BearerRef,
@@ -174,14 +175,20 @@ async function projectGitSkills(
       await handle.fs.mkdir(skillsDir)
       madeDir = true
     }
-    const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
+    // Remap `/workspace` the same way bootstrap remaps clone dirs, so shell
+    // `ln`/`cp` targets match the real provider workdir (e.g. Daytona).
+    const source = resolveHarnessCwd(
+      handle,
+      skill.into ?? resolveGitSkillDir(projection.root, skill),
+    )
     const discovered = await discoverSkillDirs(handle, source)
     for (const { name, dir } of discovered) {
-      const target = `${skillsDir}/${name}`
-      const lnCmd = `ln -s ${shellQuote(dir)} ${shellQuote(target)}`
+      const target = resolveHarnessCwd(handle, `${skillsDir}/${name}`)
+      const realDir = resolveHarnessCwd(handle, dir)
+      const lnCmd = `ln -s ${shellQuote(realDir)} ${shellQuote(target)}`
       const result = await handle.process.exec(lnCmd, { cwd: projection.root })
       if (result.exitCode !== 0) {
-        const cpCmd = `cp -r ${shellQuote(dir)} ${shellQuote(target)}`
+        const cpCmd = `cp -r ${shellQuote(realDir)} ${shellQuote(target)}`
         const copied = await handle.process.exec(cpCmd, {
           cwd: projection.root,
         })

--- a/packages/ai-codex/src/adapters/text.ts
+++ b/packages/ai-codex/src/adapters/text.ts
@@ -51,6 +51,19 @@ export type CodexApprovalMode =
 
 const DEFAULT_WORKDIR = '/workspace'
 
+/**
+ * Providers that already isolate the agent in a VM or container where Codex
+ * cannot create a nested bubblewrap user namespace. Isolation is then the
+ * outer sandbox plus `defineSandboxPolicy`. Issue #1081 item 8.
+ */
+const NESTED_BWRAP_UNSUPPORTED = new Set(['daytona', 'cloudflare'])
+
+function defaultSandboxMode(provider: string): CodexSandboxMode {
+  return NESTED_BWRAP_UNSUPPORTED.has(provider)
+    ? 'danger-full-access'
+    : 'workspace-write'
+}
+
 export interface CodexTextConfig {
   /** Working directory inside the sandbox. Defaults to `/workspace`. */
   cwd?: string
@@ -132,18 +145,20 @@ export class CodexTextAdapter<
     resume: string | undefined,
     bridge: HostToolBridge | undefined,
     policyFlags: CodexPolicyFlags,
+    provider: string,
   ): string {
     const config = this.adapterConfig
     const modelOptions = options.modelOptions
     const exe = config.codexExecutable ?? 'codex'
     const args: Array<string> = ['exec', '--experimental-json']
 
-    // Precedence: per-call modelOptions > adapter config > sandbox policy > default.
+    // Precedence: per-call modelOptions > adapter config > sandbox policy >
+    // provider default. Daytona/Cloudflare cannot nest bubblewrap.
     const sandboxMode =
       modelOptions?.sandboxMode ??
       config.sandboxMode ??
       policyFlags.sandboxMode ??
-      'workspace-write'
+      defaultSandboxMode(provider)
     const approvalPolicy =
       modelOptions?.approvalPolicy ??
       config.approvalPolicy ??
@@ -294,6 +309,7 @@ export class CodexTextAdapter<
         resume,
         bridge,
         mapPolicyToCodexFlags(policy),
+        sandbox.provider,
       )
 
       logger.request(

--- a/packages/ai-codex/tests/policy-map.test.ts
+++ b/packages/ai-codex/tests/policy-map.test.ts
@@ -49,6 +49,13 @@ describe('mapPolicyToCodexFlags', () => {
     ).toBe('on-request')
   })
 
+  it('maps default ask without ask command rules to on-request', () => {
+    expect(
+      mapPolicyToCodexFlags(defineSandboxPolicy({ default: 'ask' }))
+        .approvalPolicy,
+    ).toBe('on-request')
+  })
+
   // Headless `codex exec` refuses tools when approval_policy is on-request.
   // A deny list is a hard block, not a human prompt, so default: allow +
   // deny stays never. Issue #1081 item 1.

--- a/packages/ai-codex/tests/policy-map.test.ts
+++ b/packages/ai-codex/tests/policy-map.test.ts
@@ -41,16 +41,25 @@ describe('mapPolicyToCodexFlags', () => {
     ).toBe('untrusted')
   })
 
-  it('maps ask/deny command rules to approval_policy=on-request', () => {
+  it('maps ask command rules to approval_policy=on-request', () => {
     expect(
       mapPolicyToCodexFlags(
         defineSandboxPolicy({ commands: { ask: ['pnpm *'] } }),
       ).approvalPolicy,
     ).toBe('on-request')
+  })
+
+  // Headless `codex exec` refuses tools when approval_policy is on-request.
+  // A deny list is a hard block, not a human prompt, so default: allow +
+  // deny stays never. Issue #1081 item 1.
+  it('does not treat a deny list as on-request when default is allow', () => {
     expect(
       mapPolicyToCodexFlags(
-        defineSandboxPolicy({ default: 'allow', commands: { deny: ['rm *'] } }),
+        defineSandboxPolicy({
+          default: 'allow',
+          commands: { deny: ['rm -rf /'] },
+        }),
       ).approvalPolicy,
-    ).toBe('on-request')
+    ).toBe('never')
   })
 })

--- a/packages/ai-codex/tests/projection.test.ts
+++ b/packages/ai-codex/tests/projection.test.ts
@@ -39,6 +39,30 @@ interface FakeHandle {
   existing: Set<string>
 }
 
+/** Immediate children of `dir` from a flat path→content map. */
+function listChildren(
+  files: Map<string, string>,
+  dir: string,
+): Array<{ name: string; path: string; type: 'file' | 'dir' }> {
+  const prefix = dir.endsWith('/') ? dir : `${dir}/`
+  const children = new Map<
+    string,
+    { name: string; path: string; type: 'file' | 'dir' }
+  >()
+  for (const filePath of files.keys()) {
+    if (!filePath.startsWith(prefix)) continue
+    const rest = filePath.slice(prefix.length)
+    const name = rest.split('/')[0]
+    if (name === undefined || name === '') continue
+    children.set(name, {
+      name,
+      path: `${prefix}${name}`,
+      type: rest.includes('/') ? 'dir' : 'file',
+    })
+  }
+  return [...children.values()]
+}
+
 /** Build a fake handle that records writes/execs and tracks existing paths. */
 function makeFakeHandle(execResult: ExecResult): FakeHandle {
   const writes = new Map<string, string>()
@@ -58,6 +82,7 @@ function makeFakeHandle(execResult: ExecResult): FakeHandle {
         dirs.add(path)
         return Promise.resolve()
       },
+      list: (dir: string) => Promise.resolve(listChildren(writes, dir)),
     },
     process: {
       exec: (command: string, options?: { cwd?: string }) => {
@@ -215,5 +240,47 @@ describe('projectCodexWorkspace', () => {
     expect(fake.execs.length).toBe(execsAfterFirst)
 
     warn.mockRestore()
+  })
+
+  // Nested packs (skills/foo/SKILL.md) must be linked by the skill folder
+  // name, not the clone basename. Issue #1081 item 3.
+  it('links each nested SKILL.md folder by its skill name', async () => {
+    const fake = makeFakeHandle({ stdout: '', stderr: '', exitCode: 0 })
+    const clone = resolveGitSkillDir(ROOT, {
+      kind: 'git',
+      repo: 'owner/skills-pack',
+    })
+    fake.writes.set(`${clone}/skills/foo/SKILL.md`, '# foo')
+    fake.writes.set(`${clone}/skills/bar/SKILL.md`, '# bar')
+
+    await projectCodexWorkspace(fake.handle, {
+      skills: [gitSkill({ repo: 'owner/skills-pack' })],
+      plugins: [],
+      resolveSecret: () => '',
+      markerPath: MARKER,
+      root: ROOT,
+    })
+
+    expect(
+      fake.execs.some(
+        (e) =>
+          e.command.includes('ln -s') &&
+          e.command.includes(`${clone}/skills/foo`) &&
+          e.command.includes(`${ROOT}/.codex/skills/foo`),
+      ),
+    ).toBe(true)
+    expect(
+      fake.execs.some(
+        (e) =>
+          e.command.includes('ln -s') &&
+          e.command.includes(`${clone}/skills/bar`) &&
+          e.command.includes(`${ROOT}/.codex/skills/bar`),
+      ),
+    ).toBe(true)
+    expect(
+      fake.execs.some((e) =>
+        e.command.includes(`${ROOT}/.codex/skills/skills-pack`),
+      ),
+    ).toBe(false)
   })
 })

--- a/packages/ai-codex/tests/text-adapter.test.ts
+++ b/packages/ai-codex/tests/text-adapter.test.ts
@@ -143,6 +143,52 @@ describe('codex in-sandbox adapter', () => {
     await sbx.destroy()
   })
 
+  it('defaults to danger-full-access on Daytona-like providers', async () => {
+    const sbx = await provider.create({})
+    await sbx.fs.write('/workspace/fake-codex.mjs', FAKE_CODEX)
+    const daytonaHandle: SandboxHandle = { ...sbx, provider: 'daytona' }
+
+    const adapter = codexText('gpt-5.5-codex', {
+      codexExecutable: 'node fake-codex.mjs',
+    })
+    await collect(
+      adapter.chatStream({
+        model: 'gpt-5.5-codex',
+        messages: [{ role: 'user', content: 'say pong' }],
+        logger: noopLogger,
+        capabilities: capabilityContextWith(daytonaHandle),
+      }),
+    )
+
+    const argv = await sbx.fs.read('/workspace/codex-argv.txt')
+    expect(argv).toContain('--sandbox danger-full-access')
+    expect(argv).not.toContain('--sandbox workspace-write')
+
+    await sbx.destroy()
+  })
+
+  it('keeps workspace-write on local-process when no sandboxMode is set', async () => {
+    const sbx = await provider.create({})
+    await sbx.fs.write('/workspace/fake-codex.mjs', FAKE_CODEX)
+
+    const adapter = codexText('gpt-5.5-codex', {
+      codexExecutable: 'node fake-codex.mjs',
+    })
+    await collect(
+      adapter.chatStream({
+        model: 'gpt-5.5-codex',
+        messages: [{ role: 'user', content: 'say pong' }],
+        logger: noopLogger,
+        capabilities: capabilityContextWith(sbx),
+      }),
+    )
+
+    const argv = await sbx.fs.read('/workspace/codex-argv.txt')
+    expect(argv).toContain('--sandbox workspace-write')
+
+    await sbx.destroy()
+  })
+
   it('requires a sandbox capability', async () => {
     const adapter = codexText('gpt-5.5-codex')
     const chunks = await collect(

--- a/packages/ai-grok-build/src/adapters/policy-map.ts
+++ b/packages/ai-grok-build/src/adapters/policy-map.ts
@@ -4,8 +4,11 @@
  * Coarse mapping for the headless NDJSON harness (`grok -p`):
  * - `capabilities.fileWrite === 'deny'` → `--sandbox read-only`
  * - `capabilities.network === 'deny'` → `--disable-web-search`
- * - `default: 'deny'`, `default: 'ask'`, or ask/deny rules → conservative
- *   (omit `--always-approve`, use `--permission-mode default`)
+ * - `default: 'deny'`, `default: 'ask'`, or `commands.ask` → conservative
+ *   (omit `--always-approve`, use `--permission-mode default`).
+ *   A deny list alone is a hard block, not a human prompt, so it does
+ *   not flip the approval flag. Headless `grok -p` auto-cancels tools
+ *   when conservative is true.
  */
 import type { SandboxPolicy } from '@tanstack/ai-sandbox'
 
@@ -24,10 +27,8 @@ export function mapPolicyToGrokBuildFlags(
   if (policy.capabilities?.fileWrite === 'deny') flags.readOnly = true
   if (policy.capabilities?.network === 'deny') flags.networkDisabled = true
 
-  const hasAskOrDeny =
-    (policy.commands?.ask?.length ?? 0) > 0 ||
-    (policy.commands?.deny?.length ?? 0) > 0
-  if (hasAskOrDeny || policy.default === 'deny' || policy.default === 'ask') {
+  const hasAsk = (policy.commands?.ask?.length ?? 0) > 0
+  if (hasAsk || policy.default === 'deny' || policy.default === 'ask') {
     flags.conservative = true
   }
 

--- a/packages/ai-grok-build/src/adapters/projection.ts
+++ b/packages/ai-grok-build/src/adapters/projection.ts
@@ -38,6 +38,7 @@ import {
   discoverSkillDirs,
   isSecretRef,
   resolveGitSkillDir,
+  resolveHarnessCwd,
 } from '@tanstack/ai-sandbox'
 import type {
   BearerRef,
@@ -260,14 +261,20 @@ async function projectGitSkills(
       await handle.fs.mkdir(skillsDir)
       madeDir = true
     }
-    const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
+    // Remap `/workspace` the same way bootstrap remaps clone dirs, so shell
+    // `ln`/`cp` targets match the real provider workdir (e.g. Daytona).
+    const source = resolveHarnessCwd(
+      handle,
+      skill.into ?? resolveGitSkillDir(projection.root, skill),
+    )
     const discovered = await discoverSkillDirs(handle, source)
     for (const { name, dir } of discovered) {
-      const target = `${skillsDir}/${name}`
-      const lnCmd = `ln -s ${shellQuote(dir)} ${shellQuote(target)}`
+      const target = resolveHarnessCwd(handle, `${skillsDir}/${name}`)
+      const realDir = resolveHarnessCwd(handle, dir)
+      const lnCmd = `ln -s ${shellQuote(realDir)} ${shellQuote(target)}`
       const result = await handle.process.exec(lnCmd, { cwd: projection.root })
       if (result.exitCode !== 0) {
-        const cpCmd = `cp -r ${shellQuote(dir)} ${shellQuote(target)}`
+        const cpCmd = `cp -r ${shellQuote(realDir)} ${shellQuote(target)}`
         const copied = await handle.process.exec(cpCmd, {
           cwd: projection.root,
         })

--- a/packages/ai-grok-build/src/adapters/projection.ts
+++ b/packages/ai-grok-build/src/adapters/projection.ts
@@ -261,12 +261,9 @@ async function projectGitSkills(
       await handle.fs.mkdir(skillsDir)
       madeDir = true
     }
-    // Remap `/workspace` the same way bootstrap remaps clone dirs, so shell
-    // `ln`/`cp` targets match the real provider workdir (e.g. Daytona).
-    const source = resolveHarnessCwd(
-      handle,
-      skill.into ?? resolveGitSkillDir(projection.root, skill),
-    )
+    // Discover over virtual `/workspace` paths (handle.fs remaps). Remap only
+    // for shell `ln`/`cp`, where absolute paths must match the real workdir.
+    const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
     const discovered = await discoverSkillDirs(handle, source)
     for (const { name, dir } of discovered) {
       const target = resolveHarnessCwd(handle, `${skillsDir}/${name}`)

--- a/packages/ai-grok-build/src/adapters/projection.ts
+++ b/packages/ai-grok-build/src/adapters/projection.ts
@@ -34,7 +34,11 @@
  *   - AGENTS.md is written universally by bootstrap (grok reads it natively),
  *     so it is NOT rewritten here.
  */
-import { isSecretRef, resolveGitSkillDir } from '@tanstack/ai-sandbox'
+import {
+  discoverSkillDirs,
+  isSecretRef,
+  resolveGitSkillDir,
+} from '@tanstack/ai-sandbox'
 import type {
   BearerRef,
   HostToolBridge,
@@ -47,12 +51,6 @@ import type {
 /** POSIX single-quote escape for embedding a value in a shell command. */
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
-}
-
-/** Last path segment of a `gitSkill` clone dir, used as the skills-dir name. */
-function basenameOf(path: string): string {
-  const segments = path.split('/').filter((segment) => segment !== '')
-  return segments[segments.length - 1] ?? path
 }
 
 /** True when `value` is a `bearer(ref)` marker created by `@tanstack/ai-sandbox`. */
@@ -263,16 +261,21 @@ async function projectGitSkills(
       madeDir = true
     }
     const source = skill.into ?? resolveGitSkillDir(projection.root, skill)
-    const target = `${skillsDir}/${basenameOf(source)}`
-    const lnCmd = `ln -s ${shellQuote(source)} ${shellQuote(target)}`
-    const result = await handle.process.exec(lnCmd, { cwd: projection.root })
-    if (result.exitCode !== 0) {
-      const cpCmd = `cp -r ${shellQuote(source)} ${shellQuote(target)}`
-      const copied = await handle.process.exec(cpCmd, { cwd: projection.root })
-      if (copied.exitCode !== 0) {
-        console.warn(
-          `[grok-build] failed to link gitSkill "${skill.repo}" into ${target}: ${copied.stderr.trim()}`,
-        )
+    const discovered = await discoverSkillDirs(handle, source)
+    for (const { name, dir } of discovered) {
+      const target = `${skillsDir}/${name}`
+      const lnCmd = `ln -s ${shellQuote(dir)} ${shellQuote(target)}`
+      const result = await handle.process.exec(lnCmd, { cwd: projection.root })
+      if (result.exitCode !== 0) {
+        const cpCmd = `cp -r ${shellQuote(dir)} ${shellQuote(target)}`
+        const copied = await handle.process.exec(cpCmd, {
+          cwd: projection.root,
+        })
+        if (copied.exitCode !== 0) {
+          console.warn(
+            `[grok-build] failed to link gitSkill "${skill.repo}" into ${target}: ${copied.stderr.trim()}`,
+          )
+        }
       }
     }
   }

--- a/packages/ai-grok-build/src/adapters/text.ts
+++ b/packages/ai-grok-build/src/adapters/text.ts
@@ -75,8 +75,10 @@ export interface GrokBuildTextConfig {
   /** Extra raw CLI flags appended verbatim (advanced). */
   extraArgs?: Array<string>
   /**
-   * Harness wire protocol. Defaults to `'acp'`. Use `'streaming-json'` for the
-   * legacy headless NDJSON path.
+   * Harness wire protocol. Defaults to `'acp'`. A durable sandbox run
+   * (durability wired, no explicit protocol) uses `'streaming-json'` so the
+   * run can journal and recover. Set `'streaming-json'` yourself for the
+   * headless NDJSON path without durability.
    */
   protocol?: GrokBuildProtocol
   /** ACP transport when `protocol` is `'acp'`. Defaults to `'auto'`. */
@@ -174,7 +176,9 @@ export class GrokBuildTextAdapter<
     const alwaysApprove = !policyFlags.readOnly && !policyFlags.conservative
     if (alwaysApprove) {
       // Headless runs auto-approve tool calls only when sandbox policy is permissive.
-      args.push('--always-approve')
+      // `--no-plan` and `--no-auto-update` keep Plan Mode and the CLI update
+      // check from blocking an unattended run. Issue #1081 item 6.
+      args.push('--always-approve', '--no-plan', '--no-auto-update')
     } else {
       // Restrictive policy: headless `-p` auto-denies prompts under `default` mode.
       args.push('--permission-mode', 'default')
@@ -196,9 +200,16 @@ export class GrokBuildTextAdapter<
   private protocol(
     options: TextOptions<GrokBuildTextProviderOptions>,
   ): GrokBuildProtocol {
-    return (
-      options.modelOptions?.protocol ?? this.adapterConfig.protocol ?? 'acp'
-    )
+    const explicit =
+      options.modelOptions?.protocol ?? this.adapterConfig.protocol
+    if (explicit !== undefined) return explicit
+    // ACP never journals. A durable run with no protocol must take the
+    // NDJSON path so a host restart can recover. Issue #1081 item 5.
+    const durability = options.capabilities
+      ? getSandboxDurability(options.capabilities, { optional: true })
+      : undefined
+    if (durability !== undefined) return 'streaming-json'
+    return 'acp'
   }
 
   async *chatStream(

--- a/packages/ai-grok-build/src/provider-options.ts
+++ b/packages/ai-grok-build/src/provider-options.ts
@@ -22,8 +22,9 @@ export interface GrokBuildTextProviderOptions {
   /** Per-call override of the max harness turns. */
   maxTurns?: number
   /**
-   * Harness wire protocol. Defaults to `'acp'`. Use `'streaming-json'` for the
-   * legacy headless NDJSON path.
+   * Harness wire protocol. Defaults to `'acp'`. A durable sandbox run
+   * (durability wired, no explicit protocol) uses `'streaming-json'` so the
+   * run can journal and recover.
    */
   protocol?: GrokBuildProtocol
   /** ACP transport when `protocol` is `'acp'`. Defaults to `'auto'`. */

--- a/packages/ai-grok-build/tests/durability-protocol-warning.test.ts
+++ b/packages/ai-grok-build/tests/durability-protocol-warning.test.ts
@@ -1,31 +1,17 @@
 /**
  * `chatStreamAcp` never journals (only `chatStreamNdjson` does — see
- * `attach.test.ts`'s header comment), but `protocol` defaults to `'acp'`. So an
- * app that wires `withSandbox({ runs, durability })` and leaves `protocol`
- * unset gets a run that looks durable — it streams normally and records a run
- * row — while being silently unrecoverable: there is no journal to replay on
- * reconnect.
+ * `attach.test.ts`'s header comment). A durable sandbox run must therefore
+ * pick the journaled path when the app does not set `protocol`.
  *
- * For a FRESH run this is a WARN, not a throw (see the comment above the check
- * in `chatStreamAcp`, matching the precedent in
- * `packages/ai-sandbox/src/middleware.ts`'s `InMemoryLockStore` warning): an
- * app can legitimately wire durability once at the middleware level and still
- * choose `protocol: 'acp'` for runs it deliberately never needs to recover.
+ * Acceptance for issue #1081 item 5: `grokBuildText(model)` with durability
+ * wired and no `protocol` / `extraArgs` journals. An explicit
+ * `protocol: 'acp'` can still be a warn (fresh) or a throw (ATTACH).
  *
- * An ATTACH is the opposite — a throw, and the asymmetry is the point. A fresh
- * durable ACP run is merely unrecoverable later; an attach has already spent a
- * first attempt, so proceeding re-runs the agent against the workspace that
- * attempt mutated and double-appends its output to the run log. `attach: true`
- * therefore gets `DurableAttachNotSupportedError` before the ACP connection is
- * ever opened, never the warn.
- *
- * These tests drive `chatStreamAcp` for real — a fake ACP agent (the actual
+ * The ACP cases drive `chatStreamAcp` for real — a fake ACP agent (the actual
  * `@agentclientprotocol/sdk` agent side) spawned over stdio inside a real
  * `localProcessSandbox`, exactly like `packages/ai-acp/tests/compatible.test.ts`
  * — because the warn check sits inline in `chatStreamAcp`'s setup, ahead of
- * spawning the connection, so exercising the full path is what proves the
- * check fires (or doesn't) on the actual code path the fix touches, not a
- * hand-extracted copy of its condition.
+ * spawning the connection.
  */
 import { afterAll, describe, expect, it, vi } from 'vitest'
 import * as fsp from 'node:fs/promises'
@@ -37,6 +23,7 @@ import { localProcessSandbox } from '@tanstack/ai-sandbox-local-process'
 import {
   SandboxCapability,
   SandboxDurabilityCapability,
+  journalPaths,
 } from '@tanstack/ai-sandbox'
 import { InMemoryRunStore } from '@tanstack/ai'
 import { grokBuildText } from '../src/index'
@@ -218,11 +205,18 @@ function textOf(chunks: Array<StreamChunk>): string {
 }
 
 function adapter() {
-  // No `protocol` set: this is what exercises `chatStreamAcp`, since
-  // `protocol` defaults to `'acp'` — the exact silent-misconfiguration
-  // scenario, an app that wires durability without ever choosing a protocol.
+  // Explicit ACP: an app that chooses ACP on purpose, even with durability.
   return grokBuildText('grok-build', {
     grokExecutable: 'node fake-grok-acp-agent.mjs',
+    protocol: 'acp',
+    emitDiff: false,
+  })
+}
+
+function defaultProtocolAdapter(exe: string) {
+  // No `protocol` set: the public `grokBuildText(model)` default.
+  return grokBuildText('grok-build', {
+    grokExecutable: exe,
     emitDiff: false,
   })
 }
@@ -233,7 +227,36 @@ describe(
   'grok-build durability + ACP protocol misconfiguration warning',
   { timeout: SANDBOX_TEST_TIMEOUT },
   () => {
-    it('warns exactly once, naming the consequence and the fix, when durability is configured on the ACP (default) protocol', async () => {
+    it('journals a durable run when protocol is left unset', async () => {
+      const sbx = await provider.create({})
+      await sbx.fs.write('/workspace/fake-grok-ndjson.mjs', NDJSON_FAKE_GROK)
+      const logger = noopLogger()
+      const runId = 'r-default-protocol-journals'
+
+      const chunks = await collect(
+        defaultProtocolAdapter('node fake-grok-ndjson.mjs').chatStream({
+          model: 'grok-build',
+          runId,
+          messages: [{ role: 'user', content: 'say pong' }],
+          logger,
+          capabilities: contextWith(sbx, durability()),
+        }),
+      )
+
+      expect(textOf(chunks)).toBe('pong')
+      expect(chunks.some((c) => c.type === 'RUN_FINISHED')).toBe(true)
+      expect(logger.warn).not.toHaveBeenCalled()
+
+      // Journal file is deleted after the exit sentinel. The directory it
+      // created is the surviving proof that spawnNdjson journaled this run.
+      const paths = journalPaths(runId, JOURNAL_DIR)
+      const dirExists = await sbx.process.exec(`test -d '${paths.dir}'`)
+      expect(dirExists.exitCode).toBe(0)
+
+      await sbx.destroy()
+    })
+
+    it('warns exactly once, naming the consequence and the fix, when durability is configured on an explicit ACP protocol', async () => {
       const sbx = await provider.create({})
       await sbx.fs.write(
         '/workspace/fake-grok-acp-agent.mjs',

--- a/packages/ai-grok-build/tests/policy-map.test.ts
+++ b/packages/ai-grok-build/tests/policy-map.test.ts
@@ -41,16 +41,25 @@ describe('mapPolicyToGrokBuildFlags', () => {
     ).toBe(true)
   })
 
-  it('maps ask/deny command rules to conservative', () => {
+  it('maps ask command rules to conservative', () => {
     expect(
       mapPolicyToGrokBuildFlags(
         defineSandboxPolicy({ commands: { ask: ['pnpm *'] } }),
       ).conservative,
     ).toBe(true)
+  })
+
+  // Headless grok -p auto-cancels tools when conservative is true. A deny
+  // list is a hard block, not a human prompt, so it must not flip the
+  // approval flag. Issue #1081 item 1.
+  it('does not treat a deny list as conservative when default is allow', () => {
     expect(
       mapPolicyToGrokBuildFlags(
-        defineSandboxPolicy({ default: 'allow', commands: { deny: ['rm *'] } }),
+        defineSandboxPolicy({
+          default: 'allow',
+          commands: { deny: ['rm -rf /'] },
+        }),
       ).conservative,
-    ).toBe(true)
+    ).toBeUndefined()
   })
 })

--- a/packages/ai-grok-build/tests/projection.test.ts
+++ b/packages/ai-grok-build/tests/projection.test.ts
@@ -43,6 +43,30 @@ interface FakeHandle {
   existing: Set<string>
 }
 
+/** Immediate children of `dir` from a flat path→content map. */
+function listChildren(
+  files: Map<string, string>,
+  dir: string,
+): Array<{ name: string; path: string; type: 'file' | 'dir' }> {
+  const prefix = dir.endsWith('/') ? dir : `${dir}/`
+  const children = new Map<
+    string,
+    { name: string; path: string; type: 'file' | 'dir' }
+  >()
+  for (const filePath of files.keys()) {
+    if (!filePath.startsWith(prefix)) continue
+    const rest = filePath.slice(prefix.length)
+    const name = rest.split('/')[0]
+    if (name === undefined || name === '') continue
+    children.set(name, {
+      name,
+      path: `${prefix}${name}`,
+      type: rest.includes('/') ? 'dir' : 'file',
+    })
+  }
+  return [...children.values()]
+}
+
 /** Build a fake handle that records writes/execs and tracks existing paths. */
 function makeFakeHandle(
   execResult: ExecResult,
@@ -68,6 +92,7 @@ function makeFakeHandle(
       },
       exists: (path: string) => Promise.resolve(existing.has(path)),
       mkdir: () => Promise.resolve(),
+      list: (dir: string) => Promise.resolve(listChildren(files, dir)),
     },
     process: {
       exec: (command: string, options?: { cwd?: string }) => {
@@ -265,5 +290,49 @@ describe('projectGrokWorkspace', () => {
     expect(fake.execs.length).toBe(execsAfterFirst)
 
     warn.mockRestore()
+  })
+
+  // Nested packs (skills/foo/SKILL.md) must be linked by the skill folder
+  // name, not the clone basename. Issue #1081 item 3.
+  it('links each nested SKILL.md folder by its skill name', async () => {
+    const fake = makeFakeHandle({ stdout: '', stderr: '', exitCode: 0 })
+    const clone = resolveGitSkillDir(ROOT, {
+      kind: 'git',
+      repo: 'owner/skills-pack',
+    })
+    fake.files.set(`${clone}/skills/foo/SKILL.md`, '# foo')
+    fake.files.set(`${clone}/skills/bar/SKILL.md`, '# bar')
+    fake.existing.add(`${clone}/skills/foo/SKILL.md`)
+    fake.existing.add(`${clone}/skills/bar/SKILL.md`)
+
+    await projectGrokWorkspace(fake.handle, {
+      skills: [gitSkill({ repo: 'owner/skills-pack' })],
+      plugins: [],
+      resolveSecret: () => '',
+      markerPath: MARKER,
+      root: ROOT,
+    })
+
+    expect(
+      fake.execs.some(
+        (e) =>
+          e.command.includes('ln -s') &&
+          e.command.includes(`${clone}/skills/foo`) &&
+          e.command.includes(`${ROOT}/.grok/skills/foo`),
+      ),
+    ).toBe(true)
+    expect(
+      fake.execs.some(
+        (e) =>
+          e.command.includes('ln -s') &&
+          e.command.includes(`${clone}/skills/bar`) &&
+          e.command.includes(`${ROOT}/.grok/skills/bar`),
+      ),
+    ).toBe(true)
+    expect(
+      fake.execs.some((e) =>
+        e.command.includes(`${ROOT}/.grok/skills/skills-pack`),
+      ),
+    ).toBe(false)
   })
 })

--- a/packages/ai-grok-build/tests/text-adapter.test.ts
+++ b/packages/ai-grok-build/tests/text-adapter.test.ts
@@ -120,6 +120,8 @@ describe('grok-build in-sandbox adapter', () => {
     expect(argv).toContain('grok-build-0.1')
     expect(argv).not.toContain('--mcp-config')
     expect(argv).toContain('--always-approve')
+    expect(argv).toContain('--no-plan')
+    expect(argv).toContain('--no-auto-update')
     expect(argv).toContain('--cwd')
     // local-process: harness cwd must be the real host dir, not virtual /workspace.
     expect(argv).toContain(sbx.id)

--- a/packages/ai-sandbox-daytona/src/handle.ts
+++ b/packages/ai-sandbox-daytona/src/handle.ts
@@ -3,9 +3,9 @@
  * isolation: fs/exec/git operate inside the remote sandbox; paths are real
  * sandbox paths (default workdir `/home/daytona/workspace`).
  *
- * fs is implemented over `process.executeCommand` with base64 piping
- * (binary-safe, no extra round trips); the sandbox image must provide `sh`,
- * `base64`, and coreutils (true for the default Daytona images).
+ * fs and git use the native Daytona SDK. Blocking exec sends env through
+ * `executeCommand`'s env argument so secret values never enter the stored
+ * command string. Spawn sources a workdir env file for the same reason.
  *
  * NOTE: Daytona's `executeCommand` returns a single combined `result` string
  * (stdout+stderr interleaved) plus an `exitCode`; there is no separate stderr
@@ -14,17 +14,16 @@
  * separately via Daytona sessions.
  */
 import { randomUUID } from 'node:crypto'
-import {
-  UnsupportedCapabilityError,
-  createExecBackedGit,
-} from '@tanstack/ai-sandbox'
+import { UnsupportedCapabilityError } from '@tanstack/ai-sandbox'
 import type { Sandbox } from '@daytona/sdk'
 import type {
   ExecResult,
   ProcessOptions,
   SandboxCapabilities,
   SandboxChannel,
+  SandboxGit,
   SandboxHandle,
+  SnapshotRef,
   SpawnHandle,
 } from '@tanstack/ai-sandbox'
 
@@ -34,10 +33,7 @@ export const DAYTONA_CAPS: SandboxCapabilities = {
   env: true,
   ports: true,
   backgroundProcesses: true,
-  // Daytona background commands run in a session; there is no host→process
-  // stdin stream, so adapters that feed a prompt over stdin must deliver it via
-  // a file + shell redirection instead.
-  writableStdin: false,
+  writableStdin: true,
   // FALSE, and it must not be flipped back without a MEASUREMENT against a real
   // Daytona sandbox. It read `true` on an asserted comment: that `kill()` "deletes
   // the Daytona session via `deleteSession`, which terminates the session's running
@@ -48,10 +44,10 @@ export const DAYTONA_CAPS: SandboxCapabilities = {
   //     `stream.destroy()` detached the client while the container-side process
   //     kept running (measured: `sleep` survived `kill()`).
   //  2. `kill()` does not await any termination. The `deleteSession` call lives in
-  //     the pump's `finally`, reached only after the loop notices the abort (up to
-  //     one 400ms sleep plus an in-flight logs+status round trip later) and does one
-  //     more full `flush()`. It is also `.catch(() => {})`-swallowed, so a failed
-  //     delete is indistinguishable from a successful one.
+  //     the pump's `finally`, reached only after the status poll notices the abort
+  //     (up to one 400ms sleep plus an in-flight status round trip later). It is
+  //     also `.catch(() => {})`-swallowed, so a failed delete is indistinguishable
+  //     from a successful one.
   //  3. `deleteSession`'s own SDK doc describes it as "Clean up a completed
   //     session"; terminating a RUNNING async command is not a documented effect.
   //
@@ -63,8 +59,8 @@ export const DAYTONA_CAPS: SandboxCapabilities = {
   // `tail -f` per run; see `tests/journal.conformance.test.ts`, which measures this
   // as soon as `DAYTONA_API_KEY` is present.
   killableProcesses: false,
-  snapshots: false,
-  networkPolicy: false,
+  snapshots: true,
+  networkPolicy: true,
   // The sandbox filesystem persists for the sandbox's lifetime (across exec
   // calls and stop/resume) until it is deleted.
   durableFilesystem: true,
@@ -156,59 +152,51 @@ export class DaytonaHandle implements SandboxHandle {
 
     this.fs = {
       read: async (p) => {
-        const r = await this.exec(`base64 ${q(this.abs(p))}`)
-        if (r.exitCode !== 0) throw new Error(`read failed: ${r.stdout.trim()}`)
-        return Buffer.from(r.stdout, 'base64').toString('utf8')
+        const buf = await this.sandbox.fs.downloadFile(this.abs(p))
+        return buf.toString('utf8')
       },
       readBytes: async (p) => {
-        const r = await this.exec(`base64 ${q(this.abs(p))}`)
-        if (r.exitCode !== 0) throw new Error(`read failed: ${r.stdout.trim()}`)
-        return new Uint8Array(Buffer.from(r.stdout, 'base64'))
+        const buf = await this.sandbox.fs.downloadFile(this.abs(p))
+        return new Uint8Array(buf)
       },
       write: async (p, data) => {
         const abs = this.abs(p)
-        const b64 = Buffer.from(
-          typeof data === 'string' ? Buffer.from(data, 'utf8') : data,
-        ).toString('base64')
-        const dir = abs.replace(/\/[^/]*$/, '') || '/'
-        const r = await this.exec(
-          `mkdir -p ${q(dir)} && printf %s ${q(b64)} | base64 -d > ${q(abs)}`,
-        )
-        if (r.exitCode !== 0)
-          throw new Error(`write failed: ${r.stdout.trim()}`)
+        const parent = abs.replace(/\/[^/]*$/, '') || '/'
+        await this.sandbox.fs.createFolder(parent, '755')
+        const buf =
+          typeof data === 'string'
+            ? Buffer.from(data, 'utf8')
+            : Buffer.from(data)
+        await this.sandbox.fs.uploadFile(buf, abs)
       },
       list: async (p) => {
-        const r = await this.exec(`ls -1Ap ${q(this.abs(p))}`)
-        if (r.exitCode !== 0) throw new Error(`list failed: ${r.stdout.trim()}`)
-        return r.stdout
-          .split('\n')
-          .filter((line) => line.trim() !== '')
-          .map((entry) => {
-            const isDir = entry.endsWith('/')
-            const name = isDir ? entry.slice(0, -1) : entry
-            return {
-              name,
-              path: `${p.replace(/\/$/, '')}/${name}`,
-              type: isDir ? ('dir' as const) : ('file' as const),
-            }
-          })
+        const entries = await this.sandbox.fs.listFiles(this.abs(p))
+        return entries.map((entry) => ({
+          name: entry.name,
+          path: `${p.replace(/\/$/, '')}/${entry.name}`,
+          type: entry.isDir ? ('dir' as const) : ('file' as const),
+        }))
       },
       mkdir: async (p) => {
-        await this.exec(`mkdir -p ${q(this.abs(p))}`)
+        await this.sandbox.fs.createFolder(this.abs(p), '755')
       },
       remove: async (p) => {
-        await this.exec(`rm -rf ${q(this.abs(p))}`)
+        await this.sandbox.fs.deleteFile(this.abs(p), true)
       },
       rename: async (from, to) => {
-        await this.exec(`mv ${q(this.abs(from))} ${q(this.abs(to))}`)
+        await this.sandbox.fs.moveFiles(this.abs(from), this.abs(to))
       },
       exists: async (p) => {
-        const r = await this.exec(`test -e ${q(this.abs(p))}`)
-        return r.exitCode === 0
+        try {
+          await this.sandbox.fs.getFileDetails(this.abs(p))
+          return true
+        } catch {
+          return false
+        }
       },
     }
 
-    this.git = createExecBackedGit(this.process, this.workdir)
+    this.git = this.createNativeGit()
 
     this.ports = {
       connect: (port) => this.connectPort(port),
@@ -231,17 +219,71 @@ export class DaytonaHandle implements SandboxHandle {
     return p
   }
 
+  private mergedEnv(extra?: Record<string, string>): Record<string, string> {
+    return { ...this.envVars, ...extra }
+  }
+
   /**
-   * Prefix a command with `export`s for the sandbox env vars so they apply to
-   * the executed command. Done in-shell rather than via the SDK's env argument
-   * to stay independent of `executeCommand`'s positional-argument ordering.
+   * Session execute has no env field. Write values to a workdir file,
+   * then source that file so the stored command never contains secrets.
    */
-  private withEnv(command: string, extra?: Record<string, string>): string {
-    const merged = { ...this.envVars, ...extra }
-    const exports = Object.entries(merged)
-      .map(([k, v]) => `export ${k}=${q(v)}; `)
-      .join('')
-    return `${exports}${command}`
+  private async persistSpawnEnvFile(
+    env: Record<string, string>,
+  ): Promise<string | undefined> {
+    if (!this.sandbox.fs) return undefined
+    const path = `${this.workdir}/.tanstack-ai-env`
+    const body = Object.entries(env)
+      .map(([key, value]) => `${key}=${q(value)}`)
+      .join('\n')
+    await this.sandbox.fs.createFolder(this.workdir, '755')
+    await this.sandbox.fs.uploadFile(Buffer.from(`${body}\n`, 'utf8'), path)
+    return path
+  }
+
+  private createNativeGit(): SandboxGit {
+    const repoPath = (dir?: string): string => this.abs(dir ?? this.workdir)
+    return {
+      clone: async ({ url, dir, ref, auth }) => {
+        const path = this.abs(dir ?? this.workdir)
+        const parent = path.replace(/\/[^/]*$/, '') || '/'
+        if (this.sandbox.fs) {
+          await this.sandbox.fs.createFolder(parent, '755')
+        }
+        await this.sandbox.git.clone(
+          url,
+          path,
+          ref,
+          undefined,
+          auth?.username,
+          auth?.token,
+        )
+      },
+      status: async (dir) => {
+        const status = await this.sandbox.git.status(repoPath(dir))
+        return JSON.stringify(status)
+      },
+      add: async (paths, dir) => {
+        await this.sandbox.git.add(repoPath(dir), paths)
+      },
+      commit: async (message, dir) => {
+        await this.sandbox.git.commit(
+          repoPath(dir),
+          message,
+          'tanstack-ai',
+          'sandbox@tanstack.ai',
+        )
+      },
+      push: async (dir) => {
+        await this.sandbox.git.push(repoPath(dir))
+      },
+      pull: async (dir) => {
+        await this.sandbox.git.pull(repoPath(dir))
+      },
+      branch: async (dir) => {
+        const status = await this.sandbox.git.status(repoPath(dir))
+        return status.currentBranch
+      },
+    }
   }
 
   private async exec(
@@ -249,9 +291,11 @@ export class DaytonaHandle implements SandboxHandle {
     opts?: ProcessOptions,
   ): Promise<ExecResult> {
     const cwd = opts?.cwd ? this.abs(opts.cwd) : this.workdir
+    const env = this.mergedEnv(opts?.env)
     const response = await this.sandbox.process.executeCommand(
-      this.withEnv(command, opts?.env),
+      command,
       cwd,
+      Object.keys(env).length > 0 ? env : undefined,
     )
     return {
       // Daytona returns a single combined output string; there is no separate
@@ -270,7 +314,14 @@ export class DaytonaHandle implements SandboxHandle {
     await this.sandbox.process.createSession(sessionId)
 
     const cwd = opts?.cwd ? this.abs(opts.cwd) : this.workdir
-    const wrapped = this.withEnv(`cd ${q(cwd)} && ${command}`, opts?.env)
+    const env = this.mergedEnv(opts?.env)
+    const envFile =
+      Object.keys(env).length > 0
+        ? await this.persistSpawnEnvFile(env)
+        : undefined
+    const wrapped = envFile
+      ? `set -a; . ${q(envFile)}; set +a; cd ${q(cwd)} && ${command}`
+      : `cd ${q(cwd)} && ${command}`
     const started = await this.sandbox.process.executeSessionCommand(
       sessionId,
       { command: wrapped, runAsync: true },
@@ -286,48 +337,33 @@ export class DaytonaHandle implements SandboxHandle {
     let exitCode = 0
 
     // `kill()` and the caller's signal both feed this controller; its
-    // `signal.aborted` flag stops the poll loop.
+    // `signal.aborted` flag stops the wait. The remote command is not killed.
     const controller = new AbortController()
     const onAbort = (): void => controller.abort()
     opts?.signal?.addEventListener('abort', onAbort, { once: true })
 
-    // Poll the session command logs + status. Daytona surfaces cumulative
-    // stdout/stderr buffers, so we emit only the newly appended bytes.
+    // Stream logs over the WebSocket form. Still poll command status so
+    // `kill()` can stop the client wait without waiting for the stream.
+    void this.sandbox.process.getSessionCommandLogs(
+      sessionId,
+      cmdId,
+      (chunk) => stdoutQ.push(chunk),
+      (chunk) => stderrQ.push(chunk),
+    )
+
     const pump = (async (): Promise<void> => {
-      let lastOut = 0
-      let lastErr = 0
-      const flush = async (): Promise<boolean> => {
-        const logs = await this.sandbox.process.getSessionCommandLogs(
-          sessionId,
-          cmdId,
-        )
-        const out = logs.stdout ?? ''
-        const err = logs.stderr ?? ''
-        if (out.length > lastOut) {
-          stdoutQ.push(out.slice(lastOut))
-          lastOut = out.length
-        }
-        if (err.length > lastErr) {
-          stderrQ.push(err.slice(lastErr))
-          lastErr = err.length
-        }
-        const cmd = await this.sandbox.process.getSessionCommand(
-          sessionId,
-          cmdId,
-        )
-        if (cmd.exitCode !== undefined) {
-          exitCode = cmd.exitCode
-          return true
-        }
-        return false
-      }
       try {
         while (!controller.signal.aborted) {
-          if (await flush()) break
+          const cmd = await this.sandbox.process.getSessionCommand(
+            sessionId,
+            cmdId,
+          )
+          if (cmd.exitCode !== undefined) {
+            exitCode = cmd.exitCode
+            break
+          }
           await sleep(400)
         }
-        // Final flush to capture any bytes written between the last poll and exit.
-        await flush()
       } finally {
         opts?.signal?.removeEventListener('abort', onAbort)
         stdoutQ.end()
@@ -341,12 +377,8 @@ export class DaytonaHandle implements SandboxHandle {
       stdout: stdoutQ,
       stderr: stderrQ,
       stdin: {
-        write: () =>
-          Promise.reject(
-            new Error(
-              'daytona: background process stdin is not writable (see capabilities.writableStdin)',
-            ),
-          ),
+        write: (data) =>
+          this.sandbox.process.sendSessionCommandInput(sessionId, cmdId, data),
         end: () => Promise.resolve(),
       },
       wait: async () => {
@@ -375,8 +407,25 @@ export class DaytonaHandle implements SandboxHandle {
     return { url: signed.url, token: signed.token }
   }
 
-  // Daytona snapshots/fork are not wired through the uniform handle yet.
-  snapshot = undefined
+  async snapshot(label?: string): Promise<SnapshotRef> {
+    // Daytona container snapshots are cold: the sandbox must be stopped.
+    // Hyphen-only names match Daytona's snapshot identifier rules.
+    const name = `tanstack-ai-sandbox-snapshot-${this.id.slice(0, 12)}-${label ?? 'snap'}`
+    await this.sandbox.stop()
+    try {
+      await this.sandbox._experimental_createSnapshot(name)
+    } catch (error) {
+      try {
+        await this.sandbox.start()
+      } catch {
+        // Keep the snapshot error. A failed start must not hide it.
+      }
+      throw error
+    }
+    // `ensure()` still needs a live handle after a successful snapshot.
+    await this.sandbox.start()
+    return { id: name, ...(label !== undefined ? { label } : {}) }
+  }
 
   fork = (): Promise<SandboxHandle> => {
     throw new UnsupportedCapabilityError('daytona', 'fork')

--- a/packages/ai-sandbox-daytona/src/handle.ts
+++ b/packages/ai-sandbox-daytona/src/handle.ts
@@ -344,12 +344,16 @@ export class DaytonaHandle implements SandboxHandle {
 
     // Stream logs over the WebSocket form. Still poll command status so
     // `kill()` can stop the client wait without waiting for the stream.
-    void this.sandbox.process.getSessionCommandLogs(
-      sessionId,
-      cmdId,
-      (chunk) => stdoutQ.push(chunk),
-      (chunk) => stderrQ.push(chunk),
-    )
+    // Keep the promise so we can drain trailing chunks and so a dropped
+    // socket cannot become an unhandled rejection.
+    const logStream = this.sandbox.process
+      .getSessionCommandLogs(
+        sessionId,
+        cmdId,
+        (chunk) => stdoutQ.push(chunk),
+        (chunk) => stderrQ.push(chunk),
+      )
+      .catch(() => undefined)
 
     const pump = (async (): Promise<void> => {
       try {
@@ -366,6 +370,8 @@ export class DaytonaHandle implements SandboxHandle {
         }
       } finally {
         opts?.signal?.removeEventListener('abort', onAbort)
+        // Let the log stream finish so trailing output is not dropped.
+        await Promise.race([logStream, sleep(1000)])
         stdoutQ.end()
         stderrQ.end()
         await this.sandbox.process.deleteSession(sessionId).catch(() => {})

--- a/packages/ai-sandbox-daytona/src/provider.ts
+++ b/packages/ai-sandbox-daytona/src/provider.ts
@@ -10,6 +10,7 @@ import type {
   SandboxDestroyInput,
   SandboxHandle,
   SandboxProvider,
+  SandboxRestoreInput,
   SandboxResumeInput,
 } from '@tanstack/ai-sandbox'
 
@@ -32,6 +33,15 @@ export interface DaytonaSandboxConfig {
    * here. Defaults to `/home/daytona/workspace`.
    */
   workdir?: string
+  /**
+   * Minutes of idle time before Daytona stops the sandbox. `0` turns auto-stop
+   * off. Daytona defaults to 15 minutes when this is omitted.
+   */
+  autoStopInterval?: number
+  /**
+   * When true, Daytona deletes the sandbox as soon as it stops.
+   */
+  ephemeral?: boolean
 }
 
 const DEFAULT_WORKDIR = '/home/daytona/workspace'
@@ -61,26 +71,79 @@ class DaytonaProvider implements SandboxProvider {
     return this.config.workdir ?? DEFAULT_WORKDIR
   }
 
-  async create(input: SandboxCreateInput): Promise<SandboxHandle> {
-    const sandbox = await this.daytona.create({
-      language: this.config.language ?? 'typescript',
-      ...(this.config.snapshot !== undefined
-        ? { snapshot: this.config.snapshot }
-        : {}),
-      ...(input.env ? { envVars: input.env } : {}),
-    })
-    // A fresh Daytona sandbox has no workdir yet. Create it with the sandbox's
-    // DEFAULT cwd (the home dir) — `executeCommand` with a not-yet-existing
-    // `cwd` fails inside the toolbox ("fork/exec …: no such file or directory"),
-    // so we must NOT route this through the handle (which runs every command in
-    // `workdir`). After this, every cwd-bound command works.
+  /**
+   * A fresh Daytona sandbox has no workdir yet. Create it with the sandbox's
+   * DEFAULT cwd (the home dir) — `executeCommand` with a not-yet-existing
+   * `cwd` fails inside the toolbox ("fork/exec …: no such file or directory"),
+   * so we must NOT route this through the handle (which runs every command in
+   * `workdir`). After this, every cwd-bound command works.
+   */
+  private async wrapCreated(
+    sandbox: Awaited<ReturnType<Daytona['create']>>,
+  ): Promise<SandboxHandle> {
     await sandbox.process.executeCommand(`mkdir -p ${shQuote(this.workdir)}`)
     return new DaytonaHandle({ sandbox, workdir: this.workdir })
+  }
+
+  private createParams(input: {
+    snapshot?: string
+    id?: string
+    policy?: SandboxCreateInput['policy']
+  }): CreateSandboxFromSnapshotParams {
+    return {
+      language: this.config.language ?? 'typescript',
+      ...(input.snapshot !== undefined ? { snapshot: input.snapshot } : {}),
+      ...(input.id !== undefined ? { name: input.id } : {}),
+      ...(this.config.autoStopInterval !== undefined
+        ? { autoStopInterval: this.config.autoStopInterval }
+        : {}),
+      ...(this.config.ephemeral !== undefined
+        ? { ephemeral: this.config.ephemeral }
+        : {}),
+      ...(input.policy?.capabilities?.network === 'deny'
+        ? { networkBlockAll: true }
+        : {}),
+    }
+  }
+
+  private async wrapReady(
+    sandbox: Awaited<ReturnType<Daytona['create']>>,
+    env?: Record<string, string>,
+  ): Promise<SandboxHandle> {
+    const handle = await this.wrapCreated(sandbox)
+    if (env !== undefined) await handle.env.set(env)
+    return handle
+  }
+
+  async create(input: SandboxCreateInput): Promise<SandboxHandle> {
+    const sandbox = await this.daytona.create(
+      this.createParams({
+        snapshot: this.config.snapshot,
+        id: input.id,
+        policy: input.policy,
+      }),
+    )
+    return this.wrapReady(sandbox, input.env)
+  }
+
+  async restoreSnapshot(input: SandboxRestoreInput): Promise<SandboxHandle> {
+    const sandbox = await this.daytona.create(
+      this.createParams({
+        snapshot: input.snapshotId,
+        policy: input.policy,
+      }),
+    )
+    return this.wrapReady(sandbox, input.env)
   }
 
   async resume(input: SandboxResumeInput): Promise<SandboxHandle | null> {
     try {
       const sandbox = await this.daytona.get(input.id)
+      // Idle sandboxes auto-stop. get() still returns them, but exec fails
+      // until they are started again.
+      if (sandbox.state === 'stopped' || sandbox.state === 'archived') {
+        await sandbox.start()
+      }
       return new DaytonaHandle({ sandbox, workdir: this.workdir })
     } catch {
       // Gone / not found.

--- a/packages/ai-sandbox-daytona/tests/handle.test.ts
+++ b/packages/ai-sandbox-daytona/tests/handle.test.ts
@@ -132,9 +132,11 @@ describe('DaytonaHandle.ports.connect', () => {
 describe('DaytonaHandle.git.clone remaps /workspace', () => {
   it('clones a virtual /workspace dir into the real workdir', async () => {
     const clone = vi.fn(async () => {})
+    const createFolder = vi.fn(async () => {})
     const sandbox = {
       id: 'sbx-1',
       git: { clone },
+      fs: { createFolder, uploadFile: vi.fn(async () => {}) },
       process: {
         executeCommand: vi.fn(async () => ({ result: '', exitCode: 0 })),
       },
@@ -150,6 +152,10 @@ describe('DaytonaHandle.git.clone remaps /workspace', () => {
       dir: '/workspace/.tanstack-skills/skills-pack',
     })
 
+    expect(createFolder).toHaveBeenCalledWith(
+      '/home/daytona/workspace/.tanstack-skills',
+      '755',
+    )
     expect(clone).toHaveBeenCalledWith(
       'https://github.com/owner/skills-pack',
       '/home/daytona/workspace/.tanstack-skills/skills-pack',
@@ -332,8 +338,11 @@ describe('DaytonaHandle spawn stream and stdin', () => {
         cmdId: 'cmd-1',
       }),
     )
+    const uploadFile = vi.fn(async (_data: Buffer, _path: string) => {})
+    const createFolder = vi.fn(async () => {})
     const sandbox = {
       id: 'sbx-1',
+      fs: { createFolder, uploadFile },
       process: {
         createSession: vi.fn(async () => {}),
         executeSessionCommand,
@@ -361,8 +370,18 @@ describe('DaytonaHandle spawn stream and stdin', () => {
     const proc = await handle.process.spawn('echo hi')
     await proc.wait()
 
+    expect(uploadFile).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      '/home/daytona/workspace/.tanstack-ai-env',
+    )
+    const uploaded = uploadFile.mock.calls[0]?.[0]
+    expect(uploaded).toBeInstanceOf(Buffer)
+    expect(uploaded?.toString('utf8')).toContain(
+      "ANTHROPIC_API_KEY='sk-secret-value'",
+    )
     const request = executeSessionCommand.mock.calls[0]?.[1]
     expect(request).toBeDefined()
+    expect(request?.command).toContain('.tanstack-ai-env')
     expect(request?.command).not.toContain('sk-secret-value')
     expect(request?.command).not.toContain('export ANTHROPIC_API_KEY')
   })

--- a/packages/ai-sandbox-daytona/tests/handle.test.ts
+++ b/packages/ai-sandbox-daytona/tests/handle.test.ts
@@ -125,3 +125,396 @@ describe('DaytonaHandle.ports.connect', () => {
     })
   })
 })
+
+// Native Daytona git takes a path argument, not a shell string. A virtual
+// clone target must still land under the real workdir.
+// Issues #1081 item 4, #1085 item 4.
+describe('DaytonaHandle.git.clone remaps /workspace', () => {
+  it('clones a virtual /workspace dir into the real workdir', async () => {
+    const clone = vi.fn(async () => {})
+    const sandbox = {
+      id: 'sbx-1',
+      git: { clone },
+      process: {
+        executeCommand: vi.fn(async () => ({ result: '', exitCode: 0 })),
+      },
+      delete: vi.fn(async () => {}),
+    } as unknown as Sandbox
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    await handle.git.clone({
+      url: 'https://github.com/owner/skills-pack',
+      dir: '/workspace/.tanstack-skills/skills-pack',
+    })
+
+    expect(clone).toHaveBeenCalledWith(
+      'https://github.com/owner/skills-pack',
+      '/home/daytona/workspace/.tanstack-skills/skills-pack',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+    expect(sandbox.process.executeCommand).not.toHaveBeenCalled()
+  })
+
+  it('passes git auth as native username/password, not a command env export', async () => {
+    const clone = vi.fn(async () => {})
+    const sandbox = {
+      id: 'sbx-1',
+      git: { clone },
+      process: {
+        executeCommand: vi.fn(async () => ({ result: '', exitCode: 0 })),
+      },
+      delete: vi.fn(async () => {}),
+    } as unknown as Sandbox
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    await handle.git.clone({
+      url: 'https://github.com/owner/private-repo',
+      dir: '/workspace/app',
+      auth: { username: 'x-access-token', token: 'ghs_secret' },
+    })
+
+    expect(clone).toHaveBeenCalledWith(
+      'https://github.com/owner/private-repo',
+      '/home/daytona/workspace/app',
+      undefined,
+      undefined,
+      'x-access-token',
+      'ghs_secret',
+    )
+    expect(sandbox.process.executeCommand).not.toHaveBeenCalled()
+  })
+})
+
+// Issue #1084: secrets must not appear in the command string Daytona stores.
+// Issue #1085 item 4: fs uses the native SDK, not base64-over-exec.
+describe('DaytonaHandle env and native fs', () => {
+  it('sends per-command env through executeCommand, not export prefixes', async () => {
+    const executeCommand = vi.fn(
+      async (
+        _command: string,
+        _cwd?: string,
+        _env?: Record<string, string>,
+      ) => ({ result: '', exitCode: 0 }),
+    )
+    const sandbox = {
+      id: 'sbx-1',
+      process: { executeCommand },
+      delete: vi.fn(async () => {}),
+    } as unknown as Sandbox
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    await handle.env.set({ ANTHROPIC_API_KEY: 'sk-secret-value' })
+    await handle.process.exec('echo hello', {
+      env: { GIT_ASKPASS_TOKEN: 'ghs_secret' },
+    })
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      'echo hello',
+      '/home/daytona/workspace',
+      {
+        ANTHROPIC_API_KEY: 'sk-secret-value',
+        GIT_ASKPASS_TOKEN: 'ghs_secret',
+      },
+    )
+    const command = executeCommand.mock.calls[0]?.[0]
+    expect(command).not.toContain('sk-secret-value')
+    expect(command).not.toContain('ghs_secret')
+    expect(command).not.toContain('export ')
+  })
+
+  it('writes files through native uploadFile, not a base64 exec command', async () => {
+    const uploadFile = vi.fn(async () => {})
+    const createFolder = vi.fn(async () => {})
+    const executeCommand = vi.fn(async () => ({ result: '', exitCode: 0 }))
+    const sandbox = {
+      id: 'sbx-1',
+      fs: { uploadFile, createFolder },
+      process: { executeCommand },
+      delete: vi.fn(async () => {}),
+    } as unknown as Sandbox
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    await handle.fs.write('/workspace/note.txt', 'inside the sandbox')
+
+    expect(createFolder).toHaveBeenCalledWith('/home/daytona/workspace', '755')
+    expect(uploadFile).toHaveBeenCalledWith(
+      Buffer.from('inside the sandbox', 'utf8'),
+      '/home/daytona/workspace/note.txt',
+    )
+    expect(executeCommand).not.toHaveBeenCalled()
+  })
+
+  it('reads files through native downloadFile', async () => {
+    const downloadFile = vi.fn(async () =>
+      Buffer.from('inside the sandbox', 'utf8'),
+    )
+    const executeCommand = vi.fn(async () => ({ result: '', exitCode: 0 }))
+    const sandbox = {
+      id: 'sbx-1',
+      fs: { downloadFile },
+      process: { executeCommand },
+      delete: vi.fn(async () => {}),
+    } as unknown as Sandbox
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    await expect(handle.fs.read('/workspace/note.txt')).resolves.toBe(
+      'inside the sandbox',
+    )
+    expect(downloadFile).toHaveBeenCalledWith(
+      '/home/daytona/workspace/note.txt',
+    )
+    expect(executeCommand).not.toHaveBeenCalled()
+  })
+})
+
+// Issue #1085 items 1 and 2: spawn follows the log over the WebSocket form
+// and exposes session stdin.
+describe('DaytonaHandle spawn stream and stdin', () => {
+  it('follows session logs with the streaming getSessionCommandLogs form', async () => {
+    const getSessionCommandLogs = vi.fn(
+      async (
+        _sessionId: string,
+        _commandId: string,
+        onStdout?: (chunk: string) => void,
+        _onStderr?: (chunk: string) => void,
+      ) => {
+        onStdout?.('streamed-line\n')
+      },
+    )
+    const sandbox = {
+      id: 'sbx-1',
+      process: {
+        createSession: vi.fn(async () => {}),
+        executeSessionCommand: vi.fn(async () => ({ cmdId: 'cmd-1' })),
+        getSessionCommandLogs,
+        getSessionCommand: vi.fn(async () => ({ exitCode: 0 })),
+        deleteSession: vi.fn(async () => {}),
+        sendSessionCommandInput: vi.fn(async () => {}),
+      },
+      delete: vi.fn(async () => {}),
+    } as unknown as Sandbox
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    const proc = await handle.process.spawn('echo streamed-line')
+    let out = ''
+    for await (const chunk of proc.stdout) out += chunk
+    expect(out).toContain('streamed-line')
+    expect(await proc.wait()).toBe(0)
+    expect(getSessionCommandLogs.mock.calls[0]?.length).toBeGreaterThanOrEqual(
+      4,
+    )
+  })
+
+  it('does not put env values into the session command string', async () => {
+    const executeSessionCommand = vi.fn(
+      async (_sessionId: string, _request: { command: string }) => ({
+        cmdId: 'cmd-1',
+      }),
+    )
+    const sandbox = {
+      id: 'sbx-1',
+      process: {
+        createSession: vi.fn(async () => {}),
+        executeSessionCommand,
+        getSessionCommandLogs: vi.fn(
+          async (
+            _sessionId: string,
+            _commandId: string,
+            onStdout?: (chunk: string) => void,
+          ) => {
+            onStdout?.('')
+          },
+        ),
+        getSessionCommand: vi.fn(async () => ({ exitCode: 0 })),
+        deleteSession: vi.fn(async () => {}),
+        sendSessionCommandInput: vi.fn(async () => {}),
+      },
+      delete: vi.fn(async () => {}),
+    } as unknown as Sandbox
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    await handle.env.set({ ANTHROPIC_API_KEY: 'sk-secret-value' })
+    const proc = await handle.process.spawn('echo hi')
+    await proc.wait()
+
+    const request = executeSessionCommand.mock.calls[0]?.[1]
+    expect(request).toBeDefined()
+    expect(request?.command).not.toContain('sk-secret-value')
+    expect(request?.command).not.toContain('export ANTHROPIC_API_KEY')
+  })
+
+  it('advertises writableStdin and forwards stdin to the session command', async () => {
+    const sendSessionCommandInput = vi.fn(async () => {})
+    const sandbox = {
+      id: 'sbx-1',
+      process: {
+        createSession: vi.fn(async () => {}),
+        executeSessionCommand: vi.fn(async () => ({ cmdId: 'cmd-1' })),
+        getSessionCommandLogs: vi.fn(
+          async (
+            _sessionId: string,
+            _commandId: string,
+            onStdout?: (chunk: string) => void,
+          ) => {
+            onStdout?.('')
+          },
+        ),
+        getSessionCommand: vi.fn(async () => ({ exitCode: 0 })),
+        deleteSession: vi.fn(async () => {}),
+        sendSessionCommandInput,
+      },
+      delete: vi.fn(async () => {}),
+    } as unknown as Sandbox
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    expect(handle.capabilities.writableStdin).toBe(true)
+
+    const proc = await handle.process.spawn('cat')
+    await proc.stdin.write('prompt-line\n')
+    await proc.wait()
+
+    expect(sendSessionCommandInput).toHaveBeenCalledWith(
+      expect.stringMatching(/^tanstack-ai-spawn-/),
+      'cmd-1',
+      'prompt-line\n',
+    )
+  })
+})
+
+// Daytona container snapshots are cold: the sandbox must be stopped
+// before `_experimental_createSnapshot`, then started again so
+// `ensure()` still returns a live handle. Names are hyphen-only.
+// Issue #1081 item 7.
+function fakeSnapshotSandbox(id: string) {
+  const calls: Array<string> = []
+  const stop = vi.fn(async () => {
+    calls.push('stop')
+  })
+  const start = vi.fn(async () => {
+    calls.push('start')
+  })
+  const createSnapshot = vi.fn(async (_name: string) => {
+    calls.push('createSnapshot')
+  })
+  // Sandbox from @daytona/sdk is a large class. Tests only need these methods.
+  const sandbox = {
+    id,
+    stop,
+    start,
+    _experimental_createSnapshot: createSnapshot,
+    delete: vi.fn(async () => {}),
+  } as unknown as Sandbox
+  return { sandbox, stop, start, createSnapshot, calls }
+}
+
+describe('DaytonaHandle snapshots', () => {
+  it('advertises snapshots: true and creates a named snapshot', async () => {
+    const { sandbox, createSnapshot } = fakeSnapshotSandbox('sbx-1')
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    expect(handle.capabilities.snapshots).toBe(true)
+    expect(handle.snapshot).toBeTypeOf('function')
+
+    const ref = await handle.snapshot!('after-setup')
+    expect(createSnapshot).toHaveBeenCalledWith(
+      'tanstack-ai-sandbox-snapshot-sbx-1-after-setup',
+    )
+    expect(ref.id).toBe('tanstack-ai-sandbox-snapshot-sbx-1-after-setup')
+    expect(ref.label).toBe('after-setup')
+  })
+
+  it('stops the sandbox, creates the snapshot, then starts it again', async () => {
+    const { sandbox, stop, start, createSnapshot, calls } =
+      fakeSnapshotSandbox('sbx-1')
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    await handle.snapshot!('after-setup')
+
+    expect(stop).toHaveBeenCalledOnce()
+    expect(createSnapshot).toHaveBeenCalledOnce()
+    expect(start).toHaveBeenCalledOnce()
+    expect(calls).toEqual(['stop', 'createSnapshot', 'start'])
+  })
+
+  it('starts the sandbox again when snapshot creation fails', async () => {
+    const { sandbox, start, createSnapshot, calls } =
+      fakeSnapshotSandbox('sbx-1')
+    createSnapshot.mockImplementationOnce(async () => {
+      calls.push('createSnapshot')
+      throw new Error('sandbox must be stopped')
+    })
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    await expect(handle.snapshot!('after-setup')).rejects.toThrow(
+      'sandbox must be stopped',
+    )
+    expect(start).toHaveBeenCalledOnce()
+    expect(calls).toEqual(['stop', 'createSnapshot', 'start'])
+  })
+
+  it('keeps the snapshot error when start also fails', async () => {
+    const { sandbox, start, createSnapshot } = fakeSnapshotSandbox('sbx-1')
+    createSnapshot.mockImplementationOnce(async () => {
+      throw new Error('sandbox must be stopped')
+    })
+    start.mockRejectedValueOnce(new Error('start timed out'))
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    await expect(handle.snapshot!('after-setup')).rejects.toThrow(
+      'sandbox must be stopped',
+    )
+  })
+
+  it('names an unlabeled snapshot from the sandbox id', async () => {
+    const { sandbox, createSnapshot } = fakeSnapshotSandbox('sbx-abc123def456')
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+    })
+
+    const ref = await handle.snapshot!()
+    expect(createSnapshot).toHaveBeenCalledWith(
+      'tanstack-ai-sandbox-snapshot-sbx-abc123de-snap',
+    )
+    expect(ref.id).toBe('tanstack-ai-sandbox-snapshot-sbx-abc123de-snap')
+  })
+})

--- a/packages/ai-sandbox-daytona/tests/provider.test.ts
+++ b/packages/ai-sandbox-daytona/tests/provider.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Daytona provider snapshot restore, resume, create options, and secret
+ * handling. The SDK is mocked so these tests do not create billed sandboxes.
+ * Issues #1081 item 7, #1083, #1084, #1085.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Sandbox } from '@daytona/sdk'
+
+const create = vi.fn()
+const get = vi.fn()
+const del = vi.fn()
+
+vi.mock('@daytona/sdk', () => ({
+  Daytona: class {
+    create = create
+    get = get
+    delete = del
+  },
+}))
+
+import { daytonaSandbox } from '../src/index'
+
+function fakeRemoteSandbox(
+  id: string,
+  extras: {
+    state?: string
+    start?: ReturnType<typeof vi.fn>
+  } = {},
+): Sandbox {
+  // Sandbox from @daytona/sdk is a large class. Tests only need these fields.
+  return {
+    id,
+    state: extras.state ?? 'started',
+    start: extras.start ?? vi.fn(async () => {}),
+    process: {
+      executeCommand: vi.fn(async () => ({ result: '', exitCode: 0 })),
+    },
+    delete: vi.fn(async () => {}),
+  } as unknown as Sandbox
+}
+
+beforeEach(() => {
+  create.mockReset()
+  get.mockReset()
+  del.mockReset()
+})
+
+describe('daytonaSandbox snapshots', () => {
+  it('advertises snapshots: true and implements restoreSnapshot', () => {
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+    expect(provider.capabilities().snapshots).toBe(true)
+    expect(provider.restoreSnapshot).toBeTypeOf('function')
+  })
+
+  it('restores a snapshot by creating a sandbox from that snapshot name', async () => {
+    const restored = fakeRemoteSandbox('sbx-restored')
+    create.mockResolvedValue(restored)
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    const handle = await provider.restoreSnapshot!({
+      snapshotId: 'tanstack-ai-sandbox-snapshot-sbx-1-after-setup',
+    })
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: 'tanstack-ai-sandbox-snapshot-sbx-1-after-setup',
+      }),
+    )
+    expect(handle.id).toBe('sbx-restored')
+    expect(handle.provider).toBe('daytona')
+  })
+})
+
+// Issue #1083: Daytona stops an idle sandbox after 15 minutes. resume()
+// used to wrap daytona.get() only. A stopped sandbox accepts get() but
+// rejects executeCommand with "Is the Sandbox started?".
+describe('daytonaSandbox resume', () => {
+  it('starts a stopped sandbox before returning the handle', async () => {
+    const start = vi.fn(async () => {})
+    get.mockResolvedValue(
+      fakeRemoteSandbox('sbx-idle', { state: 'stopped', start }),
+    )
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    const handle = await provider.resume({ id: 'sbx-idle' })
+
+    expect(handle).not.toBeNull()
+    expect(handle?.id).toBe('sbx-idle')
+    expect(start).toHaveBeenCalledOnce()
+  })
+
+  it('starts an archived sandbox before returning the handle', async () => {
+    const start = vi.fn(async () => {})
+    get.mockResolvedValue(
+      fakeRemoteSandbox('sbx-archived', { state: 'archived', start }),
+    )
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    await provider.resume({ id: 'sbx-archived' })
+
+    expect(start).toHaveBeenCalledOnce()
+  })
+
+  it('does not start a sandbox that is already started', async () => {
+    const start = vi.fn(async () => {})
+    get.mockResolvedValue(
+      fakeRemoteSandbox('sbx-live', { state: 'started', start }),
+    )
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    const handle = await provider.resume({ id: 'sbx-live' })
+
+    expect(handle?.id).toBe('sbx-live')
+    expect(start).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the sandbox is gone', async () => {
+    get.mockRejectedValue(new Error('not found'))
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    await expect(provider.resume({ id: 'missing' })).resolves.toBeNull()
+  })
+})
+
+// Issue #1084: create-time envVars stay in the Daytona sandbox record
+// (GET /sandbox/:id returns them in plain text). Secrets go onto the
+// handle after create, not into the create payload.
+// Issue #1085: create must forward name, auto-stop, ephemeral, and
+// network block from the portable input / config.
+describe('daytonaSandbox create', () => {
+  it('does not put workspace secrets into create-time envVars', async () => {
+    create.mockResolvedValue(fakeRemoteSandbox('sbx-1'))
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    const handle = await provider.create({
+      env: { ANTHROPIC_API_KEY: 'sk-secret-value' },
+    })
+
+    expect(create).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        envVars: expect.anything(),
+      }),
+    )
+    const payload = create.mock.calls[0]?.[0] as { envVars?: unknown }
+    expect(payload.envVars).toBeUndefined()
+    expect(handle.id).toBe('sbx-1')
+  })
+
+  it('forwards the deterministic instance id as the Daytona name', async () => {
+    create.mockResolvedValue(fakeRemoteSandbox('sbx-1'))
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    await provider.create({ id: 'abc123def4567890' })
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'abc123def4567890' }),
+    )
+  })
+
+  it('forwards autoStopInterval from config', async () => {
+    create.mockResolvedValue(fakeRemoteSandbox('sbx-1'))
+    const provider = daytonaSandbox({
+      apiKey: 'test-key',
+      autoStopInterval: 0,
+    })
+
+    await provider.create({})
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ autoStopInterval: 0 }),
+    )
+  })
+
+  it('forwards ephemeral from config', async () => {
+    create.mockResolvedValue(fakeRemoteSandbox('sbx-1'))
+    const provider = daytonaSandbox({
+      apiKey: 'test-key',
+      ephemeral: true,
+    })
+
+    await provider.create({})
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ ephemeral: true }),
+    )
+  })
+
+  it('blocks all network when the policy denies network', async () => {
+    create.mockResolvedValue(fakeRemoteSandbox('sbx-1'))
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    await provider.create({
+      policy: { capabilities: { network: 'deny' } },
+    })
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ networkBlockAll: true }),
+    )
+  })
+
+  it('advertises networkPolicy: true', () => {
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+    expect(provider.capabilities().networkPolicy).toBe(true)
+  })
+})

--- a/packages/ai-sandbox/README.md
+++ b/packages/ai-sandbox/README.md
@@ -125,9 +125,7 @@ defineSandboxPolicy({
 })
 ```
 
-Precedence is `deny` > `ask` > `allow`. Each harness adapter maps policy onto its native permission system (coarse flags for Grok Build/Codex; full interactive `approval-requested` on Claude Code).
-
-On Daytona the user is not root. Write setup as `sudo -n apt-get …`. Do not deny `sudo *` on that provider. A Docker sandbox that runs as root can still deny `sudo *`. `network: 'deny'` on Daytona also sets `networkBlockAll` at create time.
+Precedence is `deny` > `ask` > `allow`. Each harness adapter maps policy onto its native permission system (coarse flags for Grok Build/Codex; full interactive `approval-requested` on Claude Code). Provider-specific privilege and network rules live in the [providers](../../docs/sandbox/providers.md) guide.
 
 ### Lifecycle
 
@@ -142,7 +140,7 @@ lifecycle: {
 
 ### Secrets
 
-Use `createSecrets()` so values stay behind opaque `SecretRef` tokens. They are never written to snapshots, the sandbox store, event logs, or Daytona create-time `envVars`. `ensure()` puts them back on the handle after resume:
+Use `createSecrets()` so values stay behind opaque `SecretRef` tokens. They are never written to snapshots, the sandbox store, or event logs. The sandbox layer resolves them onto the live handle at create, resume, and snapshot restore:
 
 ```typescript
 const secrets = createSecrets({ XAI_API_KEY: process.env.XAI_API_KEY ?? '' })

--- a/packages/ai-sandbox/README.md
+++ b/packages/ai-sandbox/README.md
@@ -51,7 +51,7 @@ Pick a **provider** package for where the sandbox runs:
 | `@tanstack/ai-sandbox-docker`        | Isolated containers, snapshots, resume |
 | `@tanstack/ai-sandbox-cloudflare`    | Cloudflare Workers + Containers        |
 | `@tanstack/ai-sandbox-vercel`        | Vercel Sandbox                         |
-| `@tanstack/ai-sandbox-daytona`       | Daytona dev environments               |
+| `@tanstack/ai-sandbox-daytona`       | Daytona cloud sandboxes, snapshots     |
 | `@tanstack/ai-sandbox-sprites`       | Sprites stateful sandboxes             |
 
 **Harness adapters** are separate packages. The default path is **Grok Build** (`@tanstack/ai-grok-build`); others include `@tanstack/ai-claude-code`, `@tanstack/ai-codex`, and `@tanstack/ai-opencode`. All require `withSandbox(...)` middleware — `chat()` fails fast without it.
@@ -102,6 +102,19 @@ Guard what the agent may run:
 
 ```typescript
 const policy = defineSandboxPolicy({
+  default: 'allow',
+  commands: { deny: ['rm -rf /'] },
+})
+
+defineSandbox({ id: 'agent', provider, workspace, policy })
+```
+
+Headless Grok Build and Codex stay on auto-approve when `default` is `'allow'` and there is no `ask` list. Those harnesses do not enforce `commands.deny`. Isolation is the outer sandbox. Use Claude Code when you need command-level deny.
+
+Claude Code can use an interactive policy:
+
+```typescript
+defineSandboxPolicy({
   commands: {
     allow: ['pnpm test', 'git diff'],
     ask: ['pnpm install'],
@@ -110,11 +123,11 @@ const policy = defineSandboxPolicy({
   capabilities: { fileWrite: 'allow', network: 'ask' },
   default: 'ask',
 })
-
-defineSandbox({ id: 'agent', provider, workspace, policy })
 ```
 
 Precedence is `deny` > `ask` > `allow`. Each harness adapter maps policy onto its native permission system (coarse flags for Grok Build/Codex; full interactive `approval-requested` on Claude Code).
+
+On Daytona the user is not root. Write setup as `sudo -n apt-get …`. Do not deny `sudo *` on that provider. A Docker sandbox that runs as root can still deny `sudo *`. `network: 'deny'` on Daytona also sets `networkBlockAll` at create time.
 
 ### Lifecycle
 
@@ -129,7 +142,7 @@ lifecycle: {
 
 ### Secrets
 
-Use `createSecrets()` so values stay behind opaque `SecretRef` tokens — never written to snapshots, the sandbox store, or event logs:
+Use `createSecrets()` so values stay behind opaque `SecretRef` tokens. They are never written to snapshots, the sandbox store, event logs, or Daytona create-time `envVars`. `ensure()` puts them back on the handle after resume:
 
 ```typescript
 const secrets = createSecrets({ XAI_API_KEY: process.env.XAI_API_KEY ?? '' })

--- a/packages/ai-sandbox/README.md
+++ b/packages/ai-sandbox/README.md
@@ -103,13 +103,12 @@ Guard what the agent may run:
 ```typescript
 const policy = defineSandboxPolicy({
   default: 'allow',
-  commands: { deny: ['rm -rf /'] },
 })
 
 defineSandbox({ id: 'agent', provider, workspace, policy })
 ```
 
-Headless Grok Build and Codex stay on auto-approve when `default` is `'allow'` and there is no `ask` list. Those harnesses do not enforce `commands.deny`. Isolation is the outer sandbox. Use Claude Code when you need command-level deny.
+Headless Grok Build and Codex stay on auto-approve when `default` is `'allow'` and there is no `ask` list. Isolation is the outer sandbox (Docker, Daytona, and so on). Use Claude Code when you need command-level deny.
 
 Claude Code can use an interactive policy:
 

--- a/packages/ai-sandbox/skills/ai-sandbox/SKILL.md
+++ b/packages/ai-sandbox/skills/ai-sandbox/SKILL.md
@@ -207,11 +207,10 @@ rename/exists), `git` (clone/status/add/commit/push/pull/branch), `process`
 ```typescript
 import { defineSandboxPolicy } from '@tanstack/ai-sandbox'
 
-// Headless Grok Build / Codex: stay on auto-approve. These harnesses do
-// not enforce `commands.deny`. Isolation is the outer sandbox.
+// Headless Grok Build / Codex: stay on auto-approve. Isolation is the
+// outer sandbox (Docker, Daytona, …), not commands.deny on this policy.
 const policy = defineSandboxPolicy({
   default: 'allow',
-  commands: { deny: ['rm -rf /'] },
 })
 // pass to defineSandbox({ policy }); harness adapters map it to native permissions
 ```

--- a/packages/ai-sandbox/skills/ai-sandbox/SKILL.md
+++ b/packages/ai-sandbox/skills/ai-sandbox/SKILL.md
@@ -189,8 +189,14 @@ Providers without snapshot support skip the step silently.
 
 - `localProcessSandbox()` — runs on the host (no isolation; dev loop only).
 - `dockerSandbox({ image })` — isolated container; snapshots, fork, resume-by-id.
+- `daytonaSandbox({ apiKey, snapshot, autoStopInterval, ephemeral })` —
+  Daytona cloud sandbox; snapshots after setup; resume starts a stopped or
+  archived sandbox. `/workspace` maps to `/home/daytona/workspace`. Secrets
+  stay on the handle and per-command env, not create-time `envVars`.
+  `network: 'deny'` sets `networkBlockAll`. Setup that installs packages must
+  use `sudo -n`. Do not deny `sudo *`.
 
-Both implement the same `SandboxHandle`: `fs` (read/write/list/mkdir/remove/
+All implement the same `SandboxHandle`: `fs` (read/write/list/mkdir/remove/
 rename/exists), `git` (clone/status/add/commit/push/pull/branch), `process`
 (`exec` + duplex `spawn`), `ports.connect(port)`, `env.set`, optional
 `snapshot()`/`fork()`, `destroy()`. Providers advertise support via
@@ -202,17 +208,17 @@ rename/exists), `git` (clone/status/add/commit/push/pull/branch), `process`
 ```typescript
 import { defineSandboxPolicy } from '@tanstack/ai-sandbox'
 
+// Headless Grok Build / Codex: stay on auto-approve. These harnesses do
+// not enforce `commands.deny`. Isolation is the outer sandbox.
 const policy = defineSandboxPolicy({
-  commands: {
-    allow: ['pnpm test'],
-    ask: ['curl *'],
-    deny: ['sudo *', 'rm -rf *'],
-  },
-  capabilities: { fileWrite: 'allow', network: 'ask' },
-  default: 'ask', // deny > ask > allow
+  default: 'allow',
+  commands: { deny: ['rm -rf /'] },
 })
 // pass to defineSandbox({ policy }); harness adapters map it to native permissions
 ```
+
+Claude Code can use `default: 'ask'` plus allow/ask/deny lists (including
+`deny: ['sudo *']` on Docker). Use Claude Code when you need command-level deny.
 
 ## Lifecycle &amp; resume
 

--- a/packages/ai-sandbox/skills/ai-sandbox/SKILL.md
+++ b/packages/ai-sandbox/skills/ai-sandbox/SKILL.md
@@ -190,11 +190,10 @@ Providers without snapshot support skip the step silently.
 - `localProcessSandbox()` — runs on the host (no isolation; dev loop only).
 - `dockerSandbox({ image })` — isolated container; snapshots, fork, resume-by-id.
 - `daytonaSandbox({ apiKey, snapshot, autoStopInterval, ephemeral })` —
-  Daytona cloud sandbox; snapshots after setup; resume starts a stopped or
-  archived sandbox. `/workspace` maps to `/home/daytona/workspace`. Secrets
-  stay on the handle and per-command env, not create-time `envVars`.
-  `network: 'deny'` sets `networkBlockAll`. Setup that installs packages must
-  use `sudo -n`. Do not deny `sudo *`.
+  Daytona cloud sandbox; snapshots after setup; resume starts stopped or
+  archived sandboxes. `/workspace` maps to `/home/daytona/workspace`. Setup
+  that installs packages must use `sudo -n` (do not deny `sudo *`). See
+  `docs/sandbox/providers.md` for network and secret injection details.
 
 All implement the same `SandboxHandle`: `fs` (read/write/list/mkdir/remove/
 rename/exists), `git` (clone/status/add/commit/push/pull/branch), `process`
@@ -217,8 +216,9 @@ const policy = defineSandboxPolicy({
 // pass to defineSandbox({ policy }); harness adapters map it to native permissions
 ```
 
-Claude Code can use `default: 'ask'` plus allow/ask/deny lists (including
-`deny: ['sudo *']` on Docker). Use Claude Code when you need command-level deny.
+Claude Code can use `default: 'ask'` plus allow/ask/deny lists. Use Claude Code
+when you need command-level deny. Provider privilege rules (non-root users,
+network block at create) live in `docs/sandbox/providers.md`.
 
 ## Lifecycle &amp; resume
 

--- a/packages/ai-sandbox/src/agents-file.ts
+++ b/packages/ai-sandbox/src/agents-file.ts
@@ -43,6 +43,71 @@ export function resolveGitSkillDir(
   return `${root}/.tanstack-skills/${basename}`
 }
 
+/** A folder that contains `SKILL.md`, ready to project under a harness skills dir. */
+export interface DiscoveredSkillDir {
+  name: string
+  dir: string
+}
+
+const SKILL_FILE = 'SKILL.md'
+const SKIP_DIR_NAMES = new Set(['.git', 'node_modules'])
+const MAX_SKILL_WALK_DEPTH = 6
+
+function basenameOf(path: string): string {
+  const segments = path.split('/').filter((segment) => segment !== '')
+  return segments[segments.length - 1] ?? path
+}
+
+/**
+ * Find every skill folder under a cloned `gitSkill` repo.
+ *
+ * A skill folder is a directory that contains `SKILL.md`. Nested packs
+ * (`skills/foo/SKILL.md`) are returned as `{ name: 'foo', dir: '…/skills/foo' }`.
+ * A flat clone with `SKILL.md` at the root is returned as one entry named
+ * after the clone. If no `SKILL.md` is found, the clone itself is returned
+ * so existing basename projection still works.
+ */
+export async function discoverSkillDirs(
+  handle: SandboxHandle,
+  cloneDir: string,
+): Promise<Array<DiscoveredSkillDir>> {
+  const found: Array<DiscoveredSkillDir> = []
+  await walkSkillDirs(handle, cloneDir, found, 0)
+  if (found.length === 0) {
+    return [{ name: basenameOf(cloneDir), dir: cloneDir }]
+  }
+  return found
+}
+
+async function walkSkillDirs(
+  handle: SandboxHandle,
+  dir: string,
+  found: Array<DiscoveredSkillDir>,
+  depth: number,
+): Promise<void> {
+  if (depth > MAX_SKILL_WALK_DEPTH) return
+  let entries: Awaited<ReturnType<SandboxHandle['fs']['list']>>
+  try {
+    entries = await handle.fs.list(dir)
+  } catch {
+    return
+  }
+  const hasSkill = entries.some(
+    (entry) =>
+      entry.type === 'file' &&
+      entry.name.toLowerCase() === SKILL_FILE.toLowerCase(),
+  )
+  if (hasSkill) {
+    found.push({ name: basenameOf(dir), dir })
+    return
+  }
+  for (const entry of entries) {
+    if (entry.type !== 'dir') continue
+    if (entry.name.startsWith('.') || SKIP_DIR_NAMES.has(entry.name)) continue
+    await walkSkillDirs(handle, entry.path, found, depth + 1)
+  }
+}
+
 /** Format workspace scripts as a `## Workspace scripts` markdown section. */
 export function formatWorkspaceScriptsSection(
   scripts: Record<string, string>,

--- a/packages/ai-sandbox/src/bootstrap.ts
+++ b/packages/ai-sandbox/src/bootstrap.ts
@@ -8,6 +8,7 @@
  * here — that's each adapter's `projectWorkspace()` hook, since the format
  * differs per harness.
  */
+import { resolveHarnessCwd } from './harness-cwd'
 import { buildSetupPlan } from './setup-plan'
 import { createBootstrapShell } from './shell'
 import {
@@ -98,7 +99,10 @@ export async function bootstrapWorkspace(
       const url = skill.repo.startsWith('http')
         ? skill.repo
         : `https://github.com/${skill.repo}.git`
-      const dir = skill.into ?? resolveGitSkillDir(root, skill)
+      const dir = resolveHarnessCwd(
+        handle,
+        skill.into ?? resolveGitSkillDir(root, skill),
+      )
       const auth =
         skill.secret !== undefined && workspace.secrets !== undefined
           ? { token: resolveSecret(workspace.secrets, skill.secret) }

--- a/packages/ai-sandbox/src/git-exec.ts
+++ b/packages/ai-sandbox/src/git-exec.ts
@@ -72,6 +72,13 @@ export function createExecBackedGit(
           ? ''
           : `--depth ${resolvedDepth} --single-branch `
 
+      // `git clone` does not create missing parents. gitSkill clones into
+      // `<root>/.tanstack-skills/<name>`, so create that parent first.
+      const parentSlash = target.lastIndexOf('/')
+      if (parentSlash > 0) {
+        await process.exec(`mkdir -p ${q(target.slice(0, parentSlash))}`)
+      }
+
       if (auth?.token) {
         await process.exec(
           `git -c credential.helper=${q(CREDENTIAL_HELPER)} clone ${refArg}${depthArg}-- ${q(url)} ${q(target)}`,

--- a/packages/ai-sandbox/src/index.ts
+++ b/packages/ai-sandbox/src/index.ts
@@ -130,9 +130,11 @@ export type { BootstrapResult } from './bootstrap'
 export {
   writeAgentsFile,
   resolveGitSkillDir,
+  discoverSkillDirs,
   formatWorkspaceScriptsSection,
   mergeAgentsContent,
 } from './agents-file'
+export type { DiscoveredSkillDir } from './agents-file'
 
 // Exec-backed git helper (for providers without native git)
 export { createExecBackedGit } from './git-exec'

--- a/packages/ai-sandbox/src/middleware.ts
+++ b/packages/ai-sandbox/src/middleware.ts
@@ -48,6 +48,7 @@ import {
 } from './tool-history'
 import { watchWorkspace } from './watch'
 import { DEFAULT_WORKSPACE_ROOT } from './bootstrap'
+import { resolveHarnessCwd } from './harness-cwd'
 import type { InternalLogger } from '@tanstack/ai/adapter-internals'
 import type { LockStore } from '@tanstack/ai/locks'
 import type {
@@ -570,7 +571,8 @@ export function withSandbox<TOffset extends string = string>(
 
       const workspace = definition.workspace
       if (workspace !== undefined) {
-        const root = workspace.root ?? DEFAULT_WORKSPACE_ROOT
+        const virtualRoot = workspace.root ?? DEFAULT_WORKSPACE_ROOT
+        const root = resolveHarnessCwd(handle, virtualRoot)
         const workspaceHash = computeWorkspaceHash(workspace)
         const secrets = workspace.secrets
         provideWorkspaceProjection(ctx, {

--- a/packages/ai-sandbox/src/sandbox.ts
+++ b/packages/ai-sandbox/src/sandbox.ts
@@ -123,6 +123,20 @@ const DESTROY_TIMEOUT_MS = 60 * 1000
 const fallbackStore = new InMemorySandboxInstanceStore()
 const fallbackLocks = new InMemoryLockStore()
 
+/**
+ * Put workspace secrets onto a live handle. Resume and snapshot restore skip
+ * bootstrap, so this is the only path that re-injects them after reconnect.
+ */
+async function applyWorkspaceSecrets(
+  handle: SandboxHandle,
+  workspace: WorkspaceDefinition | undefined,
+): Promise<void> {
+  if (workspace?.secrets === undefined) return
+  const resolved = resolveAllSecrets(workspace.secrets)
+  if (Object.keys(resolved).length === 0) return
+  await handle.env.set(resolved)
+}
+
 export function defineSandbox(config: SandboxConfig): SandboxDefinition {
   const keyInputFor = (ctx: SandboxEnsureContext): SandboxKeyInput => ({
     threadId:
@@ -160,6 +174,7 @@ export function defineSandbox(config: SandboxConfig): SandboxDefinition {
             signal: ctx.signal,
           })
           if (resumed) {
+            await applyWorkspaceSecrets(resumed, config.workspace)
             await store.upsert({
               ...existing,
               latestRunId: ctx.runId,
@@ -183,6 +198,7 @@ export function defineSandbox(config: SandboxConfig): SandboxDefinition {
                   : undefined,
               signal: ctx.signal,
             })
+            await applyWorkspaceSecrets(restored, config.workspace)
             await store.upsert({
               ...existing,
               providerSandboxId: restored.id,

--- a/packages/ai-sandbox/tests/agents-file.test.ts
+++ b/packages/ai-sandbox/tests/agents-file.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { writeAgentsFile } from '../src/agents-file'
+import { discoverSkillDirs, writeAgentsFile } from '../src/agents-file'
 import type { ExecResult, SandboxHandle } from '../src/contracts'
 
 interface FsWriteCall {
@@ -139,5 +139,85 @@ describe('writeAgentsFile', () => {
     // GEMINI.md must NOT be written because ln succeeded.
     const geminiCopy = fsWrites.find((w) => w.path === `${root}/GEMINI.md`)
     expect(geminiCopy).toBeUndefined()
+  })
+})
+
+describe('discoverSkillDirs', () => {
+  function listingHandle(
+    tree: Record<string, Array<{ name: string; type: 'file' | 'dir' }>>,
+  ): SandboxHandle {
+    const { handle } = makeFakeHandle()
+    handle.fs.list = (dir) => {
+      const entries = tree[dir] ?? []
+      return Promise.resolve(
+        entries.map((entry) => ({
+          name: entry.name,
+          path: `${dir}/${entry.name}`,
+          type: entry.type,
+        })),
+      )
+    }
+    return handle
+  }
+
+  it('returns nested SKILL.md folders by their folder name', async () => {
+    const handle = listingHandle({
+      '/workspace/.tanstack-skills/skills-pack': [
+        { name: 'skills', type: 'dir' },
+        { name: 'README.md', type: 'file' },
+      ],
+      '/workspace/.tanstack-skills/skills-pack/skills': [
+        { name: 'foo', type: 'dir' },
+        { name: 'bar', type: 'dir' },
+      ],
+      '/workspace/.tanstack-skills/skills-pack/skills/foo': [
+        { name: 'SKILL.md', type: 'file' },
+      ],
+      '/workspace/.tanstack-skills/skills-pack/skills/bar': [
+        { name: 'SKILL.md', type: 'file' },
+      ],
+    })
+
+    await expect(
+      discoverSkillDirs(handle, '/workspace/.tanstack-skills/skills-pack'),
+    ).resolves.toEqual([
+      {
+        name: 'foo',
+        dir: '/workspace/.tanstack-skills/skills-pack/skills/foo',
+      },
+      {
+        name: 'bar',
+        dir: '/workspace/.tanstack-skills/skills-pack/skills/bar',
+      },
+    ])
+  })
+
+  it('returns the clone itself when SKILL.md sits at the root', async () => {
+    const handle = listingHandle({
+      '/workspace/.tanstack-skills/my-skill': [
+        { name: 'SKILL.md', type: 'file' },
+        { name: 'scripts', type: 'dir' },
+      ],
+    })
+
+    await expect(
+      discoverSkillDirs(handle, '/workspace/.tanstack-skills/my-skill'),
+    ).resolves.toEqual([
+      { name: 'my-skill', dir: '/workspace/.tanstack-skills/my-skill' },
+    ])
+  })
+
+  it('falls back to the clone basename when no SKILL.md is found', async () => {
+    const handle = listingHandle({
+      '/workspace/.tanstack-skills/empty-pack': [
+        { name: 'README.md', type: 'file' },
+      ],
+    })
+
+    await expect(
+      discoverSkillDirs(handle, '/workspace/.tanstack-skills/empty-pack'),
+    ).resolves.toEqual([
+      { name: 'empty-pack', dir: '/workspace/.tanstack-skills/empty-pack' },
+    ])
   })
 })

--- a/packages/ai-sandbox/tests/bootstrap.test.ts
+++ b/packages/ai-sandbox/tests/bootstrap.test.ts
@@ -370,7 +370,10 @@ interface WriteCall {
  * - exec always resolves with exit 0 (symlinks succeed).
  * - No persistent shell needed: workspace has no `setup`.
  */
-function makeProvisioningHandle(): {
+function makeProvisioningHandle(identity?: {
+  provider?: string
+  workspaceRoot?: string
+}): {
   handle: SandboxHandle
   cloneCalls: Array<CloneCall>
   writeCalls: Array<WriteCall>
@@ -382,7 +385,10 @@ function makeProvisioningHandle(): {
 
   const handle: SandboxHandle = {
     id: 'prov',
-    provider: 'fake',
+    provider: identity?.provider ?? 'fake',
+    ...(identity?.workspaceRoot !== undefined
+      ? { workspaceRoot: identity.workspaceRoot }
+      : {}),
     capabilities: {
       fs: true,
       exec: true,
@@ -502,6 +508,27 @@ describe('bootstrapWorkspace gitSkill cloning', () => {
     await bootstrapWorkspace(handle, workspace)
 
     expect(cloneCalls[0]?.url).toBe('https://example.com/org/repo.git')
+  })
+
+  // Daytona (and other remapped providers) cannot interpolate a virtual
+  // `/workspace` dir into a shell `git clone`. Clone against the real
+  // workspaceRoot instead. Issue #1081 item 4.
+  it('remaps a virtual gitSkill dir onto handle.workspaceRoot', async () => {
+    const { handle, cloneCalls } = makeProvisioningHandle({
+      provider: 'daytona',
+      workspaceRoot: '/home/daytona/workspace',
+    })
+
+    const workspace: WorkspaceDefinition = {
+      source: { type: 'git', url: 'https://github.com/me/app' },
+      skills: [gitSkill({ repo: 'owner/skills-pack' })],
+    }
+
+    await bootstrapWorkspace(handle, workspace)
+
+    expect(cloneCalls[0]?.dir).toBe(
+      '/home/daytona/workspace/.tanstack-skills/skills-pack',
+    )
   })
 })
 

--- a/packages/ai-sandbox/tests/ensure.test.ts
+++ b/packages/ai-sandbox/tests/ensure.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { defineSandbox } from '../src/sandbox'
+import { createSecrets } from '../src/secrets'
 import { defineWorkspace, githubRepo } from '../src/workspace'
 import { InMemoryLockStore } from '@tanstack/ai/locks'
 import { InMemorySandboxInstanceStore } from '../src/instance-store'
@@ -231,5 +232,72 @@ describe('ensureSandbox algorithm', () => {
     await def.ensure({ ...ctx, runId: 'run-2' })
     expect(provider.calls.create).toBe(2)
     expect(provider.calls.resume).toBe(0)
+  })
+
+  // Secrets live in handle memory and per-command env. Resume does not
+  // re-run bootstrap, so ensure() must put them back on the live handle.
+  it('re-applies workspace secrets onto a resumed handle', async () => {
+    const provider = makeFakeProvider()
+    const def = defineSandbox({
+      id: 'repo',
+      provider,
+      workspace: defineWorkspace({
+        source: { type: 'none' },
+        secrets: createSecrets({ ANTHROPIC_API_KEY: 'sk-secret-value' }),
+      }),
+      fileEvents: false,
+    })
+    const ctx = baseCtx()
+    await def.ensure(ctx)
+
+    const applied: Array<Record<string, string>> = []
+    const originalResume = provider.resume.bind(provider)
+    provider.resume = async (input) => {
+      const handle = await originalResume(input)
+      if (!handle) return null
+      const originalSet = handle.env.set.bind(handle.env)
+      handle.env.set = async (vars) => {
+        applied.push(vars)
+        return originalSet(vars)
+      }
+      return handle
+    }
+
+    await def.ensure({ ...ctx, runId: 'run-2' })
+
+    expect(applied).toEqual([{ ANTHROPIC_API_KEY: 'sk-secret-value' }])
+  })
+
+  it('re-applies workspace secrets onto a restored snapshot handle', async () => {
+    const provider = makeFakeProvider({ resumeReturnsNull: true })
+    const def = defineSandbox({
+      id: 'repo',
+      provider,
+      workspace: defineWorkspace({
+        source: { type: 'none' },
+        secrets: createSecrets({ ANTHROPIC_API_KEY: 'sk-secret-value' }),
+      }),
+      lifecycle: { reuse: 'thread', snapshot: 'after-setup' },
+      fileEvents: false,
+    })
+    const ctx = baseCtx()
+    await def.ensure(ctx)
+
+    const applied: Array<Record<string, string>> = []
+    const restoreSnapshot = provider.restoreSnapshot
+    if (!restoreSnapshot) throw new Error('expected restoreSnapshot')
+    provider.restoreSnapshot = async (input) => {
+      const handle = await restoreSnapshot(input)
+      const originalSet = handle.env.set.bind(handle.env)
+      handle.env.set = async (vars) => {
+        applied.push(vars)
+        return originalSet(vars)
+      }
+      return handle
+    }
+
+    await def.ensure({ ...ctx, runId: 'run-2' })
+
+    expect(applied).toEqual([{ ANTHROPIC_API_KEY: 'sk-secret-value' }])
   })
 })

--- a/packages/ai-sandbox/tests/git-exec.test.ts
+++ b/packages/ai-sandbox/tests/git-exec.test.ts
@@ -120,3 +120,20 @@ it('omits depth for depth: "full" and uses N for a number', async () => {
     expect(numeric.command).toContain('--depth 50')
   }
 })
+
+// git clone fails when the parent of `dir` does not exist. gitSkill clones
+// into `<root>/.tanstack-skills/<name>`, so the parent must be created first.
+// Issue #1081 item 2.
+it('creates the clone parent directory before git clone', async () => {
+  const { process, calls } = recordingProcess()
+  const git = createExecBackedGit(process, '/workspace')
+  await git.clone({
+    url: 'https://github.com/owner/skills-pack',
+    dir: '/workspace/.tanstack-skills/skills-pack',
+  })
+  expect(calls[0]?.command).toBe("mkdir -p '/workspace/.tanstack-skills'")
+  expect(calls[1]?.command).toContain('git clone')
+  expect(calls[1]?.command).toContain(
+    "'/workspace/.tanstack-skills/skills-pack'",
+  )
+})

--- a/packages/ai-sandbox/tests/harness-cwd.test.ts
+++ b/packages/ai-sandbox/tests/harness-cwd.test.ts
@@ -8,6 +8,8 @@ function fakeHandle(
   id: string,
   workspaceRoot?: string,
 ): SandboxHandle {
+  // resolveHarnessCwd only reads provider / id / workspaceRoot. A full
+  // SandboxHandle would need fs, git, process, ports, and env stubs.
   return { provider, id, workspaceRoot } as SandboxHandle
 }
 
@@ -24,7 +26,7 @@ describe('resolveHarnessCwd', () => {
     const root = '/tmp/tanstack-ai-sandboxes/abc'
     expect(
       resolveHarnessCwd(fakeHandle('local-process', root), '/workspace/my-app'),
-    ).toBe(path.join(root, 'my-app'))
+    ).toBe(path.posix.join(root, 'my-app'))
   })
 
   it('passes virtual paths through when workspaceRoot is /workspace', () => {


### PR DESCRIPTION
## 🎯 Changes

Closes #1081, #1083, #1084, #1085.

Default `defineSandbox` + `gitSkill` + `grokBuildText` / `codexText` + `withSandbox` works on Daytona without empty `commands.deny`, a provider create wrapper, hardcoded `/home/daytona/workspace`, or hand skill symlinks.

### #1081 — headless edges
- Deny-only policy with `default: 'allow'` stays permissive for headless Grok and Codex (isolation is the outer sandbox).
- `mkdir -p` before `gitSkill` clone.
- Nested project `SKILL.md` dirs project by skill name.
- Daytona remaps `/workspace` for git, bootstrap, and harness cwd.
- Durable Grok uses `streaming-json` when durability is wired and protocol is unset.
- Headless Grok gets `--no-plan --no-auto-update`.
- Codex defaults to `danger-full-access` on Daytona/Cloudflare (no nested bwrap).
- Daytona cold snapshots: stop → `_experimental_createSnapshot` → start (hyphen names).

### #1083 — resume after idle stop
- `resume()` starts sandboxes in `stopped` or `archived` state before returning a handle.
- Optional `autoStopInterval` / `ephemeral` on `daytonaSandbox()`.

### #1084 — secrets not in create records or command strings
- Create/restore do not put secrets in Daytona `envVars`.
- `ensure()` re-applies workspace secrets after resume and restore.
- Exec env goes through `executeCommand(command, cwd, env)`.
- Spawn sources a workdir env file so the stored session command has no secret values.
- Native git clone passes username/password args.

### #1085 — use more of the Daytona SDK (no bump past 0.191.0)
- Spawn follows logs with streaming `getSessionCommandLogs`.
- `writableStdin: true` via `sendSessionCommandInput`.
- `killableProcesses` stays `false` (honest; PTY kill out of scope).
- Native `sandbox.fs` and `sandbox.git` with `/workspace` remap.
- Create forwards `name`, `autoStopInterval`, `ephemeral`, and `networkBlockAll` from policy.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with package-scoped `pnpm --filter` gates (types, oxlint, test:lib, build, test:docs). Full `pnpm test:pr` / Nx was skipped because leftover nested `worktrees/` dirs break the Nx graph on this machine.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Test plan

- [x] `@tanstack/ai-sandbox` unit tests (642)
- [x] `@tanstack/ai-sandbox-daytona` unit tests (29 passed, 3 skipped without `DAYTONA_API_KEY`)
- [x] `@tanstack/ai-grok-build` / `@tanstack/ai-codex` / `@tanstack/ai-acp` / `@tanstack/ai-claude-code` unit tests
- [x] types + oxlint + build on the six affected packages
- [x] `pnpm test:docs` (no broken links)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daytona sandboxes now support snapshots, restoration, auto-stop settings, network restrictions, writable stdin, and improved resume behavior.
  * Secrets are safely reapplied after resume and snapshot restoration.
  * Nested Git-based skills are discovered and installed individually across supported adapters.
  * Durable Grok Build runs use journaled streaming by default for recovery.
  * Provider-specific Codex sandbox defaults are supported.

* **Bug Fixes**
  * Improved sandbox filesystem, Git, session, and environment handling.
  * Command deny rules no longer unnecessarily trigger approval mode.

* **Documentation**
  * Expanded sandbox provider, policy, lifecycle, provisioning, and adapter guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->