### PR TITLE
ci: skip Playwright apt deps on GitHub runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -42,13 +42,12 @@ jobs:
       - name: Build Packages
         run: pnpm run build:all
 
+      # GitHub-hosted ubuntu-24.04 already has Chromium system libs.
+      # install-deps / --with-deps run apt-get against azure.archive.ubuntu.com
+      # and that mirror hangs, which kills this job.
       - name: Install Playwright Chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter @tanstack/ai-e2e exec playwright install --with-deps chromium
-
-      - name: Install Playwright Deps (if cached)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm --filter @tanstack/ai-e2e exec playwright install-deps chromium
+        run: pnpm --filter @tanstack/ai-e2e exec playwright install chromium
 
       - name: Run E2E Tests
         run: pnpm --filter @tanstack/ai-e2e test:e2e


### PR DESCRIPTION
## Changes

E2E jobs on many PRs die during `playwright install-deps`. That step runs `apt-get` against `azure.archive.ubuntu.com`. The mirror hangs, then the job hits the 15-minute timeout. Tests never start.

This change:

- Stops calling `install-deps` and `--with-deps`. GitHub-hosted `ubuntu-24.04` already has Chromium system libs. Cache misses still install the Chromium browser only.
- Raises the E2E job timeout from 15 minutes to 30 minutes.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

CI-only workflow change. `test:pr` does not run this job.

## Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the end-to-end test workflow timeout to reduce failures from lengthy runs.
  * Streamlined browser setup and documented dependency and mirror behavior for more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->