### PR TITLE
fix(ai): return malformed tool arguments as errors

### DIFF
--- a/.changeset/recover-malformed-tool-arguments.md
+++ b/.changeset/recover-malformed-tool-arguments.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai': patch
+---
+
+Return malformed tool arguments to the model as an error result so the agent loop can repair them.

--- a/docs/config.json
+++ b/docs/config.json
@@ -94,12 +94,13 @@
           "label": "Tool Architecture",
           "to": "tools/tool-architecture",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-08"
+          "updatedAt": "2026-08-17"
         },
         {
           "label": "Server Tools",
           "to": "tools/server-tools",
-          "addedAt": "2026-04-15"
+          "addedAt": "2026-04-15",
+          "updatedAt": "2026-08-17"
         },
         {
           "label": "Client Tools",

--- a/docs/tools/server-tools.md
+++ b/docs/tools/server-tools.md
@@ -331,6 +331,8 @@ const getUserData = getUserDataDef.server(async ({ userId }) => {
 
 **Throwing vs. returning an error:** if your `.server()` function throws, the SDK catches it and surfaces it as a tool-result *error* (the model sees the failure but you lose control over the message). Returning a structured `{ error }` shape keeps the model in control of how to recover and is usually preferable. Either way, when an `outputSchema` is defined the returned value is validated against it (Zod) before being added to the conversation — so include the `error` field in your `outputSchema` if you return it.
 
+Malformed JSON arguments and Standard Schema input validation failures are also surfaced as tool-result errors. The tool implementation is not called, and the agent loop can return the error to the model so it can repair the tool call.
+
 ## Using JSON Schema
 
 If you have existing JSON Schema definitions or prefer not to use Zod, you can define tool schemas using raw JSON Schema objects:

--- a/docs/tools/tool-architecture.md
+++ b/docs/tools/tool-architecture.md
@@ -148,6 +148,7 @@ stateDiagram-v2
         ApprovalRequested --> ApprovalResponded: user approves / denies
     }
     InputComplete --> ResultComplete: needsApproval=false, success
+    InputComplete --> ResultError: parsing, validation, or execution error
     ApprovalResponded --> ResultComplete: approved + success (output set)
     ApprovalResponded --> ResultError: approved + error
     ApprovalResponded --> Denied: user denied (no execution)
@@ -176,7 +177,7 @@ stateDiagram-v2
 |-------|-------------|---------------|
 | `streaming` | Result being streamed (future feature) | Show progress |
 | `complete` | Result is complete | Show result |
-| `error` | Error occurred during execution | Show error message |
+| `error` | Error occurred before or during execution | Show error message |
 
 ### Monitoring Tool States in React
 
@@ -436,4 +437,3 @@ All execute simultaneously, then LLM generates comparison.
 - [Client Tools](./client-tools) - Deep dive into client-side tools
 - [Tool Approval Flow](./tool-approval) - Implementing approval workflows
 - [AG-UI protocol](https://docs.ag-ui.com/introduction) - Understanding the streaming protocol
-

--- a/packages/ai/src/activities/chat/tools/tool-calls.ts
+++ b/packages/ai/src/activities/chat/tools/tool-calls.ts
@@ -813,7 +813,7 @@ export async function* executeToolCalls<TContext = unknown>(
       continue
     }
 
-    // Parse arguments, throwing error if invalid JSON
+    // Parse arguments
     let input: unknown = {}
     const argsStr = toolCall.function.arguments.trim() || '{}'
     if (argsStr) {
@@ -821,9 +821,17 @@ export async function* executeToolCalls<TContext = unknown>(
         const parsed = JSON.parse(argsStr)
         // Normalize null/non-object to {} (e.g. Anthropic empty tool_use blocks)
         input = parsed && typeof parsed === 'object' ? parsed : {}
-      } catch (parseError) {
-        // If parsing fails, throw error to fail fast
-        throw new Error(`Failed to parse tool arguments as JSON: ${argsStr}`)
+      } catch {
+        results.push({
+          toolCallId: toolCall.id,
+          toolName,
+          result: {
+            error: `Failed to parse tool arguments as JSON: ${argsStr}`,
+          },
+          input,
+          state: 'output-error',
+        })
+        continue
       }
     }
 

--- a/packages/ai/tests/tool-call-manager.test.ts
+++ b/packages/ai/tests/tool-call-manager.test.ts
@@ -932,6 +932,32 @@ describe('executeToolCalls', () => {
   })
 
   describe('argument normalization', () => {
+    it('should return malformed arguments as an error result', async () => {
+      const execute = vi.fn(() => ({ ok: true }))
+      const tool: Tool = {
+        name: 'test_tool',
+        description: 'Test tool',
+        execute,
+      }
+      const result = await drainExecuteToolCalls(
+        [makeToolCall('call_1', 'test_tool', '{')],
+        [tool],
+      )
+
+      expect(execute).not.toHaveBeenCalled()
+      expect(result.results).toEqual([
+        {
+          toolCallId: 'call_1',
+          toolName: 'test_tool',
+          result: { error: 'Failed to parse tool arguments as JSON: {' },
+          input: {},
+          state: 'output-error',
+        },
+      ])
+      expect(result.needsApproval).toHaveLength(0)
+      expect(result.needsClientExecution).toHaveLength(0)
+    })
+
     it('should normalize empty arguments to empty object', async () => {
       const tool: Tool = {
         name: 'simple_tool',

--- a/testing/e2e/src/lib/tools-test-tools.ts
+++ b/testing/e2e/src/lib/tools-test-tools.ts
@@ -226,6 +226,11 @@ export const SCENARIO_LIST = [
     label: 'Null Tool Input (Regression #265)',
     category: 'basic',
   },
+  {
+    id: 'malformed-tool-arguments',
+    label: 'Malformed Tool Arguments (Regression #1131)',
+    category: 'basic',
+  },
   // Race condition / event flow scenarios
   {
     id: 'sequential-client-tools',
@@ -342,6 +347,9 @@ export function getToolsForScenario(scenario: string) {
       return [failingTool]
 
     case 'null-tool-input':
+      return [serverTools.check_status]
+
+    case 'malformed-tool-arguments':
       return [serverTools.check_status]
 
     default:

--- a/testing/e2e/src/routes/api.tools-test.ts
+++ b/testing/e2e/src/routes/api.tools-test.ts
@@ -11,17 +11,39 @@ import type { TestRuntimeContext } from '@/lib/tools-test-tools'
 import { createTextAdapter } from '@/lib/providers'
 import { getToolsForScenario } from '@/lib/tools-test-tools'
 
-const runtimeContextScenarios = new Set([
+const providerFreeScenarios = new Set([
   'server-context',
   'client-context',
   'client-server-context',
+  'malformed-tool-arguments',
 ])
 
-function createRuntimeContextAdapter(scenario: string): AnyTextAdapter {
+function createProviderFreeAdapter(scenario: string): AnyTextAdapter {
+  const config =
+    scenario === 'malformed-tool-arguments'
+      ? {
+          arguments: '{',
+          initialText: 'Checking system status.',
+          input: undefined,
+          name: 'malformed-tool-arguments-test',
+          responseText: 'Recovered from malformed tool arguments.',
+          toolName: 'check_status',
+        }
+      : {
+          arguments: '{}',
+          initialText: 'Reading runtime context.',
+          input: {},
+          name: 'runtime-context-test',
+          responseText: 'Runtime context was read.',
+          toolName:
+            scenario === 'client-context'
+              ? 'read_client_context'
+              : 'read_server_context',
+        }
   return {
     kind: 'text',
-    name: 'runtime-context-test',
-    model: 'runtime-context-test',
+    name: config.name,
+    model: config.name,
     '~types': {
       providerOptions: {},
       inputModalities: ['text'],
@@ -31,7 +53,7 @@ function createRuntimeContextAdapter(scenario: string): AnyTextAdapter {
       systemPromptMetadata: undefined,
     },
     async *chatStream(options): AsyncGenerator<StreamChunk> {
-      const model = 'runtime-context-test'
+      const model = config.name
       const runId = options.runId ?? 'runtime-context-run'
       const threadId = options.threadId ?? 'runtime-context-thread'
       const messageId = `${runId}-message`
@@ -48,10 +70,6 @@ function createRuntimeContextAdapter(scenario: string): AnyTextAdapter {
       }
 
       if (!hasToolResult) {
-        const toolName =
-          scenario === 'client-context'
-            ? 'read_client_context'
-            : 'read_server_context'
         const toolCallId = `${scenario}-tool-call`
 
         yield {
@@ -64,7 +82,7 @@ function createRuntimeContextAdapter(scenario: string): AnyTextAdapter {
         yield {
           type: EventType.TEXT_MESSAGE_CONTENT,
           messageId,
-          delta: 'Reading runtime context.',
+          delta: config.initialText,
           model,
           timestamp: Date.now(),
         }
@@ -77,24 +95,24 @@ function createRuntimeContextAdapter(scenario: string): AnyTextAdapter {
         yield {
           type: EventType.TOOL_CALL_START,
           toolCallId,
-          toolCallName: toolName,
-          toolName,
+          toolCallName: config.toolName,
+          toolName: config.toolName,
           model,
           timestamp: Date.now(),
         }
         yield {
           type: EventType.TOOL_CALL_ARGS,
           toolCallId,
-          delta: '{}',
+          delta: config.arguments,
           model,
           timestamp: Date.now(),
         }
         yield {
           type: EventType.TOOL_CALL_END,
           toolCallId,
-          toolCallName: toolName,
-          toolName,
-          input: {},
+          toolCallName: config.toolName,
+          toolName: config.toolName,
+          ...(config.input === undefined ? {} : { input: config.input }),
           model,
           timestamp: Date.now(),
         }
@@ -119,7 +137,7 @@ function createRuntimeContextAdapter(scenario: string): AnyTextAdapter {
       yield {
         type: EventType.TEXT_MESSAGE_CONTENT,
         messageId,
-        delta: 'Runtime context was read.',
+        delta: config.responseText,
         model,
         timestamp: Date.now(),
       }
@@ -200,8 +218,8 @@ export const Route = createFileRoute('/api/tools-test')({
             return toServerSentEventsResponse(errorStream, { abortController })
           }
 
-          const adapterOptions = runtimeContextScenarios.has(scenario)
-            ? { adapter: createRuntimeContextAdapter(scenario) }
+          const adapterOptions = providerFreeScenarios.has(scenario)
+            ? { adapter: createProviderFreeAdapter(scenario) }
             : createTextAdapter('openai', undefined, aimockPort, testId)
 
           const tools = getToolsForScenario(scenario)

--- a/testing/e2e/tests/tool-error.spec.ts
+++ b/testing/e2e/tests/tool-error.spec.ts
@@ -4,6 +4,7 @@ import {
   runTest,
   waitForTestComplete,
   getMetadata,
+  getMessages,
   getToolCalls,
 } from './tools-test/helpers'
 
@@ -33,5 +34,31 @@ test.describe('Tool Error Handling', () => {
     // distinguish "failed" from "still executing" without reverse-engineering
     // the output shape (issue #718).
     expect(failingCall?.state).toBe('error')
+  })
+
+  test('malformed tool arguments produce an error result and chat continues', async ({
+    page,
+    testId,
+    aimockPort,
+  }) => {
+    await selectScenario(page, 'malformed-tool-arguments', testId, aimockPort)
+    await runTest(page)
+    await waitForTestComplete(page, 15000, 1)
+
+    const metadata = await getMetadata(page)
+    expect(metadata.hasError).toBe('false')
+
+    const toolCalls = await getToolCalls(page)
+    expect(toolCalls).toContainEqual(
+      expect.objectContaining({ name: 'check_status', state: 'error' }),
+    )
+
+    const messages = await getMessages(page)
+    const responseText = messages
+      .flatMap((message) => message.parts)
+      .filter((part) => part.type === 'text')
+      .map((part) => part.content)
+      .join(' ')
+    expect(responseText).toContain('Recovered from malformed tool arguments.')
   })
 })


### PR DESCRIPTION
Closes #1131

## 🎯 Changes

- Convert malformed JSON tool arguments into an output-error result instead of terminating the agent loop.

- Prevent the affected tool from executing while returning the parsing error to the model so it can repair the call.

- Add unit and E2E coverage confirming the conversation continues after malformed arguments.

- Clarify tool lifecycle and server-tool error documentation for failures that occur before execution.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Malformed tool arguments are now returned as tool errors instead of stopping the entire request.
  - Processing continues for other tool calls, allowing the assistant to recover and correct invalid input.
  - Invalid arguments no longer invoke the affected tool.

- **Documentation**
  - Updated tool behavior and architecture documentation to describe parsing, validation, and execution errors.

- **Tests**
  - Added coverage confirming malformed arguments produce recoverable errors and successful assistant responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->