### PR TITLE
fix(ai-client): ignore stale interrupt submissions

### DIFF
--- a/.changeset/fresh-interrupt-submissions.md
+++ b/.changeset/fresh-interrupt-submissions.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-client': patch
+---
+
+Prevent stale interrupt submissions from mutating reset or rehydrated state.

--- a/packages/ai-client/src/interrupt-manager.ts
+++ b/packages/ai-client/src/interrupt-manager.ts
@@ -102,6 +102,10 @@ interface TransactionToken {
   active: boolean
 }
 
+interface SubmissionOperation {
+  submission: InterruptManagerSubmission
+}
+
 interface RuntimeInterruptCheckpoint {
   status: InterruptItemStatus
   resolution?: RunAgentResumeItem
@@ -511,6 +515,7 @@ export class InterruptManager<
     resuming: false,
   })
   private activeTransaction: TransactionToken | undefined
+  private activeSubmissionOperation: SubmissionOperation | undefined
   private retrySubmission: InterruptManagerSubmission | undefined
   private resuming = false
   private tools: TTools | undefined
@@ -544,6 +549,7 @@ export class InterruptManager<
     hydration: InterruptManagerHydration,
     source: InterruptManagerChangeSource = 'live',
   ): void {
+    this.activeSubmissionOperation = undefined
     this.hydration = {
       threadId: hydration.threadId,
       interruptedRunId: hydration.interruptedRunId,
@@ -597,6 +603,7 @@ export class InterruptManager<
     preserveRootErrors?: boolean
     source?: InterruptManagerChangeSource
   }): void {
+    this.activeSubmissionOperation = undefined
     this.hydration = undefined
     this.items = []
     this.snapshot = Object.freeze([])
@@ -1528,25 +1535,32 @@ export class InterruptManager<
   }
 
   private submitBatch(submission: InterruptManagerSubmission): void {
+    // Track ownership so a superseded submission cannot mutate current state.
+    const operation = { submission }
+    this.activeSubmissionOperation = operation
     this.resuming = true
     this.retrySubmission = undefined
     for (const item of this.items) {
       if (isClientOwnedInterrupt(item)) item.status = 'submitting'
     }
     this.publish()
-    void this.performSubmission(submission)
+    void this.performSubmission(operation)
   }
 
   private async performSubmission(
-    submission: InterruptManagerSubmission,
+    operation: SubmissionOperation,
   ): Promise<void> {
     try {
-      await this.options.submit(submission)
+      await this.options.submit(operation.submission)
     } catch (error) {
-      this.handleSubmissionFailure(error, submission)
+      if (this.activeSubmissionOperation !== operation) return
+      this.handleSubmissionFailure(error, operation.submission)
     } finally {
-      this.resuming = false
-      this.publish()
+      if (this.activeSubmissionOperation === operation) {
+        this.activeSubmissionOperation = undefined
+        this.resuming = false
+        this.publish()
+      }
     }
   }
 

--- a/packages/ai-client/tests/chat-client-interrupts.test.ts
+++ b/packages/ai-client/tests/chat-client-interrupts.test.ts
@@ -967,6 +967,93 @@ describe('InterruptManager transactions', () => {
     expect(submit).toHaveBeenCalledTimes(2)
   })
 
+  it('ignores a submission failure after reset', async () => {
+    let rejectSubmission!: (reason?: unknown) => void
+    const submit = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSubmission = reject
+        }),
+    )
+    const manager = new InterruptManager({ submit })
+    manager.hydrate({
+      threadId: 'thread-1',
+      interruptedRunId: 'run-1',
+      generation: 1,
+      interrupts: [genericDescriptor('generic')],
+    })
+    const item = manager.getInterrupts()[0]
+    if (item?.kind !== 'generic') throw new Error('Expected generic interrupt')
+    item.resolveInterrupt('answer')
+
+    manager.reset()
+    const resetState = manager.getState()
+    rejectSubmission(new Error('offline'))
+    await settle()
+
+    expect(manager.getState()).toBe(resetState)
+    expect(manager.getInterruptErrors()).toEqual([])
+    expect(manager.getResuming()).toBe(false)
+  })
+
+  it('does not let a stale submission settle a rehydrated submission', async () => {
+    const operations: Array<{
+      resolve: () => void
+      reject: (reason?: unknown) => void
+    }> = []
+    const submit = vi.fn(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          operations.push({ resolve, reject })
+        }),
+    )
+    const manager = new InterruptManager({ submit })
+    manager.hydrate({
+      threadId: 'thread-1',
+      interruptedRunId: 'run-1',
+      generation: 1,
+      interrupts: [genericDescriptor('old')],
+    })
+    const oldItem = manager.getInterrupts()[0]
+    if (oldItem?.kind !== 'generic') {
+      throw new Error('Expected generic interrupt')
+    }
+    oldItem.resolveInterrupt('old answer')
+
+    manager.hydrate({
+      threadId: 'thread-1',
+      interruptedRunId: 'run-2',
+      generation: 2,
+      interrupts: [
+        descriptor({
+          v: INTERRUPT_BINDING_VERSION,
+          kind: 'generic',
+          interruptId: 'current',
+          interruptedRunId: 'run-2',
+          generation: 2,
+          responseSchemaHash: 'none',
+        }),
+      ],
+    })
+    const currentItem = manager.getInterrupts()[0]
+    if (currentItem?.kind !== 'generic') {
+      throw new Error('Expected generic interrupt')
+    }
+    currentItem.resolveInterrupt('current answer')
+
+    expect(operations).toHaveLength(2)
+    operations[0]!.reject(new Error('old failure'))
+    await settle()
+
+    expect(manager.getInterruptErrors()).toEqual([])
+    expect(manager.getResuming()).toBe(true)
+    expect(manager.getInterrupts()).toEqual([])
+
+    operations[1]!.resolve()
+    await settle()
+    expect(manager.getResuming()).toBe(false)
+  })
+
   it('does not enable retry for expired/stale/conflict server failures', async () => {
     for (const code of ['expired', 'stale', 'conflict'] as const) {
       const submit = vi.fn(async () => {

--- a/testing/e2e/src/routes/interrupts-test.tsx
+++ b/testing/e2e/src/routes/interrupts-test.tsx
@@ -113,6 +113,7 @@ function InterruptsTestPage() {
     sendMessage,
     isLoading,
     stop,
+    clear,
     interrupts,
     resolveInterrupts,
     cancelInterrupts,
@@ -345,6 +346,9 @@ function InterruptsTestPage() {
             Stop
           </button>
         )}
+        <button id="clear-button" onClick={clear}>
+          Clear
+        </button>
       </div>
 
       {/* Tool-approval interrupts */}

--- a/testing/e2e/tests/interrupts-test/batch.spec.ts
+++ b/testing/e2e/tests/interrupts-test/batch.spec.ts
@@ -113,6 +113,36 @@ test.describe('Batch interrupt resolution', () => {
     ).toBe(true)
   })
 
+  test('clear ignores a late interrupt submission failure', async ({
+    page,
+    testId,
+    aimockPort,
+  }) => {
+    const pageErrors: Array<Error> = []
+    page.on('pageerror', (error) => pageErrors.push(error))
+
+    await selectScenario(page, 'batch', testId, aimockPort)
+    await runTest(page)
+    await waitForApproval(page)
+    await waitForPendingApprovals(page, 3)
+
+    await approveAll(page)
+    await page.waitForFunction(
+      () =>
+        document
+          .getElementById('test-metadata')
+          ?.getAttribute('data-is-loading') === 'true',
+    )
+    await page.click('#clear-button')
+    await page.waitForTimeout(200)
+
+    const meta = await getMetadata(page)
+    expect(meta.hasError).toBe('false')
+    expect(meta.isLoading).toBe('false')
+    expect(meta.interruptCount).toBe('0')
+    expect(pageErrors).toEqual([])
+  })
+
   test.afterEach(async ({ page }, testInfo) => {
     if (testInfo.status !== testInfo.expectedStatus) {
       console.log('Metadata:', await getMetadata(page))


### PR DESCRIPTION
Fixes #1218

## 🎯 Changes

- Ignore late interrupt submission failures after the client is cleared, reset, or rehydrated.
- Track submission ownership so stale cleanup cannot overwrite the current loading, error, or interrupt state.
- Add unit and focused E2E regression coverage for late submission failures.
- The fix is in the shared AI client, so React, Solid, Vue, and Svelte need no framework-specific changes.
- Add a patch changeset for `@tanstack/ai-client`; docs were skipped because there is no public API or usage change.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale interrupt submission failures from changing chat state after a reset or rehydration.
  * Improved reliability when clearing an active batch run during loading.

* **New Features**
  * Added a Clear action to interrupt test controls, allowing chat state to be reset.

* **Tests**
  * Added coverage for reset, rehydration, and late submission failures to ensure obsolete operations are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->