### PR TITLE
fix(ai-openrouter): exclude unsupported 'prediction' param from generated model options

### DIFF
--- a/.changeset/fix-openrouter-prediction-param.md
+++ b/.changeset/fix-openrouter-prediction-param.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-openrouter': patch
+---
+
+Exclude the `prediction` parameter from the generated OpenRouter model options. The OpenRouter API newly reports it as a supported parameter, but `@openrouter/sdk`'s `ChatRequest` does not declare it (its outbound schema would strip it), so the generated `Pick<OpenRouterBaseOptions, ... | 'prediction'>` types failed to compile.

--- a/packages/ai-grok/tests/grok-adapter.test.ts
+++ b/packages/ai-grok/tests/grok-adapter.test.ts
@@ -105,7 +105,12 @@ describe('Grok adapters', () => {
   })
 
   it('exposes only the supported xAI Responses chat models', () => {
-    expect(GROK_CHAT_MODELS).toEqual(['grok-build-0.1', 'grok-4.3'])
+    expect(GROK_CHAT_MODELS).toEqual([
+      'grok-4.5',
+      'grok-4.6',
+      'grok-build-0.1',
+      'grok-4.3',
+    ])
   })
 
   describe('Text adapter', () => {

--- a/packages/ai-openrouter/src/model-meta.ts
+++ b/packages/ai-openrouter/src/model-meta.ts
@@ -5082,7 +5082,6 @@ const MISTRALAI_CODESTRAL_2508 = {
     supports: [
       'frequencyPenalty',
       'maxCompletionTokens',
-      'prediction',
       'presencePenalty',
       'responseFormat',
       'seed',
@@ -7126,7 +7125,6 @@ const OPENAI_GPT_4O = {
       'logprobs',
       'maxCompletionTokens',
       'maxCompletionTokens',
-      'prediction',
       'presencePenalty',
       'responseFormat',
       'seed',
@@ -7164,7 +7162,6 @@ const OPENAI_GPT_4O_2024_05_13 = {
       'logprobs',
       'maxCompletionTokens',
       'maxCompletionTokens',
-      'prediction',
       'presencePenalty',
       'responseFormat',
       'seed',
@@ -7202,7 +7199,6 @@ const OPENAI_GPT_4O_2024_08_06 = {
       'logprobs',
       'maxCompletionTokens',
       'maxCompletionTokens',
-      'prediction',
       'presencePenalty',
       'responseFormat',
       'seed',
@@ -7239,7 +7235,6 @@ const OPENAI_GPT_4O_2024_11_20 = {
       'logitBias',
       'logprobs',
       'maxCompletionTokens',
-      'prediction',
       'presencePenalty',
       'responseFormat',
       'seed',
@@ -7277,7 +7272,6 @@ const OPENAI_GPT_4O_MINI = {
       'logprobs',
       'maxCompletionTokens',
       'maxCompletionTokens',
-      'prediction',
       'presencePenalty',
       'responseFormat',
       'seed',
@@ -7314,7 +7308,6 @@ const OPENAI_GPT_4O_MINI_2024_07_18 = {
       'logitBias',
       'logprobs',
       'maxCompletionTokens',
-      'prediction',
       'presencePenalty',
       'responseFormat',
       'seed',
@@ -7351,7 +7344,6 @@ const OPENAI_GPT_4O_MINI_BATCH = {
       'logitBias',
       'logprobs',
       'maxCompletionTokens',
-      'prediction',
       'presencePenalty',
       'responseFormat',
       'seed',
@@ -7388,7 +7380,6 @@ const OPENAI_GPT_4O_BATCH = {
       'logitBias',
       'logprobs',
       'maxCompletionTokens',
-      'prediction',
       'presencePenalty',
       'responseFormat',
       'seed',
@@ -15070,7 +15061,6 @@ export type OpenRouterModelOptionsByName = {
       OpenRouterBaseOptions,
       | 'frequencyPenalty'
       | 'maxCompletionTokens'
-      | 'prediction'
       | 'presencePenalty'
       | 'responseFormat'
       | 'seed'
@@ -15891,7 +15881,6 @@ export type OpenRouterModelOptionsByName = {
       | 'logprobs'
       | 'maxCompletionTokens'
       | 'maxCompletionTokens'
-      | 'prediction'
       | 'presencePenalty'
       | 'responseFormat'
       | 'seed'
@@ -15909,7 +15898,6 @@ export type OpenRouterModelOptionsByName = {
       | 'logprobs'
       | 'maxCompletionTokens'
       | 'maxCompletionTokens'
-      | 'prediction'
       | 'presencePenalty'
       | 'responseFormat'
       | 'seed'
@@ -15927,7 +15915,6 @@ export type OpenRouterModelOptionsByName = {
       | 'logprobs'
       | 'maxCompletionTokens'
       | 'maxCompletionTokens'
-      | 'prediction'
       | 'presencePenalty'
       | 'responseFormat'
       | 'seed'
@@ -15944,7 +15931,6 @@ export type OpenRouterModelOptionsByName = {
       | 'logitBias'
       | 'logprobs'
       | 'maxCompletionTokens'
-      | 'prediction'
       | 'presencePenalty'
       | 'responseFormat'
       | 'seed'
@@ -15962,7 +15948,6 @@ export type OpenRouterModelOptionsByName = {
       | 'logprobs'
       | 'maxCompletionTokens'
       | 'maxCompletionTokens'
-      | 'prediction'
       | 'presencePenalty'
       | 'responseFormat'
       | 'seed'
@@ -15979,7 +15964,6 @@ export type OpenRouterModelOptionsByName = {
       | 'logitBias'
       | 'logprobs'
       | 'maxCompletionTokens'
-      | 'prediction'
       | 'presencePenalty'
       | 'responseFormat'
       | 'seed'
@@ -15996,7 +15980,6 @@ export type OpenRouterModelOptionsByName = {
       | 'logitBias'
       | 'logprobs'
       | 'maxCompletionTokens'
-      | 'prediction'
       | 'presencePenalty'
       | 'responseFormat'
       | 'seed'
@@ -16013,7 +15996,6 @@ export type OpenRouterModelOptionsByName = {
       | 'logitBias'
       | 'logprobs'
       | 'maxCompletionTokens'
-      | 'prediction'
       | 'presencePenalty'
       | 'responseFormat'
       | 'seed'

--- a/scripts/convert-openrouter-models.ts
+++ b/scripts/convert-openrouter-models.ts
@@ -248,6 +248,7 @@ function generateModelMetaString(model: OpenRouterModel): string {
     'include_reasoning',
     'verbosity',
     'web_search_options',
+    'prediction',
   ])
 
   // Build the object as a formatted string


### PR DESCRIPTION
## 🎯 Changes

Main CI went red after the OpenRouter model-metadata sync (#1048):

- The OpenRouter API newly reports `prediction` as a supported parameter, so the generator emitted `Pick<OpenRouterBaseOptions, ... | 'prediction'>` for 9 models — but `@openrouter/sdk@0.13.20`'s `ChatRequest` does not declare that field (its outbound schema would strip it at runtime), so `packages/ai-openrouter` no longer compiled (TS2344 in `model-meta.ts`, dts generation fails, which cascades into every example/e2e typecheck).
- The same sync added `grok-4.5` / `grok-4.6` to `GROK_CHAT_MODELS` without updating the ai-grok unit test that pins the list, so `test:lib` was red too.

Fix:

- Add `prediction` to the sync script's `excludedParams` set (same rationale as the existing entries: the SDK strips undeclared keys, so exposing it would silently no-op user input) and strip it from the generated `model-meta.ts`.
- Update the stale `GROK_CHAT_MODELS` test expectation.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr` (targeted: `@tanstack/ai-openrouter` build/test:lib/test:types and `@tanstack/ai-grok` test:lib are green; the full suite was red on main because of this very breakage).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OpenRouter model options by removing unsupported prediction settings from affected Mistral Codestral and GPT-4o models.
  * Prevented generated model configurations from exposing incompatible prediction parameters.

* **New Features**
  * Added support for recognizing Grok 4.5 and Grok 4.6 models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->