### PR TITLE
feat(claude-code): expose settingSources (default project) and loaded skills

### DIFF
--- a/.changeset/pink-skills-dance.md
+++ b/.changeset/pink-skills-dance.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-claude-code': minor
+---
+
+Expose Claude Code setting sources and loaded skills in session metadata.

--- a/.changeset/pink-skills-dance.md
+++ b/.changeset/pink-skills-dance.md
@@ -3,3 +3,5 @@
 ---
 
 Expose Claude Code setting sources and loaded skills in session metadata.
+
+`settingSources` defaults to `['project']`. Workspace projections (instructions, skills, MCP config) now load, and a local-process run no longer picks up the host's `~/.claude`. Pass `['user', 'project', 'local']` for CLI-equivalent behavior. Plugin projection installs at project scope.

--- a/docs/adapters/claude-code.md
+++ b/docs/adapters/claude-code.md
@@ -74,13 +74,15 @@ const stream = chat({
 | `pathToClaudeCodeExecutable` | Use a specific Claude Code executable instead of the SDK's bundled one.                                                                             |
 | `streamPartials`             | Emit true token-level text deltas (default `true`).                                                                                                 |
 | `canUseTool`                 | Custom permission handler; replaces the adapter's default handler.                                                                                  |
-| `settingSources`             | Claude Code settings tiers to load. Default `['project']`: the `cwd`'s CLAUDE.md and project settings apply, but user-level config on the host (`~/.claude` plugins, hooks, skills) is ignored. Pass `['user', 'project', 'local']` for CLI-equivalent behavior, or `[]` for full isolation. |
+| `settingSources`             | Claude Code settings tiers to load. Default `['user']`: user-level config on the host (`~/.claude` plugins, hooks, skills) is loaded. Pass `['user', 'project', 'local']` for CLI-equivalent behavior, or `[]` for full isolation. |
 
 **Permissions on headless servers.** Without an explicit `permissionMode` or `canUseTool`, the adapter installs a safe default handler: bridged TanStack tools always run, and any built-in tool call that would normally prompt a human is denied with guidance instead of hanging the request. To let the harness edit files or run commands, set `permissionMode: 'acceptEdits'` / `'bypassPermissions'`, or enumerate `allowedTools`.
 
 ## Stateful Sessions
 
 Claude Code sessions are stateful — the harness keeps the full working context (files read, commands run, conclusions reached) between turns. The adapter surfaces the session id of every run as a custom stream event named `claude-code.session-id`; thread it back via `modelOptions.sessionId` to resume the session. When resuming, only the latest user message is sent — the harness already holds the prior context.
+
+The `claude-code.session-id` event payload also includes `skills`, an array of skills loaded during SDK initialization (or an empty array when none are reported).
 
 Server endpoint:
 
@@ -182,7 +184,7 @@ const stream = chat({
 
 Pass `outputSchema` on `chat()`. Claude Code runs one harness turn, uses its native tools, and returns a typed object. The schema JSON is passed to `--json-schema` as inline JSON (the CLI rejects a file path). Tool activity and prose stream as usual. The object arrives as `structured-output.complete`, including when Claude delivers it through its built-in `StructuredOutput` tool.
 
-The adapter loads only user settings (`--setting-sources user`). A cloned repo's `.claude/settings.json` does not block headless `-p`. The adapter does not pass `--bare`, because that flag ignores a host `claude login`.
+By default, the adapter loads only user settings (`--setting-sources user`). Configure `settingSources` to include project or local settings when needed. A cloned repo's `.claude/settings.json` does not block headless `-p`. The adapter does not pass `--bare`, because that flag ignores a host `claude login`.
 
 On local-process, Claude uses your host `claude login`. On Docker, pass `ANTHROPIC_API_KEY` in the process env. A container has no host login.
 

--- a/docs/adapters/claude-code.md
+++ b/docs/adapters/claude-code.md
@@ -74,7 +74,7 @@ const stream = chat({
 | `pathToClaudeCodeExecutable` | Use a specific Claude Code executable instead of the SDK's bundled one.                                                                             |
 | `streamPartials`             | Emit true token-level text deltas (default `true`).                                                                                                 |
 | `canUseTool`                 | Custom permission handler; replaces the adapter's default handler.                                                                                  |
-| `settingSources`             | Claude Code settings tiers to load. Default `['user']`: user-level config on the host (`~/.claude` plugins, hooks, skills) is loaded. Pass `['user', 'project', 'local']` for CLI-equivalent behavior, or `[]` for full isolation. |
+| `settingSources`             | Claude Code settings tiers to load. Default `['project']`: the workspace's `CLAUDE.md`, `.claude/skills`, and `.mcp.json` apply, and the host's `~/.claude` (plugins, hooks, skills) is not loaded. Pass `['user', 'project', 'local']` for CLI-equivalent behavior, or `[]` to load no settings. |
 
 **Permissions on headless servers.** Without an explicit `permissionMode` or `canUseTool`, the adapter installs a safe default handler: bridged TanStack tools always run, and any built-in tool call that would normally prompt a human is denied with guidance instead of hanging the request. To let the harness edit files or run commands, set `permissionMode: 'acceptEdits'` / `'bypassPermissions'`, or enumerate `allowedTools`.
 
@@ -184,7 +184,7 @@ const stream = chat({
 
 Pass `outputSchema` on `chat()`. Claude Code runs one harness turn, uses its native tools, and returns a typed object. The schema JSON is passed to `--json-schema` as inline JSON (the CLI rejects a file path). Tool activity and prose stream as usual. The object arrives as `structured-output.complete`, including when Claude delivers it through its built-in `StructuredOutput` tool.
 
-By default, the adapter loads only user settings (`--setting-sources user`). Configure `settingSources` to include project or local settings when needed. A cloned repo's `.claude/settings.json` does not block headless `-p`. The adapter does not pass `--bare`, because that flag ignores a host `claude login`.
+By default, the adapter loads only project settings (`--setting-sources project`). Workspace projections (instructions, skills, MCP config) are project-scoped, so they apply. The host's `~/.claude` is not loaded, so a local-process run does not pick up your personal skills and hooks. A cloned repo's `.claude/settings.json` and hooks apply to the run. Set `settingSources` to change this. The adapter does not pass `--bare`, because that flag ignores a host `claude login`.
 
 On local-process, Claude uses your host `claude login`. On Docker, pass `ANTHROPIC_API_KEY` in the process env. A container has no host login.
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -1004,7 +1004,7 @@
           "label": "Claude Code",
           "to": "adapters/claude-code",
           "addedAt": "2026-06-12",
-          "updatedAt": "2026-08-18"
+          "updatedAt": "2026-08-24"
         },
         {
           "label": "Codex",

--- a/docs/config.json
+++ b/docs/config.json
@@ -1004,7 +1004,7 @@
           "label": "Claude Code",
           "to": "adapters/claude-code",
           "addedAt": "2026-06-12",
-          "updatedAt": "2026-08-24"
+          "updatedAt": "2026-08-25"
         },
         {
           "label": "Codex",

--- a/packages/ai-claude-code/src/adapters/projection.ts
+++ b/packages/ai-claude-code/src/adapters/projection.ts
@@ -11,7 +11,9 @@
  *   - gitSkill repos → linked under `.claude/skills/<basename>`.
  *   - agentSkill     → no reliable claude primitive pulls a public skill by
  *                      bare name, so we warn and skip rather than invent one.
- *   - plugins        → `claude plugin install <name>` (best-effort).
+ *   - plugins        → `claude plugin install <name> --scope project`
+ *                      (best-effort; project scope so the adapter's default
+ *                      `--setting-sources project` loads it).
  *
  * The secret-bearing `.mcp.json` is (re)written on EVERY call, re-resolving
  * secrets each time, so claude always reads current values and a snapshot can
@@ -176,16 +178,17 @@ function projectAgentSkills(projection: WorkspaceProjection): void {
 }
 
 /**
- * Install each declared plugin via `claude plugin install <name>`. Plugin
- * installs are best-effort: a failure (no marketplace, network, …) warns but
- * never throws, so a missing plugin can't break the run.
+ * Install each declared plugin via `claude plugin install <name>` at project
+ * scope (user scope is not read under the default `--setting-sources project`).
+ * Plugin installs are best-effort: a failure (no marketplace, network, …) warns
+ * but never throws, so a missing plugin can't break the run.
  */
 async function projectPlugins(
   handle: SandboxHandle,
   projection: WorkspaceProjection,
 ): Promise<void> {
   for (const name of projection.plugins) {
-    const cmd = `claude plugin install ${shellQuote(name)}`
+    const cmd = `claude plugin install ${shellQuote(name)} --scope project`
     try {
       const result = await handle.process.exec(cmd, { cwd: projection.root })
       if (result.exitCode !== 0) {

--- a/packages/ai-claude-code/src/adapters/text.ts
+++ b/packages/ai-claude-code/src/adapters/text.ts
@@ -214,7 +214,7 @@ export class ClaudeCodeTextAdapter<
     const exeParts = (config.claudeExecutable ?? 'claude').split(' ')
     const settingSources = config.settingSources ?? ['user']
 
-    // `--setting-sources user` before `-p`. Do not pass `--bare`: that flag
+    // `--setting-sources` before `-p`. Do not pass `--bare`: that flag
     // skips stored `claude login` credentials and prints
     // "Not logged in · Please run /login" (claude-code#51047).
     // `-p` can take the next token as the prompt, so these flags stay first.

--- a/packages/ai-claude-code/src/adapters/text.ts
+++ b/packages/ai-claude-code/src/adapters/text.ts
@@ -87,7 +87,12 @@ export interface ClaudeCodeTextConfig {
   addDirs?: Array<string>
   /** Maximum harness-internal turns (`--max-turns`). */
   maxTurns?: number
-  /** Claude Code filesystem settings loaded via `--setting-sources`. Defaults to `['user']`. */
+  /**
+   * Claude Code settings tiers loaded via `--setting-sources`. Defaults to
+   * `['project']`: workspace projections (instructions, skills, MCP config)
+   * are project-scoped, and the host's `~/.claude` stays out of local-process
+   * runs. Pass `['user', 'project', 'local']` for CLI-equivalent behavior.
+   */
   settingSources?: Array<ClaudeCodeSettingSource>
   /**
    * How `systemPrompts` from `chat()` are applied:
@@ -212,7 +217,10 @@ export class ClaudeCodeTextAdapter<
     const config = this.adapterConfig
     const modelOptions = options.modelOptions
     const exeParts = (config.claudeExecutable ?? 'claude').split(' ')
-    const settingSources = config.settingSources ?? ['user']
+    // Claude only reads project-scoped config (CLAUDE.md, `.claude/skills`,
+    // `.mcp.json`) with `project` in the sources. `user` is off by default so
+    // a local-process run does not pull in the host's `~/.claude`.
+    const settingSources = config.settingSources ?? ['project']
 
     // `--setting-sources` before `-p`. Do not pass `--bare`: that flag
     // skips stored `claude login` credentials and prints

--- a/packages/ai-claude-code/src/adapters/text.ts
+++ b/packages/ai-claude-code/src/adapters/text.ts
@@ -62,6 +62,8 @@ export type ClaudeCodePermissionMode =
   | 'bypassPermissions'
   | 'plan'
 
+export type ClaudeCodeSettingSource = 'user' | 'project' | 'local'
+
 const DEFAULT_WORKDIR = '/workspace'
 
 export interface ClaudeCodeTextConfig {
@@ -85,6 +87,8 @@ export interface ClaudeCodeTextConfig {
   addDirs?: Array<string>
   /** Maximum harness-internal turns (`--max-turns`). */
   maxTurns?: number
+  /** Claude Code filesystem settings loaded via `--setting-sources`. Defaults to `['user']`. */
+  settingSources?: Array<ClaudeCodeSettingSource>
   /**
    * How `systemPrompts` from `chat()` are applied:
    * - `'append'` (default): `--append-system-prompt` on top of the preset.
@@ -208,6 +212,7 @@ export class ClaudeCodeTextAdapter<
     const config = this.adapterConfig
     const modelOptions = options.modelOptions
     const exeParts = (config.claudeExecutable ?? 'claude').split(' ')
+    const settingSources = config.settingSources ?? ['user']
 
     // `--setting-sources user` before `-p`. Do not pass `--bare`: that flag
     // skips stored `claude login` credentials and prints
@@ -216,7 +221,7 @@ export class ClaudeCodeTextAdapter<
     const args: Array<string> = [
       ...exeParts,
       '--setting-sources',
-      'user',
+      settingSources.join(','),
       '-p',
       '--output-format',
       'stream-json',

--- a/packages/ai-claude-code/src/index.ts
+++ b/packages/ai-claude-code/src/index.ts
@@ -2,6 +2,7 @@ export { ClaudeCodeTextAdapter, claudeCodeText } from './adapters/text'
 export type {
   ClaudeCodeTextConfig,
   ClaudeCodePermissionMode,
+  ClaudeCodeSettingSource,
 } from './adapters/text'
 export type { ClaudeCodeTextProviderOptions } from './provider-options'
 export { CLAUDE_CODE_MODELS } from './model-meta'

--- a/packages/ai-claude-code/src/stream/sdk-types.ts
+++ b/packages/ai-claude-code/src/stream/sdk-types.ts
@@ -14,6 +14,7 @@ export interface SdkInitMessage {
   session_id: string
   model: string
   tools: Array<string>
+  skills?: Array<string>
   cwd?: string
 }
 

--- a/packages/ai-claude-code/src/stream/translate.ts
+++ b/packages/ai-claude-code/src/stream/translate.ts
@@ -580,6 +580,7 @@ export async function* translateSdkStream(
             sessionId: sdkMessage.session_id,
             model: sdkMessage.model,
             tools: sdkMessage.tools,
+            skills: sdkMessage.skills ?? [],
           },
         }
         continue

--- a/packages/ai-claude-code/tests/text-adapter.test.ts
+++ b/packages/ai-claude-code/tests/text-adapter.test.ts
@@ -221,6 +221,44 @@ describe('claude-code in-sandbox adapter', () => {
     await sbx.destroy()
   })
 
+  it('uses user as the default setting source', async () => {
+    const fake = [
+      `import { writeFileSync } from 'node:fs'`,
+      `writeFileSync('argv.txt', process.argv.slice(2).join(' '))`,
+      `let input = ''`,
+      `process.stdin.on('data', (d) => { input += d })`,
+      `process.stdin.on('end', () => {`,
+      `  const w = (o) => process.stdout.write(JSON.stringify(o) + '\\n')`,
+      `  w({ type: 'system', subtype: 'init', session_id: 'sess-default', model: 'haiku', tools: [] })`,
+      `  w({ type: 'result', subtype: 'success', result: 'ok', usage: { input_tokens: 1, output_tokens: 1 } })`,
+      `})`,
+    ].join('\n')
+    const sbx = await provider.create({})
+    await sbx.fs.write('/workspace/fake-claude.mjs', fake)
+
+    try {
+      const adapter = claudeCodeText('haiku', {
+        claudeExecutable: 'node fake-claude.mjs',
+        streamPartials: false,
+        emitDiff: false,
+      })
+      await collect(
+        adapter.chatStream({
+          model: 'haiku',
+          messages: [{ role: 'user', content: 'hi' }],
+          logger: noopLogger,
+          capabilities: capabilityContextWith(sbx),
+        }),
+      )
+
+      expect(await sbx.fs.read('/workspace/argv.txt')).toMatch(
+        /--setting-sources user/,
+      )
+    } finally {
+      await sbx.destroy()
+    }
+  })
+
   it('copies ANTHROPIC_API_KEY from the host process into the CLI env', async () => {
     const fake = [
       `import { writeFileSync } from 'node:fs'`,

--- a/packages/ai-claude-code/tests/text-adapter.test.ts
+++ b/packages/ai-claude-code/tests/text-adapter.test.ts
@@ -181,6 +181,7 @@ describe('claude-code in-sandbox adapter', () => {
       claudeExecutable: 'node fake-claude.mjs',
       streamPartials: false,
       emitDiff: false,
+      settingSources: ['project', 'local'],
     })
 
     const chunks = await collect(
@@ -200,7 +201,7 @@ describe('claude-code in-sandbox adapter', () => {
     const argv = await sbx.fs.read('/workspace/argv.txt')
     expect(argv).not.toContain('--bare')
     expect(argv).toContain('--setting-sources')
-    expect(argv).toContain('user')
+    expect(argv).toContain('project,local')
     expect(argv).toContain('--json-schema')
     expect(argv).toContain('"type":"object"')
     expect(argv).toContain('"summary"')

--- a/packages/ai-claude-code/tests/text-adapter.test.ts
+++ b/packages/ai-claude-code/tests/text-adapter.test.ts
@@ -221,7 +221,7 @@ describe('claude-code in-sandbox adapter', () => {
     await sbx.destroy()
   })
 
-  it('uses user as the default setting source', async () => {
+  it('uses project as the default setting source', async () => {
     const fake = [
       `import { writeFileSync } from 'node:fs'`,
       `writeFileSync('argv.txt', process.argv.slice(2).join(' '))`,
@@ -252,7 +252,7 @@ describe('claude-code in-sandbox adapter', () => {
       )
 
       expect(await sbx.fs.read('/workspace/argv.txt')).toMatch(
-        /--setting-sources user(?:\s|$)/,
+        /--setting-sources project(?:\s|$)/,
       )
     } finally {
       await sbx.destroy()

--- a/packages/ai-claude-code/tests/text-adapter.test.ts
+++ b/packages/ai-claude-code/tests/text-adapter.test.ts
@@ -252,7 +252,7 @@ describe('claude-code in-sandbox adapter', () => {
       )
 
       expect(await sbx.fs.read('/workspace/argv.txt')).toMatch(
-        /--setting-sources user/,
+        /--setting-sources user(?:\s|$)/,
       )
     } finally {
       await sbx.destroy()

--- a/packages/ai-claude-code/tests/translate.test.ts
+++ b/packages/ai-claude-code/tests/translate.test.ts
@@ -40,6 +40,7 @@ const init: AgentSdkMessage = {
   session_id: 'sess-abc',
   model: 'claude-opus-4-6',
   tools: ['Bash', 'Read'],
+  skills: ['repo-search'],
   cwd: '/tmp',
 }
 
@@ -106,8 +107,20 @@ describe('translateSdkStream', () => {
         sessionId: 'sess-abc',
         model: 'claude-opus-4-6',
         tools: ['Bash', 'Read'],
+        skills: ['repo-search'],
       },
     })
+  })
+
+  it('uses an empty skill list when the SDK init message omits skills', async () => {
+    const { skills: _skills, ...initWithoutSkills } = init
+    const chunks = await collect([
+      initWithoutSkills,
+      assistantText('hi'),
+      resultSuccess,
+    ])
+    const custom = chunks.find((c) => c.type === 'CUSTOM')
+    expect(custom).toMatchObject({ value: { skills: [] } })
   })
 
   it('maps usage onto RUN_FINISHED including cache token details', async () => {


### PR DESCRIPTION
`claudeCodeText` gets a `settingSources` option, and the `claude-code.session-id` event now reports the skills Claude Code loaded. The default is `['project']`. With it, workspace projections (instructions, skills, MCP config) reach Claude Code, and a local-process run does not load the host's `~/.claude`.

## 🎯 Changes

- Add `settingSources?: Array<'user' | 'project' | 'local'>` to `ClaudeCodeTextConfig`. The adapter passes it to `--setting-sources`.
- Default to `['project']`. Claude Code reads `CLAUDE.md`, `.claude/skills`, and `.mcp.json` only when `project` is in the sources. The old hard-coded `user` skipped every workspace projection and pulled the host's `~/.claude` into local-process runs.
- Forward the init message's `skills` list on the `claude-code.session-id` event. The list is empty when the CLI omits it.
- Install projected plugins with `claude plugin install --scope project`, so they load under the default.
- Docs: `docs/adapters/claude-code.md` (option table, settings paragraph, `skills` on the event). Changeset: minor.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

**Commands run.**

- `pnpm exec nx run-many --targets=build,test:lib,test:types,test:oxlint,test:build --projects=@tanstack/ai-claude-code`: 63 tests pass, types, lint, and publint clean.
- `pnpm test:docs` and `pnpm test:kiira`: no broken links, 1144 snippets pass.
- `pnpm exec oxfmt --check` on the changed files: clean.
- `pnpm test:pr`: passed (79 projects, exit 0).

Live checks against `claude` 2.1.241 with a `.claude/settings.json`, a `.claude/skills/repo-skill`, and a `CLAUDE.md` in the cwd:

| `--setting-sources` | repo skill loaded | `CLAUDE.md` loaded | host `~/.claude` skills |
| --- | --- | --- | --- |
| `user` | no | no | 142 |
| `project` | yes | yes | 0 |

**Manual test.** Needs `claude login` on the host.

1. Build: `pnpm exec nx run-many --targets=build --projects=@tanstack/ai-claude-code,@tanstack/ai-sandbox-local-process`
2. Save the script below as `packages/ai-claude-code/manual.mjs`.
3. From `packages/ai-claude-code`, run `node manual.mjs`. Expect `MARKER42: true` and a small skills count (built-ins only).
4. Run `node manual.mjs user`. Expect `MARKER42: false` and your host's skills count.

<details>
<summary>manual.mjs</summary>

```js
import { chat } from '@tanstack/ai'
import { claudeCodeText, SESSION_ID_EVENT } from '@tanstack/ai-claude-code'
import { defineSandbox, defineWorkspace, withSandbox } from '@tanstack/ai-sandbox'
import { localProcessSandbox } from '@tanstack/ai-sandbox-local-process'

const settingSources = process.argv[2]?.split(',')

const sandbox = defineSandbox({
  id: `manual-${process.argv[2] ?? 'default'}`,
  provider: localProcessSandbox({}),
  workspace: defineWorkspace({
    source: { type: 'none' },
    instructions: 'Always include the exact token MARKER42 in every reply.',
  }),
})

const stream = chat({
  adapter: claudeCodeText('haiku', {
    authMode: 'host',
    maxTurns: 1,
    ...(settingSources ? { settingSources } : {}),
  }),
  messages: [{ role: 'user', content: 'say ok' }],
  middleware: [withSandbox(sandbox)],
})

let text = ''
for await (const chunk of stream) {
  if (chunk.type === 'TEXT_MESSAGE_CONTENT') text += chunk.delta
  if (chunk.type === 'CUSTOM' && chunk.name === SESSION_ID_EVENT) {
    console.log('skills loaded:', chunk.value.skills.length)
  }
}
console.log('MARKER42:', text.includes('MARKER42'))
```

</details>

**How this PR makes testing easy.** `tests/text-adapter.test.ts` covers the default source and an explicit list. `tests/translate.test.ts` covers `skills` present and absent. The script above runs the full `chat()` + `withSandbox` path.

## Linked issues

Closes #1113

## Risk / rollback

This is a behavior change for every `claudeCodeText` user. Project settings now apply, and user settings do not. A cloned repo's `.claude/settings.json` and hooks now run inside the sandbox. To keep the old behavior, pass `settingSources: ['user']`. To undo, revert this PR.

## Public API change

**Before**

```ts
const adapter = claudeCodeText('claude-opus-4-8')
// Always `--setting-sources user`. No way to change it.
```

**After**

```ts
const adapter = claudeCodeText('claude-opus-4-8', {
  settingSources: ['user', 'project', 'local'], // optional, default ['project']
})

// The session event now carries the loaded skills.
useChat({
  onCustomEvent: (name, value) => {
    if (name === 'claude-code.session-id') console.log(value.skills)
  },
})
```
