### PR TITLE
fix(ai): preserve existing message ids on interrupt snapshots

### DIFF
--- a/.changeset/fix-1107-snapshot-message-ids.md
+++ b/.changeset/fix-1107-snapshot-message-ids.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai': patch
+---
+
+Preserve existing message IDs on interrupt `MESSAGES_SNAPSHOT` events.

--- a/packages/ai/src/activities/chat/index.ts
+++ b/packages/ai/src/activities/chat/index.ts
@@ -2177,7 +2177,9 @@ class TextEngine<
               ? undefined
               : JSON.stringify(message.content)
         return {
-          id: `snapshot_${this.runIdOverride ?? this.requestId}_${index}`,
+          id:
+            message.id ||
+            `snapshot_${this.runIdOverride ?? this.requestId}_${index}`,
           role: message.role,
           ...(content !== undefined ? { content } : {}),
           ...('toolCalls' in message && message.toolCalls

--- a/packages/ai/tests/chat.test.ts
+++ b/packages/ai/tests/chat.test.ts
@@ -678,6 +678,42 @@ describe('chat()', () => {
       })
     })
 
+    it('preserves existing message ids on the interrupt MESSAGES_SNAPSHOT', async () => {
+      const { adapter } = createMockAdapter({
+        iterations: [
+          [
+            ev.runStarted(),
+            ev.textStart('stream-assistant'),
+            {
+              ...ev.toolStart('call_1', 'clientSearch'),
+              parentMessageId: 'stream-assistant',
+            },
+            ev.toolArgs('call_1', '{"query":"test"}'),
+            ev.runFinished('tool_calls'),
+          ],
+        ],
+      })
+
+      const chunks = await collectChunks(
+        chat({
+          adapter,
+          runId: 'interrupt-run',
+          messages: [{ id: 'user-1', role: 'user', content: 'Search' }],
+          tools: [clientTool('clientSearch')],
+        }) as AsyncIterable<StreamChunk>,
+      )
+
+      const snapshot = chunks.find(
+        (chunk) => chunk.type === EventType.MESSAGES_SNAPSHOT,
+      )
+      expect(snapshot).toMatchObject({
+        messages: [
+          { id: 'user-1', role: 'user', content: 'Search' },
+          { id: 'stream-assistant', role: 'assistant' },
+        ],
+      })
+    })
+
     it('should yield an interrupt outcome for client tools', async () => {
       const { adapter } = createMockAdapter({
         iterations: [

--- a/packages/ai/tests/chat.test.ts
+++ b/packages/ai/tests/chat.test.ts
@@ -714,6 +714,36 @@ describe('chat()', () => {
       })
     })
 
+    it('generates a snapshot id on the interrupt MESSAGES_SNAPSHOT when a message has no id', async () => {
+      const { adapter } = createMockAdapter({
+        iterations: [
+          [
+            ev.runStarted(),
+            ev.toolStart('call_1', 'clientSearch'),
+            ev.toolArgs('call_1', '{"query":"test"}'),
+            ev.runFinished('tool_calls'),
+          ],
+        ],
+      })
+
+      const chunks = await collectChunks(
+        chat({
+          adapter,
+          runId: 'interrupt-run',
+          messages: [{ role: 'user', content: 'Search' }],
+          tools: [clientTool('clientSearch')],
+        }) as AsyncIterable<StreamChunk>,
+      )
+
+      const snapshot = chunks.find(
+        (chunk) => chunk.type === EventType.MESSAGES_SNAPSHOT,
+      )
+      expect(snapshot?.messages[0]).toMatchObject({
+        id: 'snapshot_interrupt-run_0',
+        role: 'user',
+      })
+    })
+
     it('should yield an interrupt outcome for client tools', async () => {
       const { adapter } = createMockAdapter({
         iterations: [


### PR DESCRIPTION
Keep ModelMessage.id on MESSAGES_SNAPSHOT so interrupt boundaries do not rewrite stable identity. Generate `snapshot_<run>_<index>` only when an id is missing.

Fixes #1107

## 🎯 Changes

- Keep a stored ModelMessage.id on interrupt MESSAGES_SNAPSHOT events instead of always rewriting it to `snapshot_<run>_<index>`.
- Generate `snapshot_<run>_<index>` only when a message has no id, matching the client snapshot normalizer.
- That stops a stable user/assistant identity from looking like new input after a native interrupt, which breaks dedupe, reconciliation, and in-place rendering keyed on message.id.
- Add a chat() regression that asserts user-1 and stream-assistant survive the snapshot, plus a patch changeset for @tanstack/ai.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing message IDs in chat snapshots generated when an interaction is interrupted.
  * Assigned consistent fallback IDs to messages that do not already have one.

* **Tests**
  * Added coverage for preserving existing IDs and generating deterministic IDs for messages without IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->