### PR TITLE
feat(ai-grok): add grok-imagine-image-2.0 support

### DIFF
--- a/.changeset/grok-imagine-image-2-0.md
+++ b/.changeset/grok-imagine-image-2-0.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/ai-grok': minor
+---
+
+Add first-class support for `grok-imagine-image-2.0`, the current generation of xAI's Imagine image models.
+
+- New model in `GROK_IMAGE_MODELS` and all image type maps (provider options, size, input modalities).
+- New `GrokImagineImage2ProviderOptions` with the 2.0-only `quality` option (`'low' | 'medium'`, default `'medium'`).
+- Image-editing requests now send `type: 'image_url'` on each source image (`image` / `images` entries), matching xAI's documented request shape.
+- `grok-imagine-image-quality` is marked deprecated in code comments and the docs note (kept for backward compatibility); prefer `grok-imagine-image-2.0`.

--- a/docs/adapters/grok.md
+++ b/docs/adapters/grok.md
@@ -166,35 +166,46 @@ console.log(result.summary);
 
 ## Image Generation
 
-Generate images with Grok 2 Image:
+The current generation of Grok's Imagine image models is
+`grok-imagine-image-2.0` — $0.04 per image, text-to-image plus
+image-conditioned editing. Generate an image from a text prompt:
 
 ```typescript
 import { generateImage } from "@tanstack/ai";
 import { grokImage } from "@tanstack/ai-grok";
 
 const result = await generateImage({
-  adapter: grokImage("grok-2-image-1212"),
+  adapter: grokImage("grok-imagine-image-2.0"),
   prompt: "A futuristic cityscape at sunset",
-  numberOfImages: 1,
 });
 
 console.log(result.images);
 ```
 
-The grok-imagine models (`grok-imagine-image`, `grok-imagine-image-quality`)
-are aspect-ratio sized — `size` takes an `aspectRatio_resolution` template
-like `"16:9_2k"` (the `_2k` suffix is optional):
+The grok-imagine models are aspect-ratio sized — `size` takes an
+`aspectRatio_resolution` template like `"16:9_2k"` (the `_2k` suffix is
+optional). `grok-imagine-image-2.0` also accepts a `quality` provider
+option (`"low"` | `"medium"`, default `"medium"`):
 
 ```typescript
 import { generateImage } from "@tanstack/ai";
 import { grokImage } from "@tanstack/ai-grok";
 
 const result = await generateImage({
-  adapter: grokImage("grok-imagine-image"),
+  adapter: grokImage("grok-imagine-image-2.0"),
   prompt: "A futuristic cityscape at sunset",
   size: "16:9_2k",
+  modelOptions: {
+    quality: "medium",
+  },
 });
 ```
+
+> The older `grok-imagine-image` ($0.02/image) and
+> `grok-imagine-image-quality` ($0.05/image) models remain supported but
+> are superseded — prefer `grok-imagine-image-2.0` for new work.
+> `grok-2-image-1212` is the legacy pixel-sized model; `size` takes a
+> `WIDTHxHEIGHT` value like `"1024x1024"`.
 
 ### Image Editing (image-to-image)
 
@@ -209,7 +220,7 @@ import { generateImage } from "@tanstack/ai";
 import { grokImage } from "@tanstack/ai-grok";
 
 const result = await generateImage({
-  adapter: grokImage("grok-imagine-image"),
+  adapter: grokImage("grok-imagine-image-2.0"),
   prompt: [
     {
       type: "text",

--- a/docs/config.json
+++ b/docs/config.json
@@ -808,7 +808,7 @@
           "label": "Grok (xAI)",
           "to": "adapters/grok",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-06-24"
+          "updatedAt": "2026-08-18"
         },
         {
           "label": "Groq",

--- a/packages/ai-grok/src/adapters/image.ts
+++ b/packages/ai-grok/src/adapters/image.ts
@@ -23,10 +23,10 @@ import type {
 import type OpenAI_SDK from 'openai'
 import type { GrokImageModel } from '../model-meta'
 import type {
+  GrokImageAnyProviderOptions,
   GrokImageModelInputModalitiesByName,
   GrokImageModelProviderOptionsByName,
   GrokImageModelSizeByName,
-  GrokImageProviderOptions,
 } from '../image/image-provider-options'
 import type { GrokClientConfig } from '../utils/client'
 
@@ -93,7 +93,7 @@ export class GrokImageAdapter<
   TModel extends GrokImageModel,
 > extends BaseImageAdapter<
   TModel,
-  GrokImageProviderOptions,
+  GrokImageAnyProviderOptions,
   GrokImageModelProviderOptionsByName,
   GrokImageModelSizeByName,
   GrokImageModelInputModalitiesByName
@@ -111,7 +111,7 @@ export class GrokImageAdapter<
   }
 
   async generateImages(
-    options: ImageGenerationOptions<GrokImageProviderOptions>,
+    options: ImageGenerationOptions<GrokImageAnyProviderOptions>,
   ): Promise<ImageGenerationResult> {
     const { model, numberOfImages, size, modelOptions } = options
 
@@ -210,12 +210,13 @@ export class GrokImageAdapter<
    * The `/v1/images/edits` endpoint takes `application/json` (the OpenAI
    * SDK's `images.edit()` sends `multipart/form-data`, which xAI rejects),
    * so this path issues the request directly. One input is sent as
-   * `image: { url }`; multiple inputs (up to 3) as `images: [{ url }, ...]`,
-   * addressed by xAI in the order they are sent. The prompt text is sent
-   * verbatim — no referencing markers are injected.
+   * `image: { url, type: 'image_url' }`; multiple inputs (up to 3) as
+   * `images: [{ url, type: 'image_url' }, ...]`, addressed by xAI in the
+   * order they are sent. The prompt text is sent verbatim — no referencing
+   * markers are injected.
    */
   private async editImages(
-    options: ImageGenerationOptions<GrokImageProviderOptions>,
+    options: ImageGenerationOptions<GrokImageAnyProviderOptions>,
     resolved: ResolvedMediaPrompt,
   ): Promise<ImageGenerationResult> {
     const { model, numberOfImages, size, modelOptions, logger } = options
@@ -247,8 +248,10 @@ export class GrokImageAdapter<
       model,
       prompt,
       ...(urls.length === 1
-        ? { image: { url: urls[0] } }
-        : { images: urls.map((url) => ({ url })) }),
+        ? { image: { url: urls[0], type: 'image_url' } }
+        : {
+            images: urls.map((url) => ({ url, type: 'image_url' })),
+          }),
       ...(numberOfImages !== undefined && { n: numberOfImages }),
       ...imagineSizeParams(size),
       ...modelOptions,

--- a/packages/ai-grok/src/image/image-provider-options.ts
+++ b/packages/ai-grok/src/image/image-provider-options.ts
@@ -68,6 +68,9 @@ const GROK_IMAGINE_RESOLUTIONS: ReadonlyArray<string> = ['1k', '2k']
  * Models served by xAI's Imagine API. They are aspect-ratio sized and
  * support image-conditioned generation via `/v1/images/edits`; the legacy
  * grok-2-image-1212 model is pixel-sized and text-to-image only.
+ *
+ * This prefix match covers grok-imagine-image, grok-imagine-image-quality
+ * (@deprecated tier) and grok-imagine-image-2.0.
  */
 export function isGrokImagineImageModel(model: string): boolean {
   return model.startsWith('grok-imagine-image')
@@ -142,12 +145,55 @@ export interface GrokImagineImageProviderOptions extends GrokImageBaseProviderOp
 }
 
 /**
+ * Provider options for the grok-imagine-image-2.0 model.
+ *
+ * The current generation of the Imagine image models: generation and
+ * image-conditioned editing via xAI's Imagine API. Adds the `quality`
+ * parameter (only supported on 2.0) — see
+ * https://docs.x.ai/developers/model-capabilities/images/generation
+ */
+export interface GrokImagineImage2ProviderOptions extends GrokImageBaseProviderOptions {
+  /**
+   * The format in which generated images are returned.
+   * @default 'url'
+   */
+  response_format?: 'url' | 'b64_json'
+
+  /**
+   * Output resolution.
+   * @default '1k'
+   */
+  resolution?: '1k' | '2k'
+
+  /**
+   * Generation quality. Only supported for grok-imagine-image-2.0.
+   * @default 'medium'
+   */
+  quality?: 'low' | 'medium'
+}
+
+/**
+ * Union of all Grok image provider options. Used as the base provider-options
+ * type on the adapter; model-level resolution happens at the generateImage()
+ * call site via `GrokImageModelProviderOptionsByName`.
+ */
+export type GrokImageAnyProviderOptions =
+  | GrokImageProviderOptions
+  | GrokImagineImageProviderOptions
+  | GrokImagineImage2ProviderOptions
+
+/**
  * Type-only map from model name to its specific provider options.
+ *
+ * grok-imagine-image-quality is a @deprecated older tier — prefer
+ * grok-imagine-image-2.0 (which exposes quality control via the
+ * `quality` option) for new work.
  */
 export type GrokImageModelProviderOptionsByName = {
   'grok-2-image-1212': GrokImageProviderOptions
   'grok-imagine-image': GrokImagineImageProviderOptions
   'grok-imagine-image-quality': GrokImagineImageProviderOptions
+  'grok-imagine-image-2.0': GrokImagineImage2ProviderOptions
 }
 
 /**
@@ -157,6 +203,7 @@ export type GrokImageModelSizeByName = {
   'grok-2-image-1212': GrokImageSize
   'grok-imagine-image': GrokImagineImageSize
   'grok-imagine-image-quality': GrokImagineImageSize
+  'grok-imagine-image-2.0': GrokImagineImageSize
 }
 
 /**
@@ -168,6 +215,7 @@ export type GrokImageModelInputModalitiesByName = {
   'grok-2-image-1212': readonly []
   'grok-imagine-image': readonly ['image']
   'grok-imagine-image-quality': readonly ['image']
+  'grok-imagine-image-2.0': readonly ['image']
 }
 
 /**

--- a/packages/ai-grok/src/index.ts
+++ b/packages/ai-grok/src/index.ts
@@ -28,6 +28,8 @@ export {
 } from './adapters/image'
 export type {
   GrokImageProviderOptions,
+  GrokImagineImageProviderOptions,
+  GrokImagineImage2ProviderOptions,
   GrokImageModelProviderOptionsByName,
 } from './image/image-provider-options'
 

--- a/packages/ai-grok/src/model-meta.ts
+++ b/packages/ai-grok/src/model-meta.ts
@@ -115,6 +115,11 @@ const GROK_IMAGINE_IMAGE = {
   },
 } as const satisfies ModelMeta
 
+/**
+ * @deprecated Superseded by grok-imagine-image-2.0, which exposes the same
+ * quality control as a `quality` option ('low' | 'medium'). Kept for
+ * backward compatibility — prefer grok-imagine-image-2.0 for new work.
+ */
 const GROK_IMAGINE_IMAGE_QUALITY = {
   name: 'grok-imagine-image-quality',
   supports: {
@@ -127,6 +132,24 @@ const GROK_IMAGINE_IMAGE_QUALITY = {
     },
     output: {
       normal: 0.05,
+    },
+  },
+} as const satisfies ModelMeta
+
+// Current generation of the Imagine image models. Recommended for new work.
+const GROK_IMAGINE_IMAGE_2_0 = {
+  name: 'grok-imagine-image-2.0',
+  supports: {
+    input: ['text', 'image'],
+    output: ['image'],
+  },
+  pricing: {
+    input: {
+      normal: 0,
+    },
+    output: {
+      // per generated image
+      normal: 0.04,
     },
   },
 } as const satisfies ModelMeta
@@ -229,6 +252,7 @@ export const GROK_IMAGE_MODELS = [
   GROK_2_IMAGE.name,
   GROK_IMAGINE_IMAGE.name,
   GROK_IMAGINE_IMAGE_QUALITY.name,
+  GROK_IMAGINE_IMAGE_2_0.name,
 ] as const
 
 /**

--- a/packages/ai-grok/tests/grok-adapter.test.ts
+++ b/packages/ai-grok/tests/grok-adapter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
-import { EventType, summarize } from '@tanstack/ai'
+import { EventType, generateImage, summarize } from '@tanstack/ai'
 import { createGrokText, grokText } from '../src/adapters/text'
 import { createGrokImage, grokImage } from '../src/adapters/image'
 import { createGrokSummarize, grokSummarize } from '../src/adapters/summarize'
@@ -102,6 +102,7 @@ const weatherTool: Tool = {
 describe('Grok adapters', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
   })
 
   it('exposes only the supported xAI Responses chat models', () => {
@@ -421,6 +422,19 @@ describe('Grok adapters', () => {
   })
 
   describe('Image adapter', () => {
+    /** A fetch stub that answers every edit request with one generated image. */
+    const mockEditFetch = () =>
+      vi.fn(
+        async (_input: string | URL | Request, _init?: RequestInit) =>
+          new Response(
+            JSON.stringify({ data: [{ url: 'https://e.com/o.png' }] }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          ),
+      )
+
     it('creates an image adapter with explicit API key', () => {
       const adapter = createGrokImage('grok-2-image-1212', 'test-api-key')
 
@@ -469,6 +483,167 @@ describe('Grok adapters', () => {
         }),
       )
       expect(mockGenerate.mock.calls[0]![0]).not.toHaveProperty('size')
+    })
+
+    it('creates a grok-imagine-image-2.0 adapter with explicit API key', () => {
+      const adapter = createGrokImage('grok-imagine-image-2.0', 'test-api-key')
+
+      expect(adapter).toBeDefined()
+      expect(adapter.kind).toBe('image')
+      expect(adapter.name).toBe('grok')
+      expect(adapter.model).toBe('grok-imagine-image-2.0')
+    })
+
+    it('creates a grok-imagine-image-2.0 adapter from environment variable', () => {
+      vi.stubEnv('XAI_API_KEY', 'env-api-key')
+
+      const adapter = grokImage('grok-imagine-image-2.0')
+
+      expect(adapter).toBeDefined()
+      expect(adapter.kind).toBe('image')
+      expect(adapter.model).toBe('grok-imagine-image-2.0')
+    })
+
+    it('maps the size template to aspect_ratio/resolution for 2.0', async () => {
+      const adapter = createGrokImage(
+        'grok-imagine-image-2.0',
+        'test-api-key',
+      )
+      const mockGenerate = vi.fn().mockResolvedValue({
+        data: [{ url: 'https://example.com/out.png' }],
+      })
+      ;(adapter as any).client = { images: { generate: mockGenerate } }
+
+      await adapter.generateImages({
+        model: 'grok-imagine-image-2.0',
+        prompt: 'A skyline',
+        size: '9:16_2k',
+        logger: testLogger,
+      })
+
+      expect(mockGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'grok-imagine-image-2.0',
+          aspect_ratio: '9:16',
+          resolution: '2k',
+        }),
+      )
+      expect(mockGenerate.mock.calls[0]![0]).not.toHaveProperty('size')
+    })
+
+    it('passes the 2.0 quality option through to the request', async () => {
+      const adapter = createGrokImage(
+        'grok-imagine-image-2.0',
+        'test-api-key',
+      )
+      const mockGenerate = vi.fn().mockResolvedValue({
+        data: [{ url: 'https://example.com/out.png' }],
+      })
+      ;(adapter as any).client = { images: { generate: mockGenerate } }
+
+      await adapter.generateImages({
+        model: 'grok-imagine-image-2.0',
+        prompt: 'A skyline',
+        modelOptions: { quality: 'low' },
+        logger: testLogger,
+      })
+
+      expect(mockGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'grok-imagine-image-2.0',
+          quality: 'low',
+        }),
+      )
+    })
+
+    it('sends type image_url for single-image edits on 2.0', async () => {
+      const fetchMock = mockEditFetch()
+      vi.stubGlobal('fetch', fetchMock)
+      const adapter = createGrokImage(
+        'grok-imagine-image-2.0',
+        'test-api-key',
+      )
+
+      await adapter.generateImages({
+        model: 'grok-imagine-image-2.0',
+        prompt: [
+          { type: 'text', content: 'Render this as a pencil sketch' },
+          {
+            type: 'image',
+            source: { type: 'url', value: 'https://example.com/photo.png' },
+          },
+        ],
+        logger: testLogger,
+      })
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const [url, init] = fetchMock.mock.calls[0]!
+      expect(url).toBe('https://api.x.ai/v1/images/edits')
+      const body = JSON.parse(String(init?.body))
+      expect(body).toEqual({
+        model: 'grok-imagine-image-2.0',
+        prompt: 'Render this as a pencil sketch',
+        image: { url: 'https://example.com/photo.png', type: 'image_url' },
+      })
+    })
+
+    it('sends type image_url for multi-image edits on 2.0', async () => {
+      const fetchMock = mockEditFetch()
+      vi.stubGlobal('fetch', fetchMock)
+      const adapter = createGrokImage(
+        'grok-imagine-image-2.0',
+        'test-api-key',
+      )
+
+      await adapter.generateImages({
+        model: 'grok-imagine-image-2.0',
+        prompt: [
+          { type: 'text', content: 'Blend these two scenes' },
+          {
+            type: 'image',
+            source: { type: 'url', value: 'https://example.com/a.png' },
+          },
+          {
+            type: 'image',
+            source: { type: 'url', value: 'https://example.com/b.png' },
+          },
+        ],
+        logger: testLogger,
+      })
+
+      const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body))
+      expect(body).toEqual({
+        model: 'grok-imagine-image-2.0',
+        prompt: 'Blend these two scenes',
+        images: [
+          { url: 'https://example.com/a.png', type: 'image_url' },
+          { url: 'https://example.com/b.png', type: 'image_url' },
+        ],
+      })
+    })
+
+    it('resolves model-specific provider options at the generateImage call site (#grok-2.0)', () => {
+      // Type-level regression guard: the per-model provider options are
+      // resolved at the generateImage() call site via the adapter's
+      // modelProviderOptionsByName map. This closure is type-checked but
+      // never executed — passing CI's test:types is the assertion.
+      const _typeCheck = () => {
+        // 2.0 exposes the quality option ('low' | 'medium').
+        void generateImage({
+          adapter: grokImage('grok-imagine-image-2.0'),
+          prompt: 'A skyline',
+          modelOptions: { quality: 'low' },
+        })
+        // The older imagine tier has no quality option — reject at compile time.
+        void generateImage({
+          adapter: grokImage('grok-imagine-image'),
+          prompt: 'A skyline',
+          // @ts-expect-error quality is not a valid option for grok-imagine-image
+          modelOptions: { quality: 'low' },
+        })
+      }
+
+      expect(_typeCheck).toBeInstanceOf(Function)
     })
   })
 

--- a/packages/ai-grok/tests/grok-adapter.test.ts
+++ b/packages/ai-grok/tests/grok-adapter.test.ts
@@ -106,7 +106,12 @@ describe('Grok adapters', () => {
   })
 
   it('exposes only the supported xAI Responses chat models', () => {
-    expect(GROK_CHAT_MODELS).toEqual(['grok-build-0.1', 'grok-4.3'])
+    expect(GROK_CHAT_MODELS).toEqual([
+      'grok-4.5',
+      'grok-4.6',
+      'grok-build-0.1',
+      'grok-4.3',
+    ])
   })
 
   describe('Text adapter', () => {

--- a/packages/ai-grok/tests/grok-adapter.test.ts
+++ b/packages/ai-grok/tests/grok-adapter.test.ts
@@ -510,10 +510,7 @@ describe('Grok adapters', () => {
     })
 
     it('maps the size template to aspect_ratio/resolution for 2.0', async () => {
-      const adapter = createGrokImage(
-        'grok-imagine-image-2.0',
-        'test-api-key',
-      )
+      const adapter = createGrokImage('grok-imagine-image-2.0', 'test-api-key')
       const mockGenerate = vi.fn().mockResolvedValue({
         data: [{ url: 'https://example.com/out.png' }],
       })
@@ -537,10 +534,7 @@ describe('Grok adapters', () => {
     })
 
     it('passes the 2.0 quality option through to the request', async () => {
-      const adapter = createGrokImage(
-        'grok-imagine-image-2.0',
-        'test-api-key',
-      )
+      const adapter = createGrokImage('grok-imagine-image-2.0', 'test-api-key')
       const mockGenerate = vi.fn().mockResolvedValue({
         data: [{ url: 'https://example.com/out.png' }],
       })
@@ -564,10 +558,7 @@ describe('Grok adapters', () => {
     it('sends type image_url for single-image edits on 2.0', async () => {
       const fetchMock = mockEditFetch()
       vi.stubGlobal('fetch', fetchMock)
-      const adapter = createGrokImage(
-        'grok-imagine-image-2.0',
-        'test-api-key',
-      )
+      const adapter = createGrokImage('grok-imagine-image-2.0', 'test-api-key')
 
       await adapter.generateImages({
         model: 'grok-imagine-image-2.0',
@@ -595,10 +586,7 @@ describe('Grok adapters', () => {
     it('sends type image_url for multi-image edits on 2.0', async () => {
       const fetchMock = mockEditFetch()
       vi.stubGlobal('fetch', fetchMock)
-      const adapter = createGrokImage(
-        'grok-imagine-image-2.0',
-        'test-api-key',
-      )
+      const adapter = createGrokImage('grok-imagine-image-2.0', 'test-api-key')
 
       await adapter.generateImages({
         model: 'grok-imagine-image-2.0',


### PR DESCRIPTION
## What

Add first-class support for xAI's `grok-imagine-image-2.0` model — the current generation of Grok Imagine image models — to `@tanstack/ai-grok`.

Agreed via a design interview (18 decisions); key outcomes:

- **New model** in `GROK_IMAGE_MODELS` + all image type maps (provider options, size, input modalities). $0.04/image, text+image → image.
- **New `GrokImagineImage2ProviderOptions`** with the 2.0-only `quality` option (`'low' | 'medium'`, default `'medium'`). `service_tier` is excluded from the 2.0 type but stays on the existing `grok-imagine-image*` types.
- **`type: 'image_url'` on edit requests** (single `image` and multi `images` entries), matching xAI's documented request shape and the Vercel AI SDK implementation.
- **`grok-imagine-image-quality` deprecated** in code comments + docs note (kept for backward compatibility); `grok-2-image-1212` untouched.
- **Docs**: `docs/adapters/grok.md` image section now features 2.0; `updatedAt` refreshed.
- **Tests**: factory, size→`aspect_ratio`/`resolution` mapping, `quality` passthrough, and edit body with `type: 'image_url'` (single + multi). Plus a compile-time guard that `generateImage()` resolves per-model provider options (2.0 `quality` accepted, older tier rejected).
- **Changeset**: minor.

## Second commit (test sync)

`test(ai-grok): sync chat-model expectation with #1048` — `bc8c5e86` (#1048) added `grok-4.5`/`grok-4.6` to `GROK_CHAT_MODELS` but did not update the existing expectation test, so `@tanstack/ai-grok` `test:lib` was failing on main even without this PR. This commit updates the expected list so the suite is green. Unrelated to image support but required to keep CI green for this PR.

## Checks

- `test:types` (package + nx affected)
- `test:lib` (100 tests)
- `test:oxlint` (0 errors)
- `test:build` / build / `test:dts`
- `test:docs`, `test:sherif`, `test:knip`, `test:maintainer`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Grok’s `grok-imagine-image-2.0` model.
  * Added configurable resolution, response format, and image quality options.
  * Added support for single- and multi-image editing with the new model.
  * Added image sizing and input compatibility for image generation and editing.
  * Added pricing information for generated images.

* **Documentation**
  * Updated Grok image-generation guidance, editing examples, and quality settings.
  * Documented the legacy image-quality model as deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->