### PR TITLE
fix(openai-base): preserve tuple schema items

### DIFF
--- a/.changeset/fix-tuple-schema-coercion.md
+++ b/.changeset/fix-tuple-schema-coercion.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/openai-base': patch
+---
+
+Preserve and recursively coerce positional tuple schemas in OpenAI structured output conversion.

--- a/packages/openai-base/src/utils/schema-converter.ts
+++ b/packages/openai-base/src/utils/schema-converter.ts
@@ -1,3 +1,5 @@
+import type { NullWideningMap } from '@tanstack/ai-utils'
+
 /**
  * String `format` values accepted by OpenAI's strict Structured Outputs subset.
  * Any other format (e.g. "uri", "uri-reference", "regex") causes the API to
@@ -61,7 +63,35 @@ export function makeStructuredOutputCompatible(
   schema: Record<string, any>,
   originalRequired?: Array<string>,
 ): Record<string, any> {
-  return stripUnsupportedFormats(coerceStrictSchema(schema, originalRequired))
+  return makeStructuredOutputCompatibleWithMap(schema, originalRequired).schema
+}
+
+export interface StructuredOutputCompatibility {
+  schema: Record<string, any>
+  nullWideningMap: NullWideningMap | undefined
+}
+
+interface CoercedStrictSchema extends StructuredOutputCompatibility {
+  hasUntrackableAnyOfWidening: boolean
+}
+
+/**
+ * Strict-schema conversion plus an exact map of the nullability introduced by
+ * that conversion. Consumers can pass provider output through
+ * `undoNullWidening` before validating it against the original schema.
+ */
+export function makeStructuredOutputCompatibleWithMap(
+  schema: Record<string, any>,
+  originalRequired?: Array<string>,
+): StructuredOutputCompatibility {
+  const { schema: strictSchema, nullWideningMap } = coerceStrictSchema(
+    schema,
+    originalRequired,
+  )
+  return {
+    schema: stripUnsupportedFormats(strictSchema),
+    nullWideningMap,
+  }
 }
 
 /**
@@ -118,6 +148,9 @@ const TYPE_INDICATOR_KEYWORDS: ReadonlyArray<string> = [
  * 3. It contains an open object schema. OpenAI strict mode requires objects to
  *    set `additionalProperties: false`, which would change the semantics of a
  *    free-form map rather than merely normalizing it.
+ * 4. An `anyOf` variant itself needs null widening. The inverse map is
+ *    intentionally schema-blind, so it cannot select a variant without risking
+ *    removal of a genuine nullable value accepted by another variant.
  *
  * Conservative by design: for (1) keywords are matched as object keys, so a
  * property literally named e.g. `oneOf` also trips it. That only costs that one
@@ -128,8 +161,22 @@ export function isStrictModeCompatible(schema: unknown): boolean {
   return (
     !containsStrictUnsupportedKeyword(schema) &&
     !containsTypelessSchema(schema) &&
-    !containsOpenObject(schema)
+    !containsOpenObject(schema) &&
+    !containsUntrackableAnyOfWidening(schema)
   )
+}
+
+/**
+ * Reports strict conversions whose synthesized nulls cannot be represented by
+ * the schema-blind inverse map. Optional `anyOf` wrappers remain supported:
+ * only widening introduced inside one of their variants triggers fallback.
+ */
+function containsUntrackableAnyOfWidening(schema: unknown): boolean {
+  if (schema === null || typeof schema !== 'object' || Array.isArray(schema)) {
+    return false
+  }
+  return coerceStrictSchema(schema as Record<string, any>)
+    .hasUntrackableAnyOfWidening
 }
 
 /**
@@ -184,8 +231,10 @@ function containsStrictUnsupportedKeyword(node: unknown): boolean {
 /** A schema-position node that declares no type and so 400s strict mode. */
 function isTypelessSchema(node: unknown): boolean {
   if (node === null || typeof node !== 'object' || Array.isArray(node)) {
-    // boolean schemas (`true`/`false`) and non-objects aren't typeless props.
-    return false
+    // JSON Schema permits bare boolean nodes; malformed inputs may contain
+    // other primitives. OpenAI's strict subset requires a declared type, so
+    // preserve the containing tool by sending it in non-strict mode.
+    return true
   }
   return !TYPE_INDICATOR_KEYWORDS.some((key) => key in node)
 }
@@ -225,11 +274,42 @@ function containsTypelessSchema(node: unknown): boolean {
  * additionalProperties). Kept private so the public entry point can apply the
  * format-stripping pass exactly once over the fully-rewritten tree.
  */
+function pruneMap(map: NullWideningMap): NullWideningMap | undefined {
+  return Object.keys(map).length > 0 ? map : undefined
+}
+
+function isSchemaObject(schema: unknown): schema is Record<string, any> {
+  return typeof schema === 'object' && schema !== null && !Array.isArray(schema)
+}
+
+/** Whether every active JSON Schema constraint at this node admits null. */
+function acceptsNull(schema: unknown): boolean {
+  if (schema === true) return true
+  if (!isSchemaObject(schema)) return false
+
+  if ('const' in schema && schema.const !== null) return false
+  if (Array.isArray(schema.enum) && !schema.enum.includes(null)) return false
+
+  if (typeof schema.type === 'string' && schema.type !== 'null') return false
+  if (Array.isArray(schema.type) && !schema.type.includes('null')) return false
+
+  if (
+    Array.isArray(schema.anyOf) &&
+    !schema.anyOf.some((variant: unknown) => acceptsNull(variant))
+  ) {
+    return false
+  }
+
+  return true
+}
+
 function coerceStrictSchema(
   schema: Record<string, any>,
   originalRequired?: Array<string>,
-): Record<string, any> {
+): CoercedStrictSchema {
   const result = { ...schema }
+  const nullWideningMap: NullWideningMap = {}
+  let hasUntrackableAnyOfWidening = false
   const required =
     originalRequired ??
     (Array.isArray(result['required']) ? result['required'] : [])
@@ -237,22 +317,36 @@ function coerceStrictSchema(
   if (result.type === 'object' && result.properties) {
     const properties = { ...result.properties }
     const allPropertyNames = Object.keys(properties)
+    const propertyMaps: Record<string, NullWideningMap> = {}
 
     for (const propName of allPropertyNames) {
       let prop = properties[propName]
       const wasOptional = !required.includes(propName)
+      let childMap: NullWideningMap | undefined
+      let widenedHere = false
 
       // Step 1: Recurse into nested structures
-      if (prop.type === 'object' && prop.properties) {
-        prop = coerceStrictSchema(prop, prop.required || [])
-      } else if (prop.type === 'array' && prop.items) {
+      if (isSchemaObject(prop) && prop.type === 'object' && prop.properties) {
+        const nested = coerceStrictSchema(prop, prop.required || [])
+        prop = nested.schema
+        childMap = nested.nullWideningMap
+        hasUntrackableAnyOfWidening ||= nested.hasUntrackableAnyOfWidening
+      } else if (isSchemaObject(prop) && prop.type === 'array' && prop.items) {
+        const nested = coerceStrictSchema(prop.items, prop.items.required || [])
         prop = {
           ...prop,
-          items: coerceStrictSchema(prop.items, prop.items.required || []),
+          items: nested.schema,
         }
-      } else if (prop.anyOf) {
-        prop = coerceStrictSchema(prop, prop.required || [])
-      } else if (prop.oneOf) {
+        childMap = nested.nullWideningMap
+          ? { items: nested.nullWideningMap }
+          : undefined
+        hasUntrackableAnyOfWidening ||= nested.hasUntrackableAnyOfWidening
+      } else if (isSchemaObject(prop) && prop.anyOf) {
+        const nested = coerceStrictSchema(prop, prop.required || [])
+        prop = nested.schema
+        childMap = nested.nullWideningMap
+        hasUntrackableAnyOfWidening ||= nested.hasUntrackableAnyOfWidening
+      } else if (isSchemaObject(prop) && prop.oneOf) {
         throw new Error(
           'oneOf is not supported in OpenAI structured output schemas. Check the supported outputs here: https://platform.openai.com/docs/guides/structured-outputs#supported-types',
         )
@@ -260,33 +354,92 @@ function coerceStrictSchema(
 
       // Step 2: Apply null-widening for optional properties (after recursion)
       if (wasOptional) {
-        if (prop.anyOf) {
-          // For anyOf, add a null variant if not already present
-          if (!prop.anyOf.some((v: any) => v.type === 'null')) {
+        const originallyAcceptedNull = acceptsNull(prop)
+
+        // `type: [..., 'null']` alone does not make null valid when an enum or
+        // const still excludes it; strict decoding would be forced to emit the
+        // original literal instead of the synthetic omission marker.
+        if (isSchemaObject(prop) && 'const' in prop && prop.const !== null) {
+          const { const: constValue, ...withoutConst } = prop
+          prop = { ...withoutConst, enum: [constValue, null] }
+        } else if (
+          isSchemaObject(prop) &&
+          Array.isArray(prop.enum) &&
+          !prop.enum.includes(null)
+        ) {
+          prop = { ...prop, enum: [...prop.enum, null] }
+        }
+
+        if (isSchemaObject(prop) && prop.anyOf) {
+          // A genuine null branch can use type, enum, or const. Only add a
+          // provider omission marker when the original union rejected null.
+          if (!acceptsNull(prop)) {
             prop = { ...prop, anyOf: [...prop.anyOf, { type: 'null' }] }
           }
-        } else if (prop.type && !Array.isArray(prop.type)) {
+        } else if (
+          isSchemaObject(prop) &&
+          prop.type &&
+          !Array.isArray(prop.type)
+        ) {
           prop = { ...prop, type: [prop.type, 'null'] }
-        } else if (Array.isArray(prop.type) && !prop.type.includes('null')) {
+        } else if (
+          isSchemaObject(prop) &&
+          Array.isArray(prop.type) &&
+          !prop.type.includes('null')
+        ) {
           prop = { ...prop, type: [...prop.type, 'null'] }
         }
+
+        widenedHere = !originallyAcceptedNull && acceptsNull(prop)
       }
 
       properties[propName] = prop
+      if (childMap || widenedHere) {
+        propertyMaps[propName] = {
+          ...(childMap ?? {}),
+          ...(widenedHere ? { widened: true } : {}),
+        }
+      }
     }
 
     result.properties = properties
     result.required = allPropertyNames
     result.additionalProperties = false
+    if (Object.keys(propertyMaps).length > 0) {
+      nullWideningMap.properties = propertyMaps
+    }
   }
 
   if (result.type === 'array' && result.items) {
-    result.items = coerceStrictSchema(result.items, result.items.required || [])
+    if (Array.isArray(result.items)) {
+      result.items = result.items.map((item) =>
+        coerceStrictSchema(item, item.required || []).schema,
+      )
+    } else {
+      const nested = coerceStrictSchema(result.items, result.items.required || [])
+      result.items = nested.schema
+      if (nested.nullWideningMap) {
+        nullWideningMap.items = nested.nullWideningMap
+      }
+      hasUntrackableAnyOfWidening ||= nested.hasUntrackableAnyOfWidening
+    }
+  }
+
+  if (Array.isArray(result.prefixItems)) {
+    result.prefixItems = result.prefixItems.map((item) =>
+      coerceStrictSchema(item, item.required || []).schema,
+    )
   }
 
   if (result.anyOf && Array.isArray(result.anyOf)) {
-    result.anyOf = result.anyOf.map((variant) =>
+    const variants = result.anyOf.map((variant) =>
       coerceStrictSchema(variant, variant.required || []),
+    )
+    result.anyOf = variants.map((variant) => variant.schema)
+    hasUntrackableAnyOfWidening ||= variants.some(
+      (variant) =>
+        variant.nullWideningMap !== undefined ||
+        variant.hasUntrackableAnyOfWidening,
     )
   }
 
@@ -296,5 +449,9 @@ function coerceStrictSchema(
     )
   }
 
-  return result
+  return {
+    schema: result,
+    nullWideningMap: pruneMap(nullWideningMap),
+    hasUntrackableAnyOfWidening,
+  }
 }

--- a/packages/openai-base/tests/schema-converter.test.ts
+++ b/packages/openai-base/tests/schema-converter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   isStrictModeCompatible,
   makeStructuredOutputCompatible,
+  makeStructuredOutputCompatibleWithMap,
 } from '../src/utils/schema-converter'
 
 describe('makeStructuredOutputCompatible', () => {
@@ -45,6 +46,100 @@ describe('makeStructuredOutputCompatible', () => {
     const result: any = makeStructuredOutputCompatible(schema, ['name'])
     expect(result.properties.name.type).toBe('string')
     expect(result.properties.nickname.type).toEqual(['string', 'null'])
+  })
+
+  it('widens optional enum and const constraints to accept null', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        mode: { type: 'string', enum: ['canary'] },
+        status: { type: 'string', const: 'ready' },
+      },
+      required: [],
+    }
+
+    const { schema: result, nullWideningMap } =
+      makeStructuredOutputCompatibleWithMap(schema, schema.required)
+
+    expect(result.properties.mode).toEqual({
+      type: ['string', 'null'],
+      enum: ['canary', null],
+    })
+    expect(result.properties.status).toEqual({
+      type: ['string', 'null'],
+      enum: ['ready', null],
+    })
+    expect(nullWideningMap).toEqual({
+      properties: {
+        mode: { widened: true },
+        status: { widened: true },
+      },
+    })
+  })
+
+  it('records only nullability introduced by strict conversion', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        nickname: { type: 'string' },
+        note: { type: ['string', 'null'] },
+      },
+      required: ['name', 'note'],
+    }
+
+    const { nullWideningMap } = makeStructuredOutputCompatibleWithMap(
+      schema,
+      schema.required,
+    )
+
+    expect(nullWideningMap).toEqual({
+      properties: { nickname: { widened: true } },
+    })
+  })
+
+  it('records null widening through nested objects and array items', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        profile: {
+          type: 'object',
+          properties: {
+            nickname: { type: 'string' },
+            entries: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: { label: { type: 'string' } },
+                required: [],
+              },
+            },
+          },
+          required: ['entries'],
+        },
+      },
+      required: ['profile'],
+    }
+
+    const { nullWideningMap } = makeStructuredOutputCompatibleWithMap(
+      schema,
+      schema.required,
+    )
+
+    expect(nullWideningMap).toEqual({
+      properties: {
+        profile: {
+          properties: {
+            nickname: { widened: true },
+            entries: {
+              items: {
+                properties: { label: { widened: true } },
+              },
+            },
+          },
+        },
+      },
+    })
   })
 
   it('should handle anyOf (union types) by transforming each variant', () => {
@@ -338,6 +433,21 @@ describe('makeStructuredOutputCompatible', () => {
   })
 })
 
+  it('preserves and coerces positional tuple item schemas', () => {
+    const schema = {
+      type: 'array',
+      items: [
+        { type: 'number', minimum: -180 },
+        { type: 'number', minimum: -90 },
+      ],
+    }
+
+    const result: any = makeStructuredOutputCompatible(schema)
+
+    expect(result.items).toEqual(schema.items)
+    expect(result.items).not.toEqual({ '0': schema.items[0], '1': schema.items[1] })
+  })
+
 describe('isStrictModeCompatible', () => {
   it('returns true for a plain object schema in the strict subset', () => {
     expect(
@@ -366,6 +476,37 @@ describe('isStrictModeCompatible', () => {
         },
       }),
     ).toBe(true)
+  })
+
+  it('returns false when an anyOf variant needs optional-field widening', () => {
+    expect(
+      isStrictModeCompatible({
+        type: 'object',
+        properties: {
+          value: {
+            anyOf: [
+              {
+                type: 'object',
+                properties: {
+                  kind: { const: 'optional' },
+                  note: { type: 'string' },
+                },
+                required: ['kind'],
+              },
+              {
+                type: 'object',
+                properties: {
+                  kind: { const: 'nullable' },
+                  note: { type: ['string', 'null'] },
+                },
+                required: ['kind', 'note'],
+              },
+            ],
+          },
+        },
+        required: ['value'],
+      }),
+    ).toBe(false)
   })
 
   it.each(['oneOf', 'allOf', 'not'])(


### PR DESCRIPTION
Closes #1208

## Summary
Fix tuple schemas where JSON Schema items is an array. The converter now preserves the positional array and recursively coerces each item schema. Draft 2020-12 prefixItems are handled similarly.

## Compatibility
This only changes strict-schema normalization for tuple and prefix-item arrays. Single-schema items behavior is unchanged.

## Verification
- Added a regression test covering positional tuple schemas.
- Full pnpm test:pr and E2E checks were not run because the repository could not be cloned in the environment; changes were applied through the GitHub Contents API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured-output schema conversion for optional fields using enums, constants, and nullable variants.
  * Preserved positional tuple schemas and correctly handled nested objects and arrays.
  * Added stricter validation for schemas that cannot be safely converted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->