### PR TITLE
fix(ai-grok): stop video fetch Illegal invocation on Workers

### DIFF
--- a/.changeset/grok-video-fetch-this.md
+++ b/.changeset/grok-video-fetch-this.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-grok': patch
+---
+
+Fix grok video `fetch` so Cloudflare Workers no longer throw `Illegal invocation` (issue #1184).

--- a/packages/ai-grok/src/adapters/video.ts
+++ b/packages/ai-grok/src/adapters/video.ts
@@ -147,18 +147,13 @@ export class GrokVideoAdapter<
     this.clientConfig = withGrokDefaults(config)
   }
 
-  private get fetch(): (
-    input: string,
-    init?: RequestInit,
-  ) => Promise<Response> {
-    return this.clientConfig.fetch ?? fetch
-  }
-
   private async request(
     path: string,
     init?: Omit<RequestInit, 'headers'>,
   ): Promise<Response> {
-    return await this.fetch(`${this.clientConfig.baseURL}${path}`, {
+    // workerd's fetch must be invoked with this === globalThis
+    const fetchFn = this.clientConfig.fetch ?? globalThis.fetch.bind(globalThis)
+    return await fetchFn(`${this.clientConfig.baseURL}${path}`, {
       ...init,
       headers: {
         'Content-Type': 'application/json',

--- a/packages/ai-grok/tests/video-adapter.test.ts
+++ b/packages/ai-grok/tests/video-adapter.test.ts
@@ -507,6 +507,43 @@ describe('Grok Video Adapter', () => {
         'https://proxy.example.com/v1/videos/generations',
       )
     })
+
+    it('calls the default global fetch with this === globalThis', async () => {
+      // workerd's fetch is a method: calling it with the adapter as `this`
+      // throws Illegal invocation. The adapter must invoke the global as a
+      // free function bound to globalThis.
+      const originalFetch = globalThis.fetch
+      function workerdFetch(
+        this: unknown,
+        _input: string | URL | Request,
+        _init?: RequestInit,
+      ): Promise<Response> {
+        if (this !== globalThis) {
+          throw new TypeError(
+            'Illegal invocation: function called with incorrect `this` reference.',
+          )
+        }
+        return Promise.resolve(jsonResponse({ request_id: 'req-this' }))
+      }
+      globalThis.fetch = workerdFetch as typeof fetch
+      try {
+        const adapter = createGrokVideo(
+          'grok-imagine-video-1.5',
+          'test-api-key',
+        )
+        const result = await adapter.createVideoJob({
+          model: 'grok-imagine-video-1.5',
+          prompt: i2vPrompt(),
+          logger: testLogger,
+        })
+        expect(result).toEqual({
+          jobId: 'req-this',
+          model: 'grok-imagine-video-1.5',
+        })
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
   })
 
   describe('reference-to-video', () => {

--- a/packages/ai-grok/tests/video-adapter.test.ts
+++ b/packages/ai-grok/tests/video-adapter.test.ts
@@ -508,41 +508,35 @@ describe('Grok Video Adapter', () => {
       )
     })
 
-    it('calls the default global fetch with this === globalThis', async () => {
-      // workerd's fetch is a method: calling it with the adapter as `this`
-      // throws Illegal invocation. The adapter must invoke the global as a
-      // free function bound to globalThis.
-      const originalFetch = globalThis.fetch
+    it('invokes fetch as a free function, not as an adapter method', async () => {
+      // workerd's fetch throws if `this` is the adapter. Do not assign
+      // globalThis.fetch — inject a this-sensitive stub through config.
       function workerdFetch(
         this: unknown,
         _input: string | URL | Request,
         _init?: RequestInit,
       ): Promise<Response> {
-        if (this !== globalThis) {
+        if (this !== undefined && this !== globalThis) {
           throw new TypeError(
             'Illegal invocation: function called with incorrect `this` reference.',
           )
         }
         return Promise.resolve(jsonResponse({ request_id: 'req-this' }))
       }
-      globalThis.fetch = workerdFetch as typeof fetch
-      try {
-        const adapter = createGrokVideo(
-          'grok-imagine-video-1.5',
-          'test-api-key',
-        )
-        const result = await adapter.createVideoJob({
-          model: 'grok-imagine-video-1.5',
-          prompt: i2vPrompt(),
-          logger: testLogger,
-        })
-        expect(result).toEqual({
-          jobId: 'req-this',
-          model: 'grok-imagine-video-1.5',
-        })
-      } finally {
-        globalThis.fetch = originalFetch
-      }
+      const adapter = createGrokVideo(
+        'grok-imagine-video-1.5',
+        'test-api-key',
+        { fetch: workerdFetch },
+      )
+      const result = await adapter.createVideoJob({
+        model: 'grok-imagine-video-1.5',
+        prompt: i2vPrompt(),
+        logger: testLogger,
+      })
+      expect(result).toEqual({
+        jobId: 'req-this',
+        model: 'grok-imagine-video-1.5',
+      })
     })
   })
 


### PR DESCRIPTION
The grok video test no longer assigns `globalThis.fetch`. It injects a this-sensitive stub through adapter config.

On Cloudflare Workers, `generateVideo()` with `createGrokVideo()` or `grokVideo()` threw `TypeError: Illegal invocation`. The adapter called the global `fetch` as a method, so `this` was the adapter. workerd requires `this === globalThis`. This PR calls `fetch` as a free function bound to `globalThis`.

## 🎯 Changes

The grok video adapter no longer calls `this.fetch(url)` on a getter that returns the global `fetch`. It uses `this.clientConfig.fetch ?? globalThis.fetch.bind(globalThis)` as a free function.

The regression injects a this-sensitive `fetch` through config. It does not assign `globalThis.fetch`.

Docs: skipped. Call sites did not change. This is a bug fix.

Changeset: patch for `@tanstack/ai-grok`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

**Commands run**

- `npx nx run @tanstack/ai-grok:test:lib -- tests/video-adapter.test.ts` (65 passed)
- `npx nx run-many --projects=@tanstack/ai-grok --targets=test:lib,test:types,test:oxlint` (passed)
- `pnpm test:pr` (passed on the first commit)

I skipped E2E locally. Playwright does not run on workerd, so it cannot reproduce Illegal invocation.

The E2E job on this PR failed on `generate-button` staying disabled (gemini TTS). That is the same fill/hydration flake as grok image, byteplus image, and openai TTS, which passed on retry. 589 passed. It is not the grok video `fetch` path.

**Manual test**

1. On the previous package, call `generateVideo()` with `grokVideo('grok-imagine-video-1.5')` on Cloudflare Workers. workerd throws `TypeError: Illegal invocation`.
2. Repeat the same call on this branch. The Illegal invocation error must not occur.
3. Local substitute: run `npx nx run @tanstack/ai-grok:test:lib -- tests/video-adapter.test.ts -t "invokes fetch as a free function"`.

**How this PR makes testing easy**

`packages/ai-grok/tests/video-adapter.test.ts` injects a `fetch` stub that throws if `this` is the adapter.

## Linked issues

Fixes #1184

## Risk / rollback

Low. Custom `fetch` still runs as a free function. Revert this PR to undo.

Next: wait for CI, then merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video fetching in Cloudflare Workers environments.
  * Improved fetch handling to preserve the correct execution context.
  * Added regression coverage to verify successful video job creation across supported fetch configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->