### PR TITLE
Update retired Claude model ids in code-mode-snippets and ai-solid

### DIFF
--- a/packages/ai-code-mode-snippets/README.md
+++ b/packages/ai-code-mode-snippets/README.md
@@ -42,7 +42,7 @@ const codeModeConfig = {
 const { toolsRegistry, systemPrompt, selectedSnippets } =
   await codeModeWithSnippets({
     config: codeModeConfig,
-    adapter: anthropic('claude-3-haiku'), // Cheap model for snippet selection
+    adapter: anthropic('claude-haiku-4-5'), // Cheap model for snippet selection
     snippets: {
       storage: snippetStorage,
       maxSnippetsInContext: 5,
@@ -52,7 +52,7 @@ const { toolsRegistry, systemPrompt, selectedSnippets } =
 
 // Use in chat
 const stream = chat({
-  adapter: anthropic('claude-sonnet-4-20250514'), // Main model
+  adapter: anthropic('claude-sonnet-4-6'), // Main model
   toolRegistry: toolsRegistry,
   messages,
   systemPrompts: [basePrompt, systemPrompt],

--- a/packages/ai-code-mode-snippets/test-cli/adapters.ts
+++ b/packages/ai-code-mode-snippets/test-cli/adapters.ts
@@ -31,7 +31,7 @@ export interface AdapterDefinition {
 // Model defaults from environment or sensible defaults
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o'
 const ANTHROPIC_MODEL =
-  process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514'
+  process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6'
 const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-2.5-flash'
 
 /**

--- a/packages/ai-code-mode-snippets/test-cli/adapters.ts
+++ b/packages/ai-code-mode-snippets/test-cli/adapters.ts
@@ -30,8 +30,7 @@ export interface AdapterDefinition {
 
 // Model defaults from environment or sensible defaults
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o'
-const ANTHROPIC_MODEL =
-  process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6'
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6'
 const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-2.5-flash'
 
 /**

--- a/packages/ai-code-mode-snippets/test-cli/cli.ts
+++ b/packages/ai-code-mode-snippets/test-cli/cli.ts
@@ -590,7 +590,7 @@ program
 
       try {
         const { anthropicText } = await import('@tanstack/ai-anthropic')
-        const modelName = model || 'claude-sonnet-4-20250514'
+        const modelName = model || 'claude-sonnet-4-6'
         adapter = anthropicText(modelName, { apiKey })
         logInfo(`Using Anthropic adapter with model: ${modelName}`)
       } catch (error) {
@@ -706,7 +706,7 @@ program
 
       try {
         const { anthropicText } = await import('@tanstack/ai-anthropic')
-        const modelName = model || 'claude-sonnet-4-20250514'
+        const modelName = model || 'claude-sonnet-4-6'
         adapter = anthropicText(modelName, { apiKey })
         logInfo(`Using Anthropic adapter with model: ${modelName}`)
       } catch (error) {

--- a/packages/ai-solid/README.md
+++ b/packages/ai-solid/README.md
@@ -407,7 +407,7 @@ export const Route = createFileRoute('/api/chat')({
         return toServerSentEventsResponse(
           chat({
             adapter: anthropicText(),
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             messages,
             tools, // Tools with execute functions
           }),


### PR DESCRIPTION
Five call sites and doc examples still name Claude model ids that the Anthropic API has stopped serving. Two of them are runtime defaults, so a user who runs the test CLI without `--model` or `ANTHROPIC_MODEL` gets the retired id.

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `packages/ai-code-mode-snippets/test-cli/adapters.ts` | 34 | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `packages/ai-code-mode-snippets/test-cli/cli.ts` | 593 | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `packages/ai-code-mode-snippets/test-cli/cli.ts` | 709 | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `packages/ai-code-mode-snippets/README.md` | 45 | `claude-3-haiku` | `claude-haiku-4-5` |
| `packages/ai-code-mode-snippets/README.md` | 55 | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `packages/ai-solid/README.md` | 410 | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |

Retirement dates are on the [Anthropic deprecations page](https://platform.claude.com/docs/en/about-claude/model-deprecations): `claude-sonnet-4-20250514` on 15 June 2026, and the Claude 3 Haiku snapshot that `claude-3-haiku` names on 20 April 2026.

The replacements are the ones this repo already picked elsewhere. `claude-sonnet-4-6` and `claude-haiku-4-5` both have entries in `packages/ai-anthropic/src/model-meta.ts`, and `docs/adapters/anthropic.md` uses `claude-sonnet-4-6` throughout. Neither of the two old ids is in `model-meta.ts` at all.

Three places kept the old ids on purpose.

`packages/ai-bedrock/src/model-catalog.generated.ts` carries `us.anthropic.claude-3-7-sonnet-20250219-v1:0` and two other older snapshots. The file header says it is generated by `scripts/fetch-bedrock-models.ts` and there is a `sync-models.yml` workflow that refreshes it, so hand-editing would be undone. Bedrock also runs its own model lifecycle, separate from the first-party API dates above, and I have not checked what Bedrock still serves.

`packages/ai/skills/ai-core/adapter-configuration/SKILL.md` line 115 passes a Bedrock id to `bedrockText`. Same reasoning, and it should stay consistent with whatever the generated catalog holds.

`packages/ai-bedrock/tests/adapter.test.ts` line 114 uses an old id as a fixture. The test asserts on adapter wiring, not on the model existing.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. I have not run the test CLI against the API to reproduce a failure, the claim rests on the published retirement dates and on the ids being absent from your own `model-meta.ts`. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated usage examples for backend integrations and AI-generated snippet selection to reference Claude Sonnet 4.6.
  * Refreshed Anthropic model settings throughout the documented examples for consistency.

* **Chores**
  * Updated default models used by command-line examples and testing workflows to Claude Sonnet 4.6.
  * Standardized model declarations without changing command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->