### PR TITLE
fix(ai-client): drain client-tool results after joinRun replay

### DIFF
--- a/.changeset/join-run-drain-client-tool.md
+++ b/.changeset/join-run-drain-client-tool.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-client': patch
+---
+
+Drain queued post-stream actions after a `joinRun` replay so a client-tool result from a rejoin is sent back to the server.

--- a/docs/config.json
+++ b/docs/config.json
@@ -243,7 +243,7 @@
           "label": "Advanced",
           "to": "resumable-streams/advanced",
           "addedAt": "2026-08-04",
-          "updatedAt": "2026-08-19"
+          "updatedAt": "2026-08-20"
         },
         {
           "label": "WebSockets",

--- a/docs/resumable-streams/advanced.md
+++ b/docs/resumable-streams/advanced.md
@@ -101,7 +101,9 @@ A durable run's producer is decoupled from the delivery socket. When the client
 disconnects (a page reload, a dropped connection), the response is cancelled but
 the run keeps draining into the log to its own terminal, so a reconnect or a
 mount-time `joinRun` tails it to completion. This is what makes a run resumable
-across a full reload, not just an in-session reconnect.
+across a full reload, not just an in-session reconnect. If that replay ends on
+a client tool, the client sends the tool result after the replay finishes. That
+is the same path as a live stream.
 
 A run ends early only on a genuine cancel or a failure:
 

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -1662,6 +1662,12 @@ export class ChatClient<
           }
           await this.processIncomingChunk(chunk, { defer: false })
         }
+        // Same contract as `streamResponse`: client tools may finish (and
+        // queue a resume) while `isLoading` is still true. Wait for them
+        // before teardown so `drainPostStreamActions` below sees the queue.
+        if (this.pendingToolExecutions.size > 0) {
+          await Promise.all(this.pendingToolExecutions.values())
+        }
       } catch (error) {
         // Pre-attach failures (unknown/evicted run, connect deadline abort)
         // stay soft: keep the restored transcript. Post-attach transport/parser
@@ -1703,6 +1709,7 @@ export class ChatClient<
           this.abortController = null
           this.setIsLoading(false)
           if (this.status === 'streaming') this.setStatus('ready')
+          await this.drainPostStreamActions()
         }
       }
     })()

--- a/packages/ai-client/tests/chat-client-join-run-client-tool.test.ts
+++ b/packages/ai-client/tests/chat-client-join-run-client-tool.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  EventType,
+  canonicalInterruptJson,
+  convertSchemaToJsonSchema,
+  digestInterruptJson,
+  hashSchemaInput,
+  toolDefinition,
+} from '@tanstack/ai/client'
+import { z } from 'zod'
+import { ChatClient } from '../src/chat-client'
+import { createUIMessage } from './test-utils'
+import type {
+  ResumableConnectConnectionAdapter,
+  RunAgentInputContext,
+} from '../src/connection-adapters'
+import type { StreamChunk } from '@tanstack/ai/client'
+import type { ChatClientPersistence, ChatPersistedState } from '../src/types'
+
+function memoryPersistence(initial: ChatPersistedState): ChatClientPersistence {
+  let value: ChatPersistedState | undefined = initial
+  return {
+    getItem: () => value,
+    setItem: (_id, state) => {
+      value = state
+    },
+    removeItem: () => {
+      value = undefined
+    },
+  }
+}
+
+function mountedChatClient(
+  options: ConstructorParameters<typeof ChatClient>[0],
+) {
+  const client = new ChatClient(options)
+  client.attach()
+  return client
+}
+
+function createDeferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+/**
+ * Regression for https://github.com/TanStack/ai/issues/1058
+ *
+ * A joinRun replay that ends on a client tool queues the resume while
+ * `isLoading` is true. Live `streamResponse` drains that queue in `finally`.
+ * Rejoin used its own teardown and never drained, so the tool result never
+ * went back to the server and later sends stayed blocked.
+ */
+describe('joinRun client-tool continuation (issue #1058)', () => {
+  it('posts the client-tool result after joinRun replay ends', async () => {
+    const outputSchema = z.object({ answer: z.number() })
+    const toolGate = createDeferred()
+    const lookup = toolDefinition({
+      name: 'lookup',
+      description: 'Look up',
+      inputSchema: z.object({ query: z.string() }),
+      outputSchema,
+    }).client(async () => {
+      await toolGate.promise
+      return { answer: 42 }
+    })
+    const outputSchemaHash = hashSchemaInput(outputSchema)
+    const responseSchema = convertSchemaToJsonSchema(outputSchema) ?? {}
+    const responseSchemaHash = digestInterruptJson(
+      canonicalInterruptJson(responseSchema),
+    )
+
+    const joinHold = createDeferred()
+    const connectContexts: Array<RunAgentInputContext | undefined> = []
+    let connectCount = 0
+
+    const replayChunks: Array<StreamChunk> = [
+      {
+        type: EventType.RUN_STARTED,
+        runId: 'r1',
+        threadId: 't1',
+        timestamp: 1,
+      },
+      {
+        type: EventType.TOOL_CALL_START,
+        toolCallId: 'tool-call-1',
+        toolCallName: 'lookup',
+        toolName: 'lookup',
+        timestamp: 2,
+      },
+      {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: 'tool-call-1',
+        delta: '{"query":"first"}',
+        timestamp: 3,
+      },
+      {
+        type: EventType.RUN_FINISHED,
+        runId: 'r1',
+        threadId: 't1',
+        timestamp: 4,
+        outcome: {
+          type: 'interrupt',
+          interrupts: [
+            {
+              id: 'client_tool_tool-call-1',
+              reason: 'tanstack:client_tool_execution',
+              toolCallId: 'tool-call-1',
+              responseSchema,
+              metadata: {
+                kind: 'client_tool',
+                toolName: 'lookup',
+                input: { query: 'first' },
+                'tanstack:interruptBinding': {
+                  kind: 'client-tool-execution',
+                  interruptId: 'client_tool_tool-call-1',
+                  interruptedRunId: 'r1',
+                  generation: 0,
+                  toolName: 'lookup',
+                  toolCallId: 'tool-call-1',
+                  outputSchemaHash,
+                  responseSchemaHash,
+                },
+              },
+            },
+          ],
+        },
+      },
+    ]
+
+    const joinRun = vi.fn(async function* (_runId: string) {
+      for (const chunk of replayChunks) {
+        yield chunk
+      }
+      await joinHold.promise
+    })
+
+    const connection: ResumableConnectConnectionAdapter = {
+      async *connect(_messages, _data, _signal, runContext) {
+        connectCount++
+        connectContexts.push(runContext)
+        yield {
+          type: EventType.RUN_STARTED,
+          runId: runContext?.runId ?? 'r2',
+          threadId: runContext?.threadId ?? 't1',
+          timestamp: 10,
+        }
+        yield {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: 'm1',
+          timestamp: 11,
+          delta: 'done',
+        }
+        yield {
+          type: EventType.RUN_FINISHED,
+          runId: runContext?.runId ?? 'r2',
+          threadId: runContext?.threadId ?? 't1',
+          timestamp: 12,
+          finishReason: 'stop',
+        }
+      },
+      joinRun,
+    }
+
+    const client = mountedChatClient({
+      threadId: 't1',
+      connection,
+      persistence: memoryPersistence({
+        messages: [createUIMessage('user-1', 'hi', 'user')],
+        resume: {
+          resumeState: { threadId: 't1', runId: 'r1' },
+        },
+      }),
+      tools: [lookup],
+    })
+
+    await vi.waitFor(() => {
+      expect(joinRun).toHaveBeenCalledWith('r1', expect.anything())
+    })
+    for (let i = 0; i < 10; i++) {
+      await new Promise((r) => setTimeout(r, 0))
+    }
+
+    toolGate.resolve()
+    for (let i = 0; i < 10; i++) {
+      await new Promise((r) => setTimeout(r, 0))
+    }
+
+    joinHold.resolve()
+
+    await vi.waitFor(() => {
+      expect(connectCount).toBe(1)
+    })
+
+    expect(connectContexts[0]?.parentRunId).toBe('r1')
+    expect(connectContexts[0]?.resume).toEqual([
+      {
+        interruptId: 'client_tool_tool-call-1',
+        status: 'resolved',
+        payload: { answer: 42 },
+      },
+    ])
+    expect(client.getInterruptState().interruptErrors).toEqual([])
+
+    await client.sendMessage('later')
+    expect(connectCount).toBe(2)
+  })
+})

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -92,6 +92,7 @@ Notes:
 | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `tests/delivery-durability.spec.ts`    | Transport layer: offset-tagged log, `Last-Event-ID` reconnect, second-tab join, SSE + NDJSON                                                                |
 | `tests/persistence-durability.spec.ts` | Client layer: a browser refresh restores the conversation and any pending interrupt                                                                         |
+| `tests/join-run-client-tool.spec.ts`   | Mid-run reload: `joinRun` replay that ends on a client tool drains the continuation (issue #1058)                                                           |
 | `tests/sandbox-durability.spec.ts`     | Sandbox instances: a second run resumes the persisted sandbox                                                                                               |
 | `tests/durable-takeover.spec.ts`       | Takeover with log alignment, detach-on-disconnect, out-of-band cancel in both bands, cancel-vs-disconnect divergence, and the superseded-driver epoch fence |
 
@@ -127,6 +128,7 @@ E2E coverage is mandatory for every feature, bug fix, or behavior change (see th
 | Tool system change                      | Add scenario to `tools-test-scenarios.ts` + test in `tools-test/` specs.                                                                                                                                   |
 | Middleware change                       | Add test to `middleware.spec.ts` with appropriate scenario.                                                                                                                                                |
 | Client-side change (useChat, etc.)      | Add test covering the observable behavior change.                                                                                                                                                          |
+| joinRun + client-tool continuation      | Add a spec that reloads mid-run, tails with `joinRun`, and asserts the client-tool result POSTs after replay (see `tests/join-run-client-tool.spec.ts`).                                                   |
 | Durable/detachable run + takeover       | Add a spec that disconnects mid-stream, reconnects with the same `runId`, and asserts the resumed stream continues from the aligned offset instead of restarting the agent.                                |
 | Out-of-band cancel vs. plain disconnect | Add a case distinguishing `requestRunCancel`/`wasCancelRequested` (durable cancel — record ends `'aborted'`) from an unrequested disconnect on a detachable run (record stays `'running'`, resumable).     |
 | New run-store backend                   | Run `runPersistenceConformance` from `packages/ai-persistence/src/testkit/` against it; it now pins `undefined` vs. explicit `false` on `cancelRequested` and absent vs. explicit `undefined` on `update`. |

--- a/testing/e2e/src/routeTree.gen.ts
+++ b/testing/e2e/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as ToolsTestRouteImport } from './routes/tools-test'
 import { Route as PersistenceDurabilityRouteImport } from './routes/persistence-durability'
 import { Route as MiddlewareTestRouteImport } from './routes/middleware-test'
 import { Route as MarkdownCjkRouteImport } from './routes/markdown-cjk'
+import { Route as JoinRunClientToolRouteImport } from './routes/join-run-client-tool'
 import { Route as InterruptsTestRouteImport } from './routes/interrupts-test'
 import { Route as GenerationPersistenceServerRouteImport } from './routes/generation-persistence-server'
 import { Route as GenerationPersistenceResumeRouteImport } from './routes/generation-persistence-resume'
@@ -60,6 +61,7 @@ import { Route as ApiMcpAppsChatRouteImport } from './routes/api.mcp-apps-chat'
 import { Route as ApiMcpAppsCallRouteImport } from './routes/api.mcp-apps-call'
 import { Route as ApiMaxToolCallsWireRouteImport } from './routes/api.max-tool-calls-wire'
 import { Route as ApiLazyToolsWireRouteImport } from './routes/api.lazy-tools-wire'
+import { Route as ApiJoinRunClientToolRouteImport } from './routes/api.join-run-client-tool'
 import { Route as ApiInterruptsTestRouteImport } from './routes/api.interrupts-test'
 import { Route as ApiImageRouteImport } from './routes/api.image'
 import { Route as ApiGenerationPersistenceServerRouteImport } from './routes/api.generation-persistence-server'
@@ -108,6 +110,11 @@ const MiddlewareTestRoute = MiddlewareTestRouteImport.update({
 const MarkdownCjkRoute = MarkdownCjkRouteImport.update({
   id: '/markdown-cjk',
   path: '/markdown-cjk',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const JoinRunClientToolRoute = JoinRunClientToolRouteImport.update({
+  id: '/join-run-client-tool',
+  path: '/join-run-client-tool',
   getParentRoute: () => rootRouteImport,
 } as any)
 const InterruptsTestRoute = InterruptsTestRouteImport.update({
@@ -350,6 +357,11 @@ const ApiLazyToolsWireRoute = ApiLazyToolsWireRouteImport.update({
   path: '/api/lazy-tools-wire',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiJoinRunClientToolRoute = ApiJoinRunClientToolRouteImport.update({
+  id: '/api/join-run-client-tool',
+  path: '/api/join-run-client-tool',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiInterruptsTestRoute = ApiInterruptsTestRouteImport.update({
   id: '/api/interrupts-test',
   path: '/api/interrupts-test',
@@ -490,6 +502,7 @@ export interface FileRoutesByFullPath {
   '/generation-persistence-resume': typeof GenerationPersistenceResumeRoute
   '/generation-persistence-server': typeof GenerationPersistenceServerRoute
   '/interrupts-test': typeof InterruptsTestRoute
+  '/join-run-client-tool': typeof JoinRunClientToolRoute
   '/markdown-cjk': typeof MarkdownCjkRoute
   '/middleware-test': typeof MiddlewareTestRoute
   '/persistence-durability': typeof PersistenceDurabilityRoute
@@ -514,6 +527,7 @@ export interface FileRoutesByFullPath {
   '/api/generation-persistence-server': typeof ApiGenerationPersistenceServerRoute
   '/api/image': typeof ApiImageRouteWithChildren
   '/api/interrupts-test': typeof ApiInterruptsTestRoute
+  '/api/join-run-client-tool': typeof ApiJoinRunClientToolRoute
   '/api/lazy-tools-wire': typeof ApiLazyToolsWireRoute
   '/api/max-tool-calls-wire': typeof ApiMaxToolCallsWireRoute
   '/api/mcp-apps-call': typeof ApiMcpAppsCallRoute
@@ -567,6 +581,7 @@ export interface FileRoutesByTo {
   '/generation-persistence-resume': typeof GenerationPersistenceResumeRoute
   '/generation-persistence-server': typeof GenerationPersistenceServerRoute
   '/interrupts-test': typeof InterruptsTestRoute
+  '/join-run-client-tool': typeof JoinRunClientToolRoute
   '/markdown-cjk': typeof MarkdownCjkRoute
   '/middleware-test': typeof MiddlewareTestRoute
   '/persistence-durability': typeof PersistenceDurabilityRoute
@@ -591,6 +606,7 @@ export interface FileRoutesByTo {
   '/api/generation-persistence-server': typeof ApiGenerationPersistenceServerRoute
   '/api/image': typeof ApiImageRouteWithChildren
   '/api/interrupts-test': typeof ApiInterruptsTestRoute
+  '/api/join-run-client-tool': typeof ApiJoinRunClientToolRoute
   '/api/lazy-tools-wire': typeof ApiLazyToolsWireRoute
   '/api/max-tool-calls-wire': typeof ApiMaxToolCallsWireRoute
   '/api/mcp-apps-call': typeof ApiMcpAppsCallRoute
@@ -645,6 +661,7 @@ export interface FileRoutesById {
   '/generation-persistence-resume': typeof GenerationPersistenceResumeRoute
   '/generation-persistence-server': typeof GenerationPersistenceServerRoute
   '/interrupts-test': typeof InterruptsTestRoute
+  '/join-run-client-tool': typeof JoinRunClientToolRoute
   '/markdown-cjk': typeof MarkdownCjkRoute
   '/middleware-test': typeof MiddlewareTestRoute
   '/persistence-durability': typeof PersistenceDurabilityRoute
@@ -669,6 +686,7 @@ export interface FileRoutesById {
   '/api/generation-persistence-server': typeof ApiGenerationPersistenceServerRoute
   '/api/image': typeof ApiImageRouteWithChildren
   '/api/interrupts-test': typeof ApiInterruptsTestRoute
+  '/api/join-run-client-tool': typeof ApiJoinRunClientToolRoute
   '/api/lazy-tools-wire': typeof ApiLazyToolsWireRoute
   '/api/max-tool-calls-wire': typeof ApiMaxToolCallsWireRoute
   '/api/mcp-apps-call': typeof ApiMcpAppsCallRoute
@@ -724,6 +742,7 @@ export interface FileRouteTypes {
     | '/generation-persistence-resume'
     | '/generation-persistence-server'
     | '/interrupts-test'
+    | '/join-run-client-tool'
     | '/markdown-cjk'
     | '/middleware-test'
     | '/persistence-durability'
@@ -748,6 +767,7 @@ export interface FileRouteTypes {
     | '/api/generation-persistence-server'
     | '/api/image'
     | '/api/interrupts-test'
+    | '/api/join-run-client-tool'
     | '/api/lazy-tools-wire'
     | '/api/max-tool-calls-wire'
     | '/api/mcp-apps-call'
@@ -801,6 +821,7 @@ export interface FileRouteTypes {
     | '/generation-persistence-resume'
     | '/generation-persistence-server'
     | '/interrupts-test'
+    | '/join-run-client-tool'
     | '/markdown-cjk'
     | '/middleware-test'
     | '/persistence-durability'
@@ -825,6 +846,7 @@ export interface FileRouteTypes {
     | '/api/generation-persistence-server'
     | '/api/image'
     | '/api/interrupts-test'
+    | '/api/join-run-client-tool'
     | '/api/lazy-tools-wire'
     | '/api/max-tool-calls-wire'
     | '/api/mcp-apps-call'
@@ -878,6 +900,7 @@ export interface FileRouteTypes {
     | '/generation-persistence-resume'
     | '/generation-persistence-server'
     | '/interrupts-test'
+    | '/join-run-client-tool'
     | '/markdown-cjk'
     | '/middleware-test'
     | '/persistence-durability'
@@ -902,6 +925,7 @@ export interface FileRouteTypes {
     | '/api/generation-persistence-server'
     | '/api/image'
     | '/api/interrupts-test'
+    | '/api/join-run-client-tool'
     | '/api/lazy-tools-wire'
     | '/api/max-tool-calls-wire'
     | '/api/mcp-apps-call'
@@ -956,6 +980,7 @@ export interface RootRouteChildren {
   GenerationPersistenceResumeRoute: typeof GenerationPersistenceResumeRoute
   GenerationPersistenceServerRoute: typeof GenerationPersistenceServerRoute
   InterruptsTestRoute: typeof InterruptsTestRoute
+  JoinRunClientToolRoute: typeof JoinRunClientToolRoute
   MarkdownCjkRoute: typeof MarkdownCjkRoute
   MiddlewareTestRoute: typeof MiddlewareTestRoute
   PersistenceDurabilityRoute: typeof PersistenceDurabilityRoute
@@ -980,6 +1005,7 @@ export interface RootRouteChildren {
   ApiGenerationPersistenceServerRoute: typeof ApiGenerationPersistenceServerRoute
   ApiImageRoute: typeof ApiImageRouteWithChildren
   ApiInterruptsTestRoute: typeof ApiInterruptsTestRoute
+  ApiJoinRunClientToolRoute: typeof ApiJoinRunClientToolRoute
   ApiLazyToolsWireRoute: typeof ApiLazyToolsWireRoute
   ApiMaxToolCallsWireRoute: typeof ApiMaxToolCallsWireRoute
   ApiMcpAppsCallRoute: typeof ApiMcpAppsCallRoute
@@ -1050,6 +1076,13 @@ declare module '@tanstack/react-router' {
       path: '/markdown-cjk'
       fullPath: '/markdown-cjk'
       preLoaderRoute: typeof MarkdownCjkRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/join-run-client-tool': {
+      id: '/join-run-client-tool'
+      path: '/join-run-client-tool'
+      fullPath: '/join-run-client-tool'
+      preLoaderRoute: typeof JoinRunClientToolRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/interrupts-test': {
@@ -1374,6 +1407,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiLazyToolsWireRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/join-run-client-tool': {
+      id: '/api/join-run-client-tool'
+      path: '/api/join-run-client-tool'
+      fullPath: '/api/join-run-client-tool'
+      preLoaderRoute: typeof ApiJoinRunClientToolRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/interrupts-test': {
       id: '/api/interrupts-test'
       path: '/api/interrupts-test'
@@ -1617,6 +1657,7 @@ const rootRouteChildren: RootRouteChildren = {
   GenerationPersistenceResumeRoute: GenerationPersistenceResumeRoute,
   GenerationPersistenceServerRoute: GenerationPersistenceServerRoute,
   InterruptsTestRoute: InterruptsTestRoute,
+  JoinRunClientToolRoute: JoinRunClientToolRoute,
   MarkdownCjkRoute: MarkdownCjkRoute,
   MiddlewareTestRoute: MiddlewareTestRoute,
   PersistenceDurabilityRoute: PersistenceDurabilityRoute,
@@ -1641,6 +1682,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiGenerationPersistenceServerRoute: ApiGenerationPersistenceServerRoute,
   ApiImageRoute: ApiImageRouteWithChildren,
   ApiInterruptsTestRoute: ApiInterruptsTestRoute,
+  ApiJoinRunClientToolRoute: ApiJoinRunClientToolRoute,
   ApiLazyToolsWireRoute: ApiLazyToolsWireRoute,
   ApiMaxToolCallsWireRoute: ApiMaxToolCallsWireRoute,
   ApiMcpAppsCallRoute: ApiMcpAppsCallRoute,

--- a/testing/e2e/src/routes/api.join-run-client-tool.ts
+++ b/testing/e2e/src/routes/api.join-run-client-tool.ts
@@ -1,0 +1,276 @@
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  EventType,
+  chat,
+  chatParamsFromRequestBody,
+  memoryStream,
+  resumeServerSentEventsResponse,
+  toolDefinition,
+  toServerSentEventsResponse,
+} from '@tanstack/ai'
+import { z } from 'zod'
+import type { AnyTextAdapter, ModelMessage, StreamChunk } from '@tanstack/ai'
+
+/**
+ * Provider-free harness for issue #1058: a `joinRun` replay that ends on a
+ * client tool must drain the queued resume after replay, same as a live stream.
+ *
+ * The first POST emits a client-tool interrupt, then holds the producer until
+ * the client disconnects (the spec reload) plus a short settle. That keeps
+ * `activeRun` visible so the remount `joinRun`s the log while it is still
+ * open. The client tool finishes during that hold; without the drain, the
+ * continuation POST never happens and `JOIN_OK` never appears.
+ *
+ * Exempt from the aimock policy: a fixed AG-UI sequence, never an LLM provider.
+ */
+
+const JOIN_OK = 'JOIN_OK the lookup is 42'
+const LATER_OK = 'LATER_OK the follow-up ran'
+const DISCONNECT_FALLBACK_MS = 3000
+const SETTLE_AFTER_DISCONNECT_MS = 1500
+
+const lookupTool = toolDefinition({
+  name: 'lookup',
+  description: 'Look up',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.object({ answer: z.number() }),
+}).client()
+
+const runningByThread = new Map<string, string>()
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function waitForDisconnect(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve()
+  return new Promise((resolve) => {
+    const finish = () => {
+      clearTimeout(timer)
+      signal.removeEventListener('abort', finish)
+      resolve()
+    }
+    const timer = setTimeout(finish, DISCONNECT_FALLBACK_MS)
+    signal.addEventListener('abort', finish, { once: true })
+  })
+}
+
+async function* holdAfter(
+  stream: AsyncIterable<StreamChunk>,
+  signal: AbortSignal,
+  onRelease: () => void,
+): AsyncGenerator<StreamChunk> {
+  try {
+    for await (const chunk of stream) {
+      yield chunk
+    }
+    await waitForDisconnect(signal)
+    await delay(SETTLE_AFTER_DISCONNECT_MS)
+  } finally {
+    onRelease()
+  }
+}
+
+function lastUserText(messages: Array<ModelMessage>): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (!message || message.role !== 'user') continue
+    if (typeof message.content === 'string') return message.content
+  }
+  return ''
+}
+
+function paramsLastUserText(
+  messages: Awaited<ReturnType<typeof chatParamsFromRequestBody>>['messages'],
+): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (!message || message.role !== 'user') continue
+    if ('parts' in message && Array.isArray(message.parts)) {
+      let text = ''
+      for (const part of message.parts) {
+        if (part.type === 'text') text += part.content
+      }
+      return text
+    }
+    if ('content' in message && typeof message.content === 'string') {
+      return message.content
+    }
+  }
+  return ''
+}
+
+const adapter: AnyTextAdapter = {
+  kind: 'text',
+  name: 'join-run-client-tool',
+  model: 'join-run-client-tool',
+  '~types': {
+    providerOptions: {},
+    inputModalities: ['text'],
+    messageMetadataByModality: {},
+    toolCapabilities: [],
+    toolCallMetadata: undefined,
+    systemPromptMetadata: undefined,
+  },
+  async *chatStream(options): AsyncGenerator<StreamChunk> {
+    const model = 'join-run-client-tool'
+    const runId = options.runId ?? 'join-run-client-tool-run'
+    const threadId = options.threadId ?? 'join-run-client-tool-thread'
+    const messageId = `${runId}-message`
+    const hasToolResult = options.messages.some(
+      (message) => message.role === 'tool',
+    )
+    const userText = lastUserText(options.messages)
+    const reply =
+      userText === 'later' ? LATER_OK : hasToolResult ? JOIN_OK : null
+
+    yield {
+      type: EventType.RUN_STARTED,
+      runId,
+      threadId,
+      model,
+      timestamp: Date.now(),
+    }
+
+    if (reply !== null) {
+      yield {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId,
+        role: 'assistant',
+        model,
+        timestamp: Date.now(),
+      }
+      yield {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId,
+        delta: reply,
+        model,
+        timestamp: Date.now(),
+      }
+      yield {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId,
+        model,
+        timestamp: Date.now(),
+      }
+      yield {
+        type: EventType.RUN_FINISHED,
+        runId,
+        threadId,
+        model,
+        finishReason: 'stop',
+        timestamp: Date.now(),
+      }
+      return
+    }
+
+    const toolCallId = 'join-run-lookup-1'
+    yield {
+      type: EventType.TOOL_CALL_START,
+      toolCallId,
+      toolCallName: 'lookup',
+      toolName: 'lookup',
+      model,
+      timestamp: Date.now(),
+    }
+    yield {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId,
+      delta: '{"query":"first"}',
+      model,
+      timestamp: Date.now(),
+    }
+    yield {
+      type: EventType.TOOL_CALL_END,
+      toolCallId,
+      toolCallName: 'lookup',
+      toolName: 'lookup',
+      input: { query: 'first' },
+      model,
+      timestamp: Date.now(),
+    }
+    yield {
+      type: EventType.RUN_FINISHED,
+      runId,
+      threadId,
+      model,
+      finishReason: 'tool_calls',
+      timestamp: Date.now(),
+    }
+  },
+  structuredOutput: async () => ({ data: {}, rawText: '{}' }),
+}
+
+export const Route = createFileRoute('/api/join-run-client-tool')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        let params
+        try {
+          params = await chatParamsFromRequestBody(await request.json())
+        } catch (error) {
+          return new Response(
+            error instanceof Error ? error.message : 'Bad request',
+            { status: 400 },
+          )
+        }
+
+        const isResume = (params.resume?.length ?? 0) > 0
+        const shouldHold =
+          !isResume && paramsLastUserText(params.messages) !== 'later'
+
+        if (shouldHold) {
+          runningByThread.set(params.threadId, params.runId)
+        } else {
+          runningByThread.delete(params.threadId)
+        }
+
+        const stream = chat({
+          adapter,
+          messages: params.messages,
+          tools: [lookupTool],
+          stream: true,
+          threadId: params.threadId,
+          runId: params.runId,
+          ...(params.parentRunId ? { parentRunId: params.parentRunId } : {}),
+          ...(params.resume ? { resume: params.resume } : {}),
+        })
+
+        const body = shouldHold
+          ? holdAfter(stream, request.signal, () => {
+              runningByThread.delete(params.threadId)
+            })
+          : stream
+
+        return toServerSentEventsResponse(body, {
+          durability: { adapter: memoryStream(request) },
+        })
+      },
+
+      GET: ({ request }) => {
+        const durability = memoryStream(request)
+        if (durability.resumeFrom() !== null) {
+          return resumeServerSentEventsResponse({ adapter: durability })
+        }
+
+        const threadId = new URL(request.url).searchParams.get('threadId') ?? ''
+        const runningRunId = threadId
+          ? runningByThread.get(threadId)
+          : undefined
+        const body = runningRunId
+          ? {
+              messages: [],
+              activeRun: { runId: runningRunId },
+              interrupts: null,
+            }
+          : { messages: [], activeRun: null, interrupts: null }
+        return new Response(JSON.stringify(body), {
+          headers: {
+            'content-type': 'application/json',
+            'cache-control': 'no-store',
+          },
+        })
+      },
+    },
+  },
+})

--- a/testing/e2e/src/routes/join-run-client-tool.tsx
+++ b/testing/e2e/src/routes/join-run-client-tool.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { fetchServerSentEvents, useChat } from '@tanstack/ai-react'
+import { toolDefinition } from '@tanstack/ai'
+import { z } from 'zod'
+
+/**
+ * Client half of the issue #1058 harness.
+ *
+ * `persistence: true` + a `threadId` from the URL. The spec reloads while the
+ * first run is held open. On remount the client hydrates `activeRun` and tails
+ * it with `joinRun`. The client tool polls `ALLOW_TOOL_KEY` and only finishes
+ * after remount, so the dying first page cannot drain a live continuation.
+ */
+
+const ALLOW_TOOL_KEY = 'e2e-join-run-client-tool-allow'
+const connection = fetchServerSentEvents('/api/join-run-client-tool')
+
+const lookup = toolDefinition({
+  name: 'lookup',
+  description: 'Look up',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.object({ answer: z.number() }),
+}).client(async () => {
+  const deadline = Date.now() + 60_000
+  while (sessionStorage.getItem(ALLOW_TOOL_KEY) !== '1') {
+    if (Date.now() > deadline) {
+      throw new Error('client tool was not allowed')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  return { answer: 42 }
+})
+
+export const Route = createFileRoute('/join-run-client-tool')({
+  component: JoinRunClientToolPage,
+  validateSearch: (search: Record<string, unknown>) => ({
+    threadId:
+      typeof search.threadId === 'string' && search.threadId.length > 0
+        ? search.threadId
+        : 'join-run-client-tool-thread',
+  }),
+})
+
+function JoinRunClientToolPage() {
+  const { threadId } = Route.useSearch()
+  const { messages, sendMessage, isLoading } = useChat({
+    threadId,
+    connection,
+    persistence: true,
+    tools: [lookup],
+  })
+
+  const [input, setInput] = useState('')
+  const [hydrated, setHydrated] = useState(false)
+  useEffect(() => setHydrated(true), [])
+
+  const assistantText = messages
+    .filter((message) => message.role === 'assistant')
+    .flatMap((message) =>
+      message.parts.flatMap((part) =>
+        part.type === 'text' ? [part.content] : [],
+      ),
+    )
+    .join('')
+
+  const toolPending = messages.some((message) =>
+    message.parts.some((part) => {
+      if (part.type !== 'tool-call' || part.name !== 'lookup') return false
+      return part.output === undefined
+    }),
+  )
+  const toolRan = messages.some((message) =>
+    message.parts.some((part) => {
+      if (part.type !== 'tool-call' || part.name !== 'lookup') return false
+      return part.output !== undefined
+    }),
+  )
+
+  const handleSubmit = () => {
+    const text = input.trim()
+    if (!text) return
+    setInput('')
+    void sendMessage(text)
+  }
+
+  return (
+    <div data-testid="join-run-client-tool-page" style={{ padding: 16 }}>
+      {hydrated ? <div data-testid="hydration-marker" /> : null}
+      <div data-testid="assistant-text">{assistantText || 'none'}</div>
+      <div data-testid="client-tool-pending">
+        {toolPending ? 'true' : 'false'}
+      </div>
+      <div data-testid="client-tool-ran">{toolRan ? 'true' : 'false'}</div>
+
+      <div data-testid="message-list">
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            data-testid={
+              message.role === 'user' ? 'user-message' : 'assistant-message'
+            }
+          >
+            {message.parts.map((part, index) =>
+              part.type === 'text' ? (
+                <span key={`${message.id}-${index}`}>{part.content}</span>
+              ) : null,
+            )}
+          </div>
+        ))}
+      </div>
+
+      {isLoading ? (
+        <div data-testid="loading-indicator">Generating...</div>
+      ) : null}
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+        <input
+          data-testid="chat-input"
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              handleSubmit()
+            }
+          }}
+          placeholder="Type a message..."
+        />
+        <button
+          data-testid="send-button"
+          onClick={handleSubmit}
+          disabled={!input.trim()}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/testing/e2e/tests/join-run-client-tool.spec.ts
+++ b/testing/e2e/tests/join-run-client-tool.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test'
+import { sendMessage } from './helpers'
+
+/**
+ * joinRun drain after a client-tool replay (issue #1058).
+ *
+ * The live `streamResponse` path drains queued post-stream actions in
+ * `finally`. Rejoin used a different teardown and skipped that drain, so a
+ * client-tool result from `joinRun` never went back to the server.
+ *
+ * This harness holds the first run open until disconnect, like
+ * `generation-persistence-resume.spec.ts`. The spec reloads while that run is
+ * still producing. On remount the client tails `activeRun` with `joinRun`.
+ * `JOIN_OK` is emitted only on the continuation POST that carries the tool
+ * result — so a green assertion cannot come from the first stream or from a
+ * done-restore.
+ *
+ * Provider-free: `/api/join-run-client-tool` streams a fixed AG-UI sequence
+ * through a `memoryStream` sink (exempt from the aimock policy).
+ */
+
+const ALLOW_TOOL_KEY = 'e2e-join-run-client-tool-allow'
+
+test.describe('joinRun client-tool continuation (issue #1058)', () => {
+  test('a reload mid client-tool run drains the tool result after joinRun', async ({
+    page,
+  }) => {
+    const threadId = `join-run-client-tool-${crypto.randomUUID()}`
+    await page.goto(
+      `/join-run-client-tool?threadId=${encodeURIComponent(threadId)}`,
+    )
+    await expect(page.getByTestId('hydration-marker')).toBeAttached()
+
+    await sendMessage(page, 'look up')
+    // Wait until the first POST has a hanging client tool in the log. Reloading
+    // on `isLoading` alone can beat the producer, so remount would miss
+    // `activeRun` and skip `joinRun`.
+    await expect(page.getByTestId('client-tool-pending')).toHaveText('true')
+    await expect(page.getByTestId('client-tool-ran')).toHaveText('false')
+    await expect(page.getByTestId('assistant-text')).not.toContainText(
+      'JOIN_OK',
+    )
+
+    await page.reload()
+    await expect(page.getByTestId('hydration-marker')).toBeAttached()
+    // Unlock the tool only after remount. The execute polls this flag, so a
+    // late first-page chunk cannot finish before unload and drain the live path.
+    await page.evaluate((key) => {
+      sessionStorage.setItem(key, '1')
+    }, ALLOW_TOOL_KEY)
+
+    await expect(page.getByTestId('assistant-text')).toContainText('JOIN_OK', {
+      timeout: 15_000,
+    })
+    await expect(page.getByTestId('client-tool-ran')).toHaveText('true')
+    await expect(page.getByTestId('loading-indicator')).toHaveCount(0)
+
+    await sendMessage(page, 'later')
+    await expect(page.getByTestId('assistant-text')).toContainText('LATER_OK', {
+      timeout: 15_000,
+    })
+  })
+})

--- a/testing/e2e/tests/persistence-durability.spec.ts
+++ b/testing/e2e/tests/persistence-durability.spec.ts
@@ -17,8 +17,9 @@ import type { Page } from '@playwright/test'
  * The mid-stream "rejoin an in-flight run via joinRun after reload" path is NOT
  * covered here: the harness stream completes in a single tick, so there is no
  * deterministic window to reload while a run is still producing. That resume
- * cursor is covered at the transport layer by `delivery-durability.spec.ts` and
- * in `@tanstack/ai-client` unit tests.
+ * cursor is covered at the transport layer by `delivery-durability.spec.ts`.
+ * A client-tool replay that must drain after `joinRun` (issue #1058) is in
+ * `join-run-client-tool.spec.ts`.
  */
 
 async function interruptCount(page: Page): Promise<number> {


### PR DESCRIPTION
After a page reload, a `joinRun` replay that ended on a client tool never sent the tool result back to the server. Later sends stayed blocked.

The live `streamResponse` path already drains that queue in `finally`. Rejoin used its own teardown and skipped the drain. This PR waits for pending client tools, then drains after `joinRun`, same as a live stream.

## 🎯 Changes

- `resumeInFlightRun` waits for `pendingToolExecutions`, then calls `drainPostStreamActions()`.
- Unit test holds `joinRun` open until the client tool finishes, then asserts the continuation POST.
- E2E reloads mid client-tool run, tails with `joinRun`, and asserts `JOIN_OK` (that text exists only on the continuation POST).
- Docs: one sentence on the resumable-streams advanced page.
- Patch changeset for `@tanstack/ai-client`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

**Commands run**

1. `pnpm --filter @tanstack/ai-client test:lib -- tests/chat-client-join-run-client-tool.test.ts` — pass
2. `pnpm --filter @tanstack/ai-e2e test:e2e -- join-run-client-tool.spec.ts --retries=0` — fail without drain (`JOIN_OK` missing, tool ran), pass with drain (4.9s)
3. `pnpm --filter @tanstack/ai-e2e test:types` — pass after the `output` narrow
4. `pnpm exec oxfmt --check` on the touched files — pass
5. `pnpm test:pr` — ran. Failed on local dirt: knip on untracked `marketing/`, docs links under `docs/superpowers/worktrees`, and a missing local `vitest.mjs` in some parallel `test:lib` tasks. Those files are not in this PR.

**Manual test**

1. Start a chat with a client tool and `joinRun` (durable connection + `persistence: true`).
2. Reload while the run is still open and the client tool is pending.
3. Confirm the remount tails the run, the tool finishes, and the server gets the tool result (a follow-up assistant message).
4. Send another user message. Confirm it is not stuck on loading.

**How this PR makes testing easy**

- Unit: `packages/ai-client/tests/chat-client-join-run-client-tool.test.ts`
- E2E: `pnpm --filter @tanstack/ai-e2e test:e2e -- join-run-client-tool.spec.ts`

## Linked issues

Fixes #1058

## Risk / rollback

Low. The drain matches the live stream path. Revert the PR to undo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reconnect and replay handling when a run pauses for a client-side tool.
  - Ensured tool results are sent after replay, allowing conversations to continue normally.
  - Preserved follow-up messaging after reconnecting to an interrupted run.

- **Documentation**
  - Updated resumable-stream guidance with client-tool replay behavior.
  - Added end-to-end testing documentation for reconnect and replay scenarios.

- **Tests**
  - Added coverage for reload, replay, client-tool completion, and subsequent messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->