### PR TITLE
fix(ai): avoid publishing partial tool call input

### DIFF
--- a/packages/ai/src/activities/chat/stream/processor.ts
+++ b/packages/ai/src/activities/chat/stream/processor.ts
@@ -2080,8 +2080,15 @@ export class StreamProcessor {
     // counts as a completed tool call in getCompletedToolCalls()/getState().
     toolCall.state = 'input-complete'
 
-    // Try final parse
-    toolCall.parsedArguments = this.jsonParser.parse(toolCall.arguments)
+    // Only expose input when the complete argument string is valid JSON.
+    // The streaming parser intentionally accepts partial JSON, but using its
+    // result here can silently publish truncated values when text interleaves
+    // with tool-call argument deltas.
+    try {
+      toolCall.parsedArguments = JSON.parse(toolCall.arguments)
+    } catch {
+      toolCall.parsedArguments = undefined
+    }
 
     // Don't downgrade the rendered part of a call that already reached the
     // terminal 'error' state (e.g. an output-error TOOL_CALL_RESULT arrived

--- a/packages/ai/tests/stream-processor.test.ts
+++ b/packages/ai/tests/stream-processor.test.ts
@@ -689,6 +689,30 @@ describe('StreamProcessor', () => {
   // Text-tool interleaving
   // ==========================================================================
   describe('text-tool interleaving', () => {
+    it('does not publish a partial input before TOOL_CALL_END', () => {
+      const processor = new StreamProcessor()
+      processor.prepareAssistantMessage()
+
+      processor.processChunk(ev.runStarted())
+      processor.processChunk(ev.toolStart('tc-1', 'offerTemplates'))
+      processor.processChunk(ev.toolArgs('tc-1', '{"templateIds":["mock-gsk-e'))
+      processor.processChunk(ev.textStart())
+      processor.processChunk(ev.textContent('Let me look those up. '))
+      processor.processChunk(ev.toolArgs('tc-1', 'fimosfermin"]}'))
+      processor.processChunk(ev.toolEnd('tc-1', 'offerTemplates'))
+      processor.processChunk(ev.runFinished('stop'))
+      processor.finalizeStream()
+
+      const toolCall = processor
+        .getMessages()[0]!
+        .parts.find((part) => part.type === 'tool-call') as ToolCallPart
+      expect(toolCall.state).toBe('input-complete')
+      expect(toolCall.arguments).toBe(
+        '{"templateIds":["mock-gsk-efimosfermin"]}',
+      )
+      expect(toolCall.input).toEqual({ templateIds: ['mock-gsk-efimosfermin'] })
+    })
+
     it('should reset segment text accumulation on TEXT_MESSAGE_START (existing test preserved)', () => {
       const processor = new StreamProcessor()
       processor.prepareAssistantMessage()

--- a/packages/ai/tests/stream-processor.test.ts
+++ b/packages/ai/tests/stream-processor.test.ts
@@ -695,7 +695,9 @@ describe('StreamProcessor', () => {
 
       processor.processChunk(ev.runStarted())
       processor.processChunk(ev.textStart())
-      processor.processChunk(ev.toolStart('tc-1', 'offerTemplates'))
+      processor.processChunk(
+        ev.toolStart('tc-1', 'offerTemplates', 0, 'msg-1'),
+      )
       processor.processChunk(ev.toolArgs('tc-1', '{"templateIds":["mock-gsk-e'))
       processor.processChunk(ev.textContent('Let me look those up. '))
 

--- a/packages/ai/tests/stream-processor.test.ts
+++ b/packages/ai/tests/stream-processor.test.ts
@@ -694,10 +694,17 @@ describe('StreamProcessor', () => {
       processor.prepareAssistantMessage()
 
       processor.processChunk(ev.runStarted())
+      processor.processChunk(ev.textStart())
       processor.processChunk(ev.toolStart('tc-1', 'offerTemplates'))
       processor.processChunk(ev.toolArgs('tc-1', '{"templateIds":["mock-gsk-e'))
-      processor.processChunk(ev.textStart())
       processor.processChunk(ev.textContent('Let me look those up. '))
+
+      const partialToolCall = processor
+        .getMessages()[0]!
+        .parts.find((part) => part.type === 'tool-call') as ToolCallPart
+      expect(partialToolCall.state).not.toBe('input-complete')
+      expect(partialToolCall.input).toBeUndefined()
+
       processor.processChunk(ev.toolArgs('tc-1', 'fimosfermin"]}'))
       processor.processChunk(ev.toolEnd('tc-1', 'offerTemplates'))
       processor.processChunk(ev.runFinished('stop'))


### PR DESCRIPTION
Fixes #1017

When text interleaves tool-call argument deltas, the streaming partial JSON parser could publish truncated input as input-complete. Parse finalized arguments strictly and leave input unset until the accumulated JSON is valid. Added a regression test covering the reported interleaving sequence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Tool calls now wait until completion before exposing parsed arguments.
  - Incomplete or invalid tool-call data is no longer presented as partially parsed input.

- **Tests**
  - Added coverage to verify that interleaved text does not publish incomplete tool-call arguments and that completed calls retain the full input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->