### PR TITLE
fix(ai-openrouter): refresh MiniMax model metadata

### DIFF
--- a/.changeset/refresh-minimax-openrouter-metadata.md
+++ b/.changeset/refresh-minimax-openrouter-metadata.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-openrouter': patch
+---
+
+Refresh MiniMax M2.7 and M3 context and pricing metadata.

--- a/packages/ai-openrouter/src/model-meta.ts
+++ b/packages/ai-openrouter/src/model-meta.ts
@@ -4076,11 +4076,11 @@ const MINIMAX_MINIMAX_M2_7 = {
   pricing: {
     text: {
       input: {
-        normal: 0.18,
-        cached: 0,
+        normal: 0.3,
+        cached: 0.435,
       },
       output: {
-        normal: 0.72,
+        normal: 1.2,
       },
     },
     image: 0,
@@ -4108,16 +4108,16 @@ const MINIMAX_MINIMAX_M3 = {
       'topP',
     ],
   },
-  context_window: 1048576,
+  context_window: 1000000,
   max_output_tokens: 512000,
   pricing: {
     text: {
       input: {
-        normal: 0.3,
-        cached: 0.06,
+        normal: 0.6,
+        cached: 0.12,
       },
       output: {
-        normal: 1.2,
+        normal: 2.4,
       },
     },
     image: 0,

--- a/scripts/openrouter.models.json
+++ b/scripts/openrouter.models.json
@@ -9662,11 +9662,13 @@
       "instruct_type": null
     },
     "pricing": {
-      "prompt": "0.00000018",
-      "completion": "0.00000072"
+      "prompt": "0.0000003",
+      "completion": "0.0000012",
+      "input_cache_read": "0.00000006",
+      "input_cache_write": "0.000000375"
     },
     "top_provider": {
-      "context_length": 196608,
+      "context_length": 204800,
       "max_completion_tokens": 196608,
       "is_moderated": false
     },
@@ -9782,7 +9784,7 @@
     "name": "MiniMax: MiniMax M3",
     "created": 1780245374,
     "description": "MiniMax-M3 is a multimodal foundation model from MiniMax. It supports text, image, and video inputs with text output, a 1M-token context window, and is suited for long-horizon agentic work, coding,...",
-    "context_length": 1048576,
+    "context_length": 1000000,
     "architecture": {
       "modality": "text+image+video->text",
       "input_modalities": ["text", "image", "video"],
@@ -9791,12 +9793,12 @@
       "instruct_type": null
     },
     "pricing": {
-      "prompt": "0.0000003",
-      "completion": "0.0000012",
-      "input_cache_read": "0.00000006"
+      "prompt": "0.0000006",
+      "completion": "0.0000024",
+      "input_cache_read": "0.00000012"
     },
     "top_provider": {
-      "context_length": 524288,
+      "context_length": 1000000,
       "max_completion_tokens": 512000,
       "is_moderated": false
     },


### PR DESCRIPTION
Reason: The OpenRouter MiniMax-M3 and MiniMax-M2.7 entries retained stale context-window and token-pricing metadata.

## Summary

- update the OpenRouter source snapshot with current context-window and token-pricing values
- regenerate the published OpenRouter model metadata from that snapshot
- add a patch changeset for `@tanstack/ai-openrouter`

## Checks

- `./node_modules/.bin/tsx scripts/convert-openrouter-models.ts`
- `./node_modules/.bin/oxfmt --check packages/ai-openrouter/src/model-meta.ts scripts/openrouter.models.json .changeset/refresh-minimax-openrouter-metadata.md`
- `./node_modules/.bin/tsc -p packages/ai-openrouter/tsconfig.json`
- `./node_modules/.bin/oxlint packages/ai-openrouter/src --type-aware`
- `./node_modules/.bin/vitest run packages/ai-openrouter/tests --reporter=dot --maxWorkers=1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Refreshed MiniMax M2.7 and M3 model metadata, including context limits and pricing.
  - Added cached-input pricing details for MiniMax M2.7.
  - Updated provider context limits to reflect the latest available information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->