### PR TITLE
docs: require docs, changesets, and CONTRIBUTING.md for agents

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,13 @@
 ## 🎯 Changes
 
-<!-- What changes are made in this PR? Describe the change and its motivation. -->
+<!-- What changed, and why. If you skipped docs or a changeset, say why here. -->
 
 ## ✅ Checklist
 
 - [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
 - [ ] I have tested this code locally with `pnpm run test:pr`.
+- [ ] Docs: I updated `docs/` for this change, or this change is not user-facing.
+- [ ] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.
 
 ## 🚀 Release Impact
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,20 @@ identical.
 Do not invent a title and body from memory. If you cannot load the skill,
 stop. A human-only `git push` in another terminal does not trigger this.
 
+## Contributing guide (mandatory for issues and PRs)
+
+Before you open a GitHub issue or pull request, you MUST read
+`CONTRIBUTING.md` and follow it. This is not optional.
+
+For issues: use the templates it points to. Include a minimal repro when
+you report a bug.
+
+For pull requests: fill the PR template honestly. Update `docs/` when the
+change is user-facing. Include a changeset on the PR when a published
+package changed. Do not open the PR and add those later.
+
+If you cannot read `CONTRIBUTING.md`, stop.
+
 ## Ponytail skill (mandatory for Claude, Grok, and Codex)
 
 Before you plan, write, or edit application code, tests, or examples, you

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ TanStack AI is a type-safe, provider-agnostic AI SDK for building AI-powered app
 
 **PR description skill (mandatory).** Before `gh pr create`, and after an agent `git push` on a branch that already has an open PR, load `.claude/skills/pr-description/SKILL.md` and follow it. Do not invent the title and body from memory.
 
+**Contributing guide (mandatory).** Before you open a GitHub issue or pull request, read `CONTRIBUTING.md` and follow it. Use the issue or PR template. Update `docs/` when the change is user-facing. Add a changeset on the PR when a published package changed.
+
 **Ponytail skill (mandatory).** Before planning, writing, or editing application code, tests, or examples, load `.claude/skills/ponytail/SKILL.md` and follow it. Do not design or implement without it. Ponytail does not skip this repo's quality gates, E2E tests, or the docs and PR-description skills.
 
 ## Package Manager & Tooling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,9 +121,22 @@ Tests are included in typecheck. `vite.config.ts` / `vitest.config.ts` are not �
 
 Run the suite locally with `pnpm test:e2e`. Record real LLM fixtures with `OPENAI_API_KEY=sk-... pnpm --filter @tanstack/ai-e2e record`.
 
-## Changesets
+## Documentation (required when relevant)
 
-Any change that ships in a published package requires a changeset. Examples, internal test harnesses, codemods, and docs do not.
+If the change is user-facing, update `docs/` in the same PR. Do not ship the code now and the docs later.
+
+User-facing means a caller can see or do something new or different:
+
+- New or changed public API (exports, types, flags, env vars)
+- New or changed behaviour
+- New adapter capability
+- Changed defaults, errors, or documented contracts
+
+Skip docs only when nothing user-facing changed (CI, internal tests, same-behaviour refactors, agent files). Write that reason in the PR body.
+
+## Changesets (required on the PR)
+
+Any PR that changes a published package MUST include a changeset file on that PR. Run this before you open the PR:
 
 ```bash
 pnpm changeset
@@ -134,6 +147,10 @@ Pick the affected packages and the bump type:
 - **patch**: bug fix, internal refactor, perf, docs in package, no API change.
 - **minor**: new public API, new opt-in behaviour, backwards-compatible enhancement.
 - **major**: breaking change to a published API surface. Coordinate with maintainers first.
+
+Do not add the changeset after review as a follow-up. It belongs in the first push of the PR.
+
+Skip a changeset only when the PR does not change published packages (docs, CI, examples, testing, contributing). Tick the docs/CI/dev-only box on the PR template.
 
 The defensive `ignore` list in `.changeset/config.json` blocks accidental publication from examples/testing/codemods even if `"private": true` is ever dropped.
 
@@ -146,11 +163,10 @@ The defensive `ignore` list in `.changeset/config.json` blocks accidental public
 ## Pull request flow
 
 1. Push your branch and open a PR against `main`.
-2. CI runs: `pnpm test:pr` (sherif workspace check, knip dead-code, docs link verification, ESLint, unit tests, typecheck, build artifacts, build) + the full E2E suite.
-3. Address review comments.
-4. A maintainer merges. Releases are cut via Changesets — your changeset entry lands in the next release.
-
-The PR template lists the steps. The `Test plan` section is required — describe how a reviewer can verify your change.
+2. Fill the PR template. Tick **docs** and **changeset** honestly, or say why you skipped them.
+3. CI runs: `pnpm test:pr` (sherif workspace check, knip dead-code, docs link verification, ESLint, unit tests, typecheck, build artifacts, build) + the full E2E suite.
+4. Address review comments.
+5. A maintainer merges. Releases are cut via Changesets. Your changeset entry lands in the next release.
 
 ## Adding a new provider adapter
 
@@ -161,7 +177,7 @@ The pattern lives in `packages/ai-openai/`, `packages/ai-anthropic/`, `packages/
 3. Add `model-meta.ts` so per-model type safety works.
 4. Wire the provider into `testing/e2e/feature-support.ts` and `testing/e2e/test-matrix.ts`. Existing provider-coverage tests pick it up automatically.
 5. Record fixtures (`OPENAI_API_KEY=... pnpm --filter @tanstack/ai-e2e record`) — or write deterministic ones by hand. **No real API keys at test time.**
-6. Add a `pnpm changeset` entry.
+6. Update `docs/` for the adapter, and add a `pnpm changeset` entry on the same PR.
 
 If you're building a community/third-party adapter that lives outside this repo, follow `docs/community-adapters/guide.md` instead.
 


### PR DESCRIPTION
A user-facing change must update `docs/` in the same PR. A published-package change must include a changeset on that PR. The PR template now has a checkbox for each.

Agents must read `CONTRIBUTING.md` before they open a GitHub issue or pull request. That rule is in `AGENTS.md` and `CLAUDE.md`.

Skip docs only when nothing user-facing changed. Skip a changeset only when no published package changed. Write the reason in the PR body.

This PR is contributing, template, and agent-instruction files only. It does not change a published package, so there is no changeset.

## 🎯 Changes

- CONTRIBUTING now requires `docs/` updates for user-facing work, in the same PR as the code.
- CONTRIBUTING now requires a changeset file on the PR for any published-package change, before the PR opens.
- The PR template has Docs and Changeset checkboxes.
- Claude, Grok, and Codex must follow `CONTRIBUTING.md` when they create issues or PRs.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

Contributor guide, PR template, and agent instructions only. I did not run `pnpm test:pr`. This change is not library user-facing. No published package changed.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

## Testing

1. **Commands run.** I did not run `pnpm test:pr`. Markdown only.
2. **Manual test.**
   1. Open a new PR in the GitHub UI. Confirm the template shows Docs and Changeset checkboxes.
   2. Read CONTRIBUTING.md from the PR. Confirm the Documentation and Changesets sections match the template.
   3. Ask an agent to open an issue or a PR. Confirm it reads `CONTRIBUTING.md` first.
3. **How this PR makes testing easy.** The template and `AGENTS.md` are the check. There is no automated test, command, or example-app change.

## Risk / rollback

Contributors can still skip the boxes. Agents can still skip `AGENTS.md`. This is policy, not CI. Rollback: revert this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to require documentation updates for user-facing changes and changesets for published-package changes.
  * Clarified pull request flow, testing guidance, provider adapter requirements, and when exceptions apply.
  * Added contributor guidance covering issue and pull request templates, minimal reproductions, and required documentation.
* **Chores**
  * Improved pull request templates with change rationale and documentation and changeset checklist confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->