### PR TITLE
fix(ai): allow cancelling stale tool interrupts

### DIFF
--- a/.changeset/cancel-stale-tool-interrupts.md
+++ b/.changeset/cancel-stale-tool-interrupts.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai': patch
+---
+
+Allow cancelling a tool interrupt when its runtime tool is unavailable or its schema has changed

--- a/packages/ai-persistence/tests/interrupts.test.ts
+++ b/packages/ai-persistence/tests/interrupts.test.ts
@@ -592,7 +592,7 @@ describe('interrupt persistence', () => {
   // and must therefore put the cancelled toolCallId on `cancelledToolCallIds`.
   // Otherwise the engine treats the stored tool call as unhandled and emits
   // another `client_tool_*` interrupt instead of an output-error.
-  it('completes a cancelled client-tool resume from persisted state with empty client messages', async () => {
+  it('completes a cancelled client-tool resume after its output schema changes', async () => {
     const persistence = memoryPersistence()
     await persistClientToolTurn(persistence, [clientTool('clientSearch')])
 
@@ -608,7 +608,12 @@ describe('interrupt persistence', () => {
       chat({
         adapter: afterCancel.adapter,
         messages: [],
-        tools: [clientTool('clientSearch')],
+        tools: [
+          {
+            ...clientTool('clientSearch'),
+            outputSchema: transformedDisplaySchema,
+          },
+        ],
         runId: 'r1',
         threadId: 't1',
         resume: [

--- a/packages/ai/src/interrupt-resume.ts
+++ b/packages/ai/src/interrupt-resume.ts
@@ -445,6 +445,20 @@ export async function validateInterruptResumeBatch(
       continue
     }
 
+    if (entry.status === 'cancelled') {
+      if (entry.payload !== undefined) {
+        errors.push(
+          interruptItemError(
+            input,
+            record.interruptId,
+            'invalid-payload',
+            `Cancelled interrupt ${record.interruptId} must not include a payload.`,
+          ),
+        )
+      }
+      continue
+    }
+
     const tool = runtimeTool(input.tools, binding.toolName)
     if (!tool) {
       errors.push(
@@ -511,19 +525,6 @@ export async function validateInterruptResumeBatch(
       }
     }
 
-    if (entry.status === 'cancelled') {
-      if (entry.payload !== undefined) {
-        errors.push(
-          interruptItemError(
-            input,
-            record.interruptId,
-            'invalid-payload',
-            `Cancelled interrupt ${record.interruptId} must not include a payload.`,
-          ),
-        )
-      }
-      continue
-    }
     if (schemaDrifted) continue
 
     if (binding.kind === 'client-tool-execution') {

--- a/packages/ai/tests/interrupt-resume.test.ts
+++ b/packages/ai/tests/interrupt-resume.test.ts
@@ -237,6 +237,23 @@ describe('validateInterruptResumeBatch', () => {
     ).toBe(true)
   })
 
+  it('accepts a cancelled approval when its runtime tool is unavailable', async () => {
+    const fixture = approvalFixture()
+    const result = await validateInterruptResumeBatch({
+      ...baseInput(pendingOf(fixture), [
+        {
+          interruptId: fixture.binding.interruptId,
+          status: 'cancelled',
+        },
+      ]),
+      tools: [],
+    })
+    expect(result.errors).toEqual([])
+    expect(result.resumeToolState?.cancelledToolCallIds).toEqual(
+      new Set(['call-1']),
+    )
+  })
+
   it('rejects invalid status values', async () => {
     const fixture = approvalFixture()
     const result = await validateInterruptResumeBatch(

--- a/testing/e2e/src/routes/api.interrupts-test.ts
+++ b/testing/e2e/src/routes/api.interrupts-test.ts
@@ -146,6 +146,20 @@ export const Route = createFileRoute('/api/interrupts-test')({
         const aimockPort =
           fp.aimockPort != null ? Number(fp.aimockPort) : undefined
         const isGeneric = scenario === 'feeding'
+        const scenarioTools = getServerToolsForScenario(scenario)
+        // The admit cancellation reproduces a stale approval after its schema changed.
+        const tools =
+          scenario === 'admit' &&
+          params.resume?.some((entry) => entry.status === 'cancelled')
+            ? scenarioTools.map((tool) => ({
+                ...tool,
+                inputSchema: z.object({
+                  species: z.string(),
+                  name: z.string(),
+                  source: z.string().optional(),
+                }),
+              }))
+            : scenarioTools
 
         const abortController = new AbortController()
 
@@ -153,7 +167,7 @@ export const Route = createFileRoute('/api/interrupts-test')({
           const stream = chat({
             ...createTextAdapter('openai', undefined, aimockPort, testId),
             messages: params.messages,
-            tools: getServerToolsForScenario(scenario),
+            tools,
             agentLoopStrategy: maxIterations(8),
             threadId: params.threadId,
             runId: params.runId,


### PR DESCRIPTION
Fixes #1215

## 🎯 Changes

- Allows cancelled interrupt resumes when the runtime tool is unavailable or its schema has changed, while preserving cancellation payload validation.

- Adds core, persistence, and focused E2E regression coverage.

- Docs were skipped because the existing interrupt documentation already describes this cancellation behavior.

- A patch changeset is still required before opening this PR because it changes a published package.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Cancelled tool approvals now resume successfully even when the tool is unavailable or its input schema has changed.
- Prevented unnecessary validation for cancelled operations.
- Preserved cancellation status and completion behavior during interrupted workflows.

## Tests

- Added coverage for cancelled approvals involving unavailable tools.
- Added regression coverage for resuming cancelled interrupts after schema changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->