### PR TITLE
fix(openai-base): keep tuple items arrays during strict conversion

### DIFF
--- a/.changeset/fix-tuple-schema-coercion.md
+++ b/.changeset/fix-tuple-schema-coercion.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/openai-base': patch
+---
+
+Preserve draft-07 tuple `items` arrays during strict schema conversion.
+
+Send tools that use `prefixItems` with `strict: false`. OpenAI strict mode rejects that keyword.

--- a/packages/openai-base/src/adapters/chat-completions-tool-converter.test.ts
+++ b/packages/openai-base/src/adapters/chat-completions-tool-converter.test.ts
@@ -17,6 +17,27 @@ describe('chat-completions tool converter', () => {
     expect(out.function.strict).toBe(false)
     expect(out.function.parameters).toEqual(booleanSchemaTool.inputSchema)
   })
+
+  it('keeps draft-07 tuple items as an array in strict mode', () => {
+    const out = convertFunctionToolToChatCompletionsFormat(bboxTupleTool)
+
+    expect(out.function.strict).toBe(true)
+    expect(out.function.parameters).toMatchObject({
+      properties: {
+        bbox: {
+          type: 'array',
+          items: bboxItems,
+        },
+      },
+    })
+  })
+
+  it('falls back from strict mode when prefixItems is present', () => {
+    const out = convertFunctionToolToChatCompletionsFormat(prefixItemsTool)
+
+    expect(out.function.strict).toBe(false)
+    expect(out.function.parameters).toEqual(prefixItemsTool.inputSchema)
+  })
 })
 
 const booleanSchemaInput = {
@@ -31,6 +52,43 @@ const booleanSchemaTool = {
   description: 'Accept any value',
   inputSchema: booleanSchemaInput,
 } satisfies Tool
+
+const bboxItems = [
+  { type: 'number', minimum: -180 },
+  { type: 'number', minimum: -90 },
+  { type: 'number', maximum: 180 },
+  { type: 'number', maximum: 90 },
+]
+
+const bboxTupleTool: Tool = {
+  name: 'set_bbox',
+  description: 'Set a bounding box',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      bbox: {
+        type: 'array',
+        items: bboxItems,
+      },
+    },
+    required: ['bbox'],
+  },
+}
+
+const prefixItemsTool: Tool = {
+  name: 'set_pair',
+  description: 'Set a prefix-item pair',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      pair: {
+        type: 'array',
+        prefixItems: [{ type: 'string' }, { type: 'number' }],
+      },
+    },
+    required: ['pair'],
+  },
+}
 
 const anyOfOptionalVariantTool: Tool = {
   name: 'store_variant',

--- a/packages/openai-base/src/utils/schema-converter.ts
+++ b/packages/openai-base/src/utils/schema-converter.ts
@@ -104,6 +104,8 @@ export function makeStructuredOutputCompatibleWithMap(
  * emit these.
  *
  * - `oneOf` / `allOf` / `not` — combinator keywords strict mode rejects
+ * - `prefixItems` — 2020-12 tuple keyword. openai-node's strict transform
+ *   rejects it, so we send those tools with `strict: false` instead
  * - `$ref` / `$defs` / `definitions` — references and definition pools whose
  *   object subschemas escape the `additionalProperties: false` normalization
  *   strict mode requires
@@ -112,6 +114,7 @@ const STRICT_UNSUPPORTED_KEYWORDS: ReadonlyArray<string> = [
   'oneOf',
   'allOf',
   'not',
+  'prefixItems',
   '$ref',
   '$defs',
   'definitions',
@@ -141,7 +144,7 @@ const TYPE_INDICATOR_KEYWORDS: ReadonlyArray<string> = [
  * sent with `strict: false`. Two ways that happens:
  *
  * 1. It uses a JSON-Schema keyword outside OpenAI's strict subset anywhere in
- *    the tree (`oneOf`/`allOf`/`not`/`$ref`/`$defs`).
+ *    the tree (`oneOf`/`allOf`/`not`/`prefixItems`/`$ref`/`$defs`).
  * 2. It contains a *typeless* schema node — a property/items/anyOf entry with
  *    no `type` (nor `enum`/`const`/combinator), e.g. the `{}` that `z.any()`
  *    produces. Strict mode rejects typeless schemas.
@@ -331,15 +334,10 @@ function coerceStrictSchema(
         prop = nested.schema
         childMap = nested.nullWideningMap
         hasUntrackableAnyOfWidening ||= nested.hasUntrackableAnyOfWidening
-      } else if (isSchemaObject(prop) && prop.type === 'array' && prop.items) {
-        const nested = coerceStrictSchema(prop.items, prop.items.required || [])
-        prop = {
-          ...prop,
-          items: nested.schema,
-        }
+      } else if (isSchemaObject(prop) && prop.type === 'array') {
+        const nested = coerceStrictSchema(prop, [])
+        prop = nested.schema
         childMap = nested.nullWideningMap
-          ? { items: nested.nullWideningMap }
-          : undefined
         hasUntrackableAnyOfWidening ||= nested.hasUntrackableAnyOfWidening
       } else if (isSchemaObject(prop) && prop.anyOf) {
         const nested = coerceStrictSchema(prop, prop.required || [])
@@ -411,12 +409,32 @@ function coerceStrictSchema(
   }
 
   if (result.type === 'array' && result.items) {
-    const nested = coerceStrictSchema(result.items, result.items.required || [])
-    result.items = nested.schema
-    if (nested.nullWideningMap) {
-      nullWideningMap.items = nested.nullWideningMap
+    if (Array.isArray(result.items)) {
+      const itemMaps: Array<NullWideningMap> = []
+      result.items = result.items.map((item) => {
+        if (!isSchemaObject(item)) {
+          itemMaps.push({})
+          return item
+        }
+        const nested = coerceStrictSchema(item, item.required || [])
+        itemMaps.push(nested.nullWideningMap ?? {})
+        hasUntrackableAnyOfWidening ||= nested.hasUntrackableAnyOfWidening
+        return nested.schema
+      })
+      if (itemMaps.some((map) => Object.keys(map).length > 0)) {
+        nullWideningMap.items = itemMaps
+      }
+    } else {
+      const nested = coerceStrictSchema(
+        result.items,
+        result.items.required || [],
+      )
+      result.items = nested.schema
+      if (nested.nullWideningMap) {
+        nullWideningMap.items = nested.nullWideningMap
+      }
+      hasUntrackableAnyOfWidening ||= nested.hasUntrackableAnyOfWidening
     }
-    hasUntrackableAnyOfWidening ||= nested.hasUntrackableAnyOfWidening
   }
 
   if (result.anyOf && Array.isArray(result.anyOf)) {

--- a/packages/openai-base/tests/tuple-schema-coercion.test.ts
+++ b/packages/openai-base/tests/tuple-schema-coercion.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isStrictModeCompatible,
+  makeStructuredOutputCompatible,
+  makeStructuredOutputCompatibleWithMap,
+} from '../src/utils/schema-converter'
+
+const bboxItems = [
+  { type: 'number', minimum: -180 },
+  { type: 'number', minimum: -90 },
+  { type: 'number', maximum: 180 },
+  { type: 'number', maximum: 90 },
+]
+
+describe('draft-07 tuple items', () => {
+  it('keeps per-position bbox constraints instead of spreading items into a numeric-keyed object', () => {
+    const result = makeStructuredOutputCompatible({
+      type: 'object',
+      properties: {
+        bbox: {
+          type: 'array',
+          items: bboxItems,
+          additionalItems: false,
+        },
+      },
+      required: ['bbox'],
+    })
+
+    const items = result.properties.bbox.items
+    expect(Array.isArray(items)).toBe(true)
+    expect(items).toEqual(bboxItems)
+    expect(result.properties.bbox.additionalItems).toBe(false)
+  })
+
+  it('keeps a top-level tuple items array as an array', () => {
+    const result = makeStructuredOutputCompatible({
+      type: 'array',
+      items: bboxItems,
+    })
+
+    expect(Array.isArray(result.items)).toBe(true)
+    expect(result.items).toEqual(bboxItems)
+  })
+
+  it('keeps boolean tuple entries and aligns null-widening maps by index', () => {
+    const { schema, nullWideningMap } = makeStructuredOutputCompatibleWithMap({
+      type: 'array',
+      items: [
+        false,
+        {
+          type: 'object',
+          properties: { label: { type: 'string' } },
+          required: [],
+        },
+      ],
+    })
+
+    expect(schema.items[0]).toBe(false)
+    expect(schema.items[1].additionalProperties).toBe(false)
+    expect(nullWideningMap).toEqual({
+      items: [{}, { properties: { label: { widened: true } } }],
+    })
+  })
+
+  it('still uses a single items map for a homogeneous array', () => {
+    const { nullWideningMap } = makeStructuredOutputCompatibleWithMap({
+      type: 'object',
+      properties: {
+        list: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { label: { type: 'string' } },
+            required: [],
+          },
+        },
+      },
+      required: ['list'],
+    })
+
+    expect(nullWideningMap).toEqual({
+      properties: {
+        list: {
+          items: { properties: { label: { widened: true } } },
+        },
+      },
+    })
+  })
+})
+
+describe('prefixItems strict gate', () => {
+  it('rejects prefixItems so OpenAI tools fall back to strict: false', () => {
+    expect(
+      isStrictModeCompatible({
+        type: 'array',
+        prefixItems: [{ type: 'string' }],
+      }),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Draft-07 tuple `items` arrays were spread into numeric-keyed objects, so OpenAI never saw per-position types and bounds. This PR maps each tuple position and keeps the array. Tools that use `prefixItems` now go out with `strict: false`.

## Changes

- Keep every positional schema in a draft-07 `items` array, including tuples nested in object properties.
- Keep boolean tuple entries. Pad empty maps so null-widening metadata stays aligned with each index.
- Add `prefixItems` to the strict-unsupported keyword list. OpenAI strict mode rejects that keyword.
- Docs: no new public API. The converter now matches JSON Schema for tuple `items`.
- Changeset: `.changeset/fix-tuple-schema-coercion.md` for `@tanstack/openai-base` only.

This replaces the earlier three-package diff. `packages/ai` and `packages/ai-utils` are unchanged. `undoNullWidening` already walks tuple `items` maps.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Root cause

**Issue.** A tool parameter that is a bbox tuple (`items: [{ minimum: -180 }, …]`) reaches the model with no element constraints.

**Cause.** `coerceStrictSchema` starts with `{ ...schema }`. Both array branches passed the `items` array into that function, so `[schema0, schema1]` became `{ "0": schema0, "1": schema1 }`.

**Fix.** If `items` is an array, coerce each entry and keep the array. Recurse into array properties as the full array schema so nested tuples take the same path.

## Possible alternatives

- **Convert the tuple to named object properties in app code.** That is the workaround from #1208. It does not fix the converter.
- **Also coerce `prefixItems`.** The first version of this PR did that. OpenAI strict mode rejects `prefixItems`, so a coerced schema that keeps it can 400 the whole request. This PR only trips `isStrictModeCompatible`.
- **Also rewrite `packages/ai` and `packages/ai-utils`.** Those paths are not on the OpenAI tool converter. `NullWideningMap.items` already accepts a list of maps.

## Testing

**Commands run**

1. `pnpm --filter @tanstack/openai-base... build` — passed
2. `pnpm --filter @tanstack/openai-base test:lib` — 213 passed
3. `pnpm --filter @tanstack/openai-base test:types` — passed
4. `pnpm --filter @tanstack/openai-base test:oxlint` — passed (existing `any` warnings only)
5. `pnpm test:pr` — not run
6. E2E — not run. Coverage is unit tests on the converter and the Chat Completions tool converter.

**Manual test**

1. On `main`, pass `{ type: 'array', items: [{ type: 'number', minimum: -180 }, { type: 'number', minimum: -90 }] }` to `makeStructuredOutputCompatible`. `items` becomes `{ "0": …, "1": … }`.
2. On this branch, the same call keeps `items` as an array with both minima.

Agent-written Gate 1 on this branch:

```text
PASS: tuple items stayed arrays with per-position constraints
```

On clean `main` (`0e4e340a`) the same bbox object-property case failed with:

```text
FAIL nested: items is not an array {"0":{"type":"number","minimum":-180},"1":{"type":"number","minimum":-90},"2":{"type":"number","maximum":180},"3":{"type":"number","maximum":90}}
```

**How this PR makes testing easy.** `packages/openai-base/tests/tuple-schema-coercion.test.ts` and two Chat Completions tool-converter cases.

## Linked issues

Closes #1208

## Risk / rollback

Low. Draft-07 tuple tools now keep constraints. `prefixItems` tools lose strict grammar and stay callable. Revert the PR to undo.
