### PR TITLE
fix(gemini): duplicate tool call events on UNEXPECTED_TOOL_CALL finish crash the chat run

### DIFF
--- a/.changeset/gemini-duplicate-tool-call-events.md
+++ b/.changeset/gemini-duplicate-tool-call-events.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-gemini': patch
+---
+
+Fix duplicate TOOL_CALL_START/TOOL_CALL_END events when a Gemini stream chunk carries both functionCall parts and finishReason UNEXPECTED_TOOL_CALL. The finish handler re-registered and re-emitted tool calls the per-part loop had already processed, which crashed the chat run with "Duplicate interrupt id in final batch".

--- a/packages/ai-gemini/src/adapters/text.ts
+++ b/packages/ai-gemini/src/adapters/text.ts
@@ -497,68 +497,9 @@ export class GeminiTextAdapter<
       if (chunk.candidates?.[0]?.finishReason) {
         const finishReason = chunk.candidates[0].finishReason
 
-        if (finishReason === FinishReason.UNEXPECTED_TOOL_CALL) {
-          if (chunk.candidates[0].content?.parts) {
-            for (const part of chunk.candidates[0].content.parts) {
-              const functionCall = part.functionCall
-              if (functionCall) {
-                const toolCallId =
-                  functionCall.id ||
-                  `${functionCall.name}_${Date.now()}_${nextToolIndex}`
-                const functionArgs = functionCall.args || {}
-
-                const argsString =
-                  typeof functionArgs === 'string'
-                    ? functionArgs
-                    : JSON.stringify(functionArgs)
-
-                toolCallMap.set(toolCallId, {
-                  name: functionCall.name || '',
-                  args: argsString,
-                  index: nextToolIndex++,
-                  started: true,
-                })
-
-                // Emit TOOL_CALL_START
-                yield {
-                  type: EventType.TOOL_CALL_START,
-                  toolCallId,
-                  toolCallName: functionCall.name || '',
-                  toolName: functionCall.name || '',
-                  parentMessageId: messageId,
-                  model,
-                  timestamp: Date.now(),
-                  index: nextToolIndex - 1,
-                }
-
-                // Emit TOOL_CALL_END with parsed input
-                let parsedInput: unknown = {}
-                try {
-                  const parsed =
-                    typeof functionArgs === 'string'
-                      ? JSON.parse(functionArgs)
-                      : functionArgs
-                  parsedInput =
-                    parsed && typeof parsed === 'object' ? parsed : {}
-                } catch {
-                  parsedInput = {}
-                }
-
-                yield {
-                  type: EventType.TOOL_CALL_END,
-                  toolCallId,
-                  toolCallName: functionCall.name || '',
-                  toolName: functionCall.name || '',
-                  model,
-                  timestamp: Date.now(),
-                  input: parsedInput,
-                }
-              }
-            }
-          }
-        }
-
-        // Emit TOOL_CALL_END for all tracked tool calls
+        // Emit TOOL_CALL_END for all tracked tool calls. functionCall parts on
+        // this chunk (including UNEXPECTED_TOOL_CALL finishes) were already
+        // registered and started by the per-part loop above.
         for (const [toolCallId, toolCallData] of toolCallMap.entries()) {
           let parsedInput: unknown = {}
           try {

--- a/packages/ai-gemini/tests/gemini-adapter.test.ts
+++ b/packages/ai-gemini/tests/gemini-adapter.test.ts
@@ -409,6 +409,72 @@ describe('GeminiAdapter through AI', () => {
     })
   })
 
+  it('emits exactly one TOOL_CALL_START/TOOL_CALL_END per tool call when the final chunk carries both functionCall parts and finishReason UNEXPECTED_TOOL_CALL', async () => {
+    // The per-part loop already registers and emits events for functionCall
+    // parts on every chunk, including the final one. The UNEXPECTED_TOOL_CALL
+    // finish handling must not re-emit for those same parts.
+    const streamChunks = [
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: 'call_1',
+                    name: 'lookup_weather',
+                    args: { location: 'Berlin' },
+                  },
+                },
+                {
+                  functionCall: {
+                    name: 'lookup_weather',
+                    args: { location: 'Madrid' },
+                  },
+                },
+              ],
+            },
+            finishReason: 'UNEXPECTED_TOOL_CALL',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 4,
+          candidatesTokenCount: 2,
+          totalTokenCount: 6,
+        },
+      },
+    ]
+
+    mocks.generateContentStreamSpy.mockResolvedValue(createStream(streamChunks))
+
+    const adapter = createTextAdapter()
+    const received: AdapterYieldChunk[] = []
+    for await (const chunk of chat({
+      adapter,
+      messages: [{ role: 'user', content: 'What is the weather?' }],
+      tools: [weatherTool],
+    })) {
+      received.push(chunk)
+    }
+
+    const starts = received.filter((c) => c.type === 'TOOL_CALL_START')
+    const ends = received.filter((c) => c.type === 'TOOL_CALL_END')
+
+    // Two tool calls in the chunk: exactly one START and one END for each.
+    expect(starts).toHaveLength(2)
+    expect(ends).toHaveLength(2)
+
+    const startIds = starts.map((c) =>
+      c.type === 'TOOL_CALL_START' ? c.toolCallId : '',
+    )
+    const endIds = ends.map((c) =>
+      c.type === 'TOOL_CALL_END' ? c.toolCallId : '',
+    )
+    expect(new Set(startIds).size).toBe(2)
+    expect(startIds).toContain('call_1')
+    expect(endIds.sort()).toEqual(startIds.sort())
+  })
+
   it('emits parentMessageId on tool-first tool calls matching the assistant message id', async () => {
     // A functionCall part arrives before any text. parentMessageId must bind the
     // tool call to the same assistant message id the eventual TEXT_MESSAGE_START


### PR DESCRIPTION
When a final Gemini stream chunk carries both `content.parts` with a `functionCall` and `finishReason: UNEXPECTED_TOOL_CALL`, tool call events are emitted twice. The per-part loop in `processStreamChunks` already registers each `functionCall` part and emits `TOOL_CALL_START`/`TOOL_CALL_ARGS`, and the finish handling already emits `TOOL_CALL_END` for every tracked call. The `UNEXPECTED_TOOL_CALL` branch then re-iterated the same parts of the same chunk, re-registered them, and emitted a second `TOOL_CALL_START` and `TOOL_CALL_END` (with `functionCall.id` present it overwrites the map entry; without one it mints a phantom second entry from the already-incremented index).

Downstream this is not cosmetic: the duplicate events make the engine throw `Duplicate interrupt id in final batch: client_tool_call_1` in `buildActionableInterrupts` and abort the run.

Fix: delete the redundant branch. Its work is a strict subset of the per-part loop plus the trailing `TOOL_CALL_END` loop, which also preserve `thoughtSignature` and merged args that the deleted block dropped.

Added a regression test: a final chunk with two `functionCall` parts (one with an id, one without) and `finishReason: UNEXPECTED_TOOL_CALL` must emit exactly one `TOOL_CALL_START` and one `TOOL_CALL_END` per tool call. Red on main (fails with the duplicate-interrupt throw), green with the fix. Full `ai-gemini` suite 325/325; oxlint, tsc, and build clean. Changeset included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate tool-call start and completion events in Gemini responses.
  * Prevented duplicate interrupt ID errors when unexpected tool calls contain multiple function calls.
  * Preserved the correct tool-call IDs and ensured each call emits exactly one start and end event.

* **Tests**
  * Added regression coverage for multiple function calls in a final unexpected-tool-call response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->