### PR TITLE
fix(ai | ai-persistence): handle streamed adapter errors as failed runs

### DIFF
--- a/.changeset/fail-streamed-run-errors.md
+++ b/.changeset/fail-streamed-run-errors.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/ai': patch
+'@tanstack/ai-persistence': patch
+---
+
+Route adapter-emitted `RUN_ERROR` events through middleware `onError` hooks and preserve provider error codes in persisted run failures.

--- a/packages/ai-persistence/src/middleware.ts
+++ b/packages/ai-persistence/src/middleware.ts
@@ -11,6 +11,7 @@ import {
   getGenericInterruptDefinitionRegistry,
   providePendingTurn,
   rehydrateInterruptRequest,
+  toRunErrorPayload,
 } from '@tanstack/ai/adapter-internals'
 import type {
   GenericInterruptRequest,
@@ -1808,14 +1809,14 @@ async function failRun(
   error: unknown,
   usage?: TokenUsage,
 ): Promise<void> {
-  // `RunRecord.error` is a structured `RunError`. Only `message` is filled in
-  // here: the middleware sees an opaque thrown value, and inventing a `code`
-  // from it would fabricate the stable classification consumers branch on. A
-  // provider-supplied code reaches the record through the adapter layer.
+  const runError = toRunErrorPayload(error)
   await runs?.update(runId, {
     status: 'failed',
     finishedAt: Date.now(),
-    error: { message: error instanceof Error ? error.message : String(error) },
+    error: {
+      message: runError.message,
+      ...(runError.code !== undefined ? { code: runError.code } : {}),
+    },
     ...(usage ? { usage } : {}),
   })
 }

--- a/packages/ai-persistence/tests/error-abort.test.ts
+++ b/packages/ai-persistence/tests/error-abort.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import { EventType, chat, generateImage } from '@tanstack/ai'
+import {
+  EventType,
+  chat,
+  defineChatMiddleware,
+  defineInterrupt,
+  generateImage,
+} from '@tanstack/ai'
 import type {
   AnyTextAdapter,
   GenerationAbortInfo,
@@ -52,6 +58,23 @@ const interruptFinished = (): StreamChunk => ({
   },
 })
 
+const booleanResponseSchema = {
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate(value: unknown) {
+      return typeof value === 'boolean'
+        ? { value }
+        : { issues: [{ message: 'response must be a boolean' }] }
+    },
+    jsonSchema: {
+      input() {
+        return { type: 'boolean' }
+      },
+    },
+  },
+} as const
+
 async function collect(stream: AsyncIterable<StreamChunk>) {
   const out: Array<StreamChunk> = []
   for await (const c of stream) out.push(c)
@@ -92,6 +115,70 @@ describe('chat persistence error/abort hooks', () => {
     const run = await persistence.stores.runs!.get('r1')
     expect(run?.status).toBe('failed')
     expect(run?.error).toEqual({ message: 'provider exploded' })
+  })
+
+  it('marks the run failed when the adapter emits RUN_ERROR', async () => {
+    const persistence = memoryPersistence()
+    const review = defineInterrupt({
+      id: 'review',
+      responseSchema: booleanResponseSchema,
+    })
+    const { adapter } = mockAdapter([
+      [
+        runStarted(),
+        {
+          type: EventType.RUN_ERROR,
+          message: 'provider failed',
+          code: 'provider_error',
+          timestamp: 1,
+        },
+      ],
+    ])
+
+    const chunks = await collect(
+      chat({
+        adapter,
+        interrupts: [review],
+        messages: [{ role: 'user', content: 'hi' }],
+        runId: 'r1',
+        threadId: 't1',
+        middleware: [
+          defineChatMiddleware({
+            onInterruptBoundary(ctx) {
+              if (ctx.phase !== 'afterModel') return
+              return {
+                interrupts: [
+                  review.interrupt({
+                    key: 'review',
+                    reason: 'review',
+                    message: 'Review the response',
+                  }),
+                ],
+              }
+            },
+          }),
+          withPersistence(persistence),
+        ],
+      }) as AsyncIterable<StreamChunk>,
+    )
+
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: EventType.RUN_ERROR,
+        message: 'provider failed',
+        code: 'provider_error',
+      }),
+    )
+    expect(chunks).not.toContainEqual(
+      expect.objectContaining({
+        type: EventType.RUN_FINISHED,
+        outcome: expect.objectContaining({ type: 'interrupt' }),
+      }),
+    )
+    expect(await persistence.stores.runs!.get('r1')).toMatchObject({
+      status: 'failed',
+      error: { message: 'provider failed', code: 'provider_error' },
+    })
   })
 
   it('preserves known usage when structured-output finalization fails', async () => {

--- a/packages/ai/src/activities/chat/index.ts
+++ b/packages/ai/src/activities/chat/index.ts
@@ -1183,9 +1183,8 @@ class TextEngine<
 
       if (!skipAgentLoop) {
         do {
-          if (this.earlyTermination || this.isCancelled()) {
-            return
-          }
+          if (this.earlyTermination) break
+          if (this.isCancelled()) return
 
           this.logger.agentLoop(`iteration=${this.middlewareCtx.iteration}`, {
             iteration: this.middlewareCtx.iteration,
@@ -1216,6 +1215,8 @@ class TextEngine<
             }
 
             yield* this.streamModelResponse()
+
+            if (this.earlyTermination) break
 
             if (
               yield* this.emitBoundaryInterrupts(
@@ -1783,11 +1784,8 @@ class TextEngine<
     chunk: Extract<StreamChunk, { type: 'RUN_ERROR' }>,
   ): void {
     this.earlyTermination = true
-    if (this.finalStructuredOutput && this.finalizationError === null) {
-      const message =
-        chunk.message ||
-        chunk.error?.message ||
-        'Run failed before structured output completed'
+    if (this.finalizationError === null) {
+      const message = chunk.message || chunk.error?.message || 'Run failed'
       this.finalizationError = {
         message,
         ...(chunk.code !== undefined

--- a/packages/ai/tests/middleware.test.ts
+++ b/packages/ai/tests/middleware.test.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/require-await */
 import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
 import { chat } from '../src/activities/chat/index'
+import { defineChatMiddleware } from '../src/activities/chat/middleware/define'
+import { defineInterrupt } from '../src/interrupt-definition'
+import { EventType } from '../src/types'
 import {
   collectChunks,
   createMockAdapter,
@@ -91,6 +95,72 @@ describe('chat() middleware', () => {
       }
 
       expect(onError).toHaveBeenCalledOnce()
+      expect(onFinish).not.toHaveBeenCalled()
+    })
+
+    it('should call onError when an adapter emits RUN_ERROR', async () => {
+      const onError = vi.fn()
+      const onFinish = vi.fn()
+      const review = defineInterrupt({
+        id: 'review',
+        responseSchema: z.object({ approved: z.boolean() }),
+      })
+
+      const { adapter } = createMockAdapter({
+        iterations: [
+          [
+            ev.runStarted(),
+            {
+              ...ev.runError('Provider failed'),
+              code: 'provider_error',
+            },
+          ],
+        ],
+      })
+
+      const chunks = await collectChunks(
+        chat({
+          adapter,
+          interrupts: [review],
+          messages: [{ role: 'user', content: 'Hi' }],
+          middleware: [
+            defineChatMiddleware({
+              onInterruptBoundary(ctx) {
+                if (ctx.phase !== 'afterModel') return
+                return {
+                  interrupts: [
+                    review.interrupt({
+                      key: 'review',
+                      reason: 'review',
+                      message: 'Review the response',
+                    }),
+                  ],
+                }
+              },
+            }),
+            { name: 'test', onError, onFinish },
+          ],
+        }) as AsyncIterable<StreamChunk>,
+      )
+
+      expect(chunks).toContainEqual(
+        expect.objectContaining({
+          type: EventType.RUN_ERROR,
+          message: 'Provider failed',
+          code: 'provider_error',
+        }),
+      )
+      expect(chunks).not.toContainEqual(
+        expect.objectContaining({
+          type: EventType.RUN_FINISHED,
+          outcome: expect.objectContaining({ type: 'interrupt' }),
+        }),
+      )
+      expect(onError).toHaveBeenCalledOnce()
+      expect(onError.mock.calls[0]![1].error).toMatchObject({
+        message: 'Provider failed',
+        code: 'provider_error',
+      })
       expect(onFinish).not.toHaveBeenCalled()
     })
 

--- a/testing/e2e/src/lib/phase-capture.ts
+++ b/testing/e2e/src/lib/phase-capture.ts
@@ -39,8 +39,10 @@ export interface PhaseCapture {
    * that only care about presence should use `.includes('structuredOutput')`.
    */
   phases: Array<string>
-  /** Count of `onFinish` invocations — must be exactly 1 per `chat()` call. */
+  /** Count of `onFinish` invocations. */
   onFinishCount: number
+  /** Count of `onError` invocations. */
+  onErrorCount: number
   /**
    * Chunks that were yielded out of `chat()` to the SSE consumer. Captured
    * by teeing the iterable in `api.middleware-test.ts` after the middleware
@@ -61,6 +63,7 @@ function bucketFor(captureId: string): PhaseCapture {
     bucket = {
       phases: [],
       onFinishCount: 0,
+      onErrorCount: 0,
       yieldedChunks: [],
       boundaries: [],
       resolutions: [],
@@ -76,6 +79,7 @@ export function resetPhaseCapture(captureId: string): void {
   captures.set(captureId, {
     phases: [],
     onFinishCount: 0,
+    onErrorCount: 0,
     yieldedChunks: [],
     boundaries: [],
     resolutions: [],
@@ -94,6 +98,10 @@ export function recordPhase(captureId: string, phase: string): void {
 
 export function recordOnFinish(captureId: string): void {
   bucketFor(captureId).onFinishCount += 1
+}
+
+export function recordOnError(captureId: string): void {
+  bucketFor(captureId).onErrorCount += 1
 }
 
 export function recordYieldedChunk(

--- a/testing/e2e/src/routes/api.middleware-test.ts
+++ b/testing/e2e/src/routes/api.middleware-test.ts
@@ -3,6 +3,7 @@ import {
   chat,
   chatParamsFromRequestBody,
   createCapability,
+  EventType,
   maxIterations,
   toServerSentEventsResponse,
   toolDefinition,
@@ -18,7 +19,12 @@ import {
 } from '@/lib/memory-capture'
 import { SpanStatusCode } from '@opentelemetry/api'
 import { z } from 'zod'
-import type { ChatMiddleware, StreamChunk, Tool } from '@tanstack/ai'
+import type {
+  AnyTextAdapter,
+  ChatMiddleware,
+  StreamChunk,
+  Tool,
+} from '@tanstack/ai'
 import type {
   AttributeValue,
   Attributes,
@@ -38,6 +44,7 @@ import {
   recordGenericPolicy,
   recordGenericResolution,
   recordGenericToolExecution,
+  recordOnError,
   recordOnFinish,
   recordPhase,
   recordYieldedChunk,
@@ -76,6 +83,54 @@ const weatherTool = toolDefinition({
 }).server(async (args) =>
   JSON.stringify({ city: args.city, temperature: 72, condition: 'sunny' }),
 )
+
+function createRunErrorAdapter(): AnyTextAdapter {
+  return {
+    kind: 'text',
+    name: 'run-error-test',
+    model: 'run-error-test',
+    '~types': {
+      providerOptions: {},
+      inputModalities: ['text'],
+      messageMetadataByModality: {},
+      toolCapabilities: [],
+      toolCallMetadata: undefined,
+      systemPromptMetadata: undefined,
+    },
+    async *chatStream(options): AsyncGenerator<StreamChunk> {
+      yield {
+        type: EventType.RUN_STARTED,
+        runId: options.runId ?? 'run-error-test',
+        threadId: options.threadId ?? 'run-error-test',
+        timestamp: Date.now(),
+      }
+      yield {
+        type: EventType.RUN_ERROR,
+        message: 'Provider failed',
+        code: 'provider_error',
+        timestamp: Date.now(),
+      }
+    },
+    structuredOutput: async () => ({ data: {}, rawText: '{}' }),
+  }
+}
+
+const runErrorBoundaryMiddleware: ChatMiddleware<unknown, typeof reviewPlan> = {
+  name: 'run-error-boundary',
+  onInterruptBoundary(ctx) {
+    if (ctx.phase !== 'afterModel') return
+    return {
+      interrupts: [
+        reviewPlan.interrupt({
+          key: 'run-error-review',
+          reason: 'review_required',
+          message: 'Review the response',
+          payload: { title: 'Run error review', boundary: ctx.phase },
+        }),
+      ],
+    }
+  },
+}
 
 const chunkTransformMiddleware: ChatMiddleware = {
   name: 'chunk-transform',
@@ -167,6 +222,9 @@ function createPhaseRecorderMiddleware(captureId: string): ChatMiddleware {
     },
     onFinish() {
       recordOnFinish(captureId)
+    },
+    onError() {
+      recordOnError(captureId)
     },
   }
 }
@@ -478,17 +536,21 @@ export const Route = createFileRoute('/api/middleware-test')({
           typeof fp.model === 'string' ? fp.model : undefined
 
         try {
-          const adapterOptions = createTextAdapter(
-            provider as Parameters<typeof createTextAdapter>[0],
-            modelOverride,
-            aimockPort,
-            testId,
-          )
+          const adapterOptions =
+            scenario === 'run-error'
+              ? { adapter: createRunErrorAdapter() }
+              : createTextAdapter(
+                  provider as Parameters<typeof createTextAdapter>[0],
+                  modelOverride,
+                  aimockPort,
+                  testId,
+                )
 
           const middleware: Array<ChatMiddleware> = []
           let genericLifecycleMiddleware:
             | ChatMiddleware<unknown, typeof reviewPlan>
-            | undefined
+            | undefined =
+            scenario === 'run-error' ? runErrorBoundaryMiddleware : undefined
           const genericScenario = isGenericScenario(scenario)
             ? scenario
             : undefined

--- a/testing/e2e/src/routes/middleware-test.tsx
+++ b/testing/e2e/src/routes/middleware-test.tsx
@@ -227,6 +227,7 @@ function MiddlewareTestPage() {
           <option value="basic-text">Basic Text</option>
           <option value="capability">Capability</option>
           <option value="with-tool">With Tool</option>
+          <option value="run-error">Run Error</option>
           <option value="structured-output">Structured Output</option>
           <option value="structured-output-stream">
             Structured Output (Stream)

--- a/testing/e2e/tests/middleware.spec.ts
+++ b/testing/e2e/tests/middleware.spec.ts
@@ -17,7 +17,57 @@ async function fetchOtelCapture(
   return response.json()
 }
 
+async function fetchPhaseCapture(
+  page: import('@playwright/test').Page,
+  baseURL: string | undefined,
+  testId: string | undefined,
+) {
+  if (!testId) throw new Error('phase capture test requires a testId fixture')
+  const url = `${baseURL ?? ''}/api/middleware-test?testId=${encodeURIComponent(testId)}&kind=phase`
+  const response = await page.request.get(url)
+  if (!response.ok()) {
+    throw new Error(
+      `GET ${url} failed: ${response.status()} ${await response.text()}`,
+    )
+  }
+  return response.json()
+}
+
 test.describe('Middleware Lifecycle', () => {
+  test('adapter RUN_ERROR calls onError once', async ({
+    page,
+    testId,
+    baseURL,
+  }) => {
+    const params = new URLSearchParams()
+    if (testId) params.set('testId', testId)
+    const qs = params.toString()
+    await page.goto(`/middleware-test${qs ? '?' + qs : ''}`)
+    await page.waitForTimeout(2000) // hydration
+    await page.locator('#mw-scenario-select').selectOption('run-error')
+    await page.locator('#mw-mode-select').selectOption('phase-recorder')
+    await page.locator('#mw-run-button').click()
+
+    await expect
+      .poll(async () => {
+        const capture = await fetchPhaseCapture(page, baseURL, testId)
+        return capture.onErrorCount
+      })
+      .toBe(1)
+
+    const capture = await fetchPhaseCapture(page, baseURL, testId)
+    expect(capture.onFinishCount).toBe(0)
+    expect(capture.yieldedChunks).toContainEqual(
+      expect.objectContaining({ type: 'RUN_ERROR' }),
+    )
+    expect(capture.yieldedChunks).not.toContainEqual(
+      expect.objectContaining({
+        type: 'RUN_FINISHED',
+        outcomeType: 'interrupt',
+      }),
+    )
+  })
+
   test('onChunk transforms text content', async ({
     page,
     testId,


### PR DESCRIPTION
Fixes #1171 

## 🎯 Changes

- Route adapter-emitted RUN_ERROR events through onError, before afterModel interrupts can terminate the run.

- Persist these runs as failed while preserving the provider error message and code.

- Add unit, persistence, and E2E regression coverage for the interrupt conflict.

- Add patch changesets for @tanstack/ai and @tanstack/ai-persistence.

- Docs were skipped because this restores existing lifecycle behavior without changing the public API.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adapter-reported run errors now consistently trigger middleware error handling.
  * Provider error codes are preserved when failed runs are saved.
  * Failed runs no longer emit misleading interrupt completion events.
  * Chat processing stops promptly after an error while completing necessary cleanup.
* **Testing**
  * Added coverage for error reporting, persisted failure details, and middleware lifecycle behavior across supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->