### PR TITLE
fix(ai-client): use threadId as the only client identity

### DIFF
--- a/.changeset/ssr-thread-identity.md
+++ b/.changeset/ssr-thread-identity.md
@@ -1,0 +1,11 @@
+---
+'@tanstack/ai-client': patch
+'@tanstack/ai-react': patch
+'@tanstack/ai-preact': patch
+'@tanstack/ai-vue': patch
+'@tanstack/ai-solid': patch
+'@tanstack/ai-svelte': patch
+'@tanstack/ai-angular': patch
+---
+
+Mint omitted `threadId` after the view mounts, not during render. DevTools binds the hook row to `threadId`. Persistence that is on (`true` or a storage adapter) requires a `threadId` at compile time, and throws at runtime if it is missing. Chat and generation clients no longer accept a separate `id` option. Use `threadId`.

--- a/docs/api/ai-angular.md
+++ b/docs/api/ai-angular.md
@@ -52,8 +52,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client` (minus internal state cal
 - `fetcher?` - Direct async function for one-shot generation (alternative to `connection`)
 - `tools?` - Array of client tool implementations (with `.client()` method)
 - `initialMessages?` - Initial messages array
-- `id?` - Unique identifier for this chat instance
-- `threadId?` - Thread ID for AG-UI run correlation. Persists across sends; auto-generated if omitted
+- `threadId?` - The only identity for this chat. Required when persistence is on. If omitted, minted after mount.
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field. Reactive — accepts a plain value, an Angular `Signal`, or a zero-arg getter; changes sync automatically via `effect`
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire. Reactive (same forms as `forwardedProps`)
 - `context?` - Typed client-local runtime context passed to client tool implementations. Reactive (same forms). This value is not serialized to the server
@@ -380,7 +379,7 @@ export class CustomGenerationComponent {
 }
 ```
 
-**Options:** `connection?`, `fetcher?`, `id?`, `body?` (reactive), `devtools?`, `onResult?`, `onError?`, `onProgress?`, `onChunk?`
+**Options:** `connection?`, `fetcher?`, `threadId?`, `body?` (reactive), `devtools?`, `onResult?`, `onError?`, `onProgress?`, `onChunk?`
 
 **Returns:** `generate`, `result`, `isLoading`, `error`, `status`, `stop`, `reset`, `runId`. All reactive state is a read-only `Signal<T>`.
 

--- a/docs/api/ai-client.md
+++ b/docs/api/ai-client.md
@@ -95,8 +95,7 @@ goes away. Users of the framework hooks need no change.
 
 - `connection` - Connection adapter for streaming
 - `initialMessages?` - Initial messages array
-- `id?` - Unique identifier for this chat instance
-- `threadId?` - Thread ID for AG-UI run correlation. Persists across sends; auto-generated if omitted
+- `threadId?` - The only identity for this chat. Required when persistence is on. If omitted, minted after mount.
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works — values are merged into `forwardedProps` on the wire and mirrored under the legacy `data` field for backward compatibility
 - `context?` - Typed client-local runtime context passed to client tool implementations. This value is not serialized to the server

--- a/docs/api/ai-preact.md
+++ b/docs/api/ai-preact.md
@@ -73,8 +73,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client`:
 - `connection` - Connection adapter (required)
 - `tools?` - Array of client tool implementations (with `.client()` method)
 - `initialMessages?` - Initial messages array
-- `id?` - Unique identifier for this chat instance
-- `threadId?` - Thread ID for AG-UI run correlation. Persists across sends; auto-generated if omitted
+- `threadId?` - The only identity for this chat. Required when persistence is on. If omitted, minted after mount.
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field (e.g., `{ provider: 'openai', model: 'gpt-4o' }`)
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire
 - `context?` - Typed client-local runtime context passed to client tool implementations. This value is not serialized to the server

--- a/docs/api/ai-react.md
+++ b/docs/api/ai-react.md
@@ -83,8 +83,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client`:
 - `connection` - Connection adapter (required)
 - `tools?` - Array of client tool implementations (with `.client()` method)
 - `initialMessages?` - Initial messages array
-- `id?` - Unique identifier for this chat instance
-- `threadId?` - Thread ID for AG-UI run correlation. Persists across sends; auto-generated if omitted
+- `threadId?` - The only identity for this chat. Required when persistence is on. If omitted, minted after mount.
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field (e.g., `{ provider: 'openai', model: 'gpt-4o' }`)
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire
 - `context?` - Typed client-local runtime context passed to client tool implementations. This value is not serialized to the server

--- a/docs/api/ai-solid.md
+++ b/docs/api/ai-solid.md
@@ -74,8 +74,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client`:
 - `connection` - Connection adapter (required)
 - `tools?` - Array of client tool implementations (with `.client()` method)
 - `initialMessages?` - Initial messages array
-- `id?` - Unique identifier for this chat instance
-- `threadId?` - Thread ID for AG-UI run correlation. Persists across sends; auto-generated if omitted
+- `threadId?` - The only identity for this chat. Required when persistence is on. If omitted, minted after mount.
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field (e.g., `{ provider: 'openai', model: 'gpt-4o' }`)
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire
 - `context?` - Typed client-local runtime context passed to client tool implementations. This value is not serialized to the server

--- a/docs/api/ai-svelte.md
+++ b/docs/api/ai-svelte.md
@@ -72,8 +72,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client` (minus internal state cal
 - `connection` - Connection adapter (required)
 - `tools?` - Array of client tool implementations (with `.client()` method)
 - `initialMessages?` - Initial messages array
-- `id?` - Unique identifier for this chat instance
-- `threadId?` - Thread ID for AG-UI run correlation. Persists across sends; auto-generated if omitted
+- `threadId?` - The only identity for this chat. Required when persistence is on. If omitted, minted after mount.
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field (e.g., `{ provider: 'openai', model: 'gpt-4o' }`)
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire
 - `context?` - Typed client-local runtime context passed to client tool implementations. This value is not serialized to the server
@@ -297,7 +296,7 @@ const gen = createGeneration({
 // gen.result, gen.isLoading, gen.error, gen.status
 ```
 
-**Options:** `connection?`, `fetcher?`, `id?`, `body?`, `onResult?`, `onError?`, `onProgress?`, `onChunk?`
+**Options:** `connection?`, `fetcher?`, `threadId?`, `body?`, `onResult?`, `onError?`, `onProgress?`, `onChunk?`
 
 **Returns:** `generate`, `result`, `isLoading`, `error`, `status`, `stop`, `reset`, `runId`, `updateBody` -- all state properties are reactive getters.
 

--- a/docs/api/ai-vue.md
+++ b/docs/api/ai-vue.md
@@ -70,8 +70,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client` (minus internal state cal
 - `connection` - Connection adapter (required)
 - `tools?` - Array of client tool implementations (with `.client()` method)
 - `initialMessages?` - Initial messages array
-- `id?` - Unique identifier for this chat instance
-- `threadId?` - Thread ID for AG-UI run correlation. Persists across sends; auto-generated if omitted
+- `threadId?` - The only identity for this chat. Required when persistence is on. If omitted, minted after mount.
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field (reactive -- changes are synced automatically via `watch`)
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire (reactive)
 - `context?` - Typed client-local runtime context passed to client tool implementations (reactive). This value is not serialized to the server
@@ -314,7 +313,7 @@ const { generate, result, isLoading, error, status, stop, reset } =
   });
 ```
 
-**Options:** `connection?`, `fetcher?`, `id?`, `body?`, `onResult?`, `onError?`, `onProgress?`, `onChunk?`
+**Options:** `connection?`, `fetcher?`, `threadId?`, `body?`, `onResult?`, `onError?`, `onProgress?`, `onChunk?`
 
 **Returns:** `generate`, `result`, `isLoading`, `error`, `status`, `stop`, `reset`, `runId` -- all reactive state is `DeepReadonly<ShallowRef<T>>`.
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -29,7 +29,7 @@
           "label": "Devtools",
           "to": "getting-started/devtools",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-22"
+          "updatedAt": "2026-08-19"
         },
         {
           "label": "Quick Start: Vue",
@@ -284,7 +284,8 @@
         {
           "label": "Id Map",
           "to": "persistence/id-map",
-          "addedAt": "2026-08-04"
+          "addedAt": "2026-08-04",
+          "updatedAt": "2026-08-19"
         },
         {
           "label": "Keep Generated Files",
@@ -410,7 +411,7 @@
           "label": "Generations",
           "to": "media/generations",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-08-04"
+          "updatedAt": "2026-08-19"
         },
         {
           "label": "Realtime Voice Chat",
@@ -446,7 +447,7 @@
           "label": "Image Generation",
           "to": "media/image-generation",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-08-18"
+          "updatedAt": "2026-08-19"
         },
         {
           "label": "Video Generation",
@@ -458,7 +459,7 @@
           "label": "Generation Hooks",
           "to": "media/generation-hooks",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-30"
+          "updatedAt": "2026-08-19"
         }
       ]
     },
@@ -752,43 +753,43 @@
           "label": "@tanstack/ai-client",
           "to": "api/ai-client",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-08-04"
+          "updatedAt": "2026-08-19"
         },
         {
           "label": "@tanstack/ai-react",
           "to": "api/ai-react",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-08"
+          "updatedAt": "2026-08-19"
         },
         {
           "label": "@tanstack/ai-solid",
           "to": "api/ai-solid",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-08"
+          "updatedAt": "2026-08-19"
         },
         {
           "label": "@tanstack/ai-preact",
           "to": "api/ai-preact",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-08"
+          "updatedAt": "2026-08-19"
         },
         {
           "label": "@tanstack/ai-vue",
           "to": "api/ai-vue",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-30"
+          "updatedAt": "2026-08-19"
         },
         {
           "label": "@tanstack/ai-svelte",
           "to": "api/ai-svelte",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-30"
+          "updatedAt": "2026-08-19"
         },
         {
           "label": "@tanstack/ai-angular",
           "to": "api/ai-angular",
           "addedAt": "2026-06-15",
-          "updatedAt": "2026-07-30"
+          "updatedAt": "2026-08-19"
         }
       ]
     },

--- a/docs/getting-started/devtools.md
+++ b/docs/getting-started/devtools.md
@@ -58,7 +58,7 @@ import { fetchServerSentEvents, useGenerateImage } from '@tanstack/ai-react'
 
 export function ImageStudio() {
   const image = useGenerateImage({
-    id: 'generation-hooks:useGenerateImage',
+    threadId: 'generation-hooks:useGenerateImage',
     connection: fetchServerSentEvents('/api/image'),
     devtools: {
       name: 'Image Studio',

--- a/docs/media/generation-hooks.md
+++ b/docs/media/generation-hooks.md
@@ -397,7 +397,7 @@ function EmbeddingGenerator() {
 |--------|------|-------------|
 | `connection` | `ConnectConnectionAdapter` | Streaming transport (SSE, HTTP stream, custom) |
 | `fetcher` | `GenerationFetcher<TInput, TResult>` | Direct async function (no streaming protocol needed) |
-| `id` | `string` | Unique identifier for this generation instance |
+| `threadId` | `string` | Stable scope for this generation. Required when `persistence` is on. Optional for ephemeral runs. |
 | `body` | `Record<string, any>` | Additional body parameters sent with connection requests |
 | `onResult` | `(result: TResult) => TOutput \| null \| void` | Transform or react to results |
 | `onError` | `(error: Error) => void` | Error callback |

--- a/docs/media/generations.md
+++ b/docs/media/generations.md
@@ -250,7 +250,7 @@ All generation hooks share the same interface:
 |--------|------|-------------|
 | `connection` | `ConnectionAdapter` | Streaming transport (SSE, HTTP stream, custom) |
 | `fetcher` | `(input) => Promise<Result \| Response>` | Direct async function, or server function returning an SSE `Response` |
-| `id` | `string` | Unique identifier for this instance |
+| `threadId` | `string` | Stable scope for this generation. Required when `persistence` is on. Optional for ephemeral runs. |
 | `body` | `Record<string, any>` | Additional body parameters (connection mode) |
 | `onResult` | `(result) => T \| null \| void` | Transform or react to the result |
 | `onError` | `(error) => void` | Error callback |

--- a/docs/media/image-generation.md
+++ b/docs/media/image-generation.md
@@ -460,7 +460,7 @@ The `useGenerateImage` hook accepts:
 | ------------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `connection` | `ConnectionAdapter`                                     | Streaming transport (SSE, HTTP stream, custom)                                                 |
 | `fetcher`    | `(input) => Promise<ImageGenerationResult \| Response>` | Direct async function, or server function returning an SSE `Response`                          |
-| `id`         | `string`                                                | Unique identifier for this instance                                                            |
+| `threadId`   | `string`                                                | Stable scope for this generation. Required when `persistence` is on. Optional for ephemeral runs. |
 | `body`       | `Record<string, any>`                                   | Additional body parameters (connection mode)                                                   |
 | `onResult`   | `(result) => TOutput \| null \| void`                   | Callback when images are generated. Optionally return a transformed value to store as `result` |
 | `onError`    | `(error) => void`                                       | Callback on error                                                                              |

--- a/docs/persistence/id-map.md
+++ b/docs/persistence/id-map.md
@@ -27,6 +27,14 @@ broken.
 Persistence stores and restores by `threadId`. `runId` is what you read when you
 need to talk to your own server about the execution happening right now.
 
+If you omit `threadId`, the client mints one after the view mounts. That
+ephemeral id is the wire thread and the DevTools row for this session. A reload
+starts a new conversation. Persistence needs an explicit `threadId` from your
+app.
+
+Do not pass a separate `id`. `threadId` is the only identity on chat and
+generation clients.
+
 ```tsx
 import {
   fetchServerSentEvents,
@@ -251,10 +259,10 @@ option. Chat is the same shape: the `threadId` you pass `useChat` is the one
 
 ## When you can skip `threadId`
 
-Without persistence, `threadId` is optional. The hooks fall back to a generated id
-purely to satisfy the protocol, which requires a thread id on the wire. The run
-works, it just cannot be found again, which is fine for a one-shot image you show
-and forget.
+Without persistence, `threadId` is optional. After the view mounts, the client
+mints an ephemeral thread id to satisfy the protocol. That id is also the
+DevTools row for the session. The run works, it just cannot be found again,
+which is fine for a one-shot image you show and forget.
 
 Turn `persistence` on and `threadId` becomes required, on the hook and on the
 activity the middleware wraps. `withGenerationPersistence` throws when neither

--- a/packages/ai-angular/src/inject-chat.ts
+++ b/packages/ai-angular/src/inject-chat.ts
@@ -41,8 +41,6 @@ import type {
 const EMPTY_INTERRUPTS = Object.freeze([])
 const EMPTY_INTERRUPT_ERRORS = Object.freeze([])
 
-let nextId = 0
-
 export function injectChat<
   const TTools extends ReadonlyArray<AnyClientTool> = any,
   TSchema extends SchemaInput | undefined = undefined,
@@ -61,7 +59,6 @@ export function injectChat<
 
   const destroyRef = inject(DestroyRef)
   const injector = inject(Injector)
-  const clientId = options.id || `injectChat-${nextId++}`
 
   const messages = signal<Array<UIMessage<TTools>>>(
     options.initialMessages || [],
@@ -100,18 +97,21 @@ export function injectChat<
   const client = new ChatClient<TTools, TContext>({
     devtoolsBridgeFactory: createChatDevtoolsBridge,
     ...transport,
-    id: clientId,
     ...(options.initialMessages !== undefined && {
       initialMessages: options.initialMessages,
     }),
-    ...(options.persistence !== undefined && {
-      persistence: options.persistence,
-    }),
+    ...(typeof options.threadId === 'string' && options.persistence
+      ? {
+          persistence: options.persistence,
+          threadId: options.threadId,
+        }
+      : {
+          ...(options.threadId !== undefined && { threadId: options.threadId }),
+        }),
     ...(options.initialResumeSnapshot !== undefined && {
       initialResumeSnapshot: options.initialResumeSnapshot,
     }),
     ...(bodySource !== undefined && { body: bodySource() }),
-    ...(options.threadId !== undefined && { threadId: options.threadId }),
     ...(forwardedPropsSource !== undefined && {
       forwardedProps: forwardedPropsSource(),
     }),

--- a/packages/ai-angular/src/inject-generate-audio.ts
+++ b/packages/ai-angular/src/inject-generate-audio.ts
@@ -32,10 +32,6 @@ export interface InjectGenerateAudioOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for audio generation */
   fetcher?: GenerationFetcher<AudioGenerateInput, AudioGenerationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests. Reactive. */
   body?: ReactiveOption<Record<string, any>>
   /** Display options for TanStack AI Devtools. */
@@ -110,7 +106,7 @@ export interface InjectGenerateAudioResult<
 export function injectGenerateAudio<TTransformed = void>(
   options: Omit<
     InjectGenerateAudioOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: AudioGenerationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-angular/src/inject-generate-image.ts
+++ b/packages/ai-angular/src/inject-generate-image.ts
@@ -33,7 +33,7 @@ export interface InjectGenerateImageResult<
 export function injectGenerateImage<TTransformed = void>(
   options: Omit<
     InjectGenerateImageOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: ImageGenerationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-angular/src/inject-generate-speech.ts
+++ b/packages/ai-angular/src/inject-generate-speech.ts
@@ -34,7 +34,7 @@ export interface InjectGenerateSpeechResult<TOutput = TTSResult> extends Omit<
 export function injectGenerateSpeech<TTransformed = void>(
   options: Omit<
     InjectGenerateSpeechOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TTSResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-angular/src/inject-generate-video.ts
+++ b/packages/ai-angular/src/inject-generate-video.ts
@@ -25,12 +25,9 @@ import type {
 } from '@tanstack/ai-client'
 import type { StreamChunk } from '@tanstack/ai'
 
-let nextId = 0
-
 export interface InjectGenerateVideoOptions<TOutput = VideoGenerateResult> {
   connection?: ConnectConnectionAdapter
   fetcher?: GenerationFetcher<VideoGenerateInput, VideoGenerateResult>
-  id?: string
   body?: ReactiveOption<Record<string, any>>
   devtools?: AIDevtoolsDisplayOptions
   /**
@@ -52,8 +49,8 @@ export interface InjectGenerateVideoOptions<TOutput = VideoGenerateResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -103,7 +100,7 @@ export interface InjectGenerateVideoResult<TOutput = VideoGenerateResult> {
 export function injectGenerateVideo<TTransformed = void>(
   options: Omit<
     InjectGenerateVideoOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: VideoGenerateResult) => TTransformed
   } & GenerationPersistenceOptions,
@@ -132,15 +129,18 @@ export function injectGenerateVideo<TTransformed = void>(
   const bodySource =
     options.body !== undefined ? toReactive(options.body) : undefined
 
-  // Identity: pass `threadId` alone when set (never also pass deprecated `id`).
   const baseOptions = {
     ...(bodySource !== undefined && { body: bodySource() }),
-    ...(options.threadId !== undefined
-      ? { threadId: options.threadId }
-      : { id: options.id ?? `injectGenerateVideo-${nextId++}` }),
-    ...(options.persistence !== undefined && {
-      persistence: options.persistence,
-    }),
+    ...(typeof options.threadId === 'string' && options.persistence
+      ? {
+          persistence: options.persistence,
+          threadId: options.threadId,
+        }
+      : {
+          ...(options.threadId !== undefined && {
+            threadId: options.threadId,
+          }),
+        }),
     ...(options.hydrateGeneration !== undefined && {
       hydrateGeneration: options.hydrateGeneration,
     }),

--- a/packages/ai-angular/src/inject-generation.ts
+++ b/packages/ai-angular/src/inject-generation.ts
@@ -24,17 +24,11 @@ import type {
 } from '@tanstack/ai-client'
 import type { ReactiveOption } from './internal/to-reactive'
 
-let nextId = 0
-
 export interface InjectGenerationOptions<TInput, TResult, TOutput = TResult> {
   /** Connect-based adapter for streaming transport (SSE, HTTP stream, custom) */
   connection?: ConnectConnectionAdapter
   /** Direct async function for one-shot generation (no streaming protocol needed) */
   fetcher?: GenerationFetcher<TInput, TResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional request body params. Reactive. */
   body?: ReactiveOption<Record<string, any>>
   /** Display options for TanStack AI Devtools. */
@@ -58,8 +52,8 @@ export interface InjectGenerationOptions<TInput, TResult, TOutput = TResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -145,7 +139,7 @@ export function injectGeneration<
 >(
   options: Omit<
     InjectGenerationOptions<TInput, TResult>,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TResult) => TTransformed
   } & GenerationPersistenceOptions,
@@ -170,15 +164,11 @@ export function injectGeneration<
   const bodySource =
     options.body !== undefined ? toReactive(options.body) : undefined
 
-  // Identity: pass `threadId` alone when set (never also pass deprecated `id`).
-  const clientOptions: GenerationClientOptions<TInput, TResult, TOutput> = {
+  const clientOptions: Omit<
+    GenerationClientOptions<TInput, TResult, TOutput>,
+    'persistence' | 'threadId'
+  > = {
     ...(bodySource !== undefined && { body: bodySource() }),
-    ...(options.threadId !== undefined
-      ? { threadId: options.threadId }
-      : { id: options.id ?? `injectGeneration-${nextId++}` }),
-    ...(options.persistence !== undefined && {
-      persistence: options.persistence,
-    }),
     ...(options.hydrateGeneration !== undefined && {
       hydrateGeneration: options.hydrateGeneration,
     }),
@@ -224,15 +214,29 @@ export function injectGeneration<
     },
   }
 
+  const persistenceProps =
+    typeof options.threadId === 'string' && options.persistence
+      ? {
+          persistence: options.persistence,
+          threadId: options.threadId,
+        }
+      : {
+          ...(options.threadId !== undefined && {
+            threadId: options.threadId,
+          }),
+        }
+
   let client: GenerationClient<TInput, TResult, TOutput>
   if (options.connection) {
     client = new GenerationClient({
       ...clientOptions,
+      ...persistenceProps,
       connection: options.connection,
     })
   } else if (options.fetcher) {
     client = new GenerationClient({
       ...clientOptions,
+      ...persistenceProps,
       fetcher: options.fetcher,
     })
   } else {

--- a/packages/ai-angular/src/inject-summarize.ts
+++ b/packages/ai-angular/src/inject-summarize.ts
@@ -33,7 +33,7 @@ export interface InjectSummarizeResult<
 export function injectSummarize<TTransformed = void>(
   options: Omit<
     InjectSummarizeOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: SummarizationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-angular/src/inject-transcription.ts
+++ b/packages/ai-angular/src/inject-transcription.ts
@@ -37,7 +37,7 @@ export interface InjectTranscriptionResult<
 export function injectTranscription<TTransformed = void>(
   options: Omit<
     InjectTranscriptionOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TranscriptionResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -274,8 +274,8 @@ export class ChatClient<
 > {
   private readonly processor: StreamProcessor
   private connection: SubscribeConnectionAdapter
-  private readonly uniqueId: string
-  private readonly threadId: string
+  private uniqueId: string
+  private threadId: string
   // Durable chat persistence (optional): messages + resume snapshot as one
   // combined record, so a full page reload restores the transcript, rehydrates
   // pending interrupts, and rejoins an in-flight run. Clear-during-stream
@@ -410,12 +410,12 @@ export class ChatClient<
   }
 
   constructor(options: ChatClientOptions<TTools, TContext>) {
-    this.threadId = options.threadId || this.generateUniqueId('thread')
-    // The instance/devtools id defaults to the threadId (the chat's identity),
-    // falling back to a generated id only when neither is set. `id` overrides it
-    // only for direct ChatClient users who key storage separately from the wire
-    // thread; the framework hooks never pass it.
-    this.uniqueId = options.id || this.threadId
+    // Do not mint a random thread id during construct. Framework hooks build
+    // this client during render (SSR included). The wire/devtools identity is
+    // `threadId`; it is assigned here when the caller passed one, or later in
+    // `ensureThreadId()` from attach / mount / send.
+    this.threadId = options.threadId || ''
+    this.uniqueId = this.threadId
     // `persistence` is `false`/omitted (ephemeral, in-memory), `true`
     // (server-authoritative: cache nothing client-side, hydrate the thread from
     // the server by `threadId` on mount), or a storage adapter
@@ -424,17 +424,24 @@ export class ChatClient<
     // the mount hydration and keeps a client record from shadowing server history.
     let cachesMessages = true
     if (options.persistence === true) {
+      if (!options.threadId) {
+        throw new Error(
+          '[TanStack AI] persistence needs a stable `threadId` to key on. Pass a threadId from your app (for example support-42).',
+        )
+      }
       cachesMessages = false
     } else if (options.persistence) {
       // A storage adapter: keep the combined record (transcript + resume pointer)
       // in the browser. Persistence keys on `threadId` (the conversation
-      // identity) so a reload with the same `threadId` finds the same record;
-      // `id` overrides it only when set, for apps that key storage separately
-      // from the wire thread.
-      const persistenceKey = options.id ?? this.threadId
+      // identity) so a reload with the same `threadId` finds the same record.
+      if (!options.threadId) {
+        throw new Error(
+          '[TanStack AI] persistence needs a stable `threadId` to key on. Pass a threadId from your app (for example support-42).',
+        )
+      }
       this.persistor = new ChatPersistor(
         options.persistence,
-        persistenceKey,
+        options.threadId,
         (messages) => this.processor.setMessages(messages),
         (snapshot) => this.applyPersistedResume(snapshot),
       )
@@ -798,6 +805,7 @@ export class ChatClient<
    */
   attach(): void {
     if (this.disposed || this.tailing) return
+    this.ensureThreadId()
     this.tailing = true
 
     // Full page reload with an in-flight run persisted (synchronous store):
@@ -973,12 +981,21 @@ export class ChatClient<
   }
 
   mountDevtools(): void {
+    this.ensureThreadId()
     if (this.devtoolsMounted) {
       return
     }
 
     this.devtoolsMounted = true
     this.devtoolsBridge.mountWithTools(this.processor.getMessages().length)
+  }
+
+  private ensureThreadId(): string {
+    if (!this.threadId) {
+      this.threadId = this.generateUniqueId('thread')
+    }
+    this.uniqueId = this.threadId
+    return this.threadId
   }
 
   /**
@@ -1398,10 +1415,17 @@ export class ChatClient<
   private buildDevtoolsBridgeOptions(
     devtools: ChatClientOptions['devtools'],
   ): ChatDevtoolsBridgeOptions {
+    const client = this
     return {
-      hookId: this.uniqueId,
-      clientId: this.uniqueId,
-      threadId: this.threadId,
+      get hookId() {
+        return client.uniqueId
+      },
+      get clientId() {
+        return client.uniqueId
+      },
+      get threadId() {
+        return client.threadId
+      },
       metadata: {
         hookName: devtools?.hookName ?? 'useChat',
         outputKind: devtools?.outputKind ?? 'chat',

--- a/packages/ai-client/src/devtools.ts
+++ b/packages/ai-client/src/devtools.ts
@@ -450,7 +450,6 @@ function getActiveBridgeRegistry(): Map<string, ActiveDevtoolsBridge> {
 
 export class ClientDevtoolsBridge<TSnapshot extends object> {
   protected readonly options: AIDevtoolsBridgeOptions<TSnapshot>
-  private readonly bridgeId: string
   private readonly unsubscribers: Array<Unsubscribe> = []
   private disposed = false
   private superseded = false
@@ -458,7 +457,6 @@ export class ClientDevtoolsBridge<TSnapshot extends object> {
 
   constructor(options: AIDevtoolsBridgeOptions<TSnapshot>) {
     this.options = options
-    this.bridgeId = createBridgeId(options.hookId)
   }
 
   emitRegistered(): void {
@@ -569,6 +567,12 @@ export class ClientDevtoolsBridge<TSnapshot extends object> {
 
     this.disposed = true
     if (!this.registered) {
+      this.deactivate()
+      return
+    }
+
+    const live = getActiveBridgeRegistry().get(this.options.hookId)
+    if (live !== this) {
       this.deactivate()
       return
     }
@@ -718,7 +722,6 @@ export class ClientDevtoolsBridge<TSnapshot extends object> {
       visibility,
       clientId: this.options.clientId,
       hookId: this.options.hookId,
-      correlationId: this.bridgeId,
       ...(this.options.threadId ? { threadId: this.options.threadId } : {}),
       ...(context.runId ? { runId: context.runId } : {}),
       timestamp: Date.now(),
@@ -740,25 +743,6 @@ export class ClientDevtoolsBridge<TSnapshot extends object> {
         : {}),
     }
   }
-}
-
-let bridgeIdSequence = 0
-
-function createBridgeId(hookId: string): string {
-  const cryptoLike = (
-    globalThis as {
-      crypto?: {
-        randomUUID?: () => string
-      }
-    }
-  ).crypto
-
-  if (cryptoLike?.randomUUID) {
-    return `bridge:${hookId}:${cryptoLike.randomUUID()}`
-  }
-
-  bridgeIdSequence += 1
-  return `bridge:${hookId}:${bridgeIdSequence}`
 }
 
 // Owns the chat-client devtools surface so the chat client itself stays a

--- a/packages/ai-client/src/generation-client.ts
+++ b/packages/ai-client/src/generation-client.ts
@@ -26,9 +26,11 @@ import type {
   GenerationClientOptions,
   GenerationClientState,
   GenerationFetcher,
+  GenerationPersistenceOptions,
   GenerationRestoredResult,
   GenerationResumeSnapshot,
   GenerationResumeState,
+  GenerationTransport,
 } from './generation-types'
 
 /**
@@ -108,10 +110,10 @@ export class GenerationClient<
   private readonly joinRunHandler:
     | ConnectConnectionAdapter['joinRun']
     | undefined
-  private readonly uniqueId: string
+  private uniqueId: string
   private readonly devtoolsMetadata: AIDevtoolsClientMetadata
   private readonly devtoolsBridge: GenerationDevtoolsBridge<TOutput>
-  private readonly threadId: string
+  private threadId: string
   private readonly persistenceScope: string | undefined
   // Server-driven mode (`persistence: true`): no local snapshot store; on mount
   // the client hydrates the last generation for `threadId` from the server.
@@ -133,26 +135,20 @@ export class GenerationClient<
   private serverHydrationStarted = false
 
   constructor(
-    options: GenerationClientOptions<TInput, TResult, TOutput> &
-      (
-        | { connection: ConnectConnectionAdapter; fetcher?: never }
-        | {
-            fetcher: GenerationFetcher<TInput, TResult>
-            connection?: never
-          }
-      ),
+    options: Omit<
+      GenerationClientOptions<TInput, TResult, TOutput>,
+      'persistence' | 'threadId'
+    > &
+      GenerationPersistenceOptions &
+      GenerationTransport<TInput, TResult>,
   ) {
-    // `threadId` is the single identity. Deprecated `id` is only a fallback
-    // when no threadId is given (ephemeral runs / legacy call sites).
-    this.uniqueId =
-      options.threadId ?? options.id ?? this.generateUniqueId('generation')
-    // AG-UI requires a thread id on every run, so fall back to uniqueId. The
-    // generated fallback is for the WIRE ONLY: it is not stable across reloads,
-    // so persistence must never key on it — see `persistenceScope` below.
-    this.threadId = options.threadId ?? this.uniqueId
-    // The persistence scope: the explicit `threadId` and nothing else. The
-    // types require it whenever `persistence` is set; this field keeps the
-    // fallback from silently becoming a storage key for JS callers.
+    // `threadId` is the only identity. Do not mint a random id during
+    // construct: hooks build this client during render.
+    this.threadId = options.threadId ?? ''
+    this.uniqueId = this.threadId
+    // The persistence scope is the explicit `threadId` and nothing else.
+    // The types require it whenever `persistence` is set. This field keeps a
+    // generated wire id from becoming a storage key for JS callers.
     this.persistenceScope = options.threadId
     this.connection = options.connection
     this.fetcher = options.fetcher
@@ -199,10 +195,17 @@ export class GenerationClient<
   }
 
   private buildDevtoolsBridgeOptions(): GenerationDevtoolsBridgeOptions<TOutput> {
+    const client = this
     return {
-      hookId: this.uniqueId,
-      clientId: this.uniqueId,
-      threadId: this.threadId,
+      get hookId() {
+        return client.uniqueId
+      },
+      get clientId() {
+        return client.uniqueId
+      },
+      get threadId() {
+        return client.threadId
+      },
       metadata: this.devtoolsMetadata,
       getCoreState: () => ({
         input: this.input,
@@ -216,6 +219,7 @@ export class GenerationClient<
   }
 
   mountDevtools(): void {
+    this.ensureThreadId()
     // Mounting revives a disposed client. Framework hooks call this from
     // their mount effect, so a dispose → remount cycle (e.g. React
     // StrictMode's mount → cleanup → mount replay against the same memoized
@@ -627,6 +631,14 @@ export class GenerationClient<
       ...(metadata?.outputKind ? { outputKind: metadata.outputKind } : {}),
       ...(metadata?.name ? { name: metadata.name } : {}),
     }
+  }
+
+  private ensureThreadId(): string {
+    if (!this.threadId) {
+      this.threadId = this.generateUniqueId('generation')
+    }
+    this.uniqueId = this.threadId
+    return this.threadId
   }
 
   private generateUniqueId(prefix: string): string {

--- a/packages/ai-client/src/generation-types.ts
+++ b/packages/ai-client/src/generation-types.ts
@@ -201,27 +201,23 @@ export interface GenerationResumeSnapshot {
 }
 
 /**
- * The `persistence` / `threadId` / `id` identity shared by every generation hook.
+ * The `persistence` / `threadId` identity shared by every generation hook.
  *
  * Turning persistence on **requires** a `threadId`, the stable scope runs are
  * filed under. Without one the client would hydrate by a generated id that
  * changes every reload, so nothing would ever restore; making it a type error
  * means the compiler asks for the scope instead of the runtime inventing one.
  *
- * `threadId` is the single identity for the hook, the AG-UI wire thread, and
- * persistence. Legacy `id` is deprecated and typed `never` whenever
- * `threadId` is supplied — pass one scope, not two.
+ * `threadId` is the only identity for the hook, the AG-UI wire thread, and
+ * persistence. There is no separate instance `id`.
  *
- * Ephemeral generations (no `persistence`, or `persistence: false`) may still
- * pass a deprecated `id` when they have no `threadId`, as a wire/devtools
- * fallback. Prefer giving them a `threadId` instead.
- *
- * USAGE: intersect this onto a hook's parameter and subtract the three keys
- * from the options interface, leaving that interface a plain (non-union)
+ * USAGE: intersect this onto a hook's parameter and subtract `persistence`
+ * and `threadId` from the options interface (plus any other keys the hook
+ * redeclares, such as `onResult`), leaving that interface a plain (non-union)
  * object so `Pick` / `Omit` composition elsewhere keeps working:
  *
  * ```ts
- * options: Omit<UseGenerateImageOptions, 'onResult' | 'persistence' | 'threadId' | 'id'> & {
+ * options: Omit<UseGenerateImageOptions, 'onResult' | 'persistence' | 'threadId'> & {
  *   onResult?: (result: ImageGenerationResult) => TTransformed
  * } & GenerationPersistenceOptions
  * ```
@@ -233,31 +229,13 @@ export interface GenerationResumeSnapshot {
 export type GenerationPersistenceOptions =
   | {
       persistence: true
-      /** Required by `persistence` — the stable scope runs are filed under. */
+      /** Required by `persistence`. The stable scope runs are filed under. */
       threadId: string
-      /**
-       * @deprecated Prefer `threadId`. Not allowed when `threadId` is set —
-       * `threadId` is the single identity for the hook, the wire, and persistence.
-       */
-      id?: never
     }
   | {
       persistence?: false | undefined
-      /** Stable scope for the generation slot (also the wire / devtools identity). */
-      threadId: string
-      /**
-       * @deprecated Prefer `threadId`. Not allowed when `threadId` is set.
-       */
-      id?: never
-    }
-  | {
-      persistence?: false | undefined
-      threadId?: undefined
-      /**
-       * @deprecated Prefer `threadId` as the single identity. Only allowed when
-       * `threadId` is omitted — legacy wire/devtools fallback for ephemeral runs.
-       */
-      id?: string
+      /** Stable scope for the generation slot (also the wire / DevTools identity). */
+      threadId?: string
     }
 
 // ===========================
@@ -331,27 +309,18 @@ export type GenerationTransport<TInput, TResult> =
 // eslint-disable-next-line @typescript-eslint/naming-convention -- _TInput is unused in the interface body but part of the public positional generic API (callers supply it for inference)
 export interface GenerationClientOptions<_TInput, TResult, TOutput = TResult> {
   /**
-   * @deprecated Prefer {@link GenerationClientOptions.threadId}. Legacy instance
-   * id used only as a wire/devtools fallback when `threadId` is omitted. When
-   * both are passed, `threadId` wins and `id` is ignored. Framework hooks type
-   * `id` as `never` whenever `threadId` is set — see
-   * {@link GenerationPersistenceOptions}.
-   */
-  id?: string
-
-  /**
    * The **scope** this generation belongs to: a stable, app-chosen name for the
    * slot successive runs fill, not a link to a chat conversation. This is the
-   * single identity for the client — wire thread id, devtools hook id, and
+   * only identity for the client: wire thread id, DevTools hook id, and
    * persistence key.
    *
-   * A generation hook starts empty and produces many runs over its life — each
+   * A generation hook starts empty and produces many runs over its life. Each
    * run gets its own `runId`, but they all belong to one scope. Persistence
    * keys on this: server-driven hydrates the last run for it on mount. It is
    * also sent as the AG-UI thread id on the wire, since the protocol requires
    * one.
    *
-   * Derive it from your own domain — it must be meaningful before any media
+   * Derive it from your own domain. It must be meaningful before any media
    * exists and identical after a reload:
    *
    * ```ts
@@ -360,9 +329,8 @@ export interface GenerationClientOptions<_TInput, TResult, TOutput = TResult> {
    *
    * **Required whenever `persistence` is set.** An app that cannot name the
    * scope has nothing to restore *to*, and a generated fallback would key each
-   * reload differently — silently restoring nothing. Optional only for
-   * ephemeral runs, where it falls back to deprecated `id` (or a generated id)
-   * purely to satisfy the wire and nothing is written.
+   * reload differently, silently restoring nothing. Optional only for
+   * ephemeral runs. If omitted, the client mints a wire id after mount.
    */
   threadId?: string
 

--- a/packages/ai-client/src/index.ts
+++ b/packages/ai-client/src/index.ts
@@ -30,6 +30,7 @@ export type {
   ChatClientPersistence,
   ChatPersistedState,
   ChatPersistenceOption,
+  ChatPersistenceOptions,
   ChatStorageAdapter,
   ChatClientOptions,
   ChatPendingInterrupt,

--- a/packages/ai-client/src/types.ts
+++ b/packages/ai-client/src/types.ts
@@ -628,6 +628,36 @@ export type ChatPersistenceOption<
   TTools extends ReadonlyArray<AnyClientTool> = any,
 > = boolean | ChatClientPersistence<TTools>
 
+/**
+ * The `persistence` / `threadId` pairing for `ChatClient` and the chat hooks.
+ *
+ * Persistence that is on (`true` or a storage adapter) requires a `threadId`.
+ * A minted id changes every reload, so nothing would restore. The compiler
+ * asks for the conversation id instead.
+ *
+ * Omit `persistence`, or set it to `false`, and `threadId` stays optional.
+ * The client then mints one after mount for the wire and DevTools.
+ *
+ * Intersect this onto `ChatClientOptions`. Do not apply a later plain `Omit`
+ * to that type: it collapses the union and the requirement disappears. Use
+ * {@link DistributedOmit}.
+ */
+export type ChatPersistenceOptions<
+  TTools extends ReadonlyArray<AnyClientTool> = any,
+> =
+  | {
+      persistence: true
+      threadId: string
+    }
+  | {
+      persistence: ChatClientPersistence<TTools>
+      threadId: string
+    }
+  | {
+      persistence?: false | undefined
+      threadId?: string
+    }
+
 type IsUnknown<T> = unknown extends T
   ? [T] extends [unknown]
     ? true
@@ -717,43 +747,6 @@ export interface ChatClientBaseOptions<
    * Initial messages to populate the chat
    */
   initialMessages?: Array<UIMessage<TTools>>
-
-  /**
-   * How this chat persists across reloads. See {@link ChatPersistenceOption}.
-   *
-   * - Omit or `false`: ephemeral, in-memory only.
-   * - `true`: server-authoritative. The client caches nothing and hydrates the
-   *   thread from the server by its `threadId` on mount (needs a connection with
-   *   a `hydrate` handler). Big transcripts never touch the browser, and the same
-   *   thread opens the same way on another device.
-   * - a {@link ChatClientPersistence} adapter: client-authoritative. The combined
-   *   {@link ChatPersistedState} record (transcript plus resume pointer) is cached
-   *   in the browser, restoring the transcript, pending interrupts, and an
-   *   in-flight run on reload.
-   *
-   * Use `initialResumeSnapshot` for a host-supplied in-memory rehydrate instead.
-   */
-  persistence?: ChatPersistenceOption<TTools>
-
-  /**
-   * Optional storage-key override for this chat instance, and the devtools
-   * instance id. Persistence keys on `threadId` by default; set `id` only when
-   * you need the persisted record keyed separately from the wire thread.
-   * Prefer a stable `threadId` for the common case.
-   *
-   * The framework hooks (`useChat` / `createChat`) do NOT expose `id`: a hook's
-   * identity is its `threadId`. This lower-level escape hatch exists only for
-   * direct `ChatClient` construction.
-   */
-  id?: string
-
-  /**
-   * The conversation id for this chat, stable across sends and reloads. It is
-   * the AG-UI thread key on the wire AND the key client persistence stores the
-   * conversation under, so set a stable `threadId` to have a reload restore the
-   * same conversation. If omitted, a unique thread id is generated per session.
-   */
-  threadId?: string
 
   /**
    * Initial resumable run state, useful when rehydrating a persisted client
@@ -932,14 +925,16 @@ export interface ChatClientBaseOptions<
 
 /**
  * Options for `ChatClient`. Exactly one of `connection` or `fetcher` must be
- * provided — the type-level XOR is enforced via `ChatTransport`.
+ * provided — the type-level XOR is enforced via `ChatTransport`. Persistence
+ * that is on requires a `threadId` via {@link ChatPersistenceOptions}.
  */
 export type ChatClientOptions<
   TTools extends ReadonlyArray<AnyClientTool> = any,
   TContext = InferredClientContext<TTools>,
 > = DistributedOmit<ChatClientBaseOptions<TTools, TContext>, 'context'> &
   ClientContextOptionFromTools<TTools, TContext> &
-  ChatTransport
+  ChatTransport &
+  ChatPersistenceOptions<TTools>
 
 export interface ChatRequestBody {
   messages: Array<ModelMessage>

--- a/packages/ai-client/src/video-generation-client.ts
+++ b/packages/ai-client/src/video-generation-client.ts
@@ -25,8 +25,10 @@ import type {
 import type {
   GenerationClientState,
   GenerationFetcher,
+  GenerationPersistenceOptions,
   GenerationResumeSnapshot,
   GenerationResumeState,
+  GenerationTransport,
   VideoGenerateInput,
   VideoGenerateResult,
   VideoGenerationClientOptions,
@@ -111,10 +113,10 @@ export class VideoGenerationClient<TOutput = VideoGenerateResult> {
   private readonly fetcher:
     | GenerationFetcher<VideoGenerateInput, VideoGenerateResult>
     | undefined
-  private readonly uniqueId: string
+  private uniqueId: string
   private readonly devtoolsMetadata: AIDevtoolsClientMetadata
   private readonly devtoolsBridge: VideoDevtoolsBridge<TOutput>
-  private readonly threadId: string
+  private threadId: string
   // Server-driven mode (`persistence: true`): no local snapshot store; on mount
   // the client hydrates the last generation for `threadId` from the server.
   private readonly serverDriven: boolean = false
@@ -137,22 +139,17 @@ export class VideoGenerationClient<TOutput = VideoGenerateResult> {
   private serverHydrationStarted = false
 
   constructor(
-    options: VideoGenerationClientOptions<TOutput> &
-      (
-        | { connection: ConnectConnectionAdapter; fetcher?: never }
-        | {
-            fetcher: GenerationFetcher<VideoGenerateInput, VideoGenerateResult>
-            connection?: never
-          }
-      ),
+    options: Omit<
+      VideoGenerationClientOptions<TOutput>,
+      'persistence' | 'threadId'
+    > &
+      GenerationPersistenceOptions &
+      GenerationTransport<VideoGenerateInput, VideoGenerateResult>,
   ) {
-    // `threadId` is the single identity. Deprecated `id` is only a fallback
-    // when no threadId is given (ephemeral runs / legacy call sites).
-    this.uniqueId =
-      options.threadId ?? options.id ?? this.generateUniqueId('video')
-    // The wire/hydration thread key. Server-driven mode needs a stable key, so
-    // prefer an explicit `threadId`, then legacy `id`, then a generated id.
-    this.threadId = options.threadId ?? this.uniqueId
+    // `threadId` is the only identity. Do not mint a random id during
+    // construct: hooks build this client during render.
+    this.threadId = options.threadId ?? ''
+    this.uniqueId = this.threadId
     this.connection = options.connection
     this.fetcher = options.fetcher
     this.hydrateGenerationHandler = options.hydrateGeneration
@@ -192,10 +189,17 @@ export class VideoGenerationClient<TOutput = VideoGenerateResult> {
   }
 
   private buildDevtoolsBridgeOptions(): VideoDevtoolsBridgeOptions<TOutput> {
+    const client = this
     return {
-      hookId: this.uniqueId,
-      clientId: this.uniqueId,
-      threadId: this.threadId,
+      get hookId() {
+        return client.uniqueId
+      },
+      get clientId() {
+        return client.uniqueId
+      },
+      get threadId() {
+        return client.threadId
+      },
       metadata: this.devtoolsMetadata,
       getCoreState: () => ({
         input: this.input,
@@ -211,6 +215,7 @@ export class VideoGenerationClient<TOutput = VideoGenerateResult> {
   }
 
   mountDevtools(): void {
+    this.ensureThreadId()
     // Mounting revives a disposed client. Framework hooks call this from
     // their mount effect, so a dispose → remount cycle (e.g. React
     // StrictMode's mount → cleanup → mount replay against the same memoized
@@ -675,6 +680,14 @@ export class VideoGenerationClient<TOutput = VideoGenerateResult> {
       ...(metadata?.framework ? { framework: metadata.framework } : {}),
       ...(metadata?.name ? { name: metadata.name } : {}),
     }
+  }
+
+  private ensureThreadId(): string {
+    if (!this.threadId) {
+      this.threadId = this.generateUniqueId('video')
+    }
+    this.uniqueId = this.threadId
+    return this.threadId
   }
 
   private generateUniqueId(prefix: string): string {

--- a/packages/ai-client/tests/chat-client-identity.test.ts
+++ b/packages/ai-client/tests/chat-client-identity.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ChatClient } from '../src/chat-client'
+import { createMockPersistence, createTextChunks } from './test-utils'
+import type {
+  ConnectConnectionAdapter,
+  RunAgentInputContext,
+} from '../src/connection-adapters'
+
+function createCapturingAdapter(chunks = createTextChunks('ok')): {
+  runContexts: Array<RunAgentInputContext>
+  adapter: ConnectConnectionAdapter
+} {
+  const runContexts: Array<RunAgentInputContext> = []
+  return {
+    runContexts,
+    adapter: {
+      async *connect(_messages, _data, abortSignal, runContext) {
+        if (runContext) {
+          runContexts.push(runContext)
+        }
+        for (const chunk of chunks) {
+          if (abortSignal?.aborted) {
+            return
+          }
+          yield chunk
+        }
+      },
+    },
+  }
+}
+
+describe('ChatClient identity', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('does not call crypto.randomUUID or Math.random in the constructor', () => {
+    const randomUUID = vi.fn(() => {
+      throw new Error('crypto.randomUUID during construct')
+    })
+    vi.stubGlobal('crypto', { randomUUID })
+    const mathRandom = vi.spyOn(Math, 'random')
+
+    expect(() => {
+      new ChatClient({
+        connection: createCapturingAdapter().adapter,
+      })
+    }).not.toThrow()
+
+    expect(randomUUID).not.toHaveBeenCalled()
+    expect(mathRandom).not.toHaveBeenCalled()
+  })
+
+  it('mints a thread id on first send when none is provided, and reuses it', async () => {
+    const { adapter, runContexts } = createCapturingAdapter()
+    const client = new ChatClient({ connection: adapter })
+
+    await client.sendMessage('first')
+    await client.sendMessage('second')
+
+    expect(runContexts).toHaveLength(2)
+    expect(runContexts[0]?.threadId).toMatch(/^thread-/)
+    expect(runContexts[1]?.threadId).toBe(runContexts[0]?.threadId)
+  })
+
+  it('uses the provided threadId on the wire', async () => {
+    const { adapter, runContexts } = createCapturingAdapter()
+    const client = new ChatClient({
+      connection: adapter,
+      threadId: 'support-42',
+    })
+
+    await client.sendMessage('hello')
+
+    expect(runContexts[0]?.threadId).toBe('support-42')
+  })
+
+  it('throws when persistence is set without a threadId', () => {
+    expect(() => {
+      // @ts-expect-error threadId is required whenever persistence is on
+      new ChatClient({
+        connection: createCapturingAdapter().adapter,
+        persistence: createMockPersistence(),
+      })
+    }).toThrow(/persistence needs a stable `threadId`/)
+  })
+
+  it('throws when persistence: true is set without a threadId', () => {
+    expect(() => {
+      // @ts-expect-error threadId is required whenever persistence is on
+      new ChatClient({
+        connection: createCapturingAdapter().adapter,
+        persistence: true,
+      })
+    }).toThrow(/persistence needs a stable `threadId`/)
+  })
+})

--- a/packages/ai-client/tests/chat-client.test.ts
+++ b/packages/ai-client/tests/chat-client.test.ts
@@ -92,7 +92,7 @@ describe('ChatClient', () => {
 
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -106,7 +106,7 @@ describe('ChatClient', () => {
 
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -120,7 +120,7 @@ describe('ChatClient', () => {
 
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         initialMessages: [initialMessage],
         persistence: persistence,
       })
@@ -134,7 +134,7 @@ describe('ChatClient', () => {
 
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         initialMessages: [initialMessage],
         persistence: persistence,
       })
@@ -148,7 +148,7 @@ describe('ChatClient', () => {
 
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         initialMessages: [initialMessage],
         persistence: persistence,
       })
@@ -162,7 +162,7 @@ describe('ChatClient', () => {
 
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         initialMessages: [initialMessage],
         persistence: persistence,
       })
@@ -181,7 +181,7 @@ describe('ChatClient', () => {
 
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         initialMessages: [initialMessage],
         onMessagesChange,
         persistence: persistence,
@@ -207,7 +207,7 @@ describe('ChatClient', () => {
 
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         initialMessages: [initialMessage],
         persistence: persistence,
       })
@@ -245,14 +245,13 @@ describe('ChatClient', () => {
       expect(client.getMessages()).toEqual([initialMessage])
     })
 
-    it('should use provided id or generate one', async () => {
+    it('should generate unique message ids', async () => {
       const adapter = createMockConnectionAdapter({
         chunks: createTextChunks('Response'),
       })
 
       const client1 = new ChatClient({
         connection: adapter,
-        id: 'custom-id',
       })
 
       const client2 = new ChatClient({
@@ -432,7 +431,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -527,7 +526,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -661,7 +660,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -785,7 +784,7 @@ describe('ChatClient', () => {
       // with a no-op message adapter (no durable resume storage on this branch).
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: {
           getItem: vi.fn(() => undefined),
           setItem: vi.fn(),
@@ -865,7 +864,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -918,7 +917,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
         onError,
       })
@@ -1036,7 +1035,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -1129,7 +1128,7 @@ describe('ChatClient', () => {
       const persistence = createPersistence(undefined)
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -1198,7 +1197,7 @@ describe('ChatClient', () => {
       const persistence = createPersistence(undefined)
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -1254,7 +1253,7 @@ describe('ChatClient', () => {
       const persistence = createPersistence(undefined)
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -1322,7 +1321,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: createPersistence(),
       })
 
@@ -1390,7 +1389,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -2084,7 +2083,7 @@ describe('ChatClient', () => {
         const persistence = createPersistence()
         const client = new ChatClient({
           connection,
-          id: 'chat-1',
+          threadId: 'chat-1',
           persistence: persistence,
         })
 
@@ -2457,7 +2456,7 @@ describe('ChatClient', () => {
       const persistence = createPersistence()
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -2510,7 +2509,7 @@ describe('ChatClient', () => {
       const persistence = createPersistence()
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -2549,7 +2548,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -2595,7 +2594,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -2645,7 +2644,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection: createMockConnectionAdapter(),
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -2668,7 +2667,7 @@ describe('ChatClient', () => {
       const persistence = createPersistence()
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -2685,7 +2684,7 @@ describe('ChatClient', () => {
       const persistence = createPersistence()
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -2707,7 +2706,7 @@ describe('ChatClient', () => {
       }
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         persistence: persistence,
       })
 
@@ -2756,7 +2755,7 @@ describe('ChatClient', () => {
 
       const client = new ChatClient({
         connection: adapter,
-        id: 'chat-1',
+        threadId: 'chat-1',
         initialMessages: [initialMessage],
         onMessagesChange,
         persistence: persistence,
@@ -3503,7 +3502,6 @@ describe('ChatClient', () => {
 
       const client = new ChatClient({
         connection: adapter,
-        id: 'my-conversation',
       })
 
       await client.sendMessage('Hello')

--- a/packages/ai-client/tests/chat-persistence-types.test.ts
+++ b/packages/ai-client/tests/chat-persistence-types.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Type-level tests for the `persistence` / `threadId` pairing on ChatClient.
+ * These assertions are pure types. They never construct a client at runtime.
+ *
+ * Persistence that is on (`true` or a storage adapter) requires a `threadId`.
+ * Do not apply a plain `Omit` to `ChatClientOptions` later: that collapses the
+ * union and the requirement disappears. Use `DistributedOmit`.
+ */
+
+import { describe, it } from 'vitest'
+import { createChatClientOptions } from '../src/types'
+import type { ChatClientOptions, ChatClientPersistence } from '../src/types'
+
+const connection = {
+  async *connect() {},
+}
+const persistence = {} as ChatClientPersistence
+
+describe('ChatClient persistence requires a threadId', () => {
+  it('rejects persistence: true without a threadId', () => {
+    const _typeCheck = () => {
+      // @ts-expect-error threadId is required whenever persistence is on
+      createChatClientOptions({ connection, persistence: true })
+    }
+    void _typeCheck
+  })
+
+  it('rejects a storage adapter without a threadId', () => {
+    const _typeCheck = () => {
+      // @ts-expect-error threadId is required whenever persistence is on
+      createChatClientOptions({ connection, persistence })
+    }
+    void _typeCheck
+  })
+
+  it('accepts persistence when a threadId is supplied', () => {
+    const _typeCheck = () => {
+      createChatClientOptions({
+        connection,
+        persistence: true,
+        threadId: 'support-42',
+      })
+      createChatClientOptions({
+        connection,
+        persistence,
+        threadId: 'support-42',
+      })
+    }
+    void _typeCheck
+  })
+
+  it('leaves threadId optional for ephemeral chats', () => {
+    const _typeCheck = () => {
+      createChatClientOptions({ connection })
+      createChatClientOptions({ connection, persistence: false })
+      createChatClientOptions({ connection, threadId: 'support-42' })
+    }
+    void _typeCheck
+  })
+
+  it('rejects `id` next to a required `threadId`', () => {
+    const _typeCheck = () => {
+      createChatClientOptions({
+        connection,
+        persistence: true,
+        threadId: 'support-42',
+        // @ts-expect-error id is not a ChatClient option
+        id: 'legacy',
+      })
+    }
+    void _typeCheck
+  })
+
+  it('does not list `id` on ChatClientOptions. `threadId` is present', () => {
+    type Opts = ChatClientOptions<readonly []>
+    // @ts-expect-error id is not a ChatClient option
+    type _Id = Opts['id']
+    type _ThreadId = Opts['threadId']
+    const threadId: _ThreadId = 'support-42'
+    void threadId
+  })
+})

--- a/packages/ai-client/tests/devtools.test.ts
+++ b/packages/ai-client/tests/devtools.test.ts
@@ -103,7 +103,6 @@ describe('ChatClient devtools bridge', () => {
   })
 
   function createClient(options?: {
-    id?: string
     threadId?: string
     connection?: ConnectConnectionAdapter
     tools?: ReadonlyArray<AnyClientTool>
@@ -112,7 +111,6 @@ describe('ChatClient devtools bridge', () => {
     devtoolsName?: string
   }) {
     const client = new ChatClient({
-      id: options?.id ?? 'chat-1',
       threadId: options?.threadId ?? 'thread-1',
       connection: options?.connection ?? createMockConnectionAdapter(),
       ...(options?.tools ? { tools: options.tools } : {}),
@@ -169,7 +167,7 @@ describe('ChatClient devtools bridge', () => {
 
   function dispatchToolFixture(overrides: Partial<AIDevtoolsToolFixture> = {}) {
     const fixture: AIDevtoolsToolFixture = {
-      hookId: 'chat-1',
+      hookId: 'thread-1',
       threadId: 'thread-1',
       runId: 'run-fixture',
       toolName: 'weather',
@@ -265,13 +263,62 @@ describe('ChatClient devtools bridge', () => {
       [
         'hook:registered',
         expect.objectContaining({
-          hookId: 'chat-1',
+          hookId: 'thread-1',
           lifecycle: 'mounted',
         }),
       ],
     ])
 
     client.dispose()
+  })
+
+  it('binds hook identity to threadId', () => {
+    const client = createClient({
+      threadId: 'support-42',
+    })
+
+    expect(eventClientMock.emitted('hook:registered')).toEqual([
+      [
+        'hook:registered',
+        expect.objectContaining({
+          hookId: 'support-42',
+          clientId: 'support-42',
+          threadId: 'support-42',
+        }),
+      ],
+    ])
+    const payload = eventClientMock.emitted('hook:registered')[0]?.[1]
+    expect(payload).toEqual(
+      expect.not.objectContaining({ correlationId: expect.anything() }),
+    )
+
+    client.dispose()
+  })
+
+  it('does not unregister a superseded client that shares a threadId', () => {
+    const first = createClient({
+      threadId: 'support-42',
+    })
+    const second = createClient({
+      threadId: 'support-42',
+    })
+
+    eventClientMock.emit.mockClear()
+    first.dispose()
+
+    expect(eventClientMock.emitted('hook:unregistered')).toEqual([])
+
+    second.dispose()
+
+    expect(eventClientMock.emitted('hook:unregistered')).toEqual([
+      [
+        'hook:unregistered',
+        expect.objectContaining({
+          hookId: 'support-42',
+          threadId: 'support-42',
+        }),
+      ],
+    ])
   })
 
   it('registers the chat hook and emits the initial state snapshot', () => {
@@ -285,8 +332,8 @@ describe('ChatClient devtools bridge', () => {
         timestamp: expect.any(Number),
         source: 'client',
         visibility: 'client-state',
-        hookId: 'chat-1',
-        clientId: 'chat-1',
+        hookId: 'thread-1',
+        clientId: 'thread-1',
         threadId: 'thread-1',
         hookName: 'useChat',
         framework: 'react',
@@ -301,8 +348,8 @@ describe('ChatClient devtools bridge', () => {
         eventType: 'hook:state-snapshot',
         source: 'client',
         visibility: 'client-state',
-        hookId: 'chat-1',
-        clientId: 'chat-1',
+        hookId: 'thread-1',
+        clientId: 'thread-1',
         threadId: 'thread-1',
         hookName: 'useChat',
         framework: 'react',
@@ -325,7 +372,7 @@ describe('ChatClient devtools bridge', () => {
     expect(aiEventClient.emit).toHaveBeenCalledWith(
       'hook:registered',
       expect.objectContaining({
-        hookId: 'chat-1',
+        hookId: 'thread-1',
         hookName: 'useChat',
         displayName: 'Recipe Assistant',
       }),
@@ -333,7 +380,7 @@ describe('ChatClient devtools bridge', () => {
     expect(aiEventClient.emit).toHaveBeenCalledWith(
       'hook:state-snapshot',
       expect.objectContaining({
-        hookId: 'chat-1',
+        hookId: 'thread-1',
         hookName: 'useChat',
         displayName: 'Recipe Assistant',
       }),
@@ -357,7 +404,7 @@ describe('ChatClient devtools bridge', () => {
     expect(aiEventClient.emit).toHaveBeenCalledWith(
       'tools:registered',
       expect.objectContaining({
-        hookId: 'chat-1',
+        hookId: 'thread-1',
         hookName: 'useChat',
         framework: 'react',
         outputKind: 'chat',
@@ -382,14 +429,14 @@ describe('ChatClient devtools bridge', () => {
     vi.clearAllMocks()
 
     eventClientMock.dispatch('devtools:request-state', {
-      targetHookId: 'chat-1',
+      targetHookId: 'thread-1',
     })
 
     expect(aiEventClient.emit).toHaveBeenCalledWith(
       'hook:registered',
       expect.objectContaining({
-        hookId: 'chat-1',
-        clientId: 'chat-1',
+        hookId: 'thread-1',
+        clientId: 'thread-1',
         threadId: 'thread-1',
         hookName: 'useChat',
         outputKind: 'chat',
@@ -398,15 +445,15 @@ describe('ChatClient devtools bridge', () => {
     expect(aiEventClient.emit).toHaveBeenCalledWith(
       'tools:registered',
       expect.objectContaining({
-        hookId: 'chat-1',
+        hookId: 'thread-1',
         tools: [],
       }),
     )
     expect(aiEventClient.emit).toHaveBeenCalledWith(
       'hook:state-snapshot',
       expect.objectContaining({
-        hookId: 'chat-1',
-        clientId: 'chat-1',
+        hookId: 'thread-1',
+        clientId: 'thread-1',
         threadId: 'thread-1',
         state: expect.objectContaining({
           messages: [],
@@ -426,7 +473,7 @@ describe('ChatClient devtools bridge', () => {
     expect(eventClientMock.emitAIDevtoolsEvent).toHaveBeenCalledWith(
       'hook:registered',
       expect.objectContaining({
-        hookId: 'chat-1',
+        hookId: 'thread-1',
         threadId: 'thread-1',
         hookName: 'useChat',
         lifecycle: 'mounted',
@@ -435,13 +482,13 @@ describe('ChatClient devtools bridge', () => {
 
     eventClientMock.emitAIDevtoolsEvent.mockClear()
     eventClientMock.dispatch('devtools:request-state', {
-      targetHookId: 'chat-1',
+      targetHookId: 'thread-1',
     })
 
     expect(eventClientMock.emitAIDevtoolsEvent).toHaveBeenCalledWith(
       'hook:registered',
       expect.objectContaining({
-        hookId: 'chat-1',
+        hookId: 'thread-1',
         threadId: 'thread-1',
         hookName: 'useChat',
         lifecycle: 'mounted',
@@ -450,7 +497,7 @@ describe('ChatClient devtools bridge', () => {
     expect(eventClientMock.emitAIDevtoolsEvent).toHaveBeenCalledWith(
       'hook:state-snapshot',
       expect.objectContaining({
-        hookId: 'chat-1',
+        hookId: 'thread-1',
         threadId: 'thread-1',
         state: expect.objectContaining({
           messages: [],
@@ -517,7 +564,7 @@ describe('ChatClient devtools bridge', () => {
     expect(aiEventClient.emit).toHaveBeenCalledWith(
       'devtools:tool-fixture:applied',
       expect.objectContaining({
-        hookId: 'chat-1',
+        hookId: 'thread-1',
         threadId: 'thread-1',
         runId: 'run-fixture',
         toolName: fixture.toolName,
@@ -531,7 +578,7 @@ describe('ChatClient devtools bridge', () => {
     expect(aiEventClient.emit).toHaveBeenCalledWith(
       'text:message:created',
       expect.objectContaining({
-        hookId: 'chat-1',
+        hookId: 'thread-1',
         threadId: 'thread-1',
         runId: 'run-fixture',
         toolCallId: 'fixture-call',
@@ -756,13 +803,17 @@ describe('ChatClient devtools bridge', () => {
   })
 
   it('routes hook-scoped fixture events to the latest bridge for a hook id', async () => {
-    const staleClient = createClient({ threadId: 'thread-stale' })
-    const activeClient = createClient({ threadId: 'thread-active' })
+    const staleClient = createClient({
+      threadId: 'shared-thread',
+    })
+    const activeClient = createClient({
+      threadId: 'shared-thread',
+    })
     vi.clearAllMocks()
 
     eventClientMock.dispatch('devtools:tool-fixture:apply', {
-      hookId: 'chat-1',
-      threadId: 'thread-stale',
+      hookId: 'shared-thread',
+      threadId: 'shared-thread',
       toolName: 'weather',
       input: { city: 'Paris' },
       output: { temperature: 21 },
@@ -797,13 +848,15 @@ describe('ChatClient devtools bridge', () => {
   it('keeps superseded duplicate hook bridges silent when they emit later', async () => {
     const runContexts: Array<RunAgentInputContext> = []
     const firstClient = createClient({
-      threadId: 'thread-first',
+      threadId: 'shared-thread',
       connection: createRunTrackingAdapter(
         [createTextChunks('from first', 'msg-first')],
         runContexts,
       ),
     })
-    const duplicateClient = createClient({ threadId: 'thread-duplicate' })
+    const duplicateClient = createClient({
+      threadId: 'shared-thread',
+    })
     vi.clearAllMocks()
 
     await firstClient.sendMessage('start')
@@ -821,8 +874,8 @@ describe('ChatClient devtools bridge', () => {
       [
         'hook:unregistered',
         expect.objectContaining({
-          hookId: 'chat-1',
-          threadId: 'thread-duplicate',
+          hookId: 'shared-thread',
+          threadId: 'shared-thread',
         }),
       ],
     ])
@@ -833,7 +886,7 @@ describe('ChatClient devtools bridge', () => {
     vi.clearAllMocks()
 
     const fixture: AIDevtoolsToolFixture = {
-      hookId: 'chat-1',
+      hookId: 'thread-1',
       threadId: 'thread-1',
       toolName: 'weather',
       input: { city: 'Rome' },
@@ -1048,7 +1101,7 @@ describe('ChatClient devtools bridge', () => {
       [
         'run:created',
         expect.objectContaining({
-          hookId: 'chat-1',
+          hookId: 'thread-1',
           threadId: 'thread-1',
           runId: runContext?.runId,
           status: 'created',
@@ -1059,7 +1112,7 @@ describe('ChatClient devtools bridge', () => {
       [
         'run:started',
         expect.objectContaining({
-          hookId: 'chat-1',
+          hookId: 'thread-1',
           threadId: 'thread-1',
           runId: runContext?.runId,
           status: 'started',
@@ -1070,7 +1123,7 @@ describe('ChatClient devtools bridge', () => {
       [
         'run:completed',
         expect.objectContaining({
-          hookId: 'chat-1',
+          hookId: 'thread-1',
           threadId: 'thread-1',
           runId: runContext?.runId,
           status: 'completed',
@@ -1216,8 +1269,8 @@ describe('ChatClient devtools bridge', () => {
       [
         'structured-output:started',
         expect.objectContaining({
-          hookId: 'chat-1',
-          clientId: 'chat-1',
+          hookId: 'thread-1',
+          clientId: 'thread-1',
           threadId: runContexts[0]?.threadId,
           runId: runContexts[0]?.runId,
           messageId: 'msg-structured',
@@ -1230,8 +1283,8 @@ describe('ChatClient devtools bridge', () => {
         [
           'structured-output:updated',
           expect.objectContaining({
-            hookId: 'chat-1',
-            clientId: 'chat-1',
+            hookId: 'thread-1',
+            clientId: 'thread-1',
             threadId: runContexts[0]?.threadId,
             runId: runContexts[0]?.runId,
             messageId: 'msg-structured',
@@ -1246,8 +1299,8 @@ describe('ChatClient devtools bridge', () => {
       [
         'structured-output:completed',
         expect.objectContaining({
-          hookId: 'chat-1',
-          clientId: 'chat-1',
+          hookId: 'thread-1',
+          clientId: 'thread-1',
           threadId: runContexts[0]?.threadId,
           runId: runContexts[0]?.runId,
           messageId: 'msg-structured',
@@ -1490,8 +1543,8 @@ describe('ChatClient devtools bridge', () => {
       [
         'structured-output:completed',
         expect.objectContaining({
-          hookId: 'chat-1',
-          clientId: 'chat-1',
+          hookId: 'thread-1',
+          clientId: 'thread-1',
           threadId: runContexts[0]?.threadId,
           runId: runContexts[0]?.runId,
           messageId: 'msg-structured-terminal',
@@ -1643,8 +1696,8 @@ describe('ChatClient devtools bridge', () => {
       [
         'tools:approval:requested',
         expect.objectContaining({
-          hookId: 'chat-1',
-          clientId: 'chat-1',
+          hookId: 'thread-1',
+          clientId: 'thread-1',
           threadId: runContexts[0]?.threadId,
           runId: runContexts[0]?.runId,
           streamId: expect.any(String),
@@ -1711,8 +1764,8 @@ describe('ChatClient devtools bridge', () => {
       [
         'tools:approval:responded',
         expect.objectContaining({
-          hookId: 'chat-1',
-          clientId: 'chat-1',
+          hookId: 'thread-1',
+          clientId: 'thread-1',
           toolCallId: 'approval-call-1',
           approvalId: 'approval-approval-call-1',
           approved: true,

--- a/packages/ai-client/tests/dispose-tail-leak.test.ts
+++ b/packages/ai-client/tests/dispose-tail-leak.test.ts
@@ -250,7 +250,6 @@ describe('dispose stops a late hydration from opening a tail', () => {
     }
 
     const client = mountedChatClient({
-      id: 'chat-1',
       threadId: 't1',
       connection,
       persistence: store.adapter,

--- a/packages/ai-client/tests/generation-devtools.test.ts
+++ b/packages/ai-client/tests/generation-devtools.test.ts
@@ -239,7 +239,7 @@ describe('generation client devtools bridge', () => {
 
   it('registers a generation hook and emits run lifecycle for fetcher mode', async () => {
     const client = new GenerationClient({
-      id: 'gen-1',
+      threadId: 'gen-1',
       fetcher: async () => ({ text: 'done' }),
       devtools: {
         framework: 'react',
@@ -291,7 +291,7 @@ describe('generation client devtools bridge', () => {
 
   it('includes input, progress, and renderable previews in generation snapshots', async () => {
     const client = new GenerationClient({
-      id: 'image-hook',
+      threadId: 'image-hook',
       fetcher: async () => ({
         id: 'img-1',
         model: 'image-model',
@@ -348,7 +348,7 @@ describe('generation client devtools bridge', () => {
     }
 
     const client = new GenerationClient({
-      id: 'summary-hook',
+      threadId: 'summary-hook',
       connection: { connect },
       devtools: {
         hookName: 'useSummarize',
@@ -399,7 +399,7 @@ describe('generation client devtools bridge', () => {
     }
 
     const client = new GenerationClient({
-      id: 'image-history',
+      threadId: 'image-history',
       connection: { connect },
       devtools: {
         hookName: 'useGenerateImage',
@@ -463,7 +463,7 @@ describe('generation client devtools bridge', () => {
 
   it('responds to devtools state requests for a generation hook', async () => {
     const client = new GenerationClient({
-      id: 'gen-1',
+      threadId: 'gen-1',
       fetcher: async () => ({ text: 'done' }),
       devtools: {
         framework: 'react',
@@ -505,7 +505,7 @@ describe('generation client devtools bridge', () => {
 
   it('emits errored run lifecycle for generation failures', async () => {
     const client = new GenerationClient({
-      id: 'gen-1',
+      threadId: 'gen-1',
       fetcher: async () => {
         throw new Error('Generation failed')
       },
@@ -555,7 +555,7 @@ describe('generation client devtools bridge', () => {
     const connectSpy = vi.fn(connect)
 
     const client = new GenerationClient({
-      id: 'gen-stream',
+      threadId: 'gen-stream',
       connection: {
         connect: connectSpy,
       },
@@ -616,7 +616,7 @@ describe('generation client devtools bridge', () => {
   it('does not emit hook updates after disposal', async () => {
     const deferred = createDeferred<{ text: string }>()
     const client = new GenerationClient({
-      id: 'gen-1',
+      threadId: 'gen-1',
       fetcher: async () => deferred.promise,
       devtools: {
         hookName: 'useGenerateText',
@@ -663,7 +663,7 @@ describe('generation client devtools bridge', () => {
     const connectSpy = vi.fn(connect)
 
     const client = new VideoGenerationClient({
-      id: 'video-stream',
+      threadId: 'video-stream',
       connection: {
         connect: connectSpy,
       },
@@ -698,7 +698,7 @@ describe('generation client devtools bridge', () => {
 
   it('registers a video hook and includes job state in snapshots', async () => {
     const client = new VideoGenerationClient({
-      id: 'video-1',
+      threadId: 'video-1',
       fetcher: async () => ({
         jobId: 'job-1',
         status: 'completed',
@@ -781,7 +781,7 @@ describe('generation client devtools bridge', () => {
     }
 
     const client = new VideoGenerationClient({
-      id: 'video-hook',
+      threadId: 'video-hook',
       connection: { connect },
       devtools: {
         hookName: 'useGenerateVideo',
@@ -857,7 +857,7 @@ describe('generation client devtools bridge', () => {
     }
 
     const client = new VideoGenerationClient({
-      id: 'video-history',
+      threadId: 'video-history',
       connection: { connect },
       devtools: {
         hookName: 'useGenerateVideo',

--- a/packages/ai-client/tests/generation-persistence-types.test.ts
+++ b/packages/ai-client/tests/generation-persistence-types.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Type-level tests for the `persistence` / `threadId` pairing on generation
+ * clients. These assertions are pure types. They never construct a client at
+ * runtime.
+ *
+ * Persistence that is on requires a `threadId`. Identity is only `threadId`.
+ * There is no instance `id`.
+ */
+
+import { describe, it } from 'vitest'
+import { GenerationClient } from '../src/generation-client'
+import { VideoGenerationClient } from '../src/video-generation-client'
+import type {
+  GenerationClientOptions,
+  VideoGenerationClientOptions,
+} from '../src/generation-types'
+
+const connection = {
+  async *connect() {},
+}
+
+describe('GenerationClient persistence requires a threadId', () => {
+  it('rejects persistence: true without a threadId', () => {
+    const _typeCheck = () => {
+      // @ts-expect-error threadId is required whenever persistence is on
+      new GenerationClient({ connection, persistence: true })
+      // @ts-expect-error threadId is required whenever persistence is on
+      new VideoGenerationClient({ connection, persistence: true })
+    }
+    void _typeCheck
+  })
+
+  it('accepts persistence when a threadId is supplied', () => {
+    const _typeCheck = () => {
+      new GenerationClient({
+        connection,
+        persistence: true,
+        threadId: 'product-123-hero',
+      })
+      new VideoGenerationClient({
+        connection,
+        persistence: true,
+        threadId: 'video-9-start-frame',
+      })
+    }
+    void _typeCheck
+  })
+
+  it('leaves threadId optional for ephemeral generations', () => {
+    const _typeCheck = () => {
+      new GenerationClient({ connection })
+      new GenerationClient({ connection, persistence: false })
+      new GenerationClient({ connection, threadId: 'product-123-hero' })
+      new VideoGenerationClient({ connection })
+      new VideoGenerationClient({ connection, persistence: false })
+    }
+    void _typeCheck
+  })
+
+  it('rejects `id` next to a required `threadId`', () => {
+    const _typeCheck = () => {
+      new GenerationClient({
+        connection,
+        persistence: true,
+        threadId: 'product-123-hero',
+        // @ts-expect-error id is not a generation option
+        id: 'legacy',
+      })
+      new VideoGenerationClient({
+        connection,
+        persistence: true,
+        threadId: 'video-9-start-frame',
+        // @ts-expect-error id is not a generation option
+        id: 'legacy',
+      })
+    }
+    void _typeCheck
+  })
+
+  it('does not list `id` on generation option types. `threadId` is present', () => {
+    type GenOpts = GenerationClientOptions<Record<string, unknown>, unknown>
+    // @ts-expect-error id is not a generation option
+    type _GenId = GenOpts['id']
+    // @ts-expect-error id is not a generation option
+    type _VideoId = VideoGenerationClientOptions['id']
+    const threadId: GenOpts['threadId'] = 'product-123-hero'
+    void threadId
+  })
+})

--- a/packages/ai-client/tests/resume-snapshot.test.ts
+++ b/packages/ai-client/tests/resume-snapshot.test.ts
@@ -220,7 +220,6 @@ describe('ChatClient auto-rejoin after reload', () => {
 
     let latest: Array<UIMessage> = []
     const client = mountedChatClient({
-      id: 'chat-1',
       threadId: 't1',
       connection,
       persistence: adapter,
@@ -585,7 +584,6 @@ describe('ChatClient auto-rejoin after reload', () => {
     }
     let status: string | undefined
     const client = mountedChatClient({
-      id: 'chat-quiet',
       threadId: 't1',
       connection,
       persistence: adapter,
@@ -632,7 +630,6 @@ describe('ChatClient auto-rejoin after reload', () => {
     }
     let status: string | undefined
     const client = mountedChatClient({
-      id: 'chat-dead',
       threadId: 't1',
       connection,
       persistence: adapter,
@@ -734,7 +731,6 @@ describe('ChatClient auto-rejoin after reload', () => {
     }
     const onError = vi.fn()
     const client = mountedChatClient({
-      id: 'chat-err',
       threadId: 't1',
       connection,
       persistence: adapter,

--- a/packages/ai-devtools/src/components/hooks/HookDetails.tsx
+++ b/packages/ai-devtools/src/components/hooks/HookDetails.tsx
@@ -531,9 +531,7 @@ const HookHeader: Component<{
             </span>
           </Show>
           {/* Prefer threadId as the user-facing identity (generation scope /
-              chat thread). Only show the raw registry id when it differs —
-              after the client prefers threadId over deprecated `id`, the two
-              often match and duplicating them is noise. */}
+              chat thread). Only show the raw registry id when it differs. */}
           <span data-testid="ai-devtools-hook-identity">
             {props.hook.threadId
               ? `thread ${props.hook.threadId}`

--- a/packages/ai-preact/src/types.ts
+++ b/packages/ai-preact/src/types.ts
@@ -73,10 +73,6 @@ export type UseChatOptions<
   | 'onRunIdChange'
   | 'context'
   | 'devtools'
-  // `id` is not a hook option: the hook's identity is its `threadId`, which is
-  // also the persistence key. Persist across reloads by passing a stable
-  // `threadId`; there is no separate id to set.
-  | 'id'
 > & {
   live?: boolean
   /** Display options for TanStack AI Devtools. */

--- a/packages/ai-preact/src/use-chat.ts
+++ b/packages/ai-preact/src/use-chat.ts
@@ -38,10 +38,9 @@ export function useChat<
   const TTools extends ReadonlyArray<AnyClientTool> = any,
   TContext = InferredClientContext<TTools>,
 >(options: UseChatOptions<TTools, TContext>): UseChatReturn<TTools> {
-  // The hook's identity is its `threadId` — also the persistence key, so a
-  // reload with the same `threadId` restores the same conversation. `hookId` is
-  // only a stable fallback for client-recreation keying when no `threadId` is
-  // given (an ephemeral chat), never a persistence key.
+  // The hook's identity is its `threadId`. Reload with the same `threadId`
+  // restores the same conversation. `hookId` is only a recreation key when no
+  // `threadId` is given. It is never sent on the wire.
   const hookId = useId()
   const clientId = options.threadId ?? hookId
 
@@ -122,14 +121,19 @@ export function useChat<
       ...transport,
       initialMessages: messagesToUse,
       ...(initialOptions.body !== undefined && { body: initialOptions.body }),
-      ...(initialOptions.threadId !== undefined && {
-        threadId: initialOptions.threadId,
-      }),
+      ...(typeof initialOptions.threadId === 'string' &&
+      initialOptions.persistence
+        ? {
+            persistence: initialOptions.persistence,
+            threadId: initialOptions.threadId,
+          }
+        : {
+            ...(initialOptions.threadId !== undefined && {
+              threadId: initialOptions.threadId,
+            }),
+          }),
       ...(initialOptions.forwardedProps !== undefined && {
         forwardedProps: initialOptions.forwardedProps,
-      }),
-      ...(initialOptions.persistence !== undefined && {
-        persistence: initialOptions.persistence,
       }),
       ...(initialOptions.initialResumeSnapshot !== undefined && {
         initialResumeSnapshot: initialOptions.initialResumeSnapshot,

--- a/packages/ai-react/src/types.ts
+++ b/packages/ai-react/src/types.ts
@@ -97,10 +97,6 @@ export type UseChatOptions<
   | 'onRunIdChange'
   | 'context'
   | 'devtools'
-  // `id` is not a hook option: the hook's identity is its `threadId`, which is
-  // also the persistence key. Persist across reloads by passing a stable
-  // `threadId`; there is no separate id to set.
-  | 'id'
 > & {
   /** Display options for TanStack AI Devtools. */
   devtools?: AIDevtoolsDisplayOptions

--- a/packages/ai-react/src/use-chat.ts
+++ b/packages/ai-react/src/use-chat.ts
@@ -39,10 +39,9 @@ export function useChat<
 >(
   options: UseChatOptions<TTools, TSchema, TContext>,
 ): UseChatReturn<TTools, TSchema> {
-  // The hook's identity is its `threadId` — also the persistence key, so a
-  // reload with the same `threadId` restores the same conversation. `hookId` is
-  // only a stable fallback for React's client-recreation keying when no
-  // `threadId` is given (an ephemeral chat), never a persistence key.
+  // The hook's identity is its `threadId`. Reload with the same `threadId`
+  // restores the same conversation. `hookId` is only a React recreation key
+  // when no `threadId` is given. It is never sent on the wire.
   const hookId = useId()
   const clientId = options.threadId ?? hookId
 
@@ -127,15 +126,20 @@ export function useChat<
       devtoolsBridgeFactory: createChatDevtoolsBridge,
       ...transport,
       initialMessages: messagesToUse,
+      ...(typeof initialOptions.threadId === 'string' &&
+      initialOptions.persistence
+        ? {
+            persistence: initialOptions.persistence,
+            threadId: initialOptions.threadId,
+          }
+        : {
+            ...(initialOptions.threadId !== undefined && {
+              threadId: initialOptions.threadId,
+            }),
+          }),
       ...(initialOptions.body !== undefined && { body: initialOptions.body }),
-      ...(initialOptions.threadId !== undefined && {
-        threadId: initialOptions.threadId,
-      }),
       ...(initialOptions.forwardedProps !== undefined && {
         forwardedProps: initialOptions.forwardedProps,
-      }),
-      ...(initialOptions.persistence !== undefined && {
-        persistence: initialOptions.persistence,
       }),
       ...(initialOptions.initialResumeSnapshot !== undefined && {
         initialResumeSnapshot: initialOptions.initialResumeSnapshot,

--- a/packages/ai-react/src/use-generate-audio.ts
+++ b/packages/ai-react/src/use-generate-audio.ts
@@ -21,10 +21,6 @@ export interface UseGenerateAudioOptions<TOutput = AudioGenerationResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function for audio generation */
   fetcher?: GenerationFetcher<AudioGenerateInput, AudioGenerationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -48,8 +44,8 @@ export interface UseGenerateAudioOptions<TOutput = AudioGenerationResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -144,7 +140,7 @@ export interface UseGenerateAudioReturn<TOutput = AudioGenerationResult> {
 export function useGenerateAudio<TTransformed = void>(
   options: Omit<
     UseGenerateAudioOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: AudioGenerationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-react/src/use-generate-image.ts
+++ b/packages/ai-react/src/use-generate-image.ts
@@ -21,10 +21,6 @@ export interface UseGenerateImageOptions<TOutput = ImageGenerationResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function for image generation */
   fetcher?: GenerationFetcher<ImageGenerateInput, ImageGenerationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -48,8 +44,8 @@ export interface UseGenerateImageOptions<TOutput = ImageGenerationResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -146,7 +142,7 @@ export interface UseGenerateImageReturn<TOutput = ImageGenerationResult> {
 export function useGenerateImage<TTransformed = void>(
   options: Omit<
     UseGenerateImageOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: ImageGenerationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-react/src/use-generate-speech.ts
+++ b/packages/ai-react/src/use-generate-speech.ts
@@ -21,10 +21,6 @@ export interface UseGenerateSpeechOptions<TOutput = TTSResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function for speech generation */
   fetcher?: GenerationFetcher<SpeechGenerateInput, TTSResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -48,8 +44,8 @@ export interface UseGenerateSpeechOptions<TOutput = TTSResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -140,7 +136,7 @@ export interface UseGenerateSpeechReturn<TOutput = TTSResult> {
 export function useGenerateSpeech<TTransformed = void>(
   options: Omit<
     UseGenerateSpeechOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TTSResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-react/src/use-generate-video.ts
+++ b/packages/ai-react/src/use-generate-video.ts
@@ -11,6 +11,7 @@ import type {
   InferGenerationOutputFromReturn,
   VideoGenerateInput,
   VideoGenerateResult,
+  VideoGenerationClientOptions,
   VideoStatusInfo,
 } from '@tanstack/ai-client'
 
@@ -22,10 +23,6 @@ export interface UseGenerateVideoOptions<TOutput = VideoGenerateResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function that returns a completed video result */
   fetcher?: GenerationFetcher<VideoGenerateInput, VideoGenerateResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -49,8 +46,8 @@ export interface UseGenerateVideoOptions<TOutput = VideoGenerateResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -157,7 +154,7 @@ export interface UseGenerateVideoReturn<TOutput = VideoGenerateResult> {
 export function useGenerateVideo<TTransformed = void>(
   options: Omit<
     UseGenerateVideoOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: VideoGenerateResult) => TTransformed
   } & GenerationPersistenceOptions,
@@ -169,8 +166,8 @@ export function useGenerateVideo<TTransformed = void>(
     TTransformed
   >
   const hookId = useId()
-  // Single identity: prefer `threadId`; deprecated `id` only when no threadId.
-  const clientIdentity = options.threadId ?? options.id ?? hookId
+  // The hook identity is `threadId`. `hookId` is only a React recreation key.
+  const clientIdentity = options.threadId ?? hookId
 
   const [result, setResult] = useState<TOutput | null>(null)
   const [jobId, setJobId] = useState<string | null>(null)
@@ -192,13 +189,11 @@ export function useGenerateVideo<TTransformed = void>(
     // `?.()`'s implicit `undefined` doesn't widen the function
     // return type (which `exactOptionalPropertyTypes` rejects
     // against the strict-optional target).
-    // Identity: pass `threadId` alone when set (never also pass deprecated `id`).
-    const baseOptions = {
+    const baseOptions: Omit<
+      VideoGenerationClientOptions<TOutput>,
+      'persistence' | 'threadId'
+    > = {
       body: opts.body,
-      ...(opts.threadId !== undefined
-        ? { threadId: opts.threadId }
-        : { id: opts.id ?? hookId }),
-      ...(opts.persistence !== undefined && { persistence: opts.persistence }),
       ...(opts.hydrateGeneration !== undefined && {
         hydrateGeneration: opts.hydrateGeneration,
       }),
@@ -255,9 +250,20 @@ export function useGenerateVideo<TTransformed = void>(
       },
     }
 
+    const persistenceProps =
+      typeof opts.threadId === 'string' && opts.persistence
+        ? {
+            persistence: opts.persistence,
+            threadId: opts.threadId,
+          }
+        : {
+            ...(opts.threadId !== undefined && { threadId: opts.threadId }),
+          }
+
     if (opts.connection) {
       return new VideoGenerationClient<TOutput>({
         ...baseOptions,
+        ...persistenceProps,
         connection: opts.connection,
       })
     }
@@ -265,6 +271,7 @@ export function useGenerateVideo<TTransformed = void>(
     if (opts.fetcher) {
       return new VideoGenerationClient<TOutput>({
         ...baseOptions,
+        ...persistenceProps,
         fetcher: opts.fetcher,
       })
     }

--- a/packages/ai-react/src/use-generation.ts
+++ b/packages/ai-react/src/use-generation.ts
@@ -27,10 +27,6 @@ export interface UseGenerationOptions<TInput, TResult, TOutput = TResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function for one-shot generation (no streaming protocol needed) */
   fetcher?: GenerationFetcher<TInput, TResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -54,8 +50,8 @@ export interface UseGenerationOptions<TInput, TResult, TOutput = TResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -159,7 +155,7 @@ export function useGeneration<
 >(
   options: Omit<
     UseGenerationOptions<TInput, TResult>,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TResult) => TTransformed
   } & GenerationPersistenceOptions,
@@ -169,8 +165,8 @@ export function useGeneration<
 > {
   type TOutput = InferGenerationOutputFromReturn<TResult, TTransformed>
   const hookId = useId()
-  // Single identity: prefer `threadId`; deprecated `id` only when no threadId.
-  const clientIdentity = options.threadId ?? options.id ?? hookId
+  // The hook identity is `threadId`. `hookId` is only a React recreation key.
+  const clientIdentity = options.threadId ?? hookId
 
   const [result, setResult] = useState<TOutput | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -189,13 +185,11 @@ export function useGeneration<
     // local source is `Record<string, any> | undefined`). Callbacks
     // wrap optional ones in non-returning bodies so `?.()`'s
     // implicit `undefined` doesn't pollute the function return type.
-    // Identity: pass `threadId` alone when set (never also pass deprecated `id`).
-    const clientOptions: GenerationClientOptions<TInput, TResult, TOutput> = {
+    const clientOptions: Omit<
+      GenerationClientOptions<TInput, TResult, TOutput>,
+      'persistence' | 'threadId'
+    > = {
       body: opts.body,
-      ...(opts.threadId !== undefined
-        ? { threadId: opts.threadId }
-        : { id: opts.id ?? hookId }),
-      ...(opts.persistence !== undefined && { persistence: opts.persistence }),
       ...(opts.hydrateGeneration !== undefined && {
         hydrateGeneration: opts.hydrateGeneration,
       }),
@@ -241,9 +235,20 @@ export function useGeneration<
       },
     }
 
+    const persistenceProps =
+      typeof opts.threadId === 'string' && opts.persistence
+        ? {
+            persistence: opts.persistence,
+            threadId: opts.threadId,
+          }
+        : {
+            ...(opts.threadId !== undefined && { threadId: opts.threadId }),
+          }
+
     if (opts.connection) {
       return new GenerationClient<TInput, TResult, TOutput>({
         ...clientOptions,
+        ...persistenceProps,
         connection: opts.connection,
       })
     }
@@ -251,6 +256,7 @@ export function useGeneration<
     if (opts.fetcher) {
       return new GenerationClient<TInput, TResult, TOutput>({
         ...clientOptions,
+        ...persistenceProps,
         fetcher: opts.fetcher,
       })
     }

--- a/packages/ai-react/src/use-summarize.ts
+++ b/packages/ai-react/src/use-summarize.ts
@@ -21,10 +21,6 @@ export interface UseSummarizeOptions<TOutput = SummarizationResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function for summarization */
   fetcher?: GenerationFetcher<SummarizeGenerateInput, SummarizationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -48,8 +44,8 @@ export interface UseSummarizeOptions<TOutput = SummarizationResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -143,7 +139,7 @@ export interface UseSummarizeReturn<TOutput = SummarizationResult> {
 export function useSummarize<TTransformed = void>(
   options: Omit<
     UseSummarizeOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: SummarizationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-react/src/use-transcription.ts
+++ b/packages/ai-react/src/use-transcription.ts
@@ -21,10 +21,6 @@ export interface UseTranscriptionOptions<TOutput = TranscriptionResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function for transcription */
   fetcher?: GenerationFetcher<TranscriptionGenerateInput, TranscriptionResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -48,8 +44,8 @@ export interface UseTranscriptionOptions<TOutput = TranscriptionResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -148,7 +144,7 @@ export interface UseTranscriptionReturn<TOutput = TranscriptionResult> {
 export function useTranscription<TTransformed = void>(
   options: Omit<
     UseTranscriptionOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TranscriptionResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-react/tests/use-chat-persistence-types.test.ts
+++ b/packages/ai-react/tests/use-chat-persistence-types.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Type-level tests for the `persistence` / `threadId` pairing on useChat.
+ * These assertions are pure types. They never invoke the hook at runtime.
+ */
+
+import { describe, it } from 'vitest'
+import { useChat } from '../src/use-chat'
+import type { ChatClientPersistence } from '@tanstack/ai-client'
+import type { UseChatOptions } from '../src/types'
+
+const connection = {} as never
+const persistence = {} as ChatClientPersistence
+
+describe('useChat persistence requires a threadId', () => {
+  it('rejects persistence: true without a threadId', () => {
+    const _typeCheck = () => {
+      // @ts-expect-error threadId is required whenever persistence is on
+      useChat({ connection, persistence: true })
+    }
+    void _typeCheck
+  })
+
+  it('rejects a storage adapter without a threadId', () => {
+    const _typeCheck = () => {
+      // @ts-expect-error threadId is required whenever persistence is on
+      useChat({ connection, persistence })
+    }
+    void _typeCheck
+  })
+
+  it('accepts persistence when a threadId is supplied', () => {
+    const _typeCheck = () => {
+      useChat({ connection, persistence: true, threadId: 'support-42' })
+      useChat({ connection, persistence, threadId: 'support-42' })
+    }
+    void _typeCheck
+  })
+
+  it('leaves threadId optional for ephemeral chats', () => {
+    const _typeCheck = () => {
+      useChat({ connection })
+      useChat({ connection, persistence: false })
+      useChat({ connection, threadId: 'support-42' })
+    }
+    void _typeCheck
+  })
+
+  it('does not list `id` on UseChatOptions. `threadId` is present', () => {
+    type Opts = UseChatOptions<readonly []>
+    // @ts-expect-error id is not a useChat option
+    type _Id = Opts['id']
+    type _ThreadId = Opts['threadId']
+    const threadId: _ThreadId = 'support-42'
+    void threadId
+  })
+})

--- a/packages/ai-react/tests/use-chat.test.ts
+++ b/packages/ai-react/tests/use-chat.test.ts
@@ -23,6 +23,7 @@ import type { ModelMessage, StreamChunk } from '@tanstack/ai'
 describe('useChat', () => {
   afterEach(() => {
     vi.doUnmock('react')
+    vi.unstubAllGlobals()
   })
 
   function createDeferred<T>() {
@@ -306,6 +307,48 @@ describe('useChat', () => {
       const messageId = result.current.messages[0]!.id
       expect(messageId).toBeTruthy()
       expect(messageId).not.toMatch(/^custom-id-/)
+    })
+
+    it('does not call crypto.randomUUID while rendering useChat', () => {
+      const randomUUID = vi.fn(() => {
+        throw new Error('crypto.randomUUID during render')
+      })
+      vi.stubGlobal('crypto', { randomUUID })
+
+      expect(() => {
+        renderUseChat({
+          connection: createMockConnectionAdapter(),
+        })
+      }).not.toThrow()
+
+      expect(randomUUID).not.toHaveBeenCalled()
+      vi.unstubAllGlobals()
+    })
+
+    it('sends a minted threadId that is not a React useId string', async () => {
+      const threadIds: Array<string> = []
+      const adapter: ConnectConnectionAdapter = {
+        async *connect(_messages, _data, abortSignal, runContext) {
+          if (runContext) {
+            threadIds.push(runContext.threadId)
+          }
+          for (const chunk of createTextChunks('Response')) {
+            if (abortSignal?.aborted) {
+              return
+            }
+            yield chunk
+          }
+        },
+      }
+
+      const { result } = renderUseChat({ connection: adapter })
+      await result.current.sendMessage('Test')
+
+      await waitFor(() => {
+        expect(threadIds).toHaveLength(1)
+      })
+      expect(threadIds[0]).toMatch(/^thread-/)
+      expect(threadIds[0]).not.toMatch(/^[:_]/)
     })
 
     it('should maintain client instance across re-renders', () => {

--- a/packages/ai-react/tests/use-generation-persistence-types.test.ts
+++ b/packages/ai-react/tests/use-generation-persistence-types.test.ts
@@ -16,11 +16,21 @@
  */
 
 import { describe, it } from 'vitest'
+import { useGenerateAudio } from '../src/use-generate-audio'
 import { useGenerateImage } from '../src/use-generate-image'
+import { useGenerateSpeech } from '../src/use-generate-speech'
 import { useGenerateVideo } from '../src/use-generate-video'
 import { useGeneration } from '../src/use-generation'
 import { useSummarize } from '../src/use-summarize'
 import { useTranscription } from '../src/use-transcription'
+import type { GenerationPersistenceOptions } from '@tanstack/ai-client'
+import type { UseGenerateAudioOptions } from '../src/use-generate-audio'
+import type { UseGenerateImageOptions } from '../src/use-generate-image'
+import type { UseGenerateSpeechOptions } from '../src/use-generate-speech'
+import type { UseGenerateVideoOptions } from '../src/use-generate-video'
+import type { UseGenerationOptions } from '../src/use-generation'
+import type { UseSummarizeOptions } from '../src/use-summarize'
+import type { UseTranscriptionOptions } from '../src/use-transcription'
 
 const connection = {} as never
 
@@ -38,6 +48,10 @@ describe('generation persistence requires a threadId', () => {
       useSummarize({ connection, persistence: true })
       // @ts-expect-error threadId is required whenever persistence is set
       useTranscription({ connection, persistence: true })
+      // @ts-expect-error threadId is required whenever persistence is set
+      useGenerateAudio({ connection, persistence: true })
+      // @ts-expect-error threadId is required whenever persistence is set
+      useGenerateSpeech({ connection, persistence: true })
     }
     void _typeCheck
   })
@@ -46,7 +60,12 @@ describe('generation persistence requires a threadId', () => {
     // Type-level only: never invoked, so no renderer is needed.
     const _typeCheck = () => {
       useGenerateImage({ connection, persistence: true, threadId: 'hero' })
+      useGenerateVideo({ connection, persistence: true, threadId: 'hero' })
       useGeneration({ connection, persistence: true, threadId: 'hero' })
+      useSummarize({ connection, persistence: true, threadId: 'hero' })
+      useTranscription({ connection, persistence: true, threadId: 'hero' })
+      useGenerateAudio({ connection, persistence: true, threadId: 'hero' })
+      useGenerateSpeech({ connection, persistence: true, threadId: 'hero' })
     }
     void _typeCheck
   })
@@ -54,12 +73,19 @@ describe('generation persistence requires a threadId', () => {
   it('leaves threadId optional for ephemeral generations', () => {
     // Type-level only: never invoked, so no renderer is needed.
     const _typeCheck = () => {
-      // The published no-persistence signature must keep compiling untouched —
-      // adding a required option would break every existing call site.
+      // The published no-persistence signature must keep compiling untouched.
+      // Adding a required option would break every existing call site.
       useGenerateImage({ connection })
       useGenerateImage({ connection, persistence: false })
+      useGenerateImage({ connection, threadId: 'hero' })
+      useGenerateVideo({ connection })
+      useGenerateVideo({ connection, persistence: false })
       useGeneration({ connection })
       useGeneration({ connection, persistence: false })
+      useSummarize({ connection })
+      useTranscription({ connection })
+      useGenerateAudio({ connection })
+      useGenerateSpeech({ connection })
     }
     void _typeCheck
   })
@@ -82,21 +108,57 @@ describe('generation persistence requires a threadId', () => {
     void _typeCheck
   })
 
-  it('rejects deprecated `id` when `threadId` is supplied', () => {
-    // Type-level only: never invoked, so no renderer is needed.
-    const _typeCheck = () => {
-      // @ts-expect-error id is never when threadId is set — threadId is the single identity
-      useGenerateImage({ connection, threadId: 'hero', id: 'legacy' })
-      // @ts-expect-error id is never when persistence requires threadId
-      useGenerateImage({
-        connection,
-        persistence: true,
-        threadId: 'hero',
-        id: 'legacy',
-      })
-      // Ephemeral runs may still pass a deprecated id alone.
-      useGenerateImage({ connection, id: 'legacy-ephemeral' })
-    }
-    void _typeCheck
+  it('does not list `id` on hook parameters. `threadId` is present', () => {
+    type ImageOpts = Omit<
+      UseGenerateImageOptions,
+      'onResult' | 'persistence' | 'threadId'
+    > &
+      GenerationPersistenceOptions
+    type VideoOpts = Omit<
+      UseGenerateVideoOptions,
+      'onResult' | 'persistence' | 'threadId'
+    > &
+      GenerationPersistenceOptions
+    type GenOpts = Omit<
+      UseGenerationOptions<Record<string, unknown>, unknown>,
+      'onResult' | 'persistence' | 'threadId'
+    > &
+      GenerationPersistenceOptions
+    type SummarizeOpts = Omit<
+      UseSummarizeOptions,
+      'onResult' | 'persistence' | 'threadId'
+    > &
+      GenerationPersistenceOptions
+    type TranscribeOpts = Omit<
+      UseTranscriptionOptions,
+      'onResult' | 'persistence' | 'threadId'
+    > &
+      GenerationPersistenceOptions
+    type AudioOpts = Omit<
+      UseGenerateAudioOptions,
+      'onResult' | 'persistence' | 'threadId'
+    > &
+      GenerationPersistenceOptions
+    type SpeechOpts = Omit<
+      UseGenerateSpeechOptions,
+      'onResult' | 'persistence' | 'threadId'
+    > &
+      GenerationPersistenceOptions
+    // @ts-expect-error id is not a generation hook option
+    type _ImageId = ImageOpts['id']
+    // @ts-expect-error id is not a generation hook option
+    type _VideoId = VideoOpts['id']
+    // @ts-expect-error id is not a generation hook option
+    type _GenId = GenOpts['id']
+    // @ts-expect-error id is not a generation hook option
+    type _SummarizeId = SummarizeOpts['id']
+    // @ts-expect-error id is not a generation hook option
+    type _TranscribeId = TranscribeOpts['id']
+    // @ts-expect-error id is not a generation hook option
+    type _AudioId = AudioOpts['id']
+    // @ts-expect-error id is not a generation hook option
+    type _SpeechId = SpeechOpts['id']
+    const imageThreadId: ImageOpts['threadId'] = 'hero'
+    void imageThreadId
   })
 })

--- a/packages/ai-solid/README.md
+++ b/packages/ai-solid/README.md
@@ -87,8 +87,7 @@ interface UseChatOptions {
 
   // Configuration
   initialMessages?: UIMessage[] // Starting messages
-  id?: string // Unique chat ID
-  threadId?: string // AG-UI thread ID (auto-generated if omitted)
+  threadId?: string // The only chat identity. Required when persistence is on. Minted after mount if omitted.
   forwardedProps?: Record<string, any> // Forwarded to AG-UI RunAgentInput.forwardedProps
   /** @deprecated Use `forwardedProps` instead. */
   body?: Record<string, any>

--- a/packages/ai-solid/src/types.ts
+++ b/packages/ai-solid/src/types.ts
@@ -93,10 +93,6 @@ export type UseChatOptions<
   | 'onRunIdChange'
   | 'context'
   | 'devtools'
-  // `id` is not a hook option: the hook's identity is its `threadId`, which is
-  // also the persistence key. Persist across reloads by passing a stable
-  // `threadId`; there is no separate id to set.
-  | 'id'
 > & {
   /** Display options for TanStack AI Devtools. */
   devtools?: AIDevtoolsDisplayOptions

--- a/packages/ai-solid/src/use-chat.ts
+++ b/packages/ai-solid/src/use-chat.ts
@@ -50,10 +50,9 @@ export function useChat<
     TContext
   >,
 ): UseChatReturn<TTools, TSchema> {
-  // The hook's identity is its `threadId` — also the persistence key, so a
-  // reload with the same `threadId` restores the same conversation. `hookId` is
-  // only a stable fallback for client-recreation keying when no `threadId` is
-  // given (an ephemeral chat), never a persistence key.
+  // The hook's identity is its `threadId`. Reload with the same `threadId`
+  // restores the same conversation. `hookId` is only a recreation key when no
+  // `threadId` is given. It is never sent on the wire.
   const hookId = createUniqueId()
   const clientId = options.threadId ?? hookId
 
@@ -110,14 +109,20 @@ export function useChat<
       ...(options.initialMessages !== undefined && {
         initialMessages: options.initialMessages,
       }),
-      ...(options.persistence !== undefined && {
-        persistence: options.persistence,
-      }),
+      ...(typeof options.threadId === 'string' && options.persistence
+        ? {
+            persistence: options.persistence,
+            threadId: options.threadId,
+          }
+        : {
+            ...(options.threadId !== undefined && {
+              threadId: options.threadId,
+            }),
+          }),
       ...(options.initialResumeSnapshot !== undefined && {
         initialResumeSnapshot: options.initialResumeSnapshot,
       }),
       body: options.body,
-      ...(options.threadId !== undefined && { threadId: options.threadId }),
       ...(options.forwardedProps !== undefined && {
         forwardedProps: options.forwardedProps,
       }),

--- a/packages/ai-solid/src/use-generate-audio.ts
+++ b/packages/ai-solid/src/use-generate-audio.ts
@@ -31,10 +31,6 @@ export interface UseGenerateAudioOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for audio generation */
   fetcher?: GenerationFetcher<AudioGenerateInput, AudioGenerationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -102,7 +98,7 @@ export interface UseGenerateAudioReturn<
 export function useGenerateAudio<TTransformed = void>(
   options: Omit<
     UseGenerateAudioOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: AudioGenerationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-solid/src/use-generate-image.ts
+++ b/packages/ai-solid/src/use-generate-image.ts
@@ -31,10 +31,6 @@ export interface UseGenerateImageOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for image generation */
   fetcher?: GenerationFetcher<ImageGenerateInput, ImageGenerationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -110,7 +106,7 @@ export interface UseGenerateImageReturn<
 export function useGenerateImage<TTransformed = void>(
   options: Omit<
     UseGenerateImageOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: ImageGenerationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-solid/src/use-generate-speech.ts
+++ b/packages/ai-solid/src/use-generate-speech.ts
@@ -29,10 +29,6 @@ export interface UseGenerateSpeechOptions<TOutput = TTSResult> extends Pick<
   connection?: ConnectConnectionAdapter
   /** Direct async function for speech generation */
   fetcher?: GenerationFetcher<SpeechGenerateInput, TTSResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -103,7 +99,7 @@ export interface UseGenerateSpeechReturn<TOutput = TTSResult> extends Omit<
 export function useGenerateSpeech<TTransformed = void>(
   options: Omit<
     UseGenerateSpeechOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TTSResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-solid/src/use-generate-video.ts
+++ b/packages/ai-solid/src/use-generate-video.ts
@@ -3,7 +3,6 @@ import { createVideoDevtoolsBridge } from '@tanstack/ai-client/devtools'
 import {
   createEffect,
   createSignal,
-  createUniqueId,
   onCleanup,
   onMount,
   untrack,
@@ -32,10 +31,6 @@ export interface UseGenerateVideoOptions<TOutput = VideoGenerateResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function that returns a completed video result */
   fetcher?: GenerationFetcher<VideoGenerateInput, VideoGenerateResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -59,8 +54,8 @@ export interface UseGenerateVideoOptions<TOutput = VideoGenerateResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -167,7 +162,7 @@ export interface UseGenerateVideoReturn<TOutput = VideoGenerateResult> {
 export function useGenerateVideo<TTransformed = void>(
   options: Omit<
     UseGenerateVideoOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: VideoGenerateResult) => TTransformed
   } & GenerationPersistenceOptions,
@@ -178,8 +173,6 @@ export function useGenerateVideo<TTransformed = void>(
     VideoGenerateResult,
     TTransformed
   >
-  const hookId = createUniqueId()
-
   const [result, setResult] = createSignal<TOutput | null>(null)
   const [jobId, setJobId] = createSignal<string | null>(null)
   const [videoStatus, setVideoStatus] = createSignal<VideoStatusInfo | null>(
@@ -201,13 +194,16 @@ export function useGenerateVideo<TTransformed = void>(
     // is a strict optional; EOPT forbids passing `T | undefined`.
     const baseOptions = {
       body: options.body,
-      // Identity: pass `threadId` alone when set (never also pass deprecated `id`).
-      ...(options.threadId !== undefined
-        ? { threadId: options.threadId }
-        : { id: options.id ?? hookId }),
-      ...(options.persistence !== undefined && {
-        persistence: options.persistence,
-      }),
+      ...(typeof options.threadId === 'string' && options.persistence
+        ? {
+            persistence: options.persistence,
+            threadId: options.threadId,
+          }
+        : {
+            ...(options.threadId !== undefined && {
+              threadId: options.threadId,
+            }),
+          }),
       ...(options.hydrateGeneration !== undefined && {
         hydrateGeneration: options.hydrateGeneration,
       }),

--- a/packages/ai-solid/src/use-generation.ts
+++ b/packages/ai-solid/src/use-generation.ts
@@ -3,7 +3,6 @@ import { createGenerationDevtoolsBridge } from '@tanstack/ai-client/devtools'
 import {
   createEffect,
   createSignal,
-  createUniqueId,
   onCleanup,
   onMount,
   untrack,
@@ -35,10 +34,6 @@ export interface UseGenerationOptions<TInput, TResult, TOutput = TResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function for one-shot generation (no streaming protocol needed) */
   fetcher?: GenerationFetcher<TInput, TResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -62,8 +57,8 @@ export interface UseGenerationOptions<TInput, TResult, TOutput = TResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -168,7 +163,7 @@ export function useGeneration<
 >(
   options: Omit<
     UseGenerationOptions<TInput, TResult>,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TResult) => TTransformed
   } & GenerationPersistenceOptions,
@@ -177,7 +172,6 @@ export function useGeneration<
   TInput
 > {
   type TOutput = InferGenerationOutputFromReturn<TResult, TTransformed>
-  const hookId = createUniqueId()
 
   const [result, setResult] = createSignal<TOutput | null>(null)
   const [isLoading, setIsLoading] = createSignal(false)
@@ -195,15 +189,11 @@ export function useGeneration<
     // Conditional spread on `body`: `GenerationClientOptions.body` is a
     // strict optional (`body?: Record<string, any>`) and EOPT forbids
     // assigning the source `T | undefined` directly.
-    const clientOptions: GenerationClientOptions<TInput, TResult, TOutput> = {
+    const clientOptions: Omit<
+      GenerationClientOptions<TInput, TResult, TOutput>,
+      'persistence' | 'threadId'
+    > = {
       body: options.body,
-      // Identity: pass `threadId` alone when set (never also pass deprecated `id`).
-      ...(options.threadId !== undefined
-        ? { threadId: options.threadId }
-        : { id: options.id ?? hookId }),
-      ...(options.persistence !== undefined && {
-        persistence: options.persistence,
-      }),
       ...(options.hydrateGeneration !== undefined && {
         hydrateGeneration: options.hydrateGeneration,
       }),
@@ -249,9 +239,22 @@ export function useGeneration<
       },
     }
 
+    const persistenceProps =
+      typeof options.threadId === 'string' && options.persistence
+        ? {
+            persistence: options.persistence,
+            threadId: options.threadId,
+          }
+        : {
+            ...(options.threadId !== undefined && {
+              threadId: options.threadId,
+            }),
+          }
+
     if (options.connection) {
       return new GenerationClient<TInput, TResult, TOutput>({
         ...clientOptions,
+        ...persistenceProps,
         connection: options.connection,
       })
     }
@@ -259,6 +262,7 @@ export function useGeneration<
     if (options.fetcher) {
       return new GenerationClient<TInput, TResult, TOutput>({
         ...clientOptions,
+        ...persistenceProps,
         fetcher: options.fetcher,
       })
     }

--- a/packages/ai-solid/src/use-summarize.ts
+++ b/packages/ai-solid/src/use-summarize.ts
@@ -31,10 +31,6 @@ export interface UseSummarizeOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for summarization */
   fetcher?: GenerationFetcher<SummarizeGenerateInput, SummarizationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -108,7 +104,7 @@ export interface UseSummarizeReturn<TOutput = SummarizationResult> extends Omit<
 export function useSummarize<TTransformed = void>(
   options: Omit<
     UseSummarizeOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: SummarizationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-solid/src/use-transcription.ts
+++ b/packages/ai-solid/src/use-transcription.ts
@@ -35,10 +35,6 @@ export interface UseTranscriptionOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for transcription */
   fetcher?: GenerationFetcher<TranscriptionGenerateInput, TranscriptionResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -117,7 +113,7 @@ export interface UseTranscriptionReturn<
 export function useTranscription<TTransformed = void>(
   options: Omit<
     UseTranscriptionOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TranscriptionResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-svelte/src/create-chat.svelte.ts
+++ b/packages/ai-svelte/src/create-chat.svelte.ts
@@ -115,14 +115,18 @@ export function createChat<
     ...(options.initialMessages !== undefined && {
       initialMessages: options.initialMessages,
     }),
-    ...(options.persistence !== undefined && {
-      persistence: options.persistence,
-    }),
+    ...(typeof options.threadId === 'string' && options.persistence
+      ? {
+          persistence: options.persistence,
+          threadId: options.threadId,
+        }
+      : {
+          ...(options.threadId !== undefined && { threadId: options.threadId }),
+        }),
     ...(options.initialResumeSnapshot !== undefined && {
       initialResumeSnapshot: options.initialResumeSnapshot,
     }),
     ...(options.body !== undefined && { body: options.body }),
-    ...(options.threadId !== undefined && { threadId: options.threadId }),
     ...(options.forwardedProps !== undefined && {
       forwardedProps: options.forwardedProps,
     }),

--- a/packages/ai-svelte/src/create-generate-audio.svelte.ts
+++ b/packages/ai-svelte/src/create-generate-audio.svelte.ts
@@ -30,10 +30,6 @@ export interface CreateGenerateAudioOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for audio generation */
   fetcher?: GenerationFetcher<AudioGenerateInput, AudioGenerationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -103,7 +99,7 @@ export interface CreateGenerateAudioReturn<
 export function createGenerateAudio<TTransformed = void>(
   options: Omit<
     CreateGenerateAudioOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: AudioGenerationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-svelte/src/create-generate-image.svelte.ts
+++ b/packages/ai-svelte/src/create-generate-image.svelte.ts
@@ -30,10 +30,6 @@ export interface CreateGenerateImageOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for image generation */
   fetcher?: GenerationFetcher<ImageGenerateInput, ImageGenerationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -112,7 +108,7 @@ export interface CreateGenerateImageReturn<
 export function createGenerateImage<TTransformed = void>(
   options: Omit<
     CreateGenerateImageOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: ImageGenerationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-svelte/src/create-generate-speech.svelte.ts
+++ b/packages/ai-svelte/src/create-generate-speech.svelte.ts
@@ -28,10 +28,6 @@ export interface CreateGenerateSpeechOptions<TOutput = TTSResult> extends Pick<
   connection?: ConnectConnectionAdapter
   /** Direct async function for speech generation */
   fetcher?: GenerationFetcher<SpeechGenerateInput, TTSResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -102,7 +98,7 @@ export interface CreateGenerateSpeechReturn<TOutput = TTSResult> extends Omit<
 export function createGenerateSpeech<TTransformed = void>(
   options: Omit<
     CreateGenerateSpeechOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TTSResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-svelte/src/create-generate-video.svelte.ts
+++ b/packages/ai-svelte/src/create-generate-video.svelte.ts
@@ -23,10 +23,6 @@ export interface CreateGenerateVideoOptions<TOutput = VideoGenerateResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function that returns a completed video result */
   fetcher?: GenerationFetcher<VideoGenerateInput, VideoGenerateResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -50,8 +46,8 @@ export interface CreateGenerateVideoOptions<TOutput = VideoGenerateResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -161,7 +157,7 @@ export interface CreateGenerateVideoReturn<TOutput = VideoGenerateResult> {
 export function createGenerateVideo<TTransformed = void>(
   options: Omit<
     CreateGenerateVideoOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: VideoGenerateResult) => TTransformed
   } & GenerationPersistenceOptions,
@@ -172,7 +168,6 @@ export function createGenerateVideo<TTransformed = void>(
     VideoGenerateResult,
     TTransformed
   >
-  const fallbackId = `video-${Date.now()}-${Math.random().toString(36).substring(7)}`
 
   // Create reactive state using Svelte 5 runes
   let result = $state<TOutput | null>(null)
@@ -188,15 +183,18 @@ export function createGenerateVideo<TTransformed = void>(
   // is declared `body?: Record<string, any>` (absent vs. present) under
   // `exactOptionalPropertyTypes`. The optional caller `options.body` may be
   // undefined, in which case we want the key to be absent on the target.
-  // Identity: pass `threadId` alone when set (never also pass deprecated `id`).
   const baseOptions = {
     body: options.body,
-    ...(options.threadId !== undefined
-      ? { threadId: options.threadId }
-      : { id: options.id ?? fallbackId }),
-    ...(options.persistence !== undefined && {
-      persistence: options.persistence,
-    }),
+    ...(typeof options.threadId === 'string' && options.persistence
+      ? {
+          persistence: options.persistence,
+          threadId: options.threadId,
+        }
+      : {
+          ...(options.threadId !== undefined && {
+            threadId: options.threadId,
+          }),
+        }),
     ...(options.hydrateGeneration !== undefined && {
       hydrateGeneration: options.hydrateGeneration,
     }),

--- a/packages/ai-svelte/src/create-generation.svelte.ts
+++ b/packages/ai-svelte/src/create-generation.svelte.ts
@@ -26,10 +26,6 @@ export interface CreateGenerationOptions<TInput, TResult, TOutput = TResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function for one-shot generation (no streaming protocol needed) */
   fetcher?: GenerationFetcher<TInput, TResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -53,8 +49,8 @@ export interface CreateGenerationOptions<TInput, TResult, TOutput = TResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -174,7 +170,7 @@ export function createGeneration<
 >(
   options: Omit<
     CreateGenerationOptions<TInput, TResult>,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TResult) => TTransformed
   } & GenerationPersistenceOptions,
@@ -183,8 +179,6 @@ export function createGeneration<
   TInput
 > {
   type TOutput = InferGenerationOutputFromReturn<TResult, TTransformed>
-  const fallbackId = `gen-${Date.now()}-${Math.random().toString(36).substring(7)}`
-
   // Create reactive state using Svelte 5 runes
   let result = $state<TOutput | null>(null)
   let isLoading = $state(false)
@@ -198,15 +192,11 @@ export function createGeneration<
   // `exactOptionalPropertyTypes`. Assigning `undefined` directly would be
   // rejected — the optional caller `options.body` may be undefined, in which
   // case we want the key to be absent.
-  // Identity: pass `threadId` alone when set (never also pass deprecated `id`).
-  const clientOptions: GenerationClientOptions<TInput, TResult, TOutput> = {
+  const clientOptions: Omit<
+    GenerationClientOptions<TInput, TResult, TOutput>,
+    'persistence' | 'threadId'
+  > = {
     body: options.body,
-    ...(options.threadId !== undefined
-      ? { threadId: options.threadId }
-      : { id: options.id ?? fallbackId }),
-    ...(options.persistence !== undefined && {
-      persistence: options.persistence,
-    }),
     ...(options.hydrateGeneration !== undefined && {
       hydrateGeneration: options.hydrateGeneration,
     }),
@@ -257,16 +247,30 @@ export function createGeneration<
     },
   }
 
+  const persistenceProps =
+    typeof options.threadId === 'string' && options.persistence
+      ? {
+          persistence: options.persistence,
+          threadId: options.threadId,
+        }
+      : {
+          ...(options.threadId !== undefined && {
+            threadId: options.threadId,
+          }),
+        }
+
   let client: GenerationClient<TInput, TResult, TOutput>
 
   if (options.connection) {
     client = new GenerationClient<TInput, TResult, TOutput>({
       ...clientOptions,
+      ...persistenceProps,
       connection: options.connection,
     })
   } else if (options.fetcher) {
     client = new GenerationClient<TInput, TResult, TOutput>({
       ...clientOptions,
+      ...persistenceProps,
       fetcher: options.fetcher,
     })
   } else {

--- a/packages/ai-svelte/src/create-summarize.svelte.ts
+++ b/packages/ai-svelte/src/create-summarize.svelte.ts
@@ -30,10 +30,6 @@ export interface CreateSummarizeOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for summarization */
   fetcher?: GenerationFetcher<SummarizeGenerateInput, SummarizationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -107,7 +103,7 @@ export interface CreateSummarizeReturn<
 export function createSummarize<TTransformed = void>(
   options: Omit<
     CreateSummarizeOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: SummarizationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-svelte/src/create-transcription.svelte.ts
+++ b/packages/ai-svelte/src/create-transcription.svelte.ts
@@ -34,10 +34,6 @@ export interface CreateTranscriptionOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for transcription */
   fetcher?: GenerationFetcher<TranscriptionGenerateInput, TranscriptionResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -116,7 +112,7 @@ export interface CreateTranscriptionReturn<
 export function createTranscription<TTransformed = void>(
   options: Omit<
     CreateTranscriptionOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TranscriptionResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-svelte/src/types.ts
+++ b/packages/ai-svelte/src/types.ts
@@ -92,10 +92,6 @@ export type CreateChatOptions<
   | 'onRunIdChange'
   | 'context'
   | 'devtools'
-  // `id` is not a hook option: the hook's identity is its `threadId`, which is
-  // also the persistence key. Persist across reloads by passing a stable
-  // `threadId`; there is no separate id to set.
-  | 'id'
 > & {
   live?: boolean
   /** Display options for TanStack AI Devtools. */

--- a/packages/ai-vue/src/types.ts
+++ b/packages/ai-vue/src/types.ts
@@ -94,10 +94,6 @@ export type UseChatOptions<
   | 'onRunIdChange'
   | 'context'
   | 'devtools'
-  // `id` is not a hook option: the hook's identity is its `threadId`, which is
-  // also the persistence key. Persist across reloads by passing a stable
-  // `threadId`; there is no separate id to set.
-  | 'id'
 > & {
   /** Display options for TanStack AI Devtools. */
   devtools?: AIDevtoolsDisplayOptions

--- a/packages/ai-vue/src/use-chat.ts
+++ b/packages/ai-vue/src/use-chat.ts
@@ -92,23 +92,27 @@ export function useChat<
     ? { connection: options.connection }
     : { fetcher: options.fetcher }
 
-  // The hook's identity is its `threadId`, which ChatClient also uses as the
-  // persistence key — no separate `id`. When no `threadId` is given the client
-  // generates one, so an ephemeral chat still works but is not restored on reload.
+  // The hook's identity is its `threadId`. When no `threadId` is given the
+  // client mints one after mount, so an ephemeral chat still works but is not
+  // restored on reload.
   const client = new ChatClient<TTools, TContext>({
     devtoolsBridgeFactory: createChatDevtoolsBridge,
     ...transport,
     ...(options.initialMessages !== undefined && {
       initialMessages: options.initialMessages,
     }),
-    ...(options.persistence !== undefined && {
-      persistence: options.persistence,
-    }),
+    ...(typeof options.threadId === 'string' && options.persistence
+      ? {
+          persistence: options.persistence,
+          threadId: options.threadId,
+        }
+      : {
+          ...(options.threadId !== undefined && { threadId: options.threadId }),
+        }),
     ...(options.initialResumeSnapshot !== undefined && {
       initialResumeSnapshot: options.initialResumeSnapshot,
     }),
     ...(options.body !== undefined && { body: options.body }),
-    ...(options.threadId !== undefined && { threadId: options.threadId }),
     ...(options.forwardedProps !== undefined && {
       forwardedProps: options.forwardedProps,
     }),

--- a/packages/ai-vue/src/use-generate-audio.ts
+++ b/packages/ai-vue/src/use-generate-audio.ts
@@ -31,10 +31,6 @@ export interface UseGenerateAudioOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for audio generation */
   fetcher?: GenerationFetcher<AudioGenerateInput, AudioGenerationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -102,7 +98,7 @@ export interface UseGenerateAudioReturn<
 export function useGenerateAudio<TTransformed = void>(
   options: Omit<
     UseGenerateAudioOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: AudioGenerationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-vue/src/use-generate-image.ts
+++ b/packages/ai-vue/src/use-generate-image.ts
@@ -31,10 +31,6 @@ export interface UseGenerateImageOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for image generation */
   fetcher?: GenerationFetcher<ImageGenerateInput, ImageGenerationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -112,7 +108,7 @@ export interface UseGenerateImageReturn<
 export function useGenerateImage<TTransformed = void>(
   options: Omit<
     UseGenerateImageOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: ImageGenerationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-vue/src/use-generate-speech.ts
+++ b/packages/ai-vue/src/use-generate-speech.ts
@@ -29,10 +29,6 @@ export interface UseGenerateSpeechOptions<TOutput = TTSResult> extends Pick<
   connection?: ConnectConnectionAdapter
   /** Direct async function for speech generation */
   fetcher?: GenerationFetcher<SpeechGenerateInput, TTSResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -105,7 +101,7 @@ export interface UseGenerateSpeechReturn<TOutput = TTSResult> extends Omit<
 export function useGenerateSpeech<TTransformed = void>(
   options: Omit<
     UseGenerateSpeechOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TTSResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-vue/src/use-generate-video.ts
+++ b/packages/ai-vue/src/use-generate-video.ts
@@ -1,13 +1,6 @@
 import { VideoGenerationClient } from '@tanstack/ai-client'
 import { createVideoDevtoolsBridge } from '@tanstack/ai-client/devtools'
-import {
-  onMounted,
-  onScopeDispose,
-  readonly,
-  shallowRef,
-  useId,
-  watch,
-} from 'vue'
+import { onMounted, onScopeDispose, readonly, shallowRef, watch } from 'vue'
 import type { StreamChunk } from '@tanstack/ai'
 import type {
   AIDevtoolsDisplayOptions,
@@ -32,10 +25,6 @@ export interface UseGenerateVideoOptions<TOutput = VideoGenerateResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function for creating a video job */
   fetcher?: GenerationFetcher<VideoGenerateInput, VideoGenerateResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -59,8 +48,8 @@ export interface UseGenerateVideoOptions<TOutput = VideoGenerateResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -167,7 +156,7 @@ export interface UseGenerateVideoReturn<TOutput = VideoGenerateResult> {
 export function useGenerateVideo<TTransformed = void>(
   options: Omit<
     UseGenerateVideoOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: VideoGenerateResult) => TTransformed
   } & GenerationPersistenceOptions,
@@ -178,8 +167,6 @@ export function useGenerateVideo<TTransformed = void>(
     VideoGenerateResult,
     TTransformed
   >
-  const hookId = useId()
-
   const result = shallowRef<TOutput | null>(null)
   const jobId = shallowRef<string | null>(null)
   const videoStatus = shallowRef<VideoStatusInfo | null>(null)
@@ -192,15 +179,18 @@ export function useGenerateVideo<TTransformed = void>(
   // Conditional spread on `body`: `VideoGenerationClientOptions.body` is a
   // strict optional and under EOPT we must omit the key when absent rather
   // than assign `undefined`.
-  // Identity: pass `threadId` alone when set (never also pass deprecated `id`).
   const baseOptions = {
     body: options.body,
-    ...(options.threadId !== undefined
-      ? { threadId: options.threadId }
-      : { id: options.id ?? hookId }),
-    ...(options.persistence !== undefined && {
-      persistence: options.persistence,
-    }),
+    ...(typeof options.threadId === 'string' && options.persistence
+      ? {
+          persistence: options.persistence,
+          threadId: options.threadId,
+        }
+      : {
+          ...(options.threadId !== undefined && {
+            threadId: options.threadId,
+          }),
+        }),
     ...(options.hydrateGeneration !== undefined && {
       hydrateGeneration: options.hydrateGeneration,
     }),

--- a/packages/ai-vue/src/use-generation.ts
+++ b/packages/ai-vue/src/use-generation.ts
@@ -1,13 +1,6 @@
 import { GenerationClient } from '@tanstack/ai-client'
 import { createGenerationDevtoolsBridge } from '@tanstack/ai-client/devtools'
-import {
-  onMounted,
-  onScopeDispose,
-  readonly,
-  shallowRef,
-  useId,
-  watch,
-} from 'vue'
+import { onMounted, onScopeDispose, readonly, shallowRef, watch } from 'vue'
 import type { StreamChunk } from '@tanstack/ai'
 import type {
   AIDevtoolsDisplayOptions,
@@ -35,10 +28,6 @@ export interface UseGenerationOptions<TInput, TResult, TOutput = TResult> {
   connection?: ConnectConnectionAdapter
   /** Direct async function for one-shot generation (no streaming protocol needed) */
   fetcher?: GenerationFetcher<TInput, TResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -62,8 +51,8 @@ export interface UseGenerationOptions<TInput, TResult, TOutput = TResult> {
    * id on the wire, which the protocol requires.
    *
    * **Required whenever `persistence` is set** — an app that cannot name the
-   * scope has nothing to restore to. Optional for ephemeral generations, where
-   * it falls back to `id` purely to satisfy the wire.
+   * scope has nothing to restore to. Optional for ephemeral generations. If
+   * omitted, the client mints a wire id after mount.
    */
   threadId?: string
   /**
@@ -170,7 +159,7 @@ export function useGeneration<
 >(
   options: Omit<
     UseGenerationOptions<TInput, TResult>,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TResult) => TTransformed
   } & GenerationPersistenceOptions,
@@ -179,7 +168,6 @@ export function useGeneration<
   TInput
 > {
   type TOutput = InferGenerationOutputFromReturn<TResult, TTransformed>
-  const hookId = useId()
 
   const result = shallowRef<TOutput | null>(null)
   const isLoading = shallowRef(false)
@@ -191,14 +179,11 @@ export function useGeneration<
   // Conditional spread on `body`: `GenerationClientOptions.body` is a strict
   // optional (`body?: Record<string, any>`), and under EOPT we must omit the
   // key when absent rather than assign `undefined`.
-  const clientOptions: GenerationClientOptions<TInput, TResult, TOutput> = {
+  const clientOptions: Omit<
+    GenerationClientOptions<TInput, TResult, TOutput>,
+    'persistence' | 'threadId'
+  > = {
     body: options.body,
-    ...(options.threadId !== undefined
-      ? { threadId: options.threadId }
-      : { id: options.id ?? hookId }),
-    ...(options.persistence !== undefined && {
-      persistence: options.persistence,
-    }),
     ...(options.hydrateGeneration !== undefined && {
       hydrateGeneration: options.hydrateGeneration,
     }),
@@ -249,16 +234,30 @@ export function useGeneration<
     },
   }
 
+  const persistenceProps =
+    typeof options.threadId === 'string' && options.persistence
+      ? {
+          persistence: options.persistence,
+          threadId: options.threadId,
+        }
+      : {
+          ...(options.threadId !== undefined && {
+            threadId: options.threadId,
+          }),
+        }
+
   let client: GenerationClient<TInput, TResult, TOutput>
 
   if (options.connection) {
     client = new GenerationClient<TInput, TResult, TOutput>({
       ...clientOptions,
+      ...persistenceProps,
       connection: options.connection,
     })
   } else if (options.fetcher) {
     client = new GenerationClient<TInput, TResult, TOutput>({
       ...clientOptions,
+      ...persistenceProps,
       fetcher: options.fetcher,
     })
   } else {

--- a/packages/ai-vue/src/use-summarize.ts
+++ b/packages/ai-vue/src/use-summarize.ts
@@ -31,10 +31,6 @@ export interface UseSummarizeOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for summarization */
   fetcher?: GenerationFetcher<SummarizeGenerateInput, SummarizationResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -108,7 +104,7 @@ export interface UseSummarizeReturn<TOutput = SummarizationResult> extends Omit<
 export function useSummarize<TTransformed = void>(
   options: Omit<
     UseSummarizeOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: SummarizationResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/packages/ai-vue/src/use-transcription.ts
+++ b/packages/ai-vue/src/use-transcription.ts
@@ -35,10 +35,6 @@ export interface UseTranscriptionOptions<
   connection?: ConnectConnectionAdapter
   /** Direct async function for transcription */
   fetcher?: GenerationFetcher<TranscriptionGenerateInput, TranscriptionResult>
-  /**
-   * @deprecated Prefer `threadId`. Only allowed when `threadId` is omitted (see `GenerationPersistenceOptions`).
-   */
-  id?: string
   /** Additional body parameters to send with connect-based adapter requests */
   body?: Record<string, any>
   /** Display options for TanStack AI Devtools. */
@@ -116,7 +112,7 @@ export interface UseTranscriptionReturn<
 export function useTranscription<TTransformed = void>(
   options: Omit<
     UseTranscriptionOptions,
-    'onResult' | 'persistence' | 'threadId' | 'id'
+    'onResult' | 'persistence' | 'threadId'
   > & {
     onResult?: (result: TranscriptionResult) => TTransformed
   } & GenerationPersistenceOptions,

--- a/testing/e2e/src/routes/devtools-generation-hooks.tsx
+++ b/testing/e2e/src/routes/devtools-generation-hooks.tsx
@@ -34,14 +34,14 @@ function DevtoolsGenerationHooksRoute() {
   const sharedBody = { testId, aimockPort }
 
   const image = useGenerateImage({
-    id: 'generation-hooks:useGenerateImage',
+    threadId: 'generation-hooks:useGenerateImage',
     connection: fetchServerSentEvents('/api/image'),
     body: { ...sharedBody, provider: 'openai' },
     devtools: { name: 'Image Studio' },
     onResult: duplicateSingleImageResult,
   })
   const audio = useGenerateAudio({
-    id: 'generation-hooks:useGenerateAudio',
+    threadId: 'generation-hooks:useGenerateAudio',
     fetcher: async (input) => {
       const response = await fetch('/api/audio', {
         method: 'POST',
@@ -62,26 +62,26 @@ function DevtoolsGenerationHooksRoute() {
     onResult: normalizeAudioResult,
   })
   const speech = useGenerateSpeech({
-    id: 'generation-hooks:useGenerateSpeech',
+    threadId: 'generation-hooks:useGenerateSpeech',
     connection: fetchServerSentEvents('/api/tts'),
     body: { ...sharedBody, provider: 'openai' },
     devtools: { name: 'Speech Studio' },
     onResult: normalizeSpeechResult,
   })
   const transcription = useTranscription({
-    id: 'generation-hooks:useTranscription',
+    threadId: 'generation-hooks:useTranscription',
     connection: fetchServerSentEvents('/api/transcription'),
     body: { ...sharedBody, provider: 'openai' },
     devtools: { name: 'Transcription Studio' },
   })
   const summarize = useSummarize({
-    id: 'generation-hooks:useSummarize',
+    threadId: 'generation-hooks:useSummarize',
     connection: fetchServerSentEvents('/api/summarize'),
     body: { ...sharedBody, provider: 'openai', stream: true },
     devtools: { name: 'Summary Studio' },
   })
   const video = useGenerateVideo({
-    id: 'generation-hooks:useGenerateVideo',
+    threadId: 'generation-hooks:useGenerateVideo',
     connection: fetchServerSentEvents('/api/video'),
     body: { ...sharedBody, provider: 'openai' },
     devtools: { name: 'Video Studio' },


### PR DESCRIPTION
## Changes

`threadId` is now the only client identity for chat and generation.

- Mint a `threadId` after mount when the caller omits one. Do not mint during render. This avoids random ids during SSR.
- DevTools binds the hook row to `threadId`.
- Persistence that is on (`true` or a storage adapter) requires a `threadId` at compile time. The client throws at runtime if it is missing.
- Remove the leftover client `id` option. Message ids, result ids, and stream envelope ids stay.

## Type tests

These files pin the pairing and the removed `id` option:

- `packages/ai-client/tests/chat-persistence-types.test.ts`
- `packages/ai-client/tests/generation-persistence-types.test.ts`
- `packages/ai-react/tests/use-chat-persistence-types.test.ts`
- `packages/ai-react/tests/use-generation-persistence-types.test.ts`

They cover:

- persistence on without `threadId` (type error)
- persistence on with `threadId` (ok)
- ephemeral chat/generation with optional `threadId` (ok)
- `id` is not an option (type error / missing key)
- all generation hooks: image, video, generation, summarize, transcription, audio, speech

Runtime identity tests live in `packages/ai-client/tests/chat-client-identity.test.ts`.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with focused unit tests and package typechecks.
- [x] This change affects published code, and I have generated a changeset.

## Test plan

- [ ] Open `examples/ts-react-chat` and send a message on an ephemeral chat (no `threadId`). Confirm it works after load.
- [ ] Open a persisted chat/generation with a stable `threadId` and reload. Confirm it restores.
- [ ] Confirm `useChat({ id: 'x' })` and `useGenerateImage({ id: 'x' })` are type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized chat and generation identity around `threadId` across supported frameworks and clients.
  * Omitted `threadId` values for ephemeral sessions are now created after mount and reused during the session.
  * DevTools now uses `threadId` for hook and client identity.

* **Bug Fixes**
  * Persistence now requires an explicit `threadId`, with validation during development and runtime.
  * Removed legacy automatic identity fallbacks that could produce inconsistent session identities.

* **Documentation**
  * Updated API, persistence, generation, and DevTools guidance to reflect the `threadId` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->