### PR TITLE
fix(ai-react): avoid random IDs during SSR render

### DIFF
--- a/packages/ai-client/src/devtools.ts
+++ b/packages/ai-client/src/devtools.ts
@@ -742,23 +742,11 @@ export class ClientDevtoolsBridge<TSnapshot extends object> {
   }
 }
 
-let bridgeIdSequence = 0
-
 function createBridgeId(hookId: string): string {
-  const cryptoLike = (
-    globalThis as {
-      crypto?: {
-        randomUUID?: () => string
-      }
-    }
-  ).crypto
-
-  if (cryptoLike?.randomUUID) {
-    return `bridge:${hookId}:${cryptoLike.randomUUID()}`
-  }
-
-  bridgeIdSequence += 1
-  return `bridge:${hookId}:${bridgeIdSequence}`
+  // hookId comes from React's useId and is stable across SSR and hydration.
+  // Do not generate randomness during render: crypto.randomUUID is unavailable
+  // or restricted in some server runtimes, and discarded renders must be pure.
+  return `bridge:${hookId}`
 }
 
 // Owns the chat-client devtools surface so the chat client itself stays a

--- a/packages/ai-react/src/use-chat.ts
+++ b/packages/ai-react/src/use-chat.ts
@@ -41,10 +41,10 @@ export function useChat<
 ): UseChatReturn<TTools, TSchema> {
   // The hook's identity is its `threadId` — also the persistence key, so a
   // reload with the same `threadId` restores the same conversation. `hookId` is
-  // only a stable fallback for React's client-recreation keying when no
-  // `threadId` is given (an ephemeral chat), never a persistence key.
+  // a stable fallback when an empty or missing `threadId` creates an ephemeral
+  // chat, never a persistence key.
   const hookId = useId()
-  const clientId = options.threadId ?? hookId
+  const clientId = options.threadId || hookId
 
   const [messages, setMessages] = useState<Array<UIMessage<TTools>>>(
     options.initialMessages || [],
@@ -128,10 +128,7 @@ export function useChat<
       ...transport,
       initialMessages: messagesToUse,
       ...(initialOptions.body !== undefined && { body: initialOptions.body }),
-      ...(initialOptions.threadId !== undefined && {
-        threadId: initialOptions.threadId,
-      }),
-      ...(initialOptions.threadId === undefined && { threadId: hookId }),
+      threadId: clientId,
       ...(initialOptions.forwardedProps !== undefined && {
         forwardedProps: initialOptions.forwardedProps,
       }),

--- a/packages/ai-react/src/use-chat.ts
+++ b/packages/ai-react/src/use-chat.ts
@@ -131,6 +131,7 @@ export function useChat<
       ...(initialOptions.threadId !== undefined && {
         threadId: initialOptions.threadId,
       }),
+      ...(initialOptions.threadId === undefined && { threadId: hookId }),
       ...(initialOptions.forwardedProps !== undefined && {
         forwardedProps: initialOptions.forwardedProps,
       }),

--- a/packages/ai-react/tests/use-chat.test.ts
+++ b/packages/ai-react/tests/use-chat.test.ts
@@ -290,6 +290,20 @@ describe('useChat', () => {
       expect(typeof messageId).toBe('string')
     })
 
+    it('uses the hook ID instead of generating a random ID for an empty threadId', () => {
+      const chatClientPrototype = ChatClient.prototype as unknown as {
+        generateUniqueId: () => string
+      }
+      const generateUniqueId = vi.spyOn(chatClientPrototype, 'generateUniqueId')
+
+      renderUseChat({
+        connection: createMockConnectionAdapter(),
+        threadId: '',
+      })
+
+      expect(generateUniqueId).not.toHaveBeenCalled()
+    })
+
     it('should generate id if not provided', async () => {
       const chunks = createTextChunks('Response')
       const adapter = createMockConnectionAdapter({ chunks })

--- a/packages/ai-react/tests/use-chat.test.ts
+++ b/packages/ai-react/tests/use-chat.test.ts
@@ -290,7 +290,9 @@ describe('useChat', () => {
       expect(typeof messageId).toBe('string')
     })
 
-    it('uses the hook ID instead of generating a random ID for an empty threadId', () => {
+    it.each(['', undefined])(
+      'uses the hook ID instead of generating a random ID for threadId=%s',
+      (threadId) => {
       const chatClientPrototype = ChatClient.prototype as unknown as {
         generateUniqueId: () => string
       }
@@ -298,10 +300,11 @@ describe('useChat', () => {
 
       renderUseChat({
         connection: createMockConnectionAdapter(),
-        threadId: '',
+        ...(threadId === undefined ? {} : { threadId }),
       })
 
-      expect(generateUniqueId).not.toHaveBeenCalled()
+        expect(generateUniqueId).not.toHaveBeenCalled()
+      },
     })
 
     it('should generate id if not provided', async () => {


### PR DESCRIPTION
Fixes #1089

Avoids render-time randomness in useChat by passing React's deterministic useId to ChatClient when threadId is omitted, and makes the devtools bridge identity derive solely from the stable hook ID. This keeps SSR render and hydration deterministic and avoids crypto.randomUUID during server render.

Tests: ai-client devtools suite (34 passed). ai-react use-chat suite could not run because the local workspace package link for @tanstack/ai-client is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat thread consistency when no explicit thread ID is provided.
  - Empty thread ID values now receive a stable identifier automatically.
  - Ensured bridge identifiers remain stable across sessions and interactions.
  - Preserved explicitly configured thread IDs without changes.
  - Prevented unnecessary unique ID generation during chat initialization.
  - Improved reliability when initializing chats with omitted or empty thread settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->