### PR TITLE
chore(agents): require docs, pr-description, and ponytail skills

### DIFF
--- a/.agents/skills/docs/SKILL.md
+++ b/.agents/skills/docs/SKILL.md
@@ -13,7 +13,7 @@ Work in two phases. First plan the story: who reads this, what they want, and ho
 
 The plan is not private. The user must see the readers and must choose the tone before any page is written.
 
-```
+```text
 Find docs
   → read neighbors
   → Phase 1: readers + pages
@@ -85,22 +85,26 @@ The page split comes out of this step. Do not skip it.
 ### Gate: show the personas
 
 <HARD-GATE>
-This gate is the entire turn. Listing readers in a thought, a todo, or a buried plan is not this gate. The user must see the list in a dedicated message, then the agent must stop.
+The user must see the list. Listing readers in a thought, a todo, or a buried plan is not this gate.
 
 After step 4, send a message that contains only:
 
 1. Each reader, one user story, and the page you will write for them.
 2. One question: confirm, drop a reader, or add one.
 
-If the harness has an AskQuestion (or similar) tool, use it for that question. If it does not, use a numbered list. Either way, end the turn.
+If the harness has an AskQuestion (or similar) tool, use it for that question. If it does not, use a numbered list.
 
-Do not write files. Do not start Phase 2. Do not say you will proceed unless they object.
+Then pick one path:
 
-Skip the *wait* only when one of these is true:
+**Default: stop.** This message is the entire turn. End the turn. Do not write files. Do not start Phase 2. Do not say you will proceed unless they object.
+
+**Skip the wait: continue in this same turn.** Use this path only when one of these is true:
 
 - This conversation already has the user's confirmation of this persona list.
-- The user said "use sane defaults", "just write it", or "don't ask questions". Still SHOW the list in the same turn, then continue.
+- The user said "use sane defaults", "just write it", or "don't ask questions". Still SHOW the list in this turn, then continue.
 - The change is a tiny copy edit: typo, broken link, code-fence language, or a factual fix. No new page, no new section, no rewrite of a journey.
+
+On this path, do not end the turn. After you show the list (or after a tiny copy edit, with no list), continue to the next step.
 
 These are not skips:
 
@@ -121,7 +125,7 @@ When a topic has several angles, give each its own short page and link them. A r
 
 Example. A feature for tool interrupts:
 
-```
+```text
 Bad: one page
   interrupts.md   (overview + simple case + many interrupts + custom, all crammed in)
 
@@ -134,11 +138,9 @@ Good: a small set of linked pages
 
 Each page is short and does one thing. The overview stitches them into a story.
 
-## Phase 2: write like a human
+## Gate: ask for tone
 
-Do not start this phase until the persona gate has passed, the tone gate has passed, and `simple-english` plus `i-have-adhd` are loaded.
-
-### Gate: ask for tone
+This gate sits between Phase 1 and Phase 2. Run it before you write any page. Do not nest it inside Phase 2.
 
 <HARD-GATE>
 This gate runs before any page content is written. It does not run for a doc-impact list that is only a plan.
@@ -150,13 +152,19 @@ Send a message that contains only:
 1. The tone you inferred from neighboring pages, in one line (how formal, how much setup, second person or not).
 2. One question with options: use that tone, more casual, more formal, or the user names another.
 
-If the harness has an AskQuestion (or similar) tool, use it. If it does not, use a numbered list. Either way, end the turn.
+If the harness has an AskQuestion (or similar) tool, use it. If it does not, use a numbered list.
 
-Skip the *wait* only when one of these is true:
+Then pick one path:
+
+**Default: stop.** This message is the entire turn. End the turn. Do not write page content.
+
+**Skip the wait: continue in this same turn.** Use this path only when one of these is true:
 
 - This conversation already has the user's tone choice, including an explicit "match the existing pages".
 - The user said "use sane defaults", "just write it", or "don't ask questions". Still STATE the inferred tone in one line, then continue.
 - Tiny copy edit, same carve-out as the persona gate.
+
+On this path, do not end the turn. After you state the tone (or after a tiny copy edit, with no question), continue to Phase 2.
 
 These are not skips:
 
@@ -165,6 +173,12 @@ These are not skips:
 - "Tone does not matter for a reference page."
 - "I'll match neighbors and mention it later."
 </HARD-GATE>
+
+## Phase 2: write like a human
+
+Do not write page content until the persona gate has passed, the tone gate has passed, and `simple-english` plus `i-have-adhd` are loaded.
+
+The tone gate is the heading above this one. Run that gate first. Then load the two skills. Then write.
 
 Legibility is the goal, above everything else.
 
@@ -183,7 +197,7 @@ A reader who sees the problem first knows in seconds whether they are on the rig
 
 The first line of the how is the next action (from `i-have-adhd`). The problem still comes first so they know they are on the right page.
 
-```
+```text
 Bad:
   Call useInterrupts() and pass a resolver. The resolver runs once per
   pending item inside a transaction...
@@ -202,7 +216,7 @@ The order for a guide is problem, one-line fix, then the how (steps, snippets, A
 
 Do not explain in four paragraphs what one sentence and a code block can show. Readers grasp a diff or a snippet faster than prose.
 
-```
+```text
 Bad:
   Three paragraphs describing how the config object accepts a
   middleware array, what each slot does, and how ordering works.
@@ -223,7 +237,7 @@ The moment a sentence covers more than one item, option, store, flag, or step, i
 
 The tell is a sentence that names two or more things and says something about each. Cut it into one bullet per thing, one or two sentences each.
 
-```
+```text
 Bad:
   Each store is independent. Provide only the ones you need. For chat:
   `messages` for the transcript, `runs` for run lifecycle, `interrupts` for
@@ -275,7 +289,7 @@ Docs describe what exists now. The reader never saw the old design, the earlier 
 
 Never justify the current API by comparing it to a version that did not ship. A line like "instead of `useAssistant`, this uses `usePlugin`, which makes more sense because..." is noise to someone who never knew `useAssistant` existed. Cut it and just describe `usePlugin`.
 
-```
+```text
 Bad:
   We renamed useAssistant to usePlugin and moved the tools onto it,
   so instead of calling assistant.addTool you now use plugin.tools.
@@ -296,7 +310,7 @@ The doc is read by someone who just arrived. They never saw the pull request, th
 
 **Cut rejected alternatives.** If a discussion weighed option A against option B and picked B, the doc documents B. It never names A, never says B is "better than" A, never says A "is no longer needed." The reader is not choosing between them; they use what shipped.
 
-```
+```text
 Bad:
   We use a plain JSON Schema here instead of zod, since it is lighter
   and zod is no longer a dependency.
@@ -309,7 +323,7 @@ Good:
 
 **Do not explain what something is not, when the reader never thought it was.** If a piece moved out of a module during a refactor, the doc for its new home does not warn against the old arrangement. A reader who never knew locks lived inside persistence is only confused by a paragraph insisting locks are not a persistence store and must not be passed in as one. State what the thing is now, in its own terms.
 
-```
+```text
 Bad (in the locks doc):
   Locks are not a persistence store. Do not pass a lock into the stores
   map. That used to be possible but is wrong now.

--- a/.agents/skills/docs/SKILL.md
+++ b/.agents/skills/docs/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: docs
+description: Use when writing, editing, or organizing documentation, when planning what docs a feature needs, and whenever planning or implementing a new feature or change in a repo (docs ship with the code). Also use when tempted to write docs without showing the discovered readers to the user, without asking for tone, or without loading simple-english and i-have-adhd. Triggers on "write docs for X", "document this feature", "add a guide", "update the docs", "reorganize the docs", "plan feature X", "implement X", or /docs.
+---
+
+# docs
+
+Write docs a real person wants to read. Short, plain, built around someone trying to do a real thing.
+
+"Document feature X" is not the job. "Help someone do Y with X" is the job.
+
+Work in two phases. First plan the story: who reads this, what they want, and how many pages it should be. Then write.
+
+The plan is not private. The user must see the readers and must choose the tone before any page is written.
+
+```
+Find docs
+  → read neighbors
+  → Phase 1: readers + pages
+  → PERSONA GATE (show the list, then stop)
+  → TONE GATE (ask, then stop)          [when writing pages]
+  → load simple-english + i-have-adhd   [when writing pages]
+  → Phase 2: write
+```
+
+A doc-impact list in a feature plan still runs the persona gate. It does not run the tone gate or load the writing skills until pages are actually written.
+
+## When to run
+
+Docs ship with the code. Run this skill at three moments, not only when asked.
+
+- Someone asks for docs. Write them.
+- Planning a feature or change in a repo. Before the plan is done, list which docs are new and which need updating. This doc-impact list is part of the plan, the same as the code changes. Name the reader for each page.
+- Finishing an implementation. Write or update those docs before you call the work done. A change to how something behaves that ships no doc change is not finished.
+
+## Required skills for the final pages
+
+`simple-english` and `i-have-adhd` are prerequisites. They apply to the documentation pages, not to this planning chat.
+
+Load both immediately before writing page content. Use the Skill tool if this harness has one. If it does not, Read each skill's SKILL.md from the local skills directory. Do not write pages from memory of those skills.
+
+If either skill is missing, stop and tell the user. Do not write the pages without them.
+
+How they compose:
+
+- This skill owns who the page is for, the page split, problem-then-fix, show-don't-tell, no history leak, forbidden glyphs, and neighbor structure.
+- `simple-english` owns the sentences. Use pragmatic mode. Run its self-check before you call a page done.
+- `i-have-adhd` owns the shape of the page: next action first, numbered steps, lists capped at 5 (split must vs later, or split the page), no preamble, a visible win at the end.
+
+When `i-have-adhd` is loaded from this skill, apply it to the pages only. Do not switch the rest of the session into ADHD mode. The persistence section of `i-have-adhd` does not apply here.
+
+## Find the docs first
+
+Before writing anything, find where docs live.
+
+1. Look for a docs folder. Check `docs/` first, then `documentation/`, `content/docs/`, `site/`, `website/docs/`.
+2. Found nothing? Ask the user where docs should go. Do not guess and do not create a folder on a hunch.
+3. Open 2 or 3 existing pages near where the new content belongs. Read them for copy, structure, frontmatter fields, and components. Note the apparent tone as a *candidate* for the tone gate. Do not adopt it yet.
+4. Note which components the site already uses (steps, tabs, callouts, cards, accordions, code groups, and so on). Different sites have different ones.
+5. Reuse those components to tell the story. If the site has a steps component, use it for walkthroughs. If it has tabs, use them for framework variations. If the site has none, use plain markdown. Never invent a component the site does not have.
+
+If there is no page like the one you are about to write, read the closest one you can find and match it.
+
+### What "match the neighbors" covers, and what it does not
+
+Matching neighbors is about **copy, structure, frontmatter, and components**: whether headings are sentence case, how much setup a section gets, which components carry the walkthrough, how code samples are introduced, what the frontmatter fields are.
+
+It is **not** a substitute for the tone gate. Neighbors can suggest a default. They cannot answer for the user.
+
+It is **not** permission to copy a neighbor's bad habits. Everything in [Forbidden](#forbidden) and every rule in this skill still applies to the content you write, no matter what the surrounding pages do. An existing page full of em dashes does not license one more.
+
+So: never reason "the other pages do it, so I will too" about a rule this skill states. If existing pages break a rule and you think the whole set should be brought in line, that is a separate cleanup to raise with the user, not something to settle by quietly matching the violation.
+
+## Phase 1: plan the story
+
+Do this before you write a word of content.
+
+1. List who reads this and what each one wants. A person building on a React SPA, a person on a server-rendered app, someone who just wants a quick demo, someone extending the internals. Do not stop at the first reader.
+2. Write one user story per reader: "As a X, I want to Y, so I can Z."
+3. Turn stories into pages. One journey is one page. Different journeys are different pages. A feature with three real journeys is three pages plus maybe a short overview, not one giant page.
+4. Check every reader has a path. A reader with no page is a hole in the plan. Add a page or a route for them.
+
+The page split comes out of this step. Do not skip it.
+
+### Gate: show the personas
+
+<HARD-GATE>
+This gate is the entire turn. Listing readers in a thought, a todo, or a buried plan is not this gate. The user must see the list in a dedicated message, then the agent must stop.
+
+After step 4, send a message that contains only:
+
+1. Each reader, one user story, and the page you will write for them.
+2. One question: confirm, drop a reader, or add one.
+
+If the harness has an AskQuestion (or similar) tool, use it for that question. If it does not, use a numbered list. Either way, end the turn.
+
+Do not write files. Do not start Phase 2. Do not say you will proceed unless they object.
+
+Skip the *wait* only when one of these is true:
+
+- This conversation already has the user's confirmation of this persona list.
+- The user said "use sane defaults", "just write it", or "don't ask questions". Still SHOW the list in the same turn, then continue.
+- The change is a tiny copy edit: typo, broken link, code-fence language, or a factual fix. No new page, no new section, no rewrite of a journey.
+
+These are not skips:
+
+- "The readers are obvious."
+- "The user asked for docs, so they do not want a question."
+- "I already named them in the plan."
+- "There is only one reader."
+- "This is part of implementing a feature, keep going."
+
+Writing docs is why this gate exists. It is not a reason to skip it.
+</HARD-GATE>
+
+## Less is more: split, do not cram
+
+Do not force thousands of words into one page. Long pages hide the answer.
+
+When a topic has several angles, give each its own short page and link them. A reader lands on the overview, then clicks into the exact thing they need.
+
+Example. A feature for tool interrupts:
+
+```
+Bad: one page
+  interrupts.md   (overview + simple case + many interrupts + custom, all crammed in)
+
+Good: a small set of linked pages
+  interrupts/index.md            what it is, when to use it, links out
+  interrupts/basic.md            one interrupt, start to finish
+  interrupts/multiple.md         several interrupts in a flow
+  interrupts/custom.md           build your own
+```
+
+Each page is short and does one thing. The overview stitches them into a story.
+
+## Phase 2: write like a human
+
+Do not start this phase until the persona gate has passed, the tone gate has passed, and `simple-english` plus `i-have-adhd` are loaded.
+
+### Gate: ask for tone
+
+<HARD-GATE>
+This gate runs before any page content is written. It does not run for a doc-impact list that is only a plan.
+
+Neighbors can suggest a default. They cannot answer for the user.
+
+Send a message that contains only:
+
+1. The tone you inferred from neighboring pages, in one line (how formal, how much setup, second person or not).
+2. One question with options: use that tone, more casual, more formal, or the user names another.
+
+If the harness has an AskQuestion (or similar) tool, use it. If it does not, use a numbered list. Either way, end the turn.
+
+Skip the *wait* only when one of these is true:
+
+- This conversation already has the user's tone choice, including an explicit "match the existing pages".
+- The user said "use sane defaults", "just write it", or "don't ask questions". Still STATE the inferred tone in one line, then continue.
+- Tiny copy edit, same carve-out as the persona gate.
+
+These are not skips:
+
+- "I can tell from the neighbors."
+- "The site already has a voice."
+- "Tone does not matter for a reference page."
+- "I'll match neighbors and mention it later."
+</HARD-GATE>
+
+Legibility is the goal, above everything else.
+
+- Keep it digestible. No walls of text, no huge paragraphs. Break ideas into small pieces. Give the smallest amount of info that does the job.
+- Sentences follow `simple-english` (pragmatic mode). Do not inline a weaker substitute.
+- Keep markdown light. Lists are fine. Bold headings on every line are not. Let the words carry the page.
+- Prefer plain ASCII and normal keyboard characters over fancy glyphs. Write the way a person types.
+- Second person, action first. Start with what the reader has now and what they will have at the end. No "In this guide we will explore..." openings. Just start.
+- Shape the page with `i-have-adhd`: the first line is something the reader can do, multi-step work is numbered, a list longer than 5 is split, the page ends on a visible win.
+
+### Lead with the problem, then solve it
+
+Every page opens with the problem the reader came for, in their own words, before any API. Name the situation they are stuck in. Then say in a sentence or two how the feature solves it. Only after that do you go into the technical parts and the code.
+
+A reader who sees the problem first knows in seconds whether they are on the right page. A reader who hits an API signature first has to reverse-engineer what it is even for.
+
+The first line of the how is the next action (from `i-have-adhd`). The problem still comes first so they know they are on the right page.
+
+```
+Bad:
+  Call useInterrupts() and pass a resolver. The resolver runs once per
+  pending item inside a transaction...
+
+Good:
+  Some tool calls shouldn't run without a human saying yes: moving money,
+  deleting data. An interrupt pauses the run for that decision, then picks up
+  where it left off. Here is how to gate a tool behind an approval:
+
+  [code]
+```
+
+The order for a guide is problem, one-line fix, then the how (steps, snippets, API). Keep the problem to a couple of sentences, not a background essay. The code shows how it is solved, so do not narrate the solution in prose first.
+
+### Show, do not tell
+
+Do not explain in four paragraphs what one sentence and a code block can show. Readers grasp a diff or a snippet faster than prose.
+
+```
+Bad:
+  Three paragraphs describing how the config object accepts a
+  middleware array, what each slot does, and how ordering works.
+
+Good:
+  Add your middleware to the `middleware` array. Order runs top to bottom:
+
+  const app = createApp({
+    middleware: [auth, logging],
+  })
+```
+
+One good runnable example beats a page of description. Every code sample must run when copied, not need imagination to fill gaps.
+
+### List anything that is a list
+
+The moment a sentence covers more than one item, option, store, flag, or step, it becomes a list. Do not chain them into a paragraph with commas and semicolons. A reader scanning a bulleted list finds their item in a second. In a paragraph they have to read the whole thing to learn it does not apply to them.
+
+The tell is a sentence that names two or more things and says something about each. Cut it into one bullet per thing, one or two sentences each.
+
+```
+Bad:
+  Each store is independent. Provide only the ones you need. For chat:
+  `messages` for the transcript, `runs` for run lifecycle, `interrupts` for
+  durable approvals (needs `runs`), `metadata` for namespaced key/value state.
+  For generation: `generationRuns` for the run lifecycle, plus `artifacts` and
+  `blobs` to keep generated bytes.
+
+Good:
+  Each store is independent, so provide only the ones you need.
+
+  For chat:
+
+  - `messages`: the transcript.
+  - `runs`: run lifecycle.
+  - `interrupts`: durable approvals. Needs `runs`.
+  - `metadata`: namespaced key/value state.
+
+  For generation:
+
+  - `generationRuns`: run lifecycle for a generation.
+  - `artifacts` + `blobs`: keep the generated bytes.
+```
+
+Which form to reach for:
+
+- **Bullets** for a set where order does not matter: options, stores, fields, reasons, gotchas.
+- **Numbered steps** for a sequence the reader performs in order.
+- **A table** when every item has the same two or three attributes to compare (name, meaning, when to use).
+- **A paragraph** only for a single idea that genuinely flows as prose. One thought, two or three sentences, no embedded set.
+
+Keep bullets short and parallel: the same grammatical shape, the item in `code` or bold at the front, the explanation after it. A bullet that grows past two sentences wants to be its own subsection.
+
+If a list grows past five items, split it. Put "do now" first. Put the rest on a later page, or under "later". That is the `i-have-adhd` cap, not a style preference.
+
+### Page shape for a guide
+
+Problem, fix, steps, done.
+
+- Open with the problem the reader has, in their words, and what they will have at the end.
+- Say in a sentence how the feature solves it.
+- Walk through steps they can follow and test as they go, with the code doing the explaining.
+- End when they reach the goal. Show what now works. Do not close with a vague "next steps" dump.
+
+Reference pages (props, types, signatures) stay scannable and link back to the guide that shows them in use.
+
+## Write for the reader, not the history
+
+Docs describe what exists now. The reader never saw the old design, the earlier name, the draft PR, or the API you replaced along the way. Do not make them read about it.
+
+Never justify the current API by comparing it to a version that did not ship. A line like "instead of `useAssistant`, this uses `usePlugin`, which makes more sense because..." is noise to someone who never knew `useAssistant` existed. Cut it and just describe `usePlugin`.
+
+```
+Bad:
+  We renamed useAssistant to usePlugin and moved the tools onto it,
+  so instead of calling assistant.addTool you now use plugin.tools.
+
+Good:
+  Register tools on the plugin with plugin.tools:
+
+  const plugin = usePlugin({ tools: [search] })
+```
+
+Ban this framing from the output: "instead of X", "we renamed", "previously called", "this replaces the old", "unlike the earlier", and any transitional name that never reached a release.
+
+The one exception is a real migration. If users had X in a shipped, public release and you are moving them to Y, a short "Migrating from X" note is worth writing, because those readers actually used X. A name that only lived in a branch or a draft is not that. When unsure whether an old name shipped, leave it out.
+
+## Don't leak the build process
+
+The doc is read by someone who just arrived. They never saw the pull request, the refactor, or the conversation where the design was decided (including a conversation with an agent while writing the code and the docs). Write as if the current design was always the design. Anything that only makes sense to someone who watched it change is noise to the reader.
+
+**Cut rejected alternatives.** If a discussion weighed option A against option B and picked B, the doc documents B. It never names A, never says B is "better than" A, never says A "is no longer needed." The reader is not choosing between them; they use what shipped.
+
+```
+Bad:
+  We use a plain JSON Schema here instead of zod, since it is lighter
+  and zod is no longer a dependency.
+
+Good:
+  Pass the tool's input shape as a JSON Schema:
+
+  [code]
+```
+
+**Do not explain what something is not, when the reader never thought it was.** If a piece moved out of a module during a refactor, the doc for its new home does not warn against the old arrangement. A reader who never knew locks lived inside persistence is only confused by a paragraph insisting locks are not a persistence store and must not be passed in as one. State what the thing is now, in its own terms.
+
+```
+Bad (in the locks doc):
+  Locks are not a persistence store. Do not pass a lock into the stores
+  map. That used to be possible but is wrong now.
+
+Good (in the locks doc):
+  A lock coordinates work across instances. Wire it with withLocks:
+
+  [code]
+```
+
+The test: read the sentence as a brand-new user. If it answers a question they would never ask ("wait, was this somewhere else before?") or defends a choice they never knew existed, delete it. The doc has no memory of how it got here.
+
+## Forbidden
+
+Never use these. Ever. This list has no exceptions: not "the neighboring pages use them", not "the repo's house style uses them", not "it reads better here".
+
+- Em dashes and en dashes: the long `—` and the shorter `–`. Rewrite the sentence with a comma, colon, period, or parentheses instead.
+- Separator glyphs like `×` or `·`.
+- The pattern "It's not X: it's Y." and the "Not just X, but Y" three-part build-up.
+- The phrases "key insight", "gap", and variations of them.
+
+If you catch yourself reaching for one of these, stop and rewrite the sentence in plain words.
+
+Before you call a page done, search your own added text for `—`, `–`, `×`, and `·`. If a hit survived, you rationalized it. Fix it. Flagging it in your summary is not a substitute for fixing it.
+
+Then run the `simple-english` self-check on the same added text.
+
+## Cross-linking and placement
+
+- Put new pages where they fit the reader's path, grouped by what the reader is doing ("Building with React"), not by code layer ("Frontend Package API"). Update the site's nav or index so the page is reachable. An orphan page does not ship.
+- Link related pages at the moment they help, inline in the flow, not as a "Related" dump at the bottom.
+- Cross-linking goes both ways. When you add a page, update the older pages that should point into it.
+- Do not over-link. One well-placed "need X? see Y" beats a list of maybes.
+
+## Red flags
+
+| You catch yourself | Do instead |
+|---|---|
+| Opening with an API signature or config before the problem | Name the problem the reader has first, then the one-line fix, then the code. |
+| Writing three paragraphs before any code | Cut to one sentence plus a snippet. Show it. |
+| Writing a sentence that names two or more things and explains each | Make it a bulleted list, one item per bullet. |
+| A paragraph with commas or semicolons separating a set of options/stores/flags | Same fix: that is a list, format it as one. |
+| Cramming every angle into one page | Split into short linked pages, one job each. |
+| "In this guide we will explore..." | Delete it. Start with the reader's state and goal. |
+| "Let me describe what this component does" | Describe what the reader does with it. |
+| Reaching for an em dash | Rewrite with a comma, period, or parentheses. |
+| "The surrounding pages do X, so I will too" where X breaks a rule here | Match neighbors on structure only. Follow this skill on everything it covers, and raise the existing violations as their own cleanup. |
+| Using a big word (utilize, leverage, facilitate) | Swap in the plain word. `simple-english` owns this. |
+| One page for everyone | Name the readers. Give each a path or a page. Show the list. Stop. |
+| Posting a snippet "they can adapt" | Make it complete and runnable. |
+| Guessing where docs go | Find the docs folder, or ask. Read neighbors first. |
+| Calling a feature done with no doc change | If behavior changed, docs change too. Write them before you finish. |
+| Planning a feature without a doc-impact list | Add the list of new and changed docs to the plan. Name the reader for each page. |
+| "Unlike the old X, this now..." / "we renamed X to Y" | The reader never saw X. Describe only what ships now. |
+| "we chose Y over zod because..." / "X is no longer needed" | Cut the rejected alternative. Document only what shipped, no comparison. |
+| Warning readers not to do a thing they never knew was possible (e.g. "don't pass locks as a store") | Delete it. If they never saw the old arrangement, the warning only confuses. Describe the thing in its own terms. |
+| Inventing a component the site lacks | Use only components the site already has. |
+| Skipping the persona message because readers are obvious | Show the list. Stop. Obvious is not a skip. |
+| Skipping the tone question because neighbors have a voice | Neighbors are the proposed default. Ask. Then stop. |
+| Writing pages without loading simple-english and i-have-adhd | Load both. If either is missing, stop. |
+| Treating "write the docs" as permission to skip the gates | Writing docs is why the gates exist. |
+| Listing personas inside a larger plan and continuing | That is not the gate. The gate is a dedicated message that ends the turn. |

--- a/.agents/skills/ponytail/LICENSE
+++ b/.agents/skills/ponytail/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DietrichGebert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/ponytail/SKILL.md
+++ b/.agents/skills/ponytail/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ponytail
+description: >
+  Forces the laziest solution that actually works, simplest, shortest, most
+  minimal. Channels a senior dev who has seen everything: question whether the
+  task needs to exist at all (YAGNI), reach for the standard library before
+  custom code, native platform features before dependencies, one line before
+  fifty. Supports intensity levels: lite, full (default), ultra. Use whenever
+  the user says "ponytail", "be lazy", "lazy mode", "simplest solution",
+  "minimal solution", "yagni", "do less", or "shortest path", and whenever
+  they complain about over-engineering, bloat, boilerplate, or unnecessary
+  dependencies.
+argument-hint: "[lite|full|ultra]"
+license: MIT
+---
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Stdlib does it?** Use it.
+3. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+4. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+5. **Can it be one line?** One line.
+6. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project. Two rungs work → take the
+higher one and move on. The first lazy solution that works is the right one.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later", later can scaffold for itself.
+- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins.
+- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications with a `ponytail:` comment (`// ponytail: this exists`), simple reads as intent, not ignorance. Shortcut with a known ceiling (global lock, O(n²) scan, naive heuristic)? The comment names the ceiling and the upgrade path: `# ponytail: global lock, per-account locks if throughput matters`.
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+No essays, no feature tours, no design notes. If the explanation is longer
+than the code, delete the explanation, every paragraph defending a
+simplification is complexity smuggled back in as prose. Explanation the user
+explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
+give it in full, the rule is only against unrequested prose.
+
+Pattern: `[code] → skipped: [X], add when [Y].`
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
+
+Example: "Add a cache for these API responses."
+- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
+- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
+- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling
+that prevents data loss, security measures, accessibility basics, anything
+explicitly requested. User insists on the full version → build it, no
+re-arguing.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor
+reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
+just less code, the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a
+loop, a parser, a money/security path) leaves ONE runnable check behind, the
+smallest thing that fails if the logic breaks: an `assert`-based
+`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
+fixtures, no per-function suites unless asked. Trivial one-liners need no
+test, YAGNI applies to tests too.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk (pair with Caveman for
+terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+changed or session end.
+
+The shortest path to done is the right path.

--- a/.agents/skills/ponytail/SKILL.md
+++ b/.agents/skills/ponytail/SKILL.md
@@ -10,7 +10,7 @@ description: >
   "minimal solution", "yagni", "do less", or "shortest path", and whenever
   they complain about over-engineering, bloat, boilerplate, or unnecessary
   dependencies.
-argument-hint: "[lite|full|ultra]"
+argument-hint: '[lite|full|ultra]'
 license: MIT
 ---
 
@@ -63,13 +63,14 @@ Pattern: `[code] → skipped: [X], add when [Y].`
 
 ## Intensity
 
-| Level | What change |
-|-------|------------|
-| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
-| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| Level     | What change                                                                                                                 |
+| --------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **lite**  | Build what's asked, but name the lazier alternative in one line. User picks.                                                |
+| **full**  | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default.                                 |
 | **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
 
 Example: "Add a cache for these API responses."
+
 - lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
 - full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
 - ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."

--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -49,11 +49,11 @@ Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next act
 
 Pick one kind from the diff:
 
-| Kind             | Signal                                                                           |
-| ---------------- | -------------------------------------------------------------------------------- |
-| **fix**          | Restores broken behavior. A user-visible bug, a failing test, a regression.      |
-| **feat**         | Adds behavior that did not exist. New export, new command, new user-facing flow. |
-| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change.      |
+| Kind | Signal |
+|---|---|
+| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
+| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
 
 If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
 
@@ -69,71 +69,15 @@ A **feat** PR cannot be posted until the branch has at least one of:
 If none of those exist, stop. Do not run `gh pr create`. Do not run `gh pr edit`. Tell the user what is missing. Wait until they add one, then continue.
 
 A **fix** does not use this gate. A **chore / docs** PR does not use this gate.
-
-Screenshots are not this gate. A screenshot does not replace a test, a command, or an example.
 </HARD-GATE>
 
-### 4. Screenshots (try, when the PR has UI)
-
-This step is a try, not a gate. If capture fails, still write and post the PR.
-
-The PR **has UI** when the diff changes something a person sees in a browser:
-
-- Example apps
-- Playground
-- Docs site chrome (layout, theme, nav)
-- CSS, or components that paint a screen (`.tsx`, `.jsx`, `.vue`, `.svelte`, `.html` that is not a test)
-
-The PR **does not have UI** when the diff is only adapters, types, CI, tests, or agent files.
-
-If you are not sure, treat it as UI and try.
-
-Skip this step only when there is no UI, or the user said to skip screenshots. If there is no UI, omit the Screenshots heading later.
-
-**Capture**
-
-1. Find a runnable surface (example `pnpm dev`, a preview URL).
-2. Open it with the browser tools this harness has (Playwright MCP, agent-browser, or the same).
-3. Do the user flow this PR changes.
-4. Save PNG screenshots of the result.
-5. If layout or styling changed, save desktop and mobile (about 390px wide).
-6. Cap at 4 images.
-7. Stop the preview server after the files are saved. Do not leave a watcher running.
-
-Do not invent UI with an image model. Real browser only.
-
-**Put the images on the PR**
-
-GitHub has no public upload API for `user-attachments` images. Commit the PNGs on the branch so the PR body can link to them.
-
-1. Write files under `.github/pr-screenshots/<branch-kebab>/`.
-2. Commit only those PNG files. Push.
-3. Embed with full GitHub URLs. Relative paths do not render in a PR body.
-
-```markdown
-## Screenshots
-
-Desktop
-
-![desktop](https://github.com/OWNER/REPO/blob/BRANCH/.github/pr-screenshots/name/desktop.png?raw=true)
-```
-
-Get `OWNER/REPO` from `gh repo view --json nameWithOwner`. Use the branch name in the URL.
-
-If the user already pasted `https://github.com/user-attachments/assets/...` links, use those. Do not also commit files.
-
-If capture fails, still post. Keep the Screenshots heading and write one sentence: what you tried, and why it failed.
-
-Do not wait for the user to paste images.
-Do not refuse the PR because screenshots failed.
-
-### 5. Write the title
+### 4. Write the title
 
 Match this repo's recent PR titles. In a conventional-commit repo, write `type(scope): summary`. Keep it one line.
 
 The title must still make sense if the reviewer never opens the body.
 
-### 6. Write the body
+### 5. Write the body
 
 Load `simple-english` and `i-have-adhd`, then write in this order.
 
@@ -149,7 +93,7 @@ No preamble. No "This PR aims to". Start with the fact.
 
 Fill every section honestly. Leave a checkbox unchecked when the claim is false. Do not tick "I ran `pnpm test:pr`" if you did not run it.
 
-**Extra sections after the template, in this order.** Testing and Risk / rollback are always present. Screenshots, Linked issues, and Public API change are omitted when they do not apply.
+**Extra sections after the template, in this order.** Testing and Risk / rollback are always present. Linked issues and Public API change are omitted when they do not apply.
 
 #### Testing
 
@@ -158,13 +102,6 @@ Three parts, all required:
 1. **Commands run.** What you ran, what passed, what you skipped and why. If you ran nothing, say so.
 2. **Manual test.** Numbered steps a reviewer can follow to see the change. For a **fix**, step 1 is how to reproduce the old bug, then how to confirm it is gone.
 3. **How this PR makes testing easy.** Name the artifacts on the branch: tests, a command, an example app change. If there are none (allowed for fix and chore / docs), write that. Do not invent an easy path.
-
-#### Screenshots
-
-Required when step 4 ran (the PR has UI). Omit this heading when there is no UI.
-
-- On success: the markdown images from step 4, each with a short caption (Desktop, Mobile, Before, After).
-- On failure: one sentence. What you tried, and why it failed.
 
 #### Linked issues
 
@@ -200,7 +137,7 @@ new call site
 
 Two short snippets. What a user writes today, then what they write after this PR.
 
-### 7. Post immediately
+### 6. Post immediately
 
 Do not wait for the user to approve the text.
 
@@ -209,27 +146,19 @@ Do not wait for the user to approve the text.
 
 If `gh` fails, stop and show the error. Leave the drafted body in the chat so it is not lost.
 
-If step 4 wrote PNG files, those commits must be on the remote before the body links will render. Push first, then post or edit.
+Do not attach screenshots to the PR. Do not commit screenshot files for this skill.
 
 ## Red flags
 
-| You catch yourself                                           | Do instead                                                                 |
-| ------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| Writing the body from the branch name                        | Read the diff.                                                             |
-| Ticking a template checkbox you did not do                   | Leave it unchecked and say so in Testing.                                  |
-| Posting a feat with no test, command, or example             | Stop. The feat gate failed.                                                |
-| A 1-4 sentence lead that lists files                         | Rewrite as what a user can do, or what bug is gone.                        |
-| Public API section that shows the internal diff              | Show caller usage before and after.                                        |
-| Public API section on an AGENTS.md-only PR                   | Omit the heading.                                                          |
-| "I'll update the description later" after a push             | Rewrite now with `gh pr edit`.                                             |
-| Waiting for the user to approve the text                     | Post. This skill does not wait.                                            |
-| Skipping screenshots on a UI PR because "the text is enough" | Try capture.                                                               |
-| Skipping because GitHub has no upload API                    | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs.                |
-| Relative image paths in the PR body                          | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
-| Inventing a UI image with an image model                     | Real browser only.                                                         |
-| Waiting for the user to paste images                         | Capture first. Post even if capture fails.                                 |
-| Refusing to post because screenshots failed                  | Post. Say why in Screenshots.                                              |
-| Using a screenshot as the feat-gate artifact                 | The feat gate still needs a test, a command, or an example.                |
-| Mixing unrelated files into the screenshot commit            | Add only the PNG files.                                                    |
-| Leaving a preview server running after capture               | Stop the server.                                                           |
-| Writing without loading simple-english and i-have-adhd       | Load both. If missing, stop.                                               |
+| You catch yourself | Do instead |
+|---|---|
+| Writing the body from the branch name | Read the diff. |
+| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
+| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
+| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
+| Public API section that shows the internal diff | Show caller usage before and after. |
+| Public API section on an AGENTS.md-only PR | Omit the heading. |
+| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
+| Waiting for the user to approve the text | Post. This skill does not wait. |
+| Uploading or committing screenshots for the PR body | Skip. Do not put images on the PR. |
+| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |

--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: pr-description
+description: Use when writing a pull request title or body, when about to run gh pr create, when about to git push on a branch that already has an open PR, or when the user says /pr-description, "write the PR description", or "update the PR title". Don't use for commit messages, changelogs, or review comments.
+---
+
+# pr-description
+
+Write the GitHub PR title and body, then post them. Do not wait for approval.
+
+Work from the diff, not from memory.
+
+## When to run
+
+This skill is auto plus on demand.
+
+Run it:
+
+- When the user asks for a PR title or body, or types `/pr-description`.
+- Immediately before `gh pr create`.
+- Immediately after an **agent** `git push` on a branch that already has an open PR. Then run `gh pr edit` with a fresh title and body.
+
+Do not run it on a human-only `git push` in another terminal. Do not add a git hook.
+
+A later push must rewrite the GitHub text. Do not leave a stale description.
+
+## Required skills for the title and body
+
+`simple-english` and `i-have-adhd` are prerequisites. They apply to the PR title and body, not to the rest of the session.
+
+Load both immediately before writing the title and body. Use the Skill tool if this harness has one. If it does not, Read each skill's SKILL.md. Do not write from memory of those skills.
+
+If either skill is missing, stop. Do not post a weaker substitute.
+
+When `i-have-adhd` is loaded from this skill, ignore its persistence section. Do not switch the rest of the session into ADHD mode.
+
+Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next action first in the lead, numbered steps for manual test, lists capped at 5.
+
+## Procedure
+
+### 1. Ground in the repo
+
+1. Find the base branch (`main` / `master` / `develop`).
+2. Read `git log --oneline base...HEAD` and `git diff base...HEAD`.
+3. Read `.github/pull_request_template.md` if it exists (also check `.github/PULL_REQUEST_TEMPLATE.md` and `.github/PULL_REQUEST_TEMPLATE/`).
+4. Read about 15 recent PR titles in this repo (`gh pr list --limit 15 --state all --json title`). Match that shape. Do not invent a new title style.
+5. Collect linked issues from branch name, commit messages, and `Closes #` / `Fixes #` text.
+
+### 2. Classify the PR
+
+Pick one kind from the diff:
+
+| Kind | Signal |
+|---|---|
+| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
+| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
+
+If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
+
+### 3. Feat gate: easy test path
+
+<HARD-GATE>
+A **feat** PR cannot be posted until the branch has at least one of:
+
+- A new or updated automated test that covers the new behavior
+- A command a reviewer can copy and run
+- A change in an official example app that shows the new behavior
+
+If none of those exist, stop. Do not run `gh pr create`. Do not run `gh pr edit`. Tell the user what is missing. Wait until they add one, then continue.
+
+A **fix** does not use this gate. A **chore / docs** PR does not use this gate.
+
+Screenshots are not this gate. A screenshot does not replace a test, a command, or an example.
+</HARD-GATE>
+
+### 4. Screenshots (try, when the PR has UI)
+
+This step is a try, not a gate. If capture fails, still write and post the PR.
+
+The PR **has UI** when the diff changes something a person sees in a browser:
+
+- Example apps
+- Playground
+- Docs site chrome (layout, theme, nav)
+- CSS, or components that paint a screen (`.tsx`, `.jsx`, `.vue`, `.svelte`, `.html` that is not a test)
+
+The PR **does not have UI** when the diff is only adapters, types, CI, tests, or agent files.
+
+If you are not sure, treat it as UI and try.
+
+Skip this step only when there is no UI, or the user said to skip screenshots. If there is no UI, omit the Screenshots heading later.
+
+**Capture**
+
+1. Find a runnable surface (example `pnpm dev`, a preview URL).
+2. Open it with the browser tools this harness has (Playwright MCP, agent-browser, or the same).
+3. Do the user flow this PR changes.
+4. Save PNG screenshots of the result.
+5. If layout or styling changed, save desktop and mobile (about 390px wide).
+6. Cap at 4 images.
+7. Stop the preview server after the files are saved. Do not leave a watcher running.
+
+Do not invent UI with an image model. Real browser only.
+
+**Put the images on the PR**
+
+GitHub has no public upload API for `user-attachments` images. Commit the PNGs on the branch so the PR body can link to them.
+
+1. Write files under `.github/pr-screenshots/<branch-kebab>/`.
+2. Commit only those PNG files. Push.
+3. Embed with full GitHub URLs. Relative paths do not render in a PR body.
+
+```markdown
+## Screenshots
+
+Desktop
+
+![desktop](https://github.com/OWNER/REPO/blob/BRANCH/.github/pr-screenshots/name/desktop.png?raw=true)
+```
+
+Get `OWNER/REPO` from `gh repo view --json nameWithOwner`. Use the branch name in the URL.
+
+If the user already pasted `https://github.com/user-attachments/assets/...` links, use those. Do not also commit files.
+
+If capture fails, still post. Keep the Screenshots heading and write one sentence: what you tried, and why it failed.
+
+Do not wait for the user to paste images.
+Do not refuse the PR because screenshots failed.
+
+### 5. Write the title
+
+Match this repo's recent PR titles. In a conventional-commit repo, write `type(scope): summary`. Keep it one line.
+
+The title must still make sense if the reviewer never opens the body.
+
+### 6. Write the body
+
+Load `simple-english` and `i-have-adhd`, then write in this order.
+
+**Lead (required, 1 to 4 sentences, before the template).**
+
+- **feat:** what the PR does for a user of the product.
+- **fix:** what the bug is, then how this PR fixes it.
+- **chore / docs:** what changed, in product or repo terms, not a file list.
+
+No preamble. No "This PR aims to". Start with the fact.
+
+**Repo template (required when the file exists).**
+
+Fill every section honestly. Leave a checkbox unchecked when the claim is false. Do not tick "I ran `pnpm test:pr`" if you did not run it.
+
+**Extra sections after the template, in this order.** Testing and Risk / rollback are always present. Screenshots, Linked issues, and Public API change are omitted when they do not apply.
+
+#### Testing
+
+Three parts, all required:
+
+1. **Commands run.** What you ran, what passed, what you skipped and why. If you ran nothing, say so.
+2. **Manual test.** Numbered steps a reviewer can follow to see the change. For a **fix**, step 1 is how to reproduce the old bug, then how to confirm it is gone.
+3. **How this PR makes testing easy.** Name the artifacts on the branch: tests, a command, an example app change. If there are none (allowed for fix and chore / docs), write that. Do not invent an easy path.
+
+#### Screenshots
+
+Required when step 4 ran (the PR has UI). Omit this heading when there is no UI.
+
+- On success: the markdown images from step 4, each with a short caption (Desktop, Mobile, Before, After).
+- On failure: one sentence. What you tried, and why it failed.
+
+#### Linked issues
+
+Omit this heading when nothing links. When an issue links, use `Closes #N` or `Fixes #N`.
+
+#### Risk / rollback
+
+What could break. How to undo (revert the PR, turn a flag off, and so on). If risk is low, say that in one line. Do not skip the heading.
+
+#### Public API change
+
+Omit this heading when the PR does not touch the published surface.
+
+Published surface means: exported functions, types, components, CLI flags, env vars, and documented contracts from **published** packages. Tests, internal files, agent skills, `AGENTS.md`, and `CLAUDE.md` do not count.
+
+When it does touch that surface, show **caller usage**, not the internal diff:
+
+```markdown
+## Public API change
+
+**Before**
+
+\`\`\`ts
+old call site
+\`\`\`
+
+**After**
+
+\`\`\`ts
+new call site
+\`\`\`
+```
+
+Two short snippets. What a user writes today, then what they write after this PR.
+
+### 7. Post immediately
+
+Do not wait for the user to approve the text.
+
+- No PR yet: `gh pr create --title "..." --body-file ...`
+- PR already open: `gh pr edit --title "..." --body-file ...`
+
+If `gh` fails, stop and show the error. Leave the drafted body in the chat so it is not lost.
+
+If step 4 wrote PNG files, those commits must be on the remote before the body links will render. Push first, then post or edit.
+
+## Red flags
+
+| You catch yourself | Do instead |
+|---|---|
+| Writing the body from the branch name | Read the diff. |
+| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
+| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
+| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
+| Public API section that shows the internal diff | Show caller usage before and after. |
+| Public API section on an AGENTS.md-only PR | Omit the heading. |
+| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
+| Waiting for the user to approve the text | Post. This skill does not wait. |
+| Skipping screenshots on a UI PR because "the text is enough" | Try capture. |
+| Skipping because GitHub has no upload API | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs. |
+| Relative image paths in the PR body | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
+| Inventing a UI image with an image model | Real browser only. |
+| Waiting for the user to paste images | Capture first. Post even if capture fails. |
+| Refusing to post because screenshots failed | Post. Say why in Screenshots. |
+| Using a screenshot as the feat-gate artifact | The feat gate still needs a test, a command, or an example. |
+| Mixing unrelated files into the screenshot commit | Add only the PNG files. |
+| Leaving a preview server running after capture | Stop the server. |
+| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |

--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -49,11 +49,11 @@ Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next act
 
 Pick one kind from the diff:
 
-| Kind | Signal |
-|---|---|
-| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
-| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
-| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
+| Kind             | Signal                                                                           |
+| ---------------- | -------------------------------------------------------------------------------- |
+| **fix**          | Restores broken behavior. A user-visible bug, a failing test, a regression.      |
+| **feat**         | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change.      |
 
 If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
 
@@ -213,23 +213,23 @@ If step 4 wrote PNG files, those commits must be on the remote before the body l
 
 ## Red flags
 
-| You catch yourself | Do instead |
-|---|---|
-| Writing the body from the branch name | Read the diff. |
-| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
-| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
-| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
-| Public API section that shows the internal diff | Show caller usage before and after. |
-| Public API section on an AGENTS.md-only PR | Omit the heading. |
-| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
-| Waiting for the user to approve the text | Post. This skill does not wait. |
-| Skipping screenshots on a UI PR because "the text is enough" | Try capture. |
-| Skipping because GitHub has no upload API | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs. |
-| Relative image paths in the PR body | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
-| Inventing a UI image with an image model | Real browser only. |
-| Waiting for the user to paste images | Capture first. Post even if capture fails. |
-| Refusing to post because screenshots failed | Post. Say why in Screenshots. |
-| Using a screenshot as the feat-gate artifact | The feat gate still needs a test, a command, or an example. |
-| Mixing unrelated files into the screenshot commit | Add only the PNG files. |
-| Leaving a preview server running after capture | Stop the server. |
-| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |
+| You catch yourself                                           | Do instead                                                                 |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Writing the body from the branch name                        | Read the diff.                                                             |
+| Ticking a template checkbox you did not do                   | Leave it unchecked and say so in Testing.                                  |
+| Posting a feat with no test, command, or example             | Stop. The feat gate failed.                                                |
+| A 1-4 sentence lead that lists files                         | Rewrite as what a user can do, or what bug is gone.                        |
+| Public API section that shows the internal diff              | Show caller usage before and after.                                        |
+| Public API section on an AGENTS.md-only PR                   | Omit the heading.                                                          |
+| "I'll update the description later" after a push             | Rewrite now with `gh pr edit`.                                             |
+| Waiting for the user to approve the text                     | Post. This skill does not wait.                                            |
+| Skipping screenshots on a UI PR because "the text is enough" | Try capture.                                                               |
+| Skipping because GitHub has no upload API                    | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs.                |
+| Relative image paths in the PR body                          | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
+| Inventing a UI image with an image model                     | Real browser only.                                                         |
+| Waiting for the user to paste images                         | Capture first. Post even if capture fails.                                 |
+| Refusing to post because screenshots failed                  | Post. Say why in Screenshots.                                              |
+| Using a screenshot as the feat-gate artifact                 | The feat gate still needs a test, a command, or an example.                |
+| Mixing unrelated files into the screenshot commit            | Add only the PNG files.                                                    |
+| Leaving a preview server running after capture               | Stop the server.                                                           |
+| Writing without loading simple-english and i-have-adhd       | Load both. If missing, stop.                                               |

--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -49,11 +49,11 @@ Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next act
 
 Pick one kind from the diff:
 
-| Kind | Signal |
-|---|---|
-| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
-| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
-| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
+| Kind             | Signal                                                                           |
+| ---------------- | -------------------------------------------------------------------------------- |
+| **fix**          | Restores broken behavior. A user-visible bug, a failing test, a regression.      |
+| **feat**         | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change.      |
 
 If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
 
@@ -150,15 +150,15 @@ Do not attach screenshots to the PR. Do not commit screenshot files for this ski
 
 ## Red flags
 
-| You catch yourself | Do instead |
-|---|---|
-| Writing the body from the branch name | Read the diff. |
-| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
-| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
-| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
-| Public API section that shows the internal diff | Show caller usage before and after. |
-| Public API section on an AGENTS.md-only PR | Omit the heading. |
-| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
-| Waiting for the user to approve the text | Post. This skill does not wait. |
-| Uploading or committing screenshots for the PR body | Skip. Do not put images on the PR. |
-| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |
+| You catch yourself                                     | Do instead                                          |
+| ------------------------------------------------------ | --------------------------------------------------- |
+| Writing the body from the branch name                  | Read the diff.                                      |
+| Ticking a template checkbox you did not do             | Leave it unchecked and say so in Testing.           |
+| Posting a feat with no test, command, or example       | Stop. The feat gate failed.                         |
+| A 1-4 sentence lead that lists files                   | Rewrite as what a user can do, or what bug is gone. |
+| Public API section that shows the internal diff        | Show caller usage before and after.                 |
+| Public API section on an AGENTS.md-only PR             | Omit the heading.                                   |
+| "I'll update the description later" after a push       | Rewrite now with `gh pr edit`.                      |
+| Waiting for the user to approve the text               | Post. This skill does not wait.                     |
+| Uploading or committing screenshots for the PR body    | Skip. Do not put images on the PR.                  |
+| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop.                        |

--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -13,7 +13,7 @@ Work in two phases. First plan the story: who reads this, what they want, and ho
 
 The plan is not private. The user must see the readers and must choose the tone before any page is written.
 
-```
+```text
 Find docs
   → read neighbors
   → Phase 1: readers + pages
@@ -85,22 +85,26 @@ The page split comes out of this step. Do not skip it.
 ### Gate: show the personas
 
 <HARD-GATE>
-This gate is the entire turn. Listing readers in a thought, a todo, or a buried plan is not this gate. The user must see the list in a dedicated message, then the agent must stop.
+The user must see the list. Listing readers in a thought, a todo, or a buried plan is not this gate.
 
 After step 4, send a message that contains only:
 
 1. Each reader, one user story, and the page you will write for them.
 2. One question: confirm, drop a reader, or add one.
 
-If the harness has an AskQuestion (or similar) tool, use it for that question. If it does not, use a numbered list. Either way, end the turn.
+If the harness has an AskQuestion (or similar) tool, use it for that question. If it does not, use a numbered list.
 
-Do not write files. Do not start Phase 2. Do not say you will proceed unless they object.
+Then pick one path:
 
-Skip the *wait* only when one of these is true:
+**Default: stop.** This message is the entire turn. End the turn. Do not write files. Do not start Phase 2. Do not say you will proceed unless they object.
+
+**Skip the wait: continue in this same turn.** Use this path only when one of these is true:
 
 - This conversation already has the user's confirmation of this persona list.
-- The user said "use sane defaults", "just write it", or "don't ask questions". Still SHOW the list in the same turn, then continue.
+- The user said "use sane defaults", "just write it", or "don't ask questions". Still SHOW the list in this turn, then continue.
 - The change is a tiny copy edit: typo, broken link, code-fence language, or a factual fix. No new page, no new section, no rewrite of a journey.
+
+On this path, do not end the turn. After you show the list (or after a tiny copy edit, with no list), continue to the next step.
 
 These are not skips:
 
@@ -121,7 +125,7 @@ When a topic has several angles, give each its own short page and link them. A r
 
 Example. A feature for tool interrupts:
 
-```
+```text
 Bad: one page
   interrupts.md   (overview + simple case + many interrupts + custom, all crammed in)
 
@@ -134,11 +138,9 @@ Good: a small set of linked pages
 
 Each page is short and does one thing. The overview stitches them into a story.
 
-## Phase 2: write like a human
+## Gate: ask for tone
 
-Do not start this phase until the persona gate has passed, the tone gate has passed, and `simple-english` plus `i-have-adhd` are loaded.
-
-### Gate: ask for tone
+This gate sits between Phase 1 and Phase 2. Run it before you write any page. Do not nest it inside Phase 2.
 
 <HARD-GATE>
 This gate runs before any page content is written. It does not run for a doc-impact list that is only a plan.
@@ -150,13 +152,19 @@ Send a message that contains only:
 1. The tone you inferred from neighboring pages, in one line (how formal, how much setup, second person or not).
 2. One question with options: use that tone, more casual, more formal, or the user names another.
 
-If the harness has an AskQuestion (or similar) tool, use it. If it does not, use a numbered list. Either way, end the turn.
+If the harness has an AskQuestion (or similar) tool, use it. If it does not, use a numbered list.
 
-Skip the *wait* only when one of these is true:
+Then pick one path:
+
+**Default: stop.** This message is the entire turn. End the turn. Do not write page content.
+
+**Skip the wait: continue in this same turn.** Use this path only when one of these is true:
 
 - This conversation already has the user's tone choice, including an explicit "match the existing pages".
 - The user said "use sane defaults", "just write it", or "don't ask questions". Still STATE the inferred tone in one line, then continue.
 - Tiny copy edit, same carve-out as the persona gate.
+
+On this path, do not end the turn. After you state the tone (or after a tiny copy edit, with no question), continue to Phase 2.
 
 These are not skips:
 
@@ -165,6 +173,12 @@ These are not skips:
 - "Tone does not matter for a reference page."
 - "I'll match neighbors and mention it later."
 </HARD-GATE>
+
+## Phase 2: write like a human
+
+Do not write page content until the persona gate has passed, the tone gate has passed, and `simple-english` plus `i-have-adhd` are loaded.
+
+The tone gate is the heading above this one. Run that gate first. Then load the two skills. Then write.
 
 Legibility is the goal, above everything else.
 
@@ -183,7 +197,7 @@ A reader who sees the problem first knows in seconds whether they are on the rig
 
 The first line of the how is the next action (from `i-have-adhd`). The problem still comes first so they know they are on the right page.
 
-```
+```text
 Bad:
   Call useInterrupts() and pass a resolver. The resolver runs once per
   pending item inside a transaction...
@@ -202,7 +216,7 @@ The order for a guide is problem, one-line fix, then the how (steps, snippets, A
 
 Do not explain in four paragraphs what one sentence and a code block can show. Readers grasp a diff or a snippet faster than prose.
 
-```
+```text
 Bad:
   Three paragraphs describing how the config object accepts a
   middleware array, what each slot does, and how ordering works.
@@ -223,7 +237,7 @@ The moment a sentence covers more than one item, option, store, flag, or step, i
 
 The tell is a sentence that names two or more things and says something about each. Cut it into one bullet per thing, one or two sentences each.
 
-```
+```text
 Bad:
   Each store is independent. Provide only the ones you need. For chat:
   `messages` for the transcript, `runs` for run lifecycle, `interrupts` for
@@ -275,7 +289,7 @@ Docs describe what exists now. The reader never saw the old design, the earlier 
 
 Never justify the current API by comparing it to a version that did not ship. A line like "instead of `useAssistant`, this uses `usePlugin`, which makes more sense because..." is noise to someone who never knew `useAssistant` existed. Cut it and just describe `usePlugin`.
 
-```
+```text
 Bad:
   We renamed useAssistant to usePlugin and moved the tools onto it,
   so instead of calling assistant.addTool you now use plugin.tools.
@@ -296,7 +310,7 @@ The doc is read by someone who just arrived. They never saw the pull request, th
 
 **Cut rejected alternatives.** If a discussion weighed option A against option B and picked B, the doc documents B. It never names A, never says B is "better than" A, never says A "is no longer needed." The reader is not choosing between them; they use what shipped.
 
-```
+```text
 Bad:
   We use a plain JSON Schema here instead of zod, since it is lighter
   and zod is no longer a dependency.
@@ -309,7 +323,7 @@ Good:
 
 **Do not explain what something is not, when the reader never thought it was.** If a piece moved out of a module during a refactor, the doc for its new home does not warn against the old arrangement. A reader who never knew locks lived inside persistence is only confused by a paragraph insisting locks are not a persistence store and must not be passed in as one. State what the thing is now, in its own terms.
 
-```
+```text
 Bad (in the locks doc):
   Locks are not a persistence store. Do not pass a lock into the stores
   map. That used to be possible but is wrong now.

--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: docs
+description: Use when writing, editing, or organizing documentation, when planning what docs a feature needs, and whenever planning or implementing a new feature or change in a repo (docs ship with the code). Also use when tempted to write docs without showing the discovered readers to the user, without asking for tone, or without loading simple-english and i-have-adhd. Triggers on "write docs for X", "document this feature", "add a guide", "update the docs", "reorganize the docs", "plan feature X", "implement X", or /docs.
+---
+
+# docs
+
+Write docs a real person wants to read. Short, plain, built around someone trying to do a real thing.
+
+"Document feature X" is not the job. "Help someone do Y with X" is the job.
+
+Work in two phases. First plan the story: who reads this, what they want, and how many pages it should be. Then write.
+
+The plan is not private. The user must see the readers and must choose the tone before any page is written.
+
+```
+Find docs
+  → read neighbors
+  → Phase 1: readers + pages
+  → PERSONA GATE (show the list, then stop)
+  → TONE GATE (ask, then stop)          [when writing pages]
+  → load simple-english + i-have-adhd   [when writing pages]
+  → Phase 2: write
+```
+
+A doc-impact list in a feature plan still runs the persona gate. It does not run the tone gate or load the writing skills until pages are actually written.
+
+## When to run
+
+Docs ship with the code. Run this skill at three moments, not only when asked.
+
+- Someone asks for docs. Write them.
+- Planning a feature or change in a repo. Before the plan is done, list which docs are new and which need updating. This doc-impact list is part of the plan, the same as the code changes. Name the reader for each page.
+- Finishing an implementation. Write or update those docs before you call the work done. A change to how something behaves that ships no doc change is not finished.
+
+## Required skills for the final pages
+
+`simple-english` and `i-have-adhd` are prerequisites. They apply to the documentation pages, not to this planning chat.
+
+Load both immediately before writing page content. Use the Skill tool if this harness has one. If it does not, Read each skill's SKILL.md from the local skills directory. Do not write pages from memory of those skills.
+
+If either skill is missing, stop and tell the user. Do not write the pages without them.
+
+How they compose:
+
+- This skill owns who the page is for, the page split, problem-then-fix, show-don't-tell, no history leak, forbidden glyphs, and neighbor structure.
+- `simple-english` owns the sentences. Use pragmatic mode. Run its self-check before you call a page done.
+- `i-have-adhd` owns the shape of the page: next action first, numbered steps, lists capped at 5 (split must vs later, or split the page), no preamble, a visible win at the end.
+
+When `i-have-adhd` is loaded from this skill, apply it to the pages only. Do not switch the rest of the session into ADHD mode. The persistence section of `i-have-adhd` does not apply here.
+
+## Find the docs first
+
+Before writing anything, find where docs live.
+
+1. Look for a docs folder. Check `docs/` first, then `documentation/`, `content/docs/`, `site/`, `website/docs/`.
+2. Found nothing? Ask the user where docs should go. Do not guess and do not create a folder on a hunch.
+3. Open 2 or 3 existing pages near where the new content belongs. Read them for copy, structure, frontmatter fields, and components. Note the apparent tone as a *candidate* for the tone gate. Do not adopt it yet.
+4. Note which components the site already uses (steps, tabs, callouts, cards, accordions, code groups, and so on). Different sites have different ones.
+5. Reuse those components to tell the story. If the site has a steps component, use it for walkthroughs. If it has tabs, use them for framework variations. If the site has none, use plain markdown. Never invent a component the site does not have.
+
+If there is no page like the one you are about to write, read the closest one you can find and match it.
+
+### What "match the neighbors" covers, and what it does not
+
+Matching neighbors is about **copy, structure, frontmatter, and components**: whether headings are sentence case, how much setup a section gets, which components carry the walkthrough, how code samples are introduced, what the frontmatter fields are.
+
+It is **not** a substitute for the tone gate. Neighbors can suggest a default. They cannot answer for the user.
+
+It is **not** permission to copy a neighbor's bad habits. Everything in [Forbidden](#forbidden) and every rule in this skill still applies to the content you write, no matter what the surrounding pages do. An existing page full of em dashes does not license one more.
+
+So: never reason "the other pages do it, so I will too" about a rule this skill states. If existing pages break a rule and you think the whole set should be brought in line, that is a separate cleanup to raise with the user, not something to settle by quietly matching the violation.
+
+## Phase 1: plan the story
+
+Do this before you write a word of content.
+
+1. List who reads this and what each one wants. A person building on a React SPA, a person on a server-rendered app, someone who just wants a quick demo, someone extending the internals. Do not stop at the first reader.
+2. Write one user story per reader: "As a X, I want to Y, so I can Z."
+3. Turn stories into pages. One journey is one page. Different journeys are different pages. A feature with three real journeys is three pages plus maybe a short overview, not one giant page.
+4. Check every reader has a path. A reader with no page is a hole in the plan. Add a page or a route for them.
+
+The page split comes out of this step. Do not skip it.
+
+### Gate: show the personas
+
+<HARD-GATE>
+This gate is the entire turn. Listing readers in a thought, a todo, or a buried plan is not this gate. The user must see the list in a dedicated message, then the agent must stop.
+
+After step 4, send a message that contains only:
+
+1. Each reader, one user story, and the page you will write for them.
+2. One question: confirm, drop a reader, or add one.
+
+If the harness has an AskQuestion (or similar) tool, use it for that question. If it does not, use a numbered list. Either way, end the turn.
+
+Do not write files. Do not start Phase 2. Do not say you will proceed unless they object.
+
+Skip the *wait* only when one of these is true:
+
+- This conversation already has the user's confirmation of this persona list.
+- The user said "use sane defaults", "just write it", or "don't ask questions". Still SHOW the list in the same turn, then continue.
+- The change is a tiny copy edit: typo, broken link, code-fence language, or a factual fix. No new page, no new section, no rewrite of a journey.
+
+These are not skips:
+
+- "The readers are obvious."
+- "The user asked for docs, so they do not want a question."
+- "I already named them in the plan."
+- "There is only one reader."
+- "This is part of implementing a feature, keep going."
+
+Writing docs is why this gate exists. It is not a reason to skip it.
+</HARD-GATE>
+
+## Less is more: split, do not cram
+
+Do not force thousands of words into one page. Long pages hide the answer.
+
+When a topic has several angles, give each its own short page and link them. A reader lands on the overview, then clicks into the exact thing they need.
+
+Example. A feature for tool interrupts:
+
+```
+Bad: one page
+  interrupts.md   (overview + simple case + many interrupts + custom, all crammed in)
+
+Good: a small set of linked pages
+  interrupts/index.md            what it is, when to use it, links out
+  interrupts/basic.md            one interrupt, start to finish
+  interrupts/multiple.md         several interrupts in a flow
+  interrupts/custom.md           build your own
+```
+
+Each page is short and does one thing. The overview stitches them into a story.
+
+## Phase 2: write like a human
+
+Do not start this phase until the persona gate has passed, the tone gate has passed, and `simple-english` plus `i-have-adhd` are loaded.
+
+### Gate: ask for tone
+
+<HARD-GATE>
+This gate runs before any page content is written. It does not run for a doc-impact list that is only a plan.
+
+Neighbors can suggest a default. They cannot answer for the user.
+
+Send a message that contains only:
+
+1. The tone you inferred from neighboring pages, in one line (how formal, how much setup, second person or not).
+2. One question with options: use that tone, more casual, more formal, or the user names another.
+
+If the harness has an AskQuestion (or similar) tool, use it. If it does not, use a numbered list. Either way, end the turn.
+
+Skip the *wait* only when one of these is true:
+
+- This conversation already has the user's tone choice, including an explicit "match the existing pages".
+- The user said "use sane defaults", "just write it", or "don't ask questions". Still STATE the inferred tone in one line, then continue.
+- Tiny copy edit, same carve-out as the persona gate.
+
+These are not skips:
+
+- "I can tell from the neighbors."
+- "The site already has a voice."
+- "Tone does not matter for a reference page."
+- "I'll match neighbors and mention it later."
+</HARD-GATE>
+
+Legibility is the goal, above everything else.
+
+- Keep it digestible. No walls of text, no huge paragraphs. Break ideas into small pieces. Give the smallest amount of info that does the job.
+- Sentences follow `simple-english` (pragmatic mode). Do not inline a weaker substitute.
+- Keep markdown light. Lists are fine. Bold headings on every line are not. Let the words carry the page.
+- Prefer plain ASCII and normal keyboard characters over fancy glyphs. Write the way a person types.
+- Second person, action first. Start with what the reader has now and what they will have at the end. No "In this guide we will explore..." openings. Just start.
+- Shape the page with `i-have-adhd`: the first line is something the reader can do, multi-step work is numbered, a list longer than 5 is split, the page ends on a visible win.
+
+### Lead with the problem, then solve it
+
+Every page opens with the problem the reader came for, in their own words, before any API. Name the situation they are stuck in. Then say in a sentence or two how the feature solves it. Only after that do you go into the technical parts and the code.
+
+A reader who sees the problem first knows in seconds whether they are on the right page. A reader who hits an API signature first has to reverse-engineer what it is even for.
+
+The first line of the how is the next action (from `i-have-adhd`). The problem still comes first so they know they are on the right page.
+
+```
+Bad:
+  Call useInterrupts() and pass a resolver. The resolver runs once per
+  pending item inside a transaction...
+
+Good:
+  Some tool calls shouldn't run without a human saying yes: moving money,
+  deleting data. An interrupt pauses the run for that decision, then picks up
+  where it left off. Here is how to gate a tool behind an approval:
+
+  [code]
+```
+
+The order for a guide is problem, one-line fix, then the how (steps, snippets, API). Keep the problem to a couple of sentences, not a background essay. The code shows how it is solved, so do not narrate the solution in prose first.
+
+### Show, do not tell
+
+Do not explain in four paragraphs what one sentence and a code block can show. Readers grasp a diff or a snippet faster than prose.
+
+```
+Bad:
+  Three paragraphs describing how the config object accepts a
+  middleware array, what each slot does, and how ordering works.
+
+Good:
+  Add your middleware to the `middleware` array. Order runs top to bottom:
+
+  const app = createApp({
+    middleware: [auth, logging],
+  })
+```
+
+One good runnable example beats a page of description. Every code sample must run when copied, not need imagination to fill gaps.
+
+### List anything that is a list
+
+The moment a sentence covers more than one item, option, store, flag, or step, it becomes a list. Do not chain them into a paragraph with commas and semicolons. A reader scanning a bulleted list finds their item in a second. In a paragraph they have to read the whole thing to learn it does not apply to them.
+
+The tell is a sentence that names two or more things and says something about each. Cut it into one bullet per thing, one or two sentences each.
+
+```
+Bad:
+  Each store is independent. Provide only the ones you need. For chat:
+  `messages` for the transcript, `runs` for run lifecycle, `interrupts` for
+  durable approvals (needs `runs`), `metadata` for namespaced key/value state.
+  For generation: `generationRuns` for the run lifecycle, plus `artifacts` and
+  `blobs` to keep generated bytes.
+
+Good:
+  Each store is independent, so provide only the ones you need.
+
+  For chat:
+
+  - `messages`: the transcript.
+  - `runs`: run lifecycle.
+  - `interrupts`: durable approvals. Needs `runs`.
+  - `metadata`: namespaced key/value state.
+
+  For generation:
+
+  - `generationRuns`: run lifecycle for a generation.
+  - `artifacts` + `blobs`: keep the generated bytes.
+```
+
+Which form to reach for:
+
+- **Bullets** for a set where order does not matter: options, stores, fields, reasons, gotchas.
+- **Numbered steps** for a sequence the reader performs in order.
+- **A table** when every item has the same two or three attributes to compare (name, meaning, when to use).
+- **A paragraph** only for a single idea that genuinely flows as prose. One thought, two or three sentences, no embedded set.
+
+Keep bullets short and parallel: the same grammatical shape, the item in `code` or bold at the front, the explanation after it. A bullet that grows past two sentences wants to be its own subsection.
+
+If a list grows past five items, split it. Put "do now" first. Put the rest on a later page, or under "later". That is the `i-have-adhd` cap, not a style preference.
+
+### Page shape for a guide
+
+Problem, fix, steps, done.
+
+- Open with the problem the reader has, in their words, and what they will have at the end.
+- Say in a sentence how the feature solves it.
+- Walk through steps they can follow and test as they go, with the code doing the explaining.
+- End when they reach the goal. Show what now works. Do not close with a vague "next steps" dump.
+
+Reference pages (props, types, signatures) stay scannable and link back to the guide that shows them in use.
+
+## Write for the reader, not the history
+
+Docs describe what exists now. The reader never saw the old design, the earlier name, the draft PR, or the API you replaced along the way. Do not make them read about it.
+
+Never justify the current API by comparing it to a version that did not ship. A line like "instead of `useAssistant`, this uses `usePlugin`, which makes more sense because..." is noise to someone who never knew `useAssistant` existed. Cut it and just describe `usePlugin`.
+
+```
+Bad:
+  We renamed useAssistant to usePlugin and moved the tools onto it,
+  so instead of calling assistant.addTool you now use plugin.tools.
+
+Good:
+  Register tools on the plugin with plugin.tools:
+
+  const plugin = usePlugin({ tools: [search] })
+```
+
+Ban this framing from the output: "instead of X", "we renamed", "previously called", "this replaces the old", "unlike the earlier", and any transitional name that never reached a release.
+
+The one exception is a real migration. If users had X in a shipped, public release and you are moving them to Y, a short "Migrating from X" note is worth writing, because those readers actually used X. A name that only lived in a branch or a draft is not that. When unsure whether an old name shipped, leave it out.
+
+## Don't leak the build process
+
+The doc is read by someone who just arrived. They never saw the pull request, the refactor, or the conversation where the design was decided (including a conversation with an agent while writing the code and the docs). Write as if the current design was always the design. Anything that only makes sense to someone who watched it change is noise to the reader.
+
+**Cut rejected alternatives.** If a discussion weighed option A against option B and picked B, the doc documents B. It never names A, never says B is "better than" A, never says A "is no longer needed." The reader is not choosing between them; they use what shipped.
+
+```
+Bad:
+  We use a plain JSON Schema here instead of zod, since it is lighter
+  and zod is no longer a dependency.
+
+Good:
+  Pass the tool's input shape as a JSON Schema:
+
+  [code]
+```
+
+**Do not explain what something is not, when the reader never thought it was.** If a piece moved out of a module during a refactor, the doc for its new home does not warn against the old arrangement. A reader who never knew locks lived inside persistence is only confused by a paragraph insisting locks are not a persistence store and must not be passed in as one. State what the thing is now, in its own terms.
+
+```
+Bad (in the locks doc):
+  Locks are not a persistence store. Do not pass a lock into the stores
+  map. That used to be possible but is wrong now.
+
+Good (in the locks doc):
+  A lock coordinates work across instances. Wire it with withLocks:
+
+  [code]
+```
+
+The test: read the sentence as a brand-new user. If it answers a question they would never ask ("wait, was this somewhere else before?") or defends a choice they never knew existed, delete it. The doc has no memory of how it got here.
+
+## Forbidden
+
+Never use these. Ever. This list has no exceptions: not "the neighboring pages use them", not "the repo's house style uses them", not "it reads better here".
+
+- Em dashes and en dashes: the long `—` and the shorter `–`. Rewrite the sentence with a comma, colon, period, or parentheses instead.
+- Separator glyphs like `×` or `·`.
+- The pattern "It's not X: it's Y." and the "Not just X, but Y" three-part build-up.
+- The phrases "key insight", "gap", and variations of them.
+
+If you catch yourself reaching for one of these, stop and rewrite the sentence in plain words.
+
+Before you call a page done, search your own added text for `—`, `–`, `×`, and `·`. If a hit survived, you rationalized it. Fix it. Flagging it in your summary is not a substitute for fixing it.
+
+Then run the `simple-english` self-check on the same added text.
+
+## Cross-linking and placement
+
+- Put new pages where they fit the reader's path, grouped by what the reader is doing ("Building with React"), not by code layer ("Frontend Package API"). Update the site's nav or index so the page is reachable. An orphan page does not ship.
+- Link related pages at the moment they help, inline in the flow, not as a "Related" dump at the bottom.
+- Cross-linking goes both ways. When you add a page, update the older pages that should point into it.
+- Do not over-link. One well-placed "need X? see Y" beats a list of maybes.
+
+## Red flags
+
+| You catch yourself | Do instead |
+|---|---|
+| Opening with an API signature or config before the problem | Name the problem the reader has first, then the one-line fix, then the code. |
+| Writing three paragraphs before any code | Cut to one sentence plus a snippet. Show it. |
+| Writing a sentence that names two or more things and explains each | Make it a bulleted list, one item per bullet. |
+| A paragraph with commas or semicolons separating a set of options/stores/flags | Same fix: that is a list, format it as one. |
+| Cramming every angle into one page | Split into short linked pages, one job each. |
+| "In this guide we will explore..." | Delete it. Start with the reader's state and goal. |
+| "Let me describe what this component does" | Describe what the reader does with it. |
+| Reaching for an em dash | Rewrite with a comma, period, or parentheses. |
+| "The surrounding pages do X, so I will too" where X breaks a rule here | Match neighbors on structure only. Follow this skill on everything it covers, and raise the existing violations as their own cleanup. |
+| Using a big word (utilize, leverage, facilitate) | Swap in the plain word. `simple-english` owns this. |
+| One page for everyone | Name the readers. Give each a path or a page. Show the list. Stop. |
+| Posting a snippet "they can adapt" | Make it complete and runnable. |
+| Guessing where docs go | Find the docs folder, or ask. Read neighbors first. |
+| Calling a feature done with no doc change | If behavior changed, docs change too. Write them before you finish. |
+| Planning a feature without a doc-impact list | Add the list of new and changed docs to the plan. Name the reader for each page. |
+| "Unlike the old X, this now..." / "we renamed X to Y" | The reader never saw X. Describe only what ships now. |
+| "we chose Y over zod because..." / "X is no longer needed" | Cut the rejected alternative. Document only what shipped, no comparison. |
+| Warning readers not to do a thing they never knew was possible (e.g. "don't pass locks as a store") | Delete it. If they never saw the old arrangement, the warning only confuses. Describe the thing in its own terms. |
+| Inventing a component the site lacks | Use only components the site already has. |
+| Skipping the persona message because readers are obvious | Show the list. Stop. Obvious is not a skip. |
+| Skipping the tone question because neighbors have a voice | Neighbors are the proposed default. Ask. Then stop. |
+| Writing pages without loading simple-english and i-have-adhd | Load both. If either is missing, stop. |
+| Treating "write the docs" as permission to skip the gates | Writing docs is why the gates exist. |
+| Listing personas inside a larger plan and continuing | That is not the gate. The gate is a dedicated message that ends the turn. |

--- a/.claude/skills/ponytail/LICENSE
+++ b/.claude/skills/ponytail/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DietrichGebert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/ponytail/SKILL.md
+++ b/.claude/skills/ponytail/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ponytail
+description: >
+  Forces the laziest solution that actually works, simplest, shortest, most
+  minimal. Channels a senior dev who has seen everything: question whether the
+  task needs to exist at all (YAGNI), reach for the standard library before
+  custom code, native platform features before dependencies, one line before
+  fifty. Supports intensity levels: lite, full (default), ultra. Use whenever
+  the user says "ponytail", "be lazy", "lazy mode", "simplest solution",
+  "minimal solution", "yagni", "do less", or "shortest path", and whenever
+  they complain about over-engineering, bloat, boilerplate, or unnecessary
+  dependencies.
+argument-hint: "[lite|full|ultra]"
+license: MIT
+---
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Stdlib does it?** Use it.
+3. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+4. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+5. **Can it be one line?** One line.
+6. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project. Two rungs work → take the
+higher one and move on. The first lazy solution that works is the right one.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later", later can scaffold for itself.
+- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins.
+- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications with a `ponytail:` comment (`// ponytail: this exists`), simple reads as intent, not ignorance. Shortcut with a known ceiling (global lock, O(n²) scan, naive heuristic)? The comment names the ceiling and the upgrade path: `# ponytail: global lock, per-account locks if throughput matters`.
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+No essays, no feature tours, no design notes. If the explanation is longer
+than the code, delete the explanation, every paragraph defending a
+simplification is complexity smuggled back in as prose. Explanation the user
+explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
+give it in full, the rule is only against unrequested prose.
+
+Pattern: `[code] → skipped: [X], add when [Y].`
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
+
+Example: "Add a cache for these API responses."
+- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
+- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
+- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling
+that prevents data loss, security measures, accessibility basics, anything
+explicitly requested. User insists on the full version → build it, no
+re-arguing.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor
+reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
+just less code, the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a
+loop, a parser, a money/security path) leaves ONE runnable check behind, the
+smallest thing that fails if the logic breaks: an `assert`-based
+`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
+fixtures, no per-function suites unless asked. Trivial one-liners need no
+test, YAGNI applies to tests too.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk (pair with Caveman for
+terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+changed or session end.
+
+The shortest path to done is the right path.

--- a/.claude/skills/ponytail/SKILL.md
+++ b/.claude/skills/ponytail/SKILL.md
@@ -10,7 +10,7 @@ description: >
   "minimal solution", "yagni", "do less", or "shortest path", and whenever
   they complain about over-engineering, bloat, boilerplate, or unnecessary
   dependencies.
-argument-hint: "[lite|full|ultra]"
+argument-hint: '[lite|full|ultra]'
 license: MIT
 ---
 
@@ -63,13 +63,14 @@ Pattern: `[code] → skipped: [X], add when [Y].`
 
 ## Intensity
 
-| Level | What change |
-|-------|------------|
-| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
-| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| Level     | What change                                                                                                                 |
+| --------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **lite**  | Build what's asked, but name the lazier alternative in one line. User picks.                                                |
+| **full**  | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default.                                 |
 | **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
 
 Example: "Add a cache for these API responses."
+
 - lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
 - full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
 - ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -49,11 +49,11 @@ Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next act
 
 Pick one kind from the diff:
 
-| Kind             | Signal                                                                           |
-| ---------------- | -------------------------------------------------------------------------------- |
-| **fix**          | Restores broken behavior. A user-visible bug, a failing test, a regression.      |
-| **feat**         | Adds behavior that did not exist. New export, new command, new user-facing flow. |
-| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change.      |
+| Kind | Signal |
+|---|---|
+| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
+| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
 
 If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
 
@@ -69,71 +69,15 @@ A **feat** PR cannot be posted until the branch has at least one of:
 If none of those exist, stop. Do not run `gh pr create`. Do not run `gh pr edit`. Tell the user what is missing. Wait until they add one, then continue.
 
 A **fix** does not use this gate. A **chore / docs** PR does not use this gate.
-
-Screenshots are not this gate. A screenshot does not replace a test, a command, or an example.
 </HARD-GATE>
 
-### 4. Screenshots (try, when the PR has UI)
-
-This step is a try, not a gate. If capture fails, still write and post the PR.
-
-The PR **has UI** when the diff changes something a person sees in a browser:
-
-- Example apps
-- Playground
-- Docs site chrome (layout, theme, nav)
-- CSS, or components that paint a screen (`.tsx`, `.jsx`, `.vue`, `.svelte`, `.html` that is not a test)
-
-The PR **does not have UI** when the diff is only adapters, types, CI, tests, or agent files.
-
-If you are not sure, treat it as UI and try.
-
-Skip this step only when there is no UI, or the user said to skip screenshots. If there is no UI, omit the Screenshots heading later.
-
-**Capture**
-
-1. Find a runnable surface (example `pnpm dev`, a preview URL).
-2. Open it with the browser tools this harness has (Playwright MCP, agent-browser, or the same).
-3. Do the user flow this PR changes.
-4. Save PNG screenshots of the result.
-5. If layout or styling changed, save desktop and mobile (about 390px wide).
-6. Cap at 4 images.
-7. Stop the preview server after the files are saved. Do not leave a watcher running.
-
-Do not invent UI with an image model. Real browser only.
-
-**Put the images on the PR**
-
-GitHub has no public upload API for `user-attachments` images. Commit the PNGs on the branch so the PR body can link to them.
-
-1. Write files under `.github/pr-screenshots/<branch-kebab>/`.
-2. Commit only those PNG files. Push.
-3. Embed with full GitHub URLs. Relative paths do not render in a PR body.
-
-```markdown
-## Screenshots
-
-Desktop
-
-![desktop](https://github.com/OWNER/REPO/blob/BRANCH/.github/pr-screenshots/name/desktop.png?raw=true)
-```
-
-Get `OWNER/REPO` from `gh repo view --json nameWithOwner`. Use the branch name in the URL.
-
-If the user already pasted `https://github.com/user-attachments/assets/...` links, use those. Do not also commit files.
-
-If capture fails, still post. Keep the Screenshots heading and write one sentence: what you tried, and why it failed.
-
-Do not wait for the user to paste images.
-Do not refuse the PR because screenshots failed.
-
-### 5. Write the title
+### 4. Write the title
 
 Match this repo's recent PR titles. In a conventional-commit repo, write `type(scope): summary`. Keep it one line.
 
 The title must still make sense if the reviewer never opens the body.
 
-### 6. Write the body
+### 5. Write the body
 
 Load `simple-english` and `i-have-adhd`, then write in this order.
 
@@ -149,7 +93,7 @@ No preamble. No "This PR aims to". Start with the fact.
 
 Fill every section honestly. Leave a checkbox unchecked when the claim is false. Do not tick "I ran `pnpm test:pr`" if you did not run it.
 
-**Extra sections after the template, in this order.** Testing and Risk / rollback are always present. Screenshots, Linked issues, and Public API change are omitted when they do not apply.
+**Extra sections after the template, in this order.** Testing and Risk / rollback are always present. Linked issues and Public API change are omitted when they do not apply.
 
 #### Testing
 
@@ -158,13 +102,6 @@ Three parts, all required:
 1. **Commands run.** What you ran, what passed, what you skipped and why. If you ran nothing, say so.
 2. **Manual test.** Numbered steps a reviewer can follow to see the change. For a **fix**, step 1 is how to reproduce the old bug, then how to confirm it is gone.
 3. **How this PR makes testing easy.** Name the artifacts on the branch: tests, a command, an example app change. If there are none (allowed for fix and chore / docs), write that. Do not invent an easy path.
-
-#### Screenshots
-
-Required when step 4 ran (the PR has UI). Omit this heading when there is no UI.
-
-- On success: the markdown images from step 4, each with a short caption (Desktop, Mobile, Before, After).
-- On failure: one sentence. What you tried, and why it failed.
 
 #### Linked issues
 
@@ -200,7 +137,7 @@ new call site
 
 Two short snippets. What a user writes today, then what they write after this PR.
 
-### 7. Post immediately
+### 6. Post immediately
 
 Do not wait for the user to approve the text.
 
@@ -209,27 +146,19 @@ Do not wait for the user to approve the text.
 
 If `gh` fails, stop and show the error. Leave the drafted body in the chat so it is not lost.
 
-If step 4 wrote PNG files, those commits must be on the remote before the body links will render. Push first, then post or edit.
+Do not attach screenshots to the PR. Do not commit screenshot files for this skill.
 
 ## Red flags
 
-| You catch yourself                                           | Do instead                                                                 |
-| ------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| Writing the body from the branch name                        | Read the diff.                                                             |
-| Ticking a template checkbox you did not do                   | Leave it unchecked and say so in Testing.                                  |
-| Posting a feat with no test, command, or example             | Stop. The feat gate failed.                                                |
-| A 1-4 sentence lead that lists files                         | Rewrite as what a user can do, or what bug is gone.                        |
-| Public API section that shows the internal diff              | Show caller usage before and after.                                        |
-| Public API section on an AGENTS.md-only PR                   | Omit the heading.                                                          |
-| "I'll update the description later" after a push             | Rewrite now with `gh pr edit`.                                             |
-| Waiting for the user to approve the text                     | Post. This skill does not wait.                                            |
-| Skipping screenshots on a UI PR because "the text is enough" | Try capture.                                                               |
-| Skipping because GitHub has no upload API                    | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs.                |
-| Relative image paths in the PR body                          | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
-| Inventing a UI image with an image model                     | Real browser only.                                                         |
-| Waiting for the user to paste images                         | Capture first. Post even if capture fails.                                 |
-| Refusing to post because screenshots failed                  | Post. Say why in Screenshots.                                              |
-| Using a screenshot as the feat-gate artifact                 | The feat gate still needs a test, a command, or an example.                |
-| Mixing unrelated files into the screenshot commit            | Add only the PNG files.                                                    |
-| Leaving a preview server running after capture               | Stop the server.                                                           |
-| Writing without loading simple-english and i-have-adhd       | Load both. If missing, stop.                                               |
+| You catch yourself | Do instead |
+|---|---|
+| Writing the body from the branch name | Read the diff. |
+| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
+| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
+| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
+| Public API section that shows the internal diff | Show caller usage before and after. |
+| Public API section on an AGENTS.md-only PR | Omit the heading. |
+| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
+| Waiting for the user to approve the text | Post. This skill does not wait. |
+| Uploading or committing screenshots for the PR body | Skip. Do not put images on the PR. |
+| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: pr-description
+description: Use when writing a pull request title or body, when about to run gh pr create, when about to git push on a branch that already has an open PR, or when the user says /pr-description, "write the PR description", or "update the PR title". Don't use for commit messages, changelogs, or review comments.
+---
+
+# pr-description
+
+Write the GitHub PR title and body, then post them. Do not wait for approval.
+
+Work from the diff, not from memory.
+
+## When to run
+
+This skill is auto plus on demand.
+
+Run it:
+
+- When the user asks for a PR title or body, or types `/pr-description`.
+- Immediately before `gh pr create`.
+- Immediately after an **agent** `git push` on a branch that already has an open PR. Then run `gh pr edit` with a fresh title and body.
+
+Do not run it on a human-only `git push` in another terminal. Do not add a git hook.
+
+A later push must rewrite the GitHub text. Do not leave a stale description.
+
+## Required skills for the title and body
+
+`simple-english` and `i-have-adhd` are prerequisites. They apply to the PR title and body, not to the rest of the session.
+
+Load both immediately before writing the title and body. Use the Skill tool if this harness has one. If it does not, Read each skill's SKILL.md. Do not write from memory of those skills.
+
+If either skill is missing, stop. Do not post a weaker substitute.
+
+When `i-have-adhd` is loaded from this skill, ignore its persistence section. Do not switch the rest of the session into ADHD mode.
+
+Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next action first in the lead, numbered steps for manual test, lists capped at 5.
+
+## Procedure
+
+### 1. Ground in the repo
+
+1. Find the base branch (`main` / `master` / `develop`).
+2. Read `git log --oneline base...HEAD` and `git diff base...HEAD`.
+3. Read `.github/pull_request_template.md` if it exists (also check `.github/PULL_REQUEST_TEMPLATE.md` and `.github/PULL_REQUEST_TEMPLATE/`).
+4. Read about 15 recent PR titles in this repo (`gh pr list --limit 15 --state all --json title`). Match that shape. Do not invent a new title style.
+5. Collect linked issues from branch name, commit messages, and `Closes #` / `Fixes #` text.
+
+### 2. Classify the PR
+
+Pick one kind from the diff:
+
+| Kind | Signal |
+|---|---|
+| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
+| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
+
+If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
+
+### 3. Feat gate: easy test path
+
+<HARD-GATE>
+A **feat** PR cannot be posted until the branch has at least one of:
+
+- A new or updated automated test that covers the new behavior
+- A command a reviewer can copy and run
+- A change in an official example app that shows the new behavior
+
+If none of those exist, stop. Do not run `gh pr create`. Do not run `gh pr edit`. Tell the user what is missing. Wait until they add one, then continue.
+
+A **fix** does not use this gate. A **chore / docs** PR does not use this gate.
+
+Screenshots are not this gate. A screenshot does not replace a test, a command, or an example.
+</HARD-GATE>
+
+### 4. Screenshots (try, when the PR has UI)
+
+This step is a try, not a gate. If capture fails, still write and post the PR.
+
+The PR **has UI** when the diff changes something a person sees in a browser:
+
+- Example apps
+- Playground
+- Docs site chrome (layout, theme, nav)
+- CSS, or components that paint a screen (`.tsx`, `.jsx`, `.vue`, `.svelte`, `.html` that is not a test)
+
+The PR **does not have UI** when the diff is only adapters, types, CI, tests, or agent files.
+
+If you are not sure, treat it as UI and try.
+
+Skip this step only when there is no UI, or the user said to skip screenshots. If there is no UI, omit the Screenshots heading later.
+
+**Capture**
+
+1. Find a runnable surface (example `pnpm dev`, a preview URL).
+2. Open it with the browser tools this harness has (Playwright MCP, agent-browser, or the same).
+3. Do the user flow this PR changes.
+4. Save PNG screenshots of the result.
+5. If layout or styling changed, save desktop and mobile (about 390px wide).
+6. Cap at 4 images.
+7. Stop the preview server after the files are saved. Do not leave a watcher running.
+
+Do not invent UI with an image model. Real browser only.
+
+**Put the images on the PR**
+
+GitHub has no public upload API for `user-attachments` images. Commit the PNGs on the branch so the PR body can link to them.
+
+1. Write files under `.github/pr-screenshots/<branch-kebab>/`.
+2. Commit only those PNG files. Push.
+3. Embed with full GitHub URLs. Relative paths do not render in a PR body.
+
+```markdown
+## Screenshots
+
+Desktop
+
+![desktop](https://github.com/OWNER/REPO/blob/BRANCH/.github/pr-screenshots/name/desktop.png?raw=true)
+```
+
+Get `OWNER/REPO` from `gh repo view --json nameWithOwner`. Use the branch name in the URL.
+
+If the user already pasted `https://github.com/user-attachments/assets/...` links, use those. Do not also commit files.
+
+If capture fails, still post. Keep the Screenshots heading and write one sentence: what you tried, and why it failed.
+
+Do not wait for the user to paste images.
+Do not refuse the PR because screenshots failed.
+
+### 5. Write the title
+
+Match this repo's recent PR titles. In a conventional-commit repo, write `type(scope): summary`. Keep it one line.
+
+The title must still make sense if the reviewer never opens the body.
+
+### 6. Write the body
+
+Load `simple-english` and `i-have-adhd`, then write in this order.
+
+**Lead (required, 1 to 4 sentences, before the template).**
+
+- **feat:** what the PR does for a user of the product.
+- **fix:** what the bug is, then how this PR fixes it.
+- **chore / docs:** what changed, in product or repo terms, not a file list.
+
+No preamble. No "This PR aims to". Start with the fact.
+
+**Repo template (required when the file exists).**
+
+Fill every section honestly. Leave a checkbox unchecked when the claim is false. Do not tick "I ran `pnpm test:pr`" if you did not run it.
+
+**Extra sections after the template, in this order.** Testing and Risk / rollback are always present. Screenshots, Linked issues, and Public API change are omitted when they do not apply.
+
+#### Testing
+
+Three parts, all required:
+
+1. **Commands run.** What you ran, what passed, what you skipped and why. If you ran nothing, say so.
+2. **Manual test.** Numbered steps a reviewer can follow to see the change. For a **fix**, step 1 is how to reproduce the old bug, then how to confirm it is gone.
+3. **How this PR makes testing easy.** Name the artifacts on the branch: tests, a command, an example app change. If there are none (allowed for fix and chore / docs), write that. Do not invent an easy path.
+
+#### Screenshots
+
+Required when step 4 ran (the PR has UI). Omit this heading when there is no UI.
+
+- On success: the markdown images from step 4, each with a short caption (Desktop, Mobile, Before, After).
+- On failure: one sentence. What you tried, and why it failed.
+
+#### Linked issues
+
+Omit this heading when nothing links. When an issue links, use `Closes #N` or `Fixes #N`.
+
+#### Risk / rollback
+
+What could break. How to undo (revert the PR, turn a flag off, and so on). If risk is low, say that in one line. Do not skip the heading.
+
+#### Public API change
+
+Omit this heading when the PR does not touch the published surface.
+
+Published surface means: exported functions, types, components, CLI flags, env vars, and documented contracts from **published** packages. Tests, internal files, agent skills, `AGENTS.md`, and `CLAUDE.md` do not count.
+
+When it does touch that surface, show **caller usage**, not the internal diff:
+
+```markdown
+## Public API change
+
+**Before**
+
+\`\`\`ts
+old call site
+\`\`\`
+
+**After**
+
+\`\`\`ts
+new call site
+\`\`\`
+```
+
+Two short snippets. What a user writes today, then what they write after this PR.
+
+### 7. Post immediately
+
+Do not wait for the user to approve the text.
+
+- No PR yet: `gh pr create --title "..." --body-file ...`
+- PR already open: `gh pr edit --title "..." --body-file ...`
+
+If `gh` fails, stop and show the error. Leave the drafted body in the chat so it is not lost.
+
+If step 4 wrote PNG files, those commits must be on the remote before the body links will render. Push first, then post or edit.
+
+## Red flags
+
+| You catch yourself | Do instead |
+|---|---|
+| Writing the body from the branch name | Read the diff. |
+| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
+| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
+| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
+| Public API section that shows the internal diff | Show caller usage before and after. |
+| Public API section on an AGENTS.md-only PR | Omit the heading. |
+| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
+| Waiting for the user to approve the text | Post. This skill does not wait. |
+| Skipping screenshots on a UI PR because "the text is enough" | Try capture. |
+| Skipping because GitHub has no upload API | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs. |
+| Relative image paths in the PR body | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
+| Inventing a UI image with an image model | Real browser only. |
+| Waiting for the user to paste images | Capture first. Post even if capture fails. |
+| Refusing to post because screenshots failed | Post. Say why in Screenshots. |
+| Using a screenshot as the feat-gate artifact | The feat gate still needs a test, a command, or an example. |
+| Mixing unrelated files into the screenshot commit | Add only the PNG files. |
+| Leaving a preview server running after capture | Stop the server. |
+| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -49,11 +49,11 @@ Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next act
 
 Pick one kind from the diff:
 
-| Kind | Signal |
-|---|---|
-| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
-| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
-| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
+| Kind             | Signal                                                                           |
+| ---------------- | -------------------------------------------------------------------------------- |
+| **fix**          | Restores broken behavior. A user-visible bug, a failing test, a regression.      |
+| **feat**         | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change.      |
 
 If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
 
@@ -213,23 +213,23 @@ If step 4 wrote PNG files, those commits must be on the remote before the body l
 
 ## Red flags
 
-| You catch yourself | Do instead |
-|---|---|
-| Writing the body from the branch name | Read the diff. |
-| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
-| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
-| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
-| Public API section that shows the internal diff | Show caller usage before and after. |
-| Public API section on an AGENTS.md-only PR | Omit the heading. |
-| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
-| Waiting for the user to approve the text | Post. This skill does not wait. |
-| Skipping screenshots on a UI PR because "the text is enough" | Try capture. |
-| Skipping because GitHub has no upload API | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs. |
-| Relative image paths in the PR body | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
-| Inventing a UI image with an image model | Real browser only. |
-| Waiting for the user to paste images | Capture first. Post even if capture fails. |
-| Refusing to post because screenshots failed | Post. Say why in Screenshots. |
-| Using a screenshot as the feat-gate artifact | The feat gate still needs a test, a command, or an example. |
-| Mixing unrelated files into the screenshot commit | Add only the PNG files. |
-| Leaving a preview server running after capture | Stop the server. |
-| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |
+| You catch yourself                                           | Do instead                                                                 |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Writing the body from the branch name                        | Read the diff.                                                             |
+| Ticking a template checkbox you did not do                   | Leave it unchecked and say so in Testing.                                  |
+| Posting a feat with no test, command, or example             | Stop. The feat gate failed.                                                |
+| A 1-4 sentence lead that lists files                         | Rewrite as what a user can do, or what bug is gone.                        |
+| Public API section that shows the internal diff              | Show caller usage before and after.                                        |
+| Public API section on an AGENTS.md-only PR                   | Omit the heading.                                                          |
+| "I'll update the description later" after a push             | Rewrite now with `gh pr edit`.                                             |
+| Waiting for the user to approve the text                     | Post. This skill does not wait.                                            |
+| Skipping screenshots on a UI PR because "the text is enough" | Try capture.                                                               |
+| Skipping because GitHub has no upload API                    | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs.                |
+| Relative image paths in the PR body                          | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
+| Inventing a UI image with an image model                     | Real browser only.                                                         |
+| Waiting for the user to paste images                         | Capture first. Post even if capture fails.                                 |
+| Refusing to post because screenshots failed                  | Post. Say why in Screenshots.                                              |
+| Using a screenshot as the feat-gate artifact                 | The feat gate still needs a test, a command, or an example.                |
+| Mixing unrelated files into the screenshot commit            | Add only the PNG files.                                                    |
+| Leaving a preview server running after capture               | Stop the server.                                                           |
+| Writing without loading simple-english and i-have-adhd       | Load both. If missing, stop.                                               |

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -49,11 +49,11 @@ Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next act
 
 Pick one kind from the diff:
 
-| Kind | Signal |
-|---|---|
-| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
-| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
-| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
+| Kind             | Signal                                                                           |
+| ---------------- | -------------------------------------------------------------------------------- |
+| **fix**          | Restores broken behavior. A user-visible bug, a failing test, a regression.      |
+| **feat**         | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change.      |
 
 If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
 
@@ -150,15 +150,15 @@ Do not attach screenshots to the PR. Do not commit screenshot files for this ski
 
 ## Red flags
 
-| You catch yourself | Do instead |
-|---|---|
-| Writing the body from the branch name | Read the diff. |
-| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
-| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
-| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
-| Public API section that shows the internal diff | Show caller usage before and after. |
-| Public API section on an AGENTS.md-only PR | Omit the heading. |
-| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
-| Waiting for the user to approve the text | Post. This skill does not wait. |
-| Uploading or committing screenshots for the PR body | Skip. Do not put images on the PR. |
-| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |
+| You catch yourself                                     | Do instead                                          |
+| ------------------------------------------------------ | --------------------------------------------------- |
+| Writing the body from the branch name                  | Read the diff.                                      |
+| Ticking a template checkbox you did not do             | Leave it unchecked and say so in Testing.           |
+| Posting a feat with no test, command, or example       | Stop. The feat gate failed.                         |
+| A 1-4 sentence lead that lists files                   | Rewrite as what a user can do, or what bug is gone. |
+| Public API section that shows the internal diff        | Show caller usage before and after.                 |
+| Public API section on an AGENTS.md-only PR             | Omit the heading.                                   |
+| "I'll update the description later" after a push       | Rewrite now with `gh pr edit`.                      |
+| Waiting for the user to approve the text               | Post. This skill does not wait.                     |
+| Uploading or committing screenshots for the PR body    | Skip. Do not put images on the PR.                  |
+| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop.                        |

--- a/.grok/skills/docs/SKILL.md
+++ b/.grok/skills/docs/SKILL.md
@@ -13,7 +13,7 @@ Work in two phases. First plan the story: who reads this, what they want, and ho
 
 The plan is not private. The user must see the readers and must choose the tone before any page is written.
 
-```
+```text
 Find docs
   → read neighbors
   → Phase 1: readers + pages
@@ -85,22 +85,26 @@ The page split comes out of this step. Do not skip it.
 ### Gate: show the personas
 
 <HARD-GATE>
-This gate is the entire turn. Listing readers in a thought, a todo, or a buried plan is not this gate. The user must see the list in a dedicated message, then the agent must stop.
+The user must see the list. Listing readers in a thought, a todo, or a buried plan is not this gate.
 
 After step 4, send a message that contains only:
 
 1. Each reader, one user story, and the page you will write for them.
 2. One question: confirm, drop a reader, or add one.
 
-If the harness has an AskQuestion (or similar) tool, use it for that question. If it does not, use a numbered list. Either way, end the turn.
+If the harness has an AskQuestion (or similar) tool, use it for that question. If it does not, use a numbered list.
 
-Do not write files. Do not start Phase 2. Do not say you will proceed unless they object.
+Then pick one path:
 
-Skip the *wait* only when one of these is true:
+**Default: stop.** This message is the entire turn. End the turn. Do not write files. Do not start Phase 2. Do not say you will proceed unless they object.
+
+**Skip the wait: continue in this same turn.** Use this path only when one of these is true:
 
 - This conversation already has the user's confirmation of this persona list.
-- The user said "use sane defaults", "just write it", or "don't ask questions". Still SHOW the list in the same turn, then continue.
+- The user said "use sane defaults", "just write it", or "don't ask questions". Still SHOW the list in this turn, then continue.
 - The change is a tiny copy edit: typo, broken link, code-fence language, or a factual fix. No new page, no new section, no rewrite of a journey.
+
+On this path, do not end the turn. After you show the list (or after a tiny copy edit, with no list), continue to the next step.
 
 These are not skips:
 
@@ -121,7 +125,7 @@ When a topic has several angles, give each its own short page and link them. A r
 
 Example. A feature for tool interrupts:
 
-```
+```text
 Bad: one page
   interrupts.md   (overview + simple case + many interrupts + custom, all crammed in)
 
@@ -134,11 +138,9 @@ Good: a small set of linked pages
 
 Each page is short and does one thing. The overview stitches them into a story.
 
-## Phase 2: write like a human
+## Gate: ask for tone
 
-Do not start this phase until the persona gate has passed, the tone gate has passed, and `simple-english` plus `i-have-adhd` are loaded.
-
-### Gate: ask for tone
+This gate sits between Phase 1 and Phase 2. Run it before you write any page. Do not nest it inside Phase 2.
 
 <HARD-GATE>
 This gate runs before any page content is written. It does not run for a doc-impact list that is only a plan.
@@ -150,13 +152,19 @@ Send a message that contains only:
 1. The tone you inferred from neighboring pages, in one line (how formal, how much setup, second person or not).
 2. One question with options: use that tone, more casual, more formal, or the user names another.
 
-If the harness has an AskQuestion (or similar) tool, use it. If it does not, use a numbered list. Either way, end the turn.
+If the harness has an AskQuestion (or similar) tool, use it. If it does not, use a numbered list.
 
-Skip the *wait* only when one of these is true:
+Then pick one path:
+
+**Default: stop.** This message is the entire turn. End the turn. Do not write page content.
+
+**Skip the wait: continue in this same turn.** Use this path only when one of these is true:
 
 - This conversation already has the user's tone choice, including an explicit "match the existing pages".
 - The user said "use sane defaults", "just write it", or "don't ask questions". Still STATE the inferred tone in one line, then continue.
 - Tiny copy edit, same carve-out as the persona gate.
+
+On this path, do not end the turn. After you state the tone (or after a tiny copy edit, with no question), continue to Phase 2.
 
 These are not skips:
 
@@ -165,6 +173,12 @@ These are not skips:
 - "Tone does not matter for a reference page."
 - "I'll match neighbors and mention it later."
 </HARD-GATE>
+
+## Phase 2: write like a human
+
+Do not write page content until the persona gate has passed, the tone gate has passed, and `simple-english` plus `i-have-adhd` are loaded.
+
+The tone gate is the heading above this one. Run that gate first. Then load the two skills. Then write.
 
 Legibility is the goal, above everything else.
 
@@ -183,7 +197,7 @@ A reader who sees the problem first knows in seconds whether they are on the rig
 
 The first line of the how is the next action (from `i-have-adhd`). The problem still comes first so they know they are on the right page.
 
-```
+```text
 Bad:
   Call useInterrupts() and pass a resolver. The resolver runs once per
   pending item inside a transaction...
@@ -202,7 +216,7 @@ The order for a guide is problem, one-line fix, then the how (steps, snippets, A
 
 Do not explain in four paragraphs what one sentence and a code block can show. Readers grasp a diff or a snippet faster than prose.
 
-```
+```text
 Bad:
   Three paragraphs describing how the config object accepts a
   middleware array, what each slot does, and how ordering works.
@@ -223,7 +237,7 @@ The moment a sentence covers more than one item, option, store, flag, or step, i
 
 The tell is a sentence that names two or more things and says something about each. Cut it into one bullet per thing, one or two sentences each.
 
-```
+```text
 Bad:
   Each store is independent. Provide only the ones you need. For chat:
   `messages` for the transcript, `runs` for run lifecycle, `interrupts` for
@@ -275,7 +289,7 @@ Docs describe what exists now. The reader never saw the old design, the earlier 
 
 Never justify the current API by comparing it to a version that did not ship. A line like "instead of `useAssistant`, this uses `usePlugin`, which makes more sense because..." is noise to someone who never knew `useAssistant` existed. Cut it and just describe `usePlugin`.
 
-```
+```text
 Bad:
   We renamed useAssistant to usePlugin and moved the tools onto it,
   so instead of calling assistant.addTool you now use plugin.tools.
@@ -296,7 +310,7 @@ The doc is read by someone who just arrived. They never saw the pull request, th
 
 **Cut rejected alternatives.** If a discussion weighed option A against option B and picked B, the doc documents B. It never names A, never says B is "better than" A, never says A "is no longer needed." The reader is not choosing between them; they use what shipped.
 
-```
+```text
 Bad:
   We use a plain JSON Schema here instead of zod, since it is lighter
   and zod is no longer a dependency.
@@ -309,7 +323,7 @@ Good:
 
 **Do not explain what something is not, when the reader never thought it was.** If a piece moved out of a module during a refactor, the doc for its new home does not warn against the old arrangement. A reader who never knew locks lived inside persistence is only confused by a paragraph insisting locks are not a persistence store and must not be passed in as one. State what the thing is now, in its own terms.
 
-```
+```text
 Bad (in the locks doc):
   Locks are not a persistence store. Do not pass a lock into the stores
   map. That used to be possible but is wrong now.

--- a/.grok/skills/docs/SKILL.md
+++ b/.grok/skills/docs/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: docs
+description: Use when writing, editing, or organizing documentation, when planning what docs a feature needs, and whenever planning or implementing a new feature or change in a repo (docs ship with the code). Also use when tempted to write docs without showing the discovered readers to the user, without asking for tone, or without loading simple-english and i-have-adhd. Triggers on "write docs for X", "document this feature", "add a guide", "update the docs", "reorganize the docs", "plan feature X", "implement X", or /docs.
+---
+
+# docs
+
+Write docs a real person wants to read. Short, plain, built around someone trying to do a real thing.
+
+"Document feature X" is not the job. "Help someone do Y with X" is the job.
+
+Work in two phases. First plan the story: who reads this, what they want, and how many pages it should be. Then write.
+
+The plan is not private. The user must see the readers and must choose the tone before any page is written.
+
+```
+Find docs
+  → read neighbors
+  → Phase 1: readers + pages
+  → PERSONA GATE (show the list, then stop)
+  → TONE GATE (ask, then stop)          [when writing pages]
+  → load simple-english + i-have-adhd   [when writing pages]
+  → Phase 2: write
+```
+
+A doc-impact list in a feature plan still runs the persona gate. It does not run the tone gate or load the writing skills until pages are actually written.
+
+## When to run
+
+Docs ship with the code. Run this skill at three moments, not only when asked.
+
+- Someone asks for docs. Write them.
+- Planning a feature or change in a repo. Before the plan is done, list which docs are new and which need updating. This doc-impact list is part of the plan, the same as the code changes. Name the reader for each page.
+- Finishing an implementation. Write or update those docs before you call the work done. A change to how something behaves that ships no doc change is not finished.
+
+## Required skills for the final pages
+
+`simple-english` and `i-have-adhd` are prerequisites. They apply to the documentation pages, not to this planning chat.
+
+Load both immediately before writing page content. Use the Skill tool if this harness has one. If it does not, Read each skill's SKILL.md from the local skills directory. Do not write pages from memory of those skills.
+
+If either skill is missing, stop and tell the user. Do not write the pages without them.
+
+How they compose:
+
+- This skill owns who the page is for, the page split, problem-then-fix, show-don't-tell, no history leak, forbidden glyphs, and neighbor structure.
+- `simple-english` owns the sentences. Use pragmatic mode. Run its self-check before you call a page done.
+- `i-have-adhd` owns the shape of the page: next action first, numbered steps, lists capped at 5 (split must vs later, or split the page), no preamble, a visible win at the end.
+
+When `i-have-adhd` is loaded from this skill, apply it to the pages only. Do not switch the rest of the session into ADHD mode. The persistence section of `i-have-adhd` does not apply here.
+
+## Find the docs first
+
+Before writing anything, find where docs live.
+
+1. Look for a docs folder. Check `docs/` first, then `documentation/`, `content/docs/`, `site/`, `website/docs/`.
+2. Found nothing? Ask the user where docs should go. Do not guess and do not create a folder on a hunch.
+3. Open 2 or 3 existing pages near where the new content belongs. Read them for copy, structure, frontmatter fields, and components. Note the apparent tone as a *candidate* for the tone gate. Do not adopt it yet.
+4. Note which components the site already uses (steps, tabs, callouts, cards, accordions, code groups, and so on). Different sites have different ones.
+5. Reuse those components to tell the story. If the site has a steps component, use it for walkthroughs. If it has tabs, use them for framework variations. If the site has none, use plain markdown. Never invent a component the site does not have.
+
+If there is no page like the one you are about to write, read the closest one you can find and match it.
+
+### What "match the neighbors" covers, and what it does not
+
+Matching neighbors is about **copy, structure, frontmatter, and components**: whether headings are sentence case, how much setup a section gets, which components carry the walkthrough, how code samples are introduced, what the frontmatter fields are.
+
+It is **not** a substitute for the tone gate. Neighbors can suggest a default. They cannot answer for the user.
+
+It is **not** permission to copy a neighbor's bad habits. Everything in [Forbidden](#forbidden) and every rule in this skill still applies to the content you write, no matter what the surrounding pages do. An existing page full of em dashes does not license one more.
+
+So: never reason "the other pages do it, so I will too" about a rule this skill states. If existing pages break a rule and you think the whole set should be brought in line, that is a separate cleanup to raise with the user, not something to settle by quietly matching the violation.
+
+## Phase 1: plan the story
+
+Do this before you write a word of content.
+
+1. List who reads this and what each one wants. A person building on a React SPA, a person on a server-rendered app, someone who just wants a quick demo, someone extending the internals. Do not stop at the first reader.
+2. Write one user story per reader: "As a X, I want to Y, so I can Z."
+3. Turn stories into pages. One journey is one page. Different journeys are different pages. A feature with three real journeys is three pages plus maybe a short overview, not one giant page.
+4. Check every reader has a path. A reader with no page is a hole in the plan. Add a page or a route for them.
+
+The page split comes out of this step. Do not skip it.
+
+### Gate: show the personas
+
+<HARD-GATE>
+This gate is the entire turn. Listing readers in a thought, a todo, or a buried plan is not this gate. The user must see the list in a dedicated message, then the agent must stop.
+
+After step 4, send a message that contains only:
+
+1. Each reader, one user story, and the page you will write for them.
+2. One question: confirm, drop a reader, or add one.
+
+If the harness has an AskQuestion (or similar) tool, use it for that question. If it does not, use a numbered list. Either way, end the turn.
+
+Do not write files. Do not start Phase 2. Do not say you will proceed unless they object.
+
+Skip the *wait* only when one of these is true:
+
+- This conversation already has the user's confirmation of this persona list.
+- The user said "use sane defaults", "just write it", or "don't ask questions". Still SHOW the list in the same turn, then continue.
+- The change is a tiny copy edit: typo, broken link, code-fence language, or a factual fix. No new page, no new section, no rewrite of a journey.
+
+These are not skips:
+
+- "The readers are obvious."
+- "The user asked for docs, so they do not want a question."
+- "I already named them in the plan."
+- "There is only one reader."
+- "This is part of implementing a feature, keep going."
+
+Writing docs is why this gate exists. It is not a reason to skip it.
+</HARD-GATE>
+
+## Less is more: split, do not cram
+
+Do not force thousands of words into one page. Long pages hide the answer.
+
+When a topic has several angles, give each its own short page and link them. A reader lands on the overview, then clicks into the exact thing they need.
+
+Example. A feature for tool interrupts:
+
+```
+Bad: one page
+  interrupts.md   (overview + simple case + many interrupts + custom, all crammed in)
+
+Good: a small set of linked pages
+  interrupts/index.md            what it is, when to use it, links out
+  interrupts/basic.md            one interrupt, start to finish
+  interrupts/multiple.md         several interrupts in a flow
+  interrupts/custom.md           build your own
+```
+
+Each page is short and does one thing. The overview stitches them into a story.
+
+## Phase 2: write like a human
+
+Do not start this phase until the persona gate has passed, the tone gate has passed, and `simple-english` plus `i-have-adhd` are loaded.
+
+### Gate: ask for tone
+
+<HARD-GATE>
+This gate runs before any page content is written. It does not run for a doc-impact list that is only a plan.
+
+Neighbors can suggest a default. They cannot answer for the user.
+
+Send a message that contains only:
+
+1. The tone you inferred from neighboring pages, in one line (how formal, how much setup, second person or not).
+2. One question with options: use that tone, more casual, more formal, or the user names another.
+
+If the harness has an AskQuestion (or similar) tool, use it. If it does not, use a numbered list. Either way, end the turn.
+
+Skip the *wait* only when one of these is true:
+
+- This conversation already has the user's tone choice, including an explicit "match the existing pages".
+- The user said "use sane defaults", "just write it", or "don't ask questions". Still STATE the inferred tone in one line, then continue.
+- Tiny copy edit, same carve-out as the persona gate.
+
+These are not skips:
+
+- "I can tell from the neighbors."
+- "The site already has a voice."
+- "Tone does not matter for a reference page."
+- "I'll match neighbors and mention it later."
+</HARD-GATE>
+
+Legibility is the goal, above everything else.
+
+- Keep it digestible. No walls of text, no huge paragraphs. Break ideas into small pieces. Give the smallest amount of info that does the job.
+- Sentences follow `simple-english` (pragmatic mode). Do not inline a weaker substitute.
+- Keep markdown light. Lists are fine. Bold headings on every line are not. Let the words carry the page.
+- Prefer plain ASCII and normal keyboard characters over fancy glyphs. Write the way a person types.
+- Second person, action first. Start with what the reader has now and what they will have at the end. No "In this guide we will explore..." openings. Just start.
+- Shape the page with `i-have-adhd`: the first line is something the reader can do, multi-step work is numbered, a list longer than 5 is split, the page ends on a visible win.
+
+### Lead with the problem, then solve it
+
+Every page opens with the problem the reader came for, in their own words, before any API. Name the situation they are stuck in. Then say in a sentence or two how the feature solves it. Only after that do you go into the technical parts and the code.
+
+A reader who sees the problem first knows in seconds whether they are on the right page. A reader who hits an API signature first has to reverse-engineer what it is even for.
+
+The first line of the how is the next action (from `i-have-adhd`). The problem still comes first so they know they are on the right page.
+
+```
+Bad:
+  Call useInterrupts() and pass a resolver. The resolver runs once per
+  pending item inside a transaction...
+
+Good:
+  Some tool calls shouldn't run without a human saying yes: moving money,
+  deleting data. An interrupt pauses the run for that decision, then picks up
+  where it left off. Here is how to gate a tool behind an approval:
+
+  [code]
+```
+
+The order for a guide is problem, one-line fix, then the how (steps, snippets, API). Keep the problem to a couple of sentences, not a background essay. The code shows how it is solved, so do not narrate the solution in prose first.
+
+### Show, do not tell
+
+Do not explain in four paragraphs what one sentence and a code block can show. Readers grasp a diff or a snippet faster than prose.
+
+```
+Bad:
+  Three paragraphs describing how the config object accepts a
+  middleware array, what each slot does, and how ordering works.
+
+Good:
+  Add your middleware to the `middleware` array. Order runs top to bottom:
+
+  const app = createApp({
+    middleware: [auth, logging],
+  })
+```
+
+One good runnable example beats a page of description. Every code sample must run when copied, not need imagination to fill gaps.
+
+### List anything that is a list
+
+The moment a sentence covers more than one item, option, store, flag, or step, it becomes a list. Do not chain them into a paragraph with commas and semicolons. A reader scanning a bulleted list finds their item in a second. In a paragraph they have to read the whole thing to learn it does not apply to them.
+
+The tell is a sentence that names two or more things and says something about each. Cut it into one bullet per thing, one or two sentences each.
+
+```
+Bad:
+  Each store is independent. Provide only the ones you need. For chat:
+  `messages` for the transcript, `runs` for run lifecycle, `interrupts` for
+  durable approvals (needs `runs`), `metadata` for namespaced key/value state.
+  For generation: `generationRuns` for the run lifecycle, plus `artifacts` and
+  `blobs` to keep generated bytes.
+
+Good:
+  Each store is independent, so provide only the ones you need.
+
+  For chat:
+
+  - `messages`: the transcript.
+  - `runs`: run lifecycle.
+  - `interrupts`: durable approvals. Needs `runs`.
+  - `metadata`: namespaced key/value state.
+
+  For generation:
+
+  - `generationRuns`: run lifecycle for a generation.
+  - `artifacts` + `blobs`: keep the generated bytes.
+```
+
+Which form to reach for:
+
+- **Bullets** for a set where order does not matter: options, stores, fields, reasons, gotchas.
+- **Numbered steps** for a sequence the reader performs in order.
+- **A table** when every item has the same two or three attributes to compare (name, meaning, when to use).
+- **A paragraph** only for a single idea that genuinely flows as prose. One thought, two or three sentences, no embedded set.
+
+Keep bullets short and parallel: the same grammatical shape, the item in `code` or bold at the front, the explanation after it. A bullet that grows past two sentences wants to be its own subsection.
+
+If a list grows past five items, split it. Put "do now" first. Put the rest on a later page, or under "later". That is the `i-have-adhd` cap, not a style preference.
+
+### Page shape for a guide
+
+Problem, fix, steps, done.
+
+- Open with the problem the reader has, in their words, and what they will have at the end.
+- Say in a sentence how the feature solves it.
+- Walk through steps they can follow and test as they go, with the code doing the explaining.
+- End when they reach the goal. Show what now works. Do not close with a vague "next steps" dump.
+
+Reference pages (props, types, signatures) stay scannable and link back to the guide that shows them in use.
+
+## Write for the reader, not the history
+
+Docs describe what exists now. The reader never saw the old design, the earlier name, the draft PR, or the API you replaced along the way. Do not make them read about it.
+
+Never justify the current API by comparing it to a version that did not ship. A line like "instead of `useAssistant`, this uses `usePlugin`, which makes more sense because..." is noise to someone who never knew `useAssistant` existed. Cut it and just describe `usePlugin`.
+
+```
+Bad:
+  We renamed useAssistant to usePlugin and moved the tools onto it,
+  so instead of calling assistant.addTool you now use plugin.tools.
+
+Good:
+  Register tools on the plugin with plugin.tools:
+
+  const plugin = usePlugin({ tools: [search] })
+```
+
+Ban this framing from the output: "instead of X", "we renamed", "previously called", "this replaces the old", "unlike the earlier", and any transitional name that never reached a release.
+
+The one exception is a real migration. If users had X in a shipped, public release and you are moving them to Y, a short "Migrating from X" note is worth writing, because those readers actually used X. A name that only lived in a branch or a draft is not that. When unsure whether an old name shipped, leave it out.
+
+## Don't leak the build process
+
+The doc is read by someone who just arrived. They never saw the pull request, the refactor, or the conversation where the design was decided (including a conversation with an agent while writing the code and the docs). Write as if the current design was always the design. Anything that only makes sense to someone who watched it change is noise to the reader.
+
+**Cut rejected alternatives.** If a discussion weighed option A against option B and picked B, the doc documents B. It never names A, never says B is "better than" A, never says A "is no longer needed." The reader is not choosing between them; they use what shipped.
+
+```
+Bad:
+  We use a plain JSON Schema here instead of zod, since it is lighter
+  and zod is no longer a dependency.
+
+Good:
+  Pass the tool's input shape as a JSON Schema:
+
+  [code]
+```
+
+**Do not explain what something is not, when the reader never thought it was.** If a piece moved out of a module during a refactor, the doc for its new home does not warn against the old arrangement. A reader who never knew locks lived inside persistence is only confused by a paragraph insisting locks are not a persistence store and must not be passed in as one. State what the thing is now, in its own terms.
+
+```
+Bad (in the locks doc):
+  Locks are not a persistence store. Do not pass a lock into the stores
+  map. That used to be possible but is wrong now.
+
+Good (in the locks doc):
+  A lock coordinates work across instances. Wire it with withLocks:
+
+  [code]
+```
+
+The test: read the sentence as a brand-new user. If it answers a question they would never ask ("wait, was this somewhere else before?") or defends a choice they never knew existed, delete it. The doc has no memory of how it got here.
+
+## Forbidden
+
+Never use these. Ever. This list has no exceptions: not "the neighboring pages use them", not "the repo's house style uses them", not "it reads better here".
+
+- Em dashes and en dashes: the long `—` and the shorter `–`. Rewrite the sentence with a comma, colon, period, or parentheses instead.
+- Separator glyphs like `×` or `·`.
+- The pattern "It's not X: it's Y." and the "Not just X, but Y" three-part build-up.
+- The phrases "key insight", "gap", and variations of them.
+
+If you catch yourself reaching for one of these, stop and rewrite the sentence in plain words.
+
+Before you call a page done, search your own added text for `—`, `–`, `×`, and `·`. If a hit survived, you rationalized it. Fix it. Flagging it in your summary is not a substitute for fixing it.
+
+Then run the `simple-english` self-check on the same added text.
+
+## Cross-linking and placement
+
+- Put new pages where they fit the reader's path, grouped by what the reader is doing ("Building with React"), not by code layer ("Frontend Package API"). Update the site's nav or index so the page is reachable. An orphan page does not ship.
+- Link related pages at the moment they help, inline in the flow, not as a "Related" dump at the bottom.
+- Cross-linking goes both ways. When you add a page, update the older pages that should point into it.
+- Do not over-link. One well-placed "need X? see Y" beats a list of maybes.
+
+## Red flags
+
+| You catch yourself | Do instead |
+|---|---|
+| Opening with an API signature or config before the problem | Name the problem the reader has first, then the one-line fix, then the code. |
+| Writing three paragraphs before any code | Cut to one sentence plus a snippet. Show it. |
+| Writing a sentence that names two or more things and explains each | Make it a bulleted list, one item per bullet. |
+| A paragraph with commas or semicolons separating a set of options/stores/flags | Same fix: that is a list, format it as one. |
+| Cramming every angle into one page | Split into short linked pages, one job each. |
+| "In this guide we will explore..." | Delete it. Start with the reader's state and goal. |
+| "Let me describe what this component does" | Describe what the reader does with it. |
+| Reaching for an em dash | Rewrite with a comma, period, or parentheses. |
+| "The surrounding pages do X, so I will too" where X breaks a rule here | Match neighbors on structure only. Follow this skill on everything it covers, and raise the existing violations as their own cleanup. |
+| Using a big word (utilize, leverage, facilitate) | Swap in the plain word. `simple-english` owns this. |
+| One page for everyone | Name the readers. Give each a path or a page. Show the list. Stop. |
+| Posting a snippet "they can adapt" | Make it complete and runnable. |
+| Guessing where docs go | Find the docs folder, or ask. Read neighbors first. |
+| Calling a feature done with no doc change | If behavior changed, docs change too. Write them before you finish. |
+| Planning a feature without a doc-impact list | Add the list of new and changed docs to the plan. Name the reader for each page. |
+| "Unlike the old X, this now..." / "we renamed X to Y" | The reader never saw X. Describe only what ships now. |
+| "we chose Y over zod because..." / "X is no longer needed" | Cut the rejected alternative. Document only what shipped, no comparison. |
+| Warning readers not to do a thing they never knew was possible (e.g. "don't pass locks as a store") | Delete it. If they never saw the old arrangement, the warning only confuses. Describe the thing in its own terms. |
+| Inventing a component the site lacks | Use only components the site already has. |
+| Skipping the persona message because readers are obvious | Show the list. Stop. Obvious is not a skip. |
+| Skipping the tone question because neighbors have a voice | Neighbors are the proposed default. Ask. Then stop. |
+| Writing pages without loading simple-english and i-have-adhd | Load both. If either is missing, stop. |
+| Treating "write the docs" as permission to skip the gates | Writing docs is why the gates exist. |
+| Listing personas inside a larger plan and continuing | That is not the gate. The gate is a dedicated message that ends the turn. |

--- a/.grok/skills/ponytail/LICENSE
+++ b/.grok/skills/ponytail/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DietrichGebert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.grok/skills/ponytail/SKILL.md
+++ b/.grok/skills/ponytail/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ponytail
+description: >
+  Forces the laziest solution that actually works, simplest, shortest, most
+  minimal. Channels a senior dev who has seen everything: question whether the
+  task needs to exist at all (YAGNI), reach for the standard library before
+  custom code, native platform features before dependencies, one line before
+  fifty. Supports intensity levels: lite, full (default), ultra. Use whenever
+  the user says "ponytail", "be lazy", "lazy mode", "simplest solution",
+  "minimal solution", "yagni", "do less", or "shortest path", and whenever
+  they complain about over-engineering, bloat, boilerplate, or unnecessary
+  dependencies.
+argument-hint: "[lite|full|ultra]"
+license: MIT
+---
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Stdlib does it?** Use it.
+3. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+4. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+5. **Can it be one line?** One line.
+6. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project. Two rungs work → take the
+higher one and move on. The first lazy solution that works is the right one.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later", later can scaffold for itself.
+- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins.
+- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications with a `ponytail:` comment (`// ponytail: this exists`), simple reads as intent, not ignorance. Shortcut with a known ceiling (global lock, O(n²) scan, naive heuristic)? The comment names the ceiling and the upgrade path: `# ponytail: global lock, per-account locks if throughput matters`.
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+No essays, no feature tours, no design notes. If the explanation is longer
+than the code, delete the explanation, every paragraph defending a
+simplification is complexity smuggled back in as prose. Explanation the user
+explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
+give it in full, the rule is only against unrequested prose.
+
+Pattern: `[code] → skipped: [X], add when [Y].`
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
+
+Example: "Add a cache for these API responses."
+- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
+- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
+- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling
+that prevents data loss, security measures, accessibility basics, anything
+explicitly requested. User insists on the full version → build it, no
+re-arguing.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor
+reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
+just less code, the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a
+loop, a parser, a money/security path) leaves ONE runnable check behind, the
+smallest thing that fails if the logic breaks: an `assert`-based
+`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
+fixtures, no per-function suites unless asked. Trivial one-liners need no
+test, YAGNI applies to tests too.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk (pair with Caveman for
+terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+changed or session end.
+
+The shortest path to done is the right path.

--- a/.grok/skills/ponytail/SKILL.md
+++ b/.grok/skills/ponytail/SKILL.md
@@ -10,7 +10,7 @@ description: >
   "minimal solution", "yagni", "do less", or "shortest path", and whenever
   they complain about over-engineering, bloat, boilerplate, or unnecessary
   dependencies.
-argument-hint: "[lite|full|ultra]"
+argument-hint: '[lite|full|ultra]'
 license: MIT
 ---
 
@@ -63,13 +63,14 @@ Pattern: `[code] → skipped: [X], add when [Y].`
 
 ## Intensity
 
-| Level | What change |
-|-------|------------|
-| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
-| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| Level     | What change                                                                                                                 |
+| --------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **lite**  | Build what's asked, but name the lazier alternative in one line. User picks.                                                |
+| **full**  | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default.                                 |
 | **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
 
 Example: "Add a cache for these API responses."
+
 - lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
 - full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
 - ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."

--- a/.grok/skills/pr-description/SKILL.md
+++ b/.grok/skills/pr-description/SKILL.md
@@ -49,11 +49,11 @@ Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next act
 
 Pick one kind from the diff:
 
-| Kind             | Signal                                                                           |
-| ---------------- | -------------------------------------------------------------------------------- |
-| **fix**          | Restores broken behavior. A user-visible bug, a failing test, a regression.      |
-| **feat**         | Adds behavior that did not exist. New export, new command, new user-facing flow. |
-| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change.      |
+| Kind | Signal |
+|---|---|
+| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
+| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
 
 If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
 
@@ -69,71 +69,15 @@ A **feat** PR cannot be posted until the branch has at least one of:
 If none of those exist, stop. Do not run `gh pr create`. Do not run `gh pr edit`. Tell the user what is missing. Wait until they add one, then continue.
 
 A **fix** does not use this gate. A **chore / docs** PR does not use this gate.
-
-Screenshots are not this gate. A screenshot does not replace a test, a command, or an example.
 </HARD-GATE>
 
-### 4. Screenshots (try, when the PR has UI)
-
-This step is a try, not a gate. If capture fails, still write and post the PR.
-
-The PR **has UI** when the diff changes something a person sees in a browser:
-
-- Example apps
-- Playground
-- Docs site chrome (layout, theme, nav)
-- CSS, or components that paint a screen (`.tsx`, `.jsx`, `.vue`, `.svelte`, `.html` that is not a test)
-
-The PR **does not have UI** when the diff is only adapters, types, CI, tests, or agent files.
-
-If you are not sure, treat it as UI and try.
-
-Skip this step only when there is no UI, or the user said to skip screenshots. If there is no UI, omit the Screenshots heading later.
-
-**Capture**
-
-1. Find a runnable surface (example `pnpm dev`, a preview URL).
-2. Open it with the browser tools this harness has (Playwright MCP, agent-browser, or the same).
-3. Do the user flow this PR changes.
-4. Save PNG screenshots of the result.
-5. If layout or styling changed, save desktop and mobile (about 390px wide).
-6. Cap at 4 images.
-7. Stop the preview server after the files are saved. Do not leave a watcher running.
-
-Do not invent UI with an image model. Real browser only.
-
-**Put the images on the PR**
-
-GitHub has no public upload API for `user-attachments` images. Commit the PNGs on the branch so the PR body can link to them.
-
-1. Write files under `.github/pr-screenshots/<branch-kebab>/`.
-2. Commit only those PNG files. Push.
-3. Embed with full GitHub URLs. Relative paths do not render in a PR body.
-
-```markdown
-## Screenshots
-
-Desktop
-
-![desktop](https://github.com/OWNER/REPO/blob/BRANCH/.github/pr-screenshots/name/desktop.png?raw=true)
-```
-
-Get `OWNER/REPO` from `gh repo view --json nameWithOwner`. Use the branch name in the URL.
-
-If the user already pasted `https://github.com/user-attachments/assets/...` links, use those. Do not also commit files.
-
-If capture fails, still post. Keep the Screenshots heading and write one sentence: what you tried, and why it failed.
-
-Do not wait for the user to paste images.
-Do not refuse the PR because screenshots failed.
-
-### 5. Write the title
+### 4. Write the title
 
 Match this repo's recent PR titles. In a conventional-commit repo, write `type(scope): summary`. Keep it one line.
 
 The title must still make sense if the reviewer never opens the body.
 
-### 6. Write the body
+### 5. Write the body
 
 Load `simple-english` and `i-have-adhd`, then write in this order.
 
@@ -149,7 +93,7 @@ No preamble. No "This PR aims to". Start with the fact.
 
 Fill every section honestly. Leave a checkbox unchecked when the claim is false. Do not tick "I ran `pnpm test:pr`" if you did not run it.
 
-**Extra sections after the template, in this order.** Testing and Risk / rollback are always present. Screenshots, Linked issues, and Public API change are omitted when they do not apply.
+**Extra sections after the template, in this order.** Testing and Risk / rollback are always present. Linked issues and Public API change are omitted when they do not apply.
 
 #### Testing
 
@@ -158,13 +102,6 @@ Three parts, all required:
 1. **Commands run.** What you ran, what passed, what you skipped and why. If you ran nothing, say so.
 2. **Manual test.** Numbered steps a reviewer can follow to see the change. For a **fix**, step 1 is how to reproduce the old bug, then how to confirm it is gone.
 3. **How this PR makes testing easy.** Name the artifacts on the branch: tests, a command, an example app change. If there are none (allowed for fix and chore / docs), write that. Do not invent an easy path.
-
-#### Screenshots
-
-Required when step 4 ran (the PR has UI). Omit this heading when there is no UI.
-
-- On success: the markdown images from step 4, each with a short caption (Desktop, Mobile, Before, After).
-- On failure: one sentence. What you tried, and why it failed.
 
 #### Linked issues
 
@@ -200,7 +137,7 @@ new call site
 
 Two short snippets. What a user writes today, then what they write after this PR.
 
-### 7. Post immediately
+### 6. Post immediately
 
 Do not wait for the user to approve the text.
 
@@ -209,27 +146,19 @@ Do not wait for the user to approve the text.
 
 If `gh` fails, stop and show the error. Leave the drafted body in the chat so it is not lost.
 
-If step 4 wrote PNG files, those commits must be on the remote before the body links will render. Push first, then post or edit.
+Do not attach screenshots to the PR. Do not commit screenshot files for this skill.
 
 ## Red flags
 
-| You catch yourself                                           | Do instead                                                                 |
-| ------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| Writing the body from the branch name                        | Read the diff.                                                             |
-| Ticking a template checkbox you did not do                   | Leave it unchecked and say so in Testing.                                  |
-| Posting a feat with no test, command, or example             | Stop. The feat gate failed.                                                |
-| A 1-4 sentence lead that lists files                         | Rewrite as what a user can do, or what bug is gone.                        |
-| Public API section that shows the internal diff              | Show caller usage before and after.                                        |
-| Public API section on an AGENTS.md-only PR                   | Omit the heading.                                                          |
-| "I'll update the description later" after a push             | Rewrite now with `gh pr edit`.                                             |
-| Waiting for the user to approve the text                     | Post. This skill does not wait.                                            |
-| Skipping screenshots on a UI PR because "the text is enough" | Try capture.                                                               |
-| Skipping because GitHub has no upload API                    | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs.                |
-| Relative image paths in the PR body                          | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
-| Inventing a UI image with an image model                     | Real browser only.                                                         |
-| Waiting for the user to paste images                         | Capture first. Post even if capture fails.                                 |
-| Refusing to post because screenshots failed                  | Post. Say why in Screenshots.                                              |
-| Using a screenshot as the feat-gate artifact                 | The feat gate still needs a test, a command, or an example.                |
-| Mixing unrelated files into the screenshot commit            | Add only the PNG files.                                                    |
-| Leaving a preview server running after capture               | Stop the server.                                                           |
-| Writing without loading simple-english and i-have-adhd       | Load both. If missing, stop.                                               |
+| You catch yourself | Do instead |
+|---|---|
+| Writing the body from the branch name | Read the diff. |
+| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
+| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
+| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
+| Public API section that shows the internal diff | Show caller usage before and after. |
+| Public API section on an AGENTS.md-only PR | Omit the heading. |
+| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
+| Waiting for the user to approve the text | Post. This skill does not wait. |
+| Uploading or committing screenshots for the PR body | Skip. Do not put images on the PR. |
+| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |

--- a/.grok/skills/pr-description/SKILL.md
+++ b/.grok/skills/pr-description/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: pr-description
+description: Use when writing a pull request title or body, when about to run gh pr create, when about to git push on a branch that already has an open PR, or when the user says /pr-description, "write the PR description", or "update the PR title". Don't use for commit messages, changelogs, or review comments.
+---
+
+# pr-description
+
+Write the GitHub PR title and body, then post them. Do not wait for approval.
+
+Work from the diff, not from memory.
+
+## When to run
+
+This skill is auto plus on demand.
+
+Run it:
+
+- When the user asks for a PR title or body, or types `/pr-description`.
+- Immediately before `gh pr create`.
+- Immediately after an **agent** `git push` on a branch that already has an open PR. Then run `gh pr edit` with a fresh title and body.
+
+Do not run it on a human-only `git push` in another terminal. Do not add a git hook.
+
+A later push must rewrite the GitHub text. Do not leave a stale description.
+
+## Required skills for the title and body
+
+`simple-english` and `i-have-adhd` are prerequisites. They apply to the PR title and body, not to the rest of the session.
+
+Load both immediately before writing the title and body. Use the Skill tool if this harness has one. If it does not, Read each skill's SKILL.md. Do not write from memory of those skills.
+
+If either skill is missing, stop. Do not post a weaker substitute.
+
+When `i-have-adhd` is loaded from this skill, ignore its persistence section. Do not switch the rest of the session into ADHD mode.
+
+Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next action first in the lead, numbered steps for manual test, lists capped at 5.
+
+## Procedure
+
+### 1. Ground in the repo
+
+1. Find the base branch (`main` / `master` / `develop`).
+2. Read `git log --oneline base...HEAD` and `git diff base...HEAD`.
+3. Read `.github/pull_request_template.md` if it exists (also check `.github/PULL_REQUEST_TEMPLATE.md` and `.github/PULL_REQUEST_TEMPLATE/`).
+4. Read about 15 recent PR titles in this repo (`gh pr list --limit 15 --state all --json title`). Match that shape. Do not invent a new title style.
+5. Collect linked issues from branch name, commit messages, and `Closes #` / `Fixes #` text.
+
+### 2. Classify the PR
+
+Pick one kind from the diff:
+
+| Kind | Signal |
+|---|---|
+| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
+| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
+
+If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
+
+### 3. Feat gate: easy test path
+
+<HARD-GATE>
+A **feat** PR cannot be posted until the branch has at least one of:
+
+- A new or updated automated test that covers the new behavior
+- A command a reviewer can copy and run
+- A change in an official example app that shows the new behavior
+
+If none of those exist, stop. Do not run `gh pr create`. Do not run `gh pr edit`. Tell the user what is missing. Wait until they add one, then continue.
+
+A **fix** does not use this gate. A **chore / docs** PR does not use this gate.
+
+Screenshots are not this gate. A screenshot does not replace a test, a command, or an example.
+</HARD-GATE>
+
+### 4. Screenshots (try, when the PR has UI)
+
+This step is a try, not a gate. If capture fails, still write and post the PR.
+
+The PR **has UI** when the diff changes something a person sees in a browser:
+
+- Example apps
+- Playground
+- Docs site chrome (layout, theme, nav)
+- CSS, or components that paint a screen (`.tsx`, `.jsx`, `.vue`, `.svelte`, `.html` that is not a test)
+
+The PR **does not have UI** when the diff is only adapters, types, CI, tests, or agent files.
+
+If you are not sure, treat it as UI and try.
+
+Skip this step only when there is no UI, or the user said to skip screenshots. If there is no UI, omit the Screenshots heading later.
+
+**Capture**
+
+1. Find a runnable surface (example `pnpm dev`, a preview URL).
+2. Open it with the browser tools this harness has (Playwright MCP, agent-browser, or the same).
+3. Do the user flow this PR changes.
+4. Save PNG screenshots of the result.
+5. If layout or styling changed, save desktop and mobile (about 390px wide).
+6. Cap at 4 images.
+7. Stop the preview server after the files are saved. Do not leave a watcher running.
+
+Do not invent UI with an image model. Real browser only.
+
+**Put the images on the PR**
+
+GitHub has no public upload API for `user-attachments` images. Commit the PNGs on the branch so the PR body can link to them.
+
+1. Write files under `.github/pr-screenshots/<branch-kebab>/`.
+2. Commit only those PNG files. Push.
+3. Embed with full GitHub URLs. Relative paths do not render in a PR body.
+
+```markdown
+## Screenshots
+
+Desktop
+
+![desktop](https://github.com/OWNER/REPO/blob/BRANCH/.github/pr-screenshots/name/desktop.png?raw=true)
+```
+
+Get `OWNER/REPO` from `gh repo view --json nameWithOwner`. Use the branch name in the URL.
+
+If the user already pasted `https://github.com/user-attachments/assets/...` links, use those. Do not also commit files.
+
+If capture fails, still post. Keep the Screenshots heading and write one sentence: what you tried, and why it failed.
+
+Do not wait for the user to paste images.
+Do not refuse the PR because screenshots failed.
+
+### 5. Write the title
+
+Match this repo's recent PR titles. In a conventional-commit repo, write `type(scope): summary`. Keep it one line.
+
+The title must still make sense if the reviewer never opens the body.
+
+### 6. Write the body
+
+Load `simple-english` and `i-have-adhd`, then write in this order.
+
+**Lead (required, 1 to 4 sentences, before the template).**
+
+- **feat:** what the PR does for a user of the product.
+- **fix:** what the bug is, then how this PR fixes it.
+- **chore / docs:** what changed, in product or repo terms, not a file list.
+
+No preamble. No "This PR aims to". Start with the fact.
+
+**Repo template (required when the file exists).**
+
+Fill every section honestly. Leave a checkbox unchecked when the claim is false. Do not tick "I ran `pnpm test:pr`" if you did not run it.
+
+**Extra sections after the template, in this order.** Testing and Risk / rollback are always present. Screenshots, Linked issues, and Public API change are omitted when they do not apply.
+
+#### Testing
+
+Three parts, all required:
+
+1. **Commands run.** What you ran, what passed, what you skipped and why. If you ran nothing, say so.
+2. **Manual test.** Numbered steps a reviewer can follow to see the change. For a **fix**, step 1 is how to reproduce the old bug, then how to confirm it is gone.
+3. **How this PR makes testing easy.** Name the artifacts on the branch: tests, a command, an example app change. If there are none (allowed for fix and chore / docs), write that. Do not invent an easy path.
+
+#### Screenshots
+
+Required when step 4 ran (the PR has UI). Omit this heading when there is no UI.
+
+- On success: the markdown images from step 4, each with a short caption (Desktop, Mobile, Before, After).
+- On failure: one sentence. What you tried, and why it failed.
+
+#### Linked issues
+
+Omit this heading when nothing links. When an issue links, use `Closes #N` or `Fixes #N`.
+
+#### Risk / rollback
+
+What could break. How to undo (revert the PR, turn a flag off, and so on). If risk is low, say that in one line. Do not skip the heading.
+
+#### Public API change
+
+Omit this heading when the PR does not touch the published surface.
+
+Published surface means: exported functions, types, components, CLI flags, env vars, and documented contracts from **published** packages. Tests, internal files, agent skills, `AGENTS.md`, and `CLAUDE.md` do not count.
+
+When it does touch that surface, show **caller usage**, not the internal diff:
+
+```markdown
+## Public API change
+
+**Before**
+
+\`\`\`ts
+old call site
+\`\`\`
+
+**After**
+
+\`\`\`ts
+new call site
+\`\`\`
+```
+
+Two short snippets. What a user writes today, then what they write after this PR.
+
+### 7. Post immediately
+
+Do not wait for the user to approve the text.
+
+- No PR yet: `gh pr create --title "..." --body-file ...`
+- PR already open: `gh pr edit --title "..." --body-file ...`
+
+If `gh` fails, stop and show the error. Leave the drafted body in the chat so it is not lost.
+
+If step 4 wrote PNG files, those commits must be on the remote before the body links will render. Push first, then post or edit.
+
+## Red flags
+
+| You catch yourself | Do instead |
+|---|---|
+| Writing the body from the branch name | Read the diff. |
+| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
+| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
+| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
+| Public API section that shows the internal diff | Show caller usage before and after. |
+| Public API section on an AGENTS.md-only PR | Omit the heading. |
+| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
+| Waiting for the user to approve the text | Post. This skill does not wait. |
+| Skipping screenshots on a UI PR because "the text is enough" | Try capture. |
+| Skipping because GitHub has no upload API | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs. |
+| Relative image paths in the PR body | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
+| Inventing a UI image with an image model | Real browser only. |
+| Waiting for the user to paste images | Capture first. Post even if capture fails. |
+| Refusing to post because screenshots failed | Post. Say why in Screenshots. |
+| Using a screenshot as the feat-gate artifact | The feat gate still needs a test, a command, or an example. |
+| Mixing unrelated files into the screenshot commit | Add only the PNG files. |
+| Leaving a preview server running after capture | Stop the server. |
+| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |

--- a/.grok/skills/pr-description/SKILL.md
+++ b/.grok/skills/pr-description/SKILL.md
@@ -49,11 +49,11 @@ Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next act
 
 Pick one kind from the diff:
 
-| Kind | Signal |
-|---|---|
-| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
-| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
-| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
+| Kind             | Signal                                                                           |
+| ---------------- | -------------------------------------------------------------------------------- |
+| **fix**          | Restores broken behavior. A user-visible bug, a failing test, a regression.      |
+| **feat**         | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change.      |
 
 If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
 
@@ -213,23 +213,23 @@ If step 4 wrote PNG files, those commits must be on the remote before the body l
 
 ## Red flags
 
-| You catch yourself | Do instead |
-|---|---|
-| Writing the body from the branch name | Read the diff. |
-| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
-| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
-| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
-| Public API section that shows the internal diff | Show caller usage before and after. |
-| Public API section on an AGENTS.md-only PR | Omit the heading. |
-| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
-| Waiting for the user to approve the text | Post. This skill does not wait. |
-| Skipping screenshots on a UI PR because "the text is enough" | Try capture. |
-| Skipping because GitHub has no upload API | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs. |
-| Relative image paths in the PR body | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
-| Inventing a UI image with an image model | Real browser only. |
-| Waiting for the user to paste images | Capture first. Post even if capture fails. |
-| Refusing to post because screenshots failed | Post. Say why in Screenshots. |
-| Using a screenshot as the feat-gate artifact | The feat gate still needs a test, a command, or an example. |
-| Mixing unrelated files into the screenshot commit | Add only the PNG files. |
-| Leaving a preview server running after capture | Stop the server. |
-| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |
+| You catch yourself                                           | Do instead                                                                 |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Writing the body from the branch name                        | Read the diff.                                                             |
+| Ticking a template checkbox you did not do                   | Leave it unchecked and say so in Testing.                                  |
+| Posting a feat with no test, command, or example             | Stop. The feat gate failed.                                                |
+| A 1-4 sentence lead that lists files                         | Rewrite as what a user can do, or what bug is gone.                        |
+| Public API section that shows the internal diff              | Show caller usage before and after.                                        |
+| Public API section on an AGENTS.md-only PR                   | Omit the heading.                                                          |
+| "I'll update the description later" after a push             | Rewrite now with `gh pr edit`.                                             |
+| Waiting for the user to approve the text                     | Post. This skill does not wait.                                            |
+| Skipping screenshots on a UI PR because "the text is enough" | Try capture.                                                               |
+| Skipping because GitHub has no upload API                    | Commit PNGs on the branch. Use `blob/...png?raw=true` URLs.                |
+| Relative image paths in the PR body                          | Use full `https://github.com/OWNER/REPO/blob/BRANCH/...png?raw=true` URLs. |
+| Inventing a UI image with an image model                     | Real browser only.                                                         |
+| Waiting for the user to paste images                         | Capture first. Post even if capture fails.                                 |
+| Refusing to post because screenshots failed                  | Post. Say why in Screenshots.                                              |
+| Using a screenshot as the feat-gate artifact                 | The feat gate still needs a test, a command, or an example.                |
+| Mixing unrelated files into the screenshot commit            | Add only the PNG files.                                                    |
+| Leaving a preview server running after capture               | Stop the server.                                                           |
+| Writing without loading simple-english and i-have-adhd       | Load both. If missing, stop.                                               |

--- a/.grok/skills/pr-description/SKILL.md
+++ b/.grok/skills/pr-description/SKILL.md
@@ -49,11 +49,11 @@ Use pragmatic `simple-english`. Then shape the text with `i-have-adhd`: next act
 
 Pick one kind from the diff:
 
-| Kind | Signal |
-|---|---|
-| **fix** | Restores broken behavior. A user-visible bug, a failing test, a regression. |
-| **feat** | Adds behavior that did not exist. New export, new command, new user-facing flow. |
-| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change. |
+| Kind             | Signal                                                                           |
+| ---------------- | -------------------------------------------------------------------------------- |
+| **fix**          | Restores broken behavior. A user-visible bug, a failing test, a regression.      |
+| **feat**         | Adds behavior that did not exist. New export, new command, new user-facing flow. |
+| **chore / docs** | Agent files, CI, docs-only, refactors with no user-visible behavior change.      |
 
 If both a feat and a fix are in the diff, the larger user-visible story wins. Say so in the lead.
 
@@ -150,15 +150,15 @@ Do not attach screenshots to the PR. Do not commit screenshot files for this ski
 
 ## Red flags
 
-| You catch yourself | Do instead |
-|---|---|
-| Writing the body from the branch name | Read the diff. |
-| Ticking a template checkbox you did not do | Leave it unchecked and say so in Testing. |
-| Posting a feat with no test, command, or example | Stop. The feat gate failed. |
-| A 1-4 sentence lead that lists files | Rewrite as what a user can do, or what bug is gone. |
-| Public API section that shows the internal diff | Show caller usage before and after. |
-| Public API section on an AGENTS.md-only PR | Omit the heading. |
-| "I'll update the description later" after a push | Rewrite now with `gh pr edit`. |
-| Waiting for the user to approve the text | Post. This skill does not wait. |
-| Uploading or committing screenshots for the PR body | Skip. Do not put images on the PR. |
-| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop. |
+| You catch yourself                                     | Do instead                                          |
+| ------------------------------------------------------ | --------------------------------------------------- |
+| Writing the body from the branch name                  | Read the diff.                                      |
+| Ticking a template checkbox you did not do             | Leave it unchecked and say so in Testing.           |
+| Posting a feat with no test, command, or example       | Stop. The feat gate failed.                         |
+| A 1-4 sentence lead that lists files                   | Rewrite as what a user can do, or what bug is gone. |
+| Public API section that shows the internal diff        | Show caller usage before and after.                 |
+| Public API section on an AGENTS.md-only PR             | Omit the heading.                                   |
+| "I'll update the description later" after a push       | Rewrite now with `gh pr edit`.                      |
+| Waiting for the user to approve the text               | Post. This skill does not wait.                     |
+| Uploading or committing screenshots for the PR body    | Skip. Do not put images on the PR.                  |
+| Writing without loading simple-english and i-have-adhd | Load both. If missing, stop.                        |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,23 @@ identical.
 Do not invent a title and body from memory. If you cannot load the skill,
 stop. A human-only `git push` in another terminal does not trigger this.
 
+## Ponytail skill (mandatory for Claude, Grok, and Codex)
+
+Before you plan, write, or edit application code, tests, or examples, you
+MUST load the `ponytail` skill and follow it. This is not optional.
+
+Use the Skill tool if this harness has one. If it does not, Read
+`.claude/skills/ponytail/SKILL.md` (copies also live at
+`.agents/skills/ponytail/SKILL.md` for Codex and
+`.grok/skills/ponytail/SKILL.md` for Grok). Keep those three files
+identical.
+
+Do not design or implement from memory of this file. If you cannot load the
+skill, stop.
+
+Ponytail does not skip this repo's quality gates, E2E tests, or the `docs`
+and `pr-description` skills. Load those when their own rules say so.
+
 ## Dependency Install
 
 Run `pnpm install` before starting any task and again after every merge with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,21 @@ to skip.
 This also applies when planning a feature (include a doc-impact list) and
 when finishing a behavior change (docs must update before the work is done).
 
+## PR description skill (mandatory for Claude, Grok, and Codex)
+
+Before `gh pr create`, and after an agent `git push` on a branch that already
+has an open PR, you MUST load the `pr-description` skill and follow it.
+This is not optional.
+
+Use the Skill tool if this harness has one. If it does not, Read
+`.claude/skills/pr-description/SKILL.md` (copies also live at
+`.agents/skills/pr-description/SKILL.md` for Codex and
+`.grok/skills/pr-description/SKILL.md` for Grok). Keep those three files
+identical.
+
+Do not invent a title and body from memory. If you cannot load the skill,
+stop. A human-only `git push` in another terminal does not trigger this.
+
 ## Dependency Install
 
 Run `pnpm install` before starting any task and again after every merge with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,23 @@ Cross-agent guidance for this repository. See `CLAUDE.md` for the full project
 overview, architecture, and conventions — this file mirrors the rules that
 apply to every coding agent regardless of tool.
 
+## Docs skill (mandatory for Claude, Grok, and Codex)
+
+Before you plan, write, edit, or reorganize any file under `docs/`, you MUST
+load the `docs` skill and follow it. This is not optional.
+
+Use the Skill tool if this harness has one. If it does not, Read
+`.claude/skills/docs/SKILL.md` (copies also live at
+`.agents/skills/docs/SKILL.md` for Codex and `.grok/skills/docs/SKILL.md`
+for Grok). Keep those three files identical.
+
+Do not write docs from memory of this file. If you cannot load the skill,
+stop. Tiny copy edits still load the skill; the skill decides which gates
+to skip.
+
+This also applies when planning a feature (include a doc-impact list) and
+when finishing a behavior change (docs must update before the work is done).
+
 ## Dependency Install
 
 Run `pnpm install` before starting any task and again after every merge with
@@ -49,7 +66,8 @@ Do **not** rely on CI as your first signal. Run locally, fix, then push.
 
 ## Documentation
 
-When editing docs under `docs/`:
+Load the `docs` skill first (see **Docs skill** above). Then also obey
+these TanStack-specific rules when editing docs under `docs/`:
 
 - **No `as` type-assertion casts in code samples.** Examples must type-check
   without `as SomeType` — narrow `unknown` values with `typeof` / `in`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ TanStack AI is a type-safe, provider-agnostic AI SDK for building AI-powered app
 
 **PR description skill (mandatory).** Before `gh pr create`, and after an agent `git push` on a branch that already has an open PR, load `.claude/skills/pr-description/SKILL.md` and follow it. Do not invent the title and body from memory.
 
+**Ponytail skill (mandatory).** Before planning, writing, or editing application code, tests, or examples, load `.claude/skills/ponytail/SKILL.md` and follow it. Do not design or implement without it. Ponytail does not skip this repo's quality gates, E2E tests, or the docs and PR-description skills.
+
 ## Package Manager & Tooling
 
 - **Package Manager**: pnpm@10.17.0 (required)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 TanStack AI is a type-safe, provider-agnostic AI SDK for building AI-powered applications. The repository is a **pnpm monorepo** managed with **Nx** that includes TypeScript packages, plus multiple framework examples.
 
+**Docs skill (mandatory).** Before planning, writing, editing, or reorganizing anything under `docs/`, load `.claude/skills/docs/SKILL.md` and follow it. Do not write docs without it. See **Documentation** below for TanStack-specific rules that also apply.
+
 ## Package Manager & Tooling
 
 - **Package Manager**: pnpm@10.17.0 (required)
@@ -341,6 +343,17 @@ OPENAI_API_KEY=sk-... pnpm --filter @tanstack/ai-e2e record
 **Guide:** See `testing/e2e/README.md` for full instructions on adding tests, recording fixtures, and troubleshooting.
 
 ### Documentation
+
+**MANDATORY: load the `docs` skill before touching docs.** Before you
+plan, write, edit, or reorganize any file under `docs/`, load the `docs`
+skill at `.claude/skills/docs/SKILL.md` (Skill tool, or Read the file).
+Do not write docs from memory of this section. If you cannot load the
+skill, stop. Tiny copy edits still load the skill; the skill decides
+which gates to skip. This also applies when planning a feature (include
+a doc-impact list) and when finishing a behavior change (docs must
+update before the work is done).
+
+Then also obey these TanStack-specific rules:
 
 - Docs are in `docs/` directory (Markdown)
 - Auto-generated docs via `pnpm generate-docs` (TypeDoc)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ TanStack AI is a type-safe, provider-agnostic AI SDK for building AI-powered app
 
 **Docs skill (mandatory).** Before planning, writing, editing, or reorganizing anything under `docs/`, load `.claude/skills/docs/SKILL.md` and follow it. Do not write docs without it. See **Documentation** below for TanStack-specific rules that also apply.
 
+**PR description skill (mandatory).** Before `gh pr create`, and after an agent `git push` on a branch that already has an open PR, load `.claude/skills/pr-description/SKILL.md` and follow it. Do not invent the title and body from memory.
+
 ## Package Manager & Tooling
 
 - **Package Manager**: pnpm@10.17.0 (required)


### PR DESCRIPTION
Review the three skills under `.claude/skills/`, then the mandatory blocks in `AGENTS.md` and `CLAUDE.md`.

This PR adds the `docs`, `pr-description`, and `ponytail` skills to the repo. Claude, Grok, and Codex must load `docs` before any work under `docs/`. They must load `pr-description` before `gh pr create`, and after an agent push on an open PR. They must load `ponytail` before they plan or edit application code, tests, or examples.

The three copies of each skill must stay identical: `.claude/skills/` (Claude Code), `.agents/skills/` (Codex), `.grok/skills/` (Grok). TanStack docs rules still apply after `docs` loads (no `as` casts, both sides of the coin, latest models, `addedAt` / `updatedAt`). Ponytail does not skip quality gates, E2E, or the other two skills.

`pr-description` writes the title and body from the diff, then posts. It does not put screenshots on the PR.

## 🎯 Changes

- Add `docs` and require it before planning, writing, or editing files under `docs/`.
- Add `pr-description` and require it before `gh pr create`, and after an agent `git push` on an open PR.
- Add `ponytail` and require it before planning, writing, or editing application code, tests, or examples.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

Agent-instruction and skill files only. I did not run `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

## Testing

1. **Commands run.** I did not run `pnpm test:pr`. These files are agent skills and instruction markdown. No published package changed.
2. **Manual test.**
   1. Ask an agent to edit a file under `docs/`. Confirm it loads `.claude/skills/docs/SKILL.md`.
   2. Ask an agent to change application code. Confirm it loads `.claude/skills/ponytail/SKILL.md` and takes the shortest working path.
   3. Ask an agent to open a PR. Confirm it loads `.claude/skills/pr-description/SKILL.md` and posts a title plus body from the diff.
3. **How this PR makes testing easy.** The artifacts are the three skill copies plus the mandatory blocks in `AGENTS.md` and `CLAUDE.md`. There is no automated test, command, or example-app change.

## Risk / rollback

If an agent ignores `AGENTS.md`, it can skip the skills. A skill cannot enforce itself. Rollback: revert this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added standardized workflows for creating and updating documentation, including persona, tone, planning, discovery, cross-linking, and review guidance.
  - Added guidance for preparing pull request descriptions based on repository changes, testing, risks, and public API impact.
  - Clarified failure handling and when workflows should pause for confirmation or continue with approved defaults.

- **Workflow Improvements**
  - Added a minimal-solution workflow emphasizing focused changes, validation, accessibility, security, and runnable checks.
  - Added consistent skill guidance across supported development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->