### PR TITLE
feat: add Lovable AI Gateway adapter

### DIFF
--- a/.changeset/lovable-gateway.md
+++ b/.changeset/lovable-gateway.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-lovable': minor
+---
+
+Add a Lovable AI Gateway adapter for chat, embeddings, image, video, speech, transcription, and BYOK

--- a/docs/adapters/lovable.md
+++ b/docs/adapters/lovable.md
@@ -1,0 +1,264 @@
+---
+title: Lovable AI Gateway
+id: lovable-adapter
+description: "Use one Lovable API key to call Google and OpenAI models through Lovable AI Gateway. Chat, embeddings, image, video, speech, and transcription all work with @tanstack/ai-lovable."
+keywords:
+  - tanstack ai
+  - lovable
+  - ai gateway
+  - adapter
+  - chat
+  - responses
+  - embeddings
+  - image generation
+  - video generation
+  - tts
+  - transcription
+---
+
+Install `@tanstack/ai-lovable`. Then call `lovableText` with a model id such as `google/gemini-3.7-flash`.
+
+Lovable AI Gateway sits in front of Google and OpenAI models. You use one project key. You do not set up a provider account.
+
+## Installation
+
+```bash
+npm install @tanstack/ai-lovable
+```
+
+## Auth
+
+Set `LOVABLE_API_KEY`. Lovable creates this key for each Cloud project.
+
+```bash
+export LOVABLE_API_KEY="..."
+```
+
+You can also pass the key to a `create*` factory:
+
+```typescript
+import { createLovableText } from "@tanstack/ai-lovable"
+
+const adapter = createLovableText(
+  "google/gemini-3.7-flash",
+  process.env.LOVABLE_API_KEY!,
+)
+```
+
+The adapter sends `Authorization: Bearer`, `Lovable-API-Key`, and `X-Lovable-AIG-SDK: tanstack-ai`. Calls go to `https://ai.gateway.lovable.dev/v1`.
+
+## Chat
+
+The default adapter uses the OpenAI Responses API. Model ids use the `google/` or `openai/` form.
+
+**Server.** An endpoint that streams the reply over SSE:
+
+```typescript
+import { chat, toServerSentEventsResponse } from "@tanstack/ai"
+import { lovableText } from "@tanstack/ai-lovable"
+
+export async function POST(request: Request) {
+  const { messages } = await request.json()
+
+  const stream = chat({
+    adapter: lovableText("google/gemini-3.7-flash"),
+    messages,
+  })
+
+  return toServerSentEventsResponse(stream)
+}
+```
+
+**Client.** The same `useChat` hook as every other provider:
+
+```tsx
+import { useState } from "react"
+import { fetchServerSentEvents, useChat } from "@tanstack/ai-react"
+
+export function Chat() {
+  const [input, setInput] = useState("")
+
+  const { messages, sendMessage, isLoading } = useChat({
+    connection: fetchServerSentEvents("/api/chat"),
+  })
+
+  return (
+    <div>
+      {messages.map((message) => (
+        <div key={message.id}>
+          <strong>{message.role}</strong>
+          {message.parts.map((part, index) =>
+            part.type === "text" ? <p key={index}>{part.content}</p> : null,
+          )}
+        </div>
+      ))}
+
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          if (!input.trim() || isLoading) return
+          sendMessage(input)
+          setInput("")
+        }}
+      >
+        <input value={input} onChange={(event) => setInput(event.target.value)} />
+        <button type="submit" disabled={isLoading}>
+          Send
+        </button>
+      </form>
+    </div>
+  )
+}
+```
+
+## Chat Completions
+
+Pass `{ api: "chat" }` when the model must talk to Chat Completions. The default is Responses.
+
+```typescript
+import { chat } from "@tanstack/ai"
+import { lovableText } from "@tanstack/ai-lovable"
+
+const stream = chat({
+  adapter: lovableText("openai/gpt-5.5", { api: "chat" }),
+  messages: [{ role: "user", content: "Hello" }],
+})
+```
+
+`api: "responses"` is the same as the default. `api: "chat-completions"` is the same as `api: "chat"`.
+
+## Summarize
+
+```typescript
+import { summarize } from "@tanstack/ai"
+import { lovableSummarize } from "@tanstack/ai-lovable"
+
+const result = await summarize({
+  adapter: lovableSummarize("google/gemini-3.7-flash"),
+  text: "The Fender Stratocaster is a versatile electric guitar.",
+})
+```
+
+## Images
+
+Generate a new image, or pass image parts to edit one. OpenAI image models also accept a mask part (`metadata.role === "mask"`).
+
+```typescript
+import { generateImage } from "@tanstack/ai"
+import { lovableImage } from "@tanstack/ai-lovable"
+
+const result = await generateImage({
+  adapter: lovableImage("openai/gpt-image-2"),
+  prompt: "a red guitar on a wooden bench",
+})
+```
+
+## Video
+
+Video jobs are async. Create a job, poll status, then fetch the MP4 URL. Clips last 4, 6, or 8 seconds. 1080p and 4K clips are always 8 seconds. 4K works only on `google/veo-3.1-fast` and `google/veo-3.1`.
+
+```typescript
+import { generateVideo } from "@tanstack/ai"
+import { lovableVideo } from "@tanstack/ai-lovable"
+
+const { jobId } = await generateVideo({
+  adapter: lovableVideo("google/veo-3.1-lite"),
+  prompt: "a red guitar on a wooden bench, slow camera push-in",
+  duration: 4,
+  size: "1280x720",
+})
+```
+
+Then poll `getVideoJobStatus` with that `jobId`. When the job is complete, the result includes the MP4 URL.
+
+Pass one image part in `prompt` to animate a still frame.
+
+## Embeddings
+
+```typescript
+import { embed } from "@tanstack/ai"
+import { lovableEmbedding } from "@tanstack/ai-lovable"
+
+const result = await embed({
+  adapter: lovableEmbedding("google/gemini-embedding-2"),
+  input: "a red guitar",
+})
+
+console.log(result.embeddings[0]?.vector)
+```
+
+## Speech
+
+```typescript
+import { generateSpeech } from "@tanstack/ai"
+import { lovableSpeech } from "@tanstack/ai-lovable"
+
+const result = await generateSpeech({
+  adapter: lovableSpeech("openai/gpt-4o-mini-tts"),
+  text: "Welcome to the guitar shop.",
+  voice: "nova",
+})
+```
+
+## Transcription
+
+```typescript
+import { generateTranscription } from "@tanstack/ai"
+import { lovableTranscription } from "@tanstack/ai-lovable"
+
+const audio = await fetch("/voice-note.mp3").then((response) => response.blob())
+
+const result = await generateTranscription({
+  adapter: lovableTranscription("openai/gpt-4o-mini-transcribe"),
+  audio,
+  language: "en",
+})
+
+console.log(result.text)
+```
+
+## Bring Your Own Key
+
+Users can paste a Lovable project key in the browser. Import `lovableByok` from `@tanstack/ai-lovable/byok`, not from the package main entry.
+
+```typescript
+import { createLovableText } from "@tanstack/ai-lovable"
+import { lovableByok } from "@tanstack/ai-lovable/byok"
+import { byokMissing, getByokKey } from "@tanstack/ai/byok/server"
+
+export async function POST(request: Request) {
+  const apiKey = getByokKey(request, lovableByok)
+  if (!apiKey) return byokMissing(lovableByok)
+
+  const adapter = createLovableText("google/gemini-3.7-flash", apiKey)
+  // ...
+}
+```
+
+See [Bring Your Own Key](../advanced/byok) for the client store and a save UI.
+
+## Models
+
+Pass any model id the gateway accepts. Curated ids get type metadata.
+
+Chat:
+
+- Default: `google/gemini-3.7-flash`
+- Fast OpenAI: `openai/gpt-5.5`
+
+Image, video, embeddings, and speech:
+
+- Image default: `openai/gpt-image-2`
+- Video default: `google/veo-3.1-lite`
+- Embedding default: `google/gemini-embedding-2`
+- Speech default: `openai/gpt-4o-mini-tts`
+- Transcription default: `openai/gpt-4o-mini-transcribe`
+
+The curated lists are `LOVABLE_CHAT_MODELS`, `LOVABLE_IMAGE_MODELS`, `LOVABLE_VIDEO_MODELS`, `LOVABLE_EMBEDDING_MODELS`, `LOVABLE_TTS_MODELS`, and `LOVABLE_TRANSCRIPTION_MODELS`.
+
+## Errors
+
+- `429 Too Many Requests`: the workspace hit its request-per-minute limit.
+- `402 Payment Required`: the workspace is out of credits.
+
+See [Lovable AI features](https://docs.lovable.dev/features/ai) for models, credits, and rate limits.

--- a/docs/adapters/openai-compatible.md
+++ b/docs/adapters/openai-compatible.md
@@ -21,7 +21,7 @@ keywords:
 
 Many providers expose the OpenAI **Chat Completions** API (`/chat/completions`) — DeepSeek, Moonshot/Kimi, Together, Fireworks, Cerebras, Alibaba Qwen, Perplexity, NVIDIA NIM, and local servers like LM Studio, Ollama, and vLLM. Instead of a dedicated package per provider, TanStack AI ships one generic adapter: point it at any compatible `baseURL`, give it your models, and you get the same type-safe `chat()` experience as the first-class adapters.
 
-Use this when your provider speaks the OpenAI Chat Completions wire format but doesn't have its own `@tanstack/ai-*` package. If a dedicated adapter exists (OpenAI, Grok, Groq, OpenRouter), prefer it — those carry curated per-model metadata. For Vercel AI Gateway, install `@tanstack/ai-vercel-gateway` and use `vercelGatewayText`. See [Vercel AI Gateway](./vercel-gateway.md).
+Use this when your provider speaks the OpenAI Chat Completions wire format but doesn't have its own `@tanstack/ai-*` package. If a dedicated adapter exists (OpenAI, Grok, Groq, OpenRouter), prefer it. Those carry curated per-model metadata. For Vercel AI Gateway, install `@tanstack/ai-vercel-gateway` and use `vercelGatewayText`. See [Vercel AI Gateway](./vercel-gateway.md). For Lovable AI Gateway, install `@tanstack/ai-lovable` and use `lovableText` (plus image, video, embeddings, and speech factories). See [Lovable AI Gateway](./lovable.md).
 
 Perplexity Sonar chat stays on this adapter. [`@tanstack/ai-perplexity`](./perplexity.md) is Search/grounding only — it does not replace `openaiCompatible` for `chat()`. Optional: pass `defaultHeaders: getPerplexityIntegrationHeaders()` from that package to send Perplexity's `X-Pplx-Integration` attribution header.
 

--- a/docs/advanced/byok.md
+++ b/docs/advanced/byok.md
@@ -179,3 +179,4 @@ For other cases:
 
 - Image and audio POSTs use the same store. See [Generation Hooks](../media/generation-hooks#usegenerateaudio).
 - OpenRouter can mint a key with OAuth. See [Sign in with OpenRouter](../adapters/openrouter#sign-in-with-openrouter-byok).
+- Lovable uses `lovableByok` from `@tanstack/ai-lovable/byok`. See [Lovable AI Gateway](../adapters/lovable#bring-your-own-key).

--- a/docs/config.json
+++ b/docs/config.json
@@ -13,7 +13,7 @@
           "label": "Overview",
           "to": "getting-started/overview",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-08-21"
+          "updatedAt": "2026-08-24"
         },
         {
           "label": "Quick Start: React",
@@ -394,7 +394,7 @@
           "label": "Streaming UIs",
           "to": "structured-outputs/streaming",
           "addedAt": "2026-05-19",
-          "updatedAt": "2026-08-20"
+          "updatedAt": "2026-08-24"
         },
         {
           "label": "Multi-Turn Chat",
@@ -765,7 +765,7 @@
           "label": "Bring Your Own Key",
           "to": "advanced/byok",
           "addedAt": "2026-08-18",
-          "updatedAt": "2026-08-22"
+          "updatedAt": "2026-08-24"
         },
         {
           "label": "Debug Logging",
@@ -984,10 +984,16 @@
           "updatedAt": "2026-08-12"
         },
         {
+          "label": "Lovable AI Gateway",
+          "to": "adapters/lovable",
+          "addedAt": "2026-08-24",
+          "updatedAt": "2026-08-24"
+        },
+        {
           "label": "OpenAI-Compatible",
           "to": "adapters/openai-compatible",
           "addedAt": "2026-06-01",
-          "updatedAt": "2026-08-13"
+          "updatedAt": "2026-08-24"
         },
         {
           "label": "LLM Gateway",

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -125,6 +125,7 @@ With the help of adapters, TanStack AI can connect to various LLM providers. Ava
 - **@tanstack/ai-byteplus** - BytePlus (Seed chat, Seedance video, Seedream image, Seed Speech)
 - **@tanstack/ai-fal** - fal (image & video generation)
 - **@tanstack/ai-llmgateway** - LLM Gateway (hundreds of models via one OpenAI-compatible endpoint, self-hostable)
+- **@tanstack/ai-lovable** - Lovable AI Gateway (Google and OpenAI chat, image, video, embeddings, and speech via one project key)
 
 ## Next Steps
 

--- a/docs/structured-outputs/streaming.md
+++ b/docs/structured-outputs/streaming.md
@@ -187,6 +187,7 @@ Streaming structured output works with **every adapter**, but only some support 
 | `@tanstack/ai-bedrock` | Native stream through Converse or an OpenAI-compatible API |
 | `@tanstack/ai-byteplus` | Native single-request stream on supported models; unsupported models emit `RUN_ERROR` |
 | `@tanstack/ai-llmgateway` | Native single-request stream (Chat Completions, `response_format: json_schema`) |
+| `@tanstack/ai-lovable` | Native single-request stream (Responses or Chat Completions) |
 | Other adapters (anthropic, gemini, ollama, …) | Fallback: runs non-streaming `structuredOutput` and emits the final object as one `structured-output.complete` event |
 
 The fallback path keeps the consumer code identical across providers — you always read the final object off `structured-output.complete` — but you won't see incremental deltas unless the adapter implements `structuredOutputStream` natively.

--- a/packages/ai-lovable/LICENSE
+++ b/packages/ai-lovable/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Tanner Linsley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/ai-lovable/README.md
+++ b/packages/ai-lovable/README.md
@@ -1,0 +1,37 @@
+# @tanstack/ai-lovable
+
+Lovable AI Gateway adapter for TanStack AI.
+
+## Installation
+
+```bash
+npm install @tanstack/ai-lovable
+```
+
+## Auth
+
+Set `LOVABLE_API_KEY`. Lovable creates this key per Cloud project.
+
+```bash
+export LOVABLE_API_KEY="..."
+```
+
+You can also pass the key to a `create*` factory.
+
+## Usage
+
+```typescript
+import { chat } from '@tanstack/ai'
+import { lovableText } from '@tanstack/ai-lovable'
+
+const adapter = lovableText('google/gemini-3.7-flash')
+
+const stream = chat({
+  adapter,
+  messages: [{ role: 'user', content: 'Hello' }],
+})
+```
+
+The default text adapter uses the Responses API. Pass `{ api: 'chat' }` for Chat Completions.
+
+See [docs/adapters/lovable.md](../../docs/adapters/lovable.md) for chat, images, video, embeddings, speech, transcription, and BYOK.

--- a/packages/ai-lovable/package.json
+++ b/packages/ai-lovable/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@tanstack/ai-lovable",
+  "version": "0.0.0",
+  "description": "Lovable AI Gateway adapter for TanStack AI chat, embeddings, image, video, speech, and transcription.",
+  "author": "Tanner Linsley",
+  "license": "MIT",
+  "homepage": "https://tanstack.com/ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TanStack/ai.git",
+    "directory": "packages/ai-lovable"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/ai/issues"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
+  "type": "module",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js"
+    },
+    "./byok": {
+      "types": "./dist/esm/byok.d.ts",
+      "import": "./dist/esm/byok.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "clean": "premove ./build ./dist",
+    "lint:fix": "oxlint src --type-aware --fix",
+    "test:build": "publint --strict",
+    "test:oxlint": "oxlint src --type-aware",
+    "test:lib": "vitest run",
+    "test:lib:dev": "pnpm test:lib --watch",
+    "test:types": "tsc"
+  },
+  "keywords": [
+    "ai",
+    "ai-sdk",
+    "typescript",
+    "tanstack",
+    "lovable",
+    "ai-gateway",
+    "adapter",
+    "llm",
+    "chat",
+    "embeddings",
+    "image-generation",
+    "video-generation",
+    "tts",
+    "transcription",
+    "streaming"
+  ],
+  "devDependencies": {
+    "@tanstack/ai": "workspace:*",
+    "@vitest/coverage-v8": "4.1.10",
+    "vite": "^8.2.1",
+    "zod": "^4.2.0"
+  },
+  "peerDependencies": {
+    "@tanstack/ai": "workspace:^",
+    "zod": "^4.0.0"
+  },
+  "dependencies": {
+    "@tanstack/ai-utils": "workspace:^",
+    "@tanstack/openai-base": "workspace:^",
+    "openai": "^6.41.0"
+  }
+}

--- a/packages/ai-lovable/src/adapters/embedding.ts
+++ b/packages/ai-lovable/src/adapters/embedding.ts
@@ -1,0 +1,102 @@
+import OpenAI from 'openai'
+import { BaseEmbeddingAdapter } from '@tanstack/ai/adapters'
+import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
+import { generateId } from '@tanstack/ai-utils'
+import { requireTextOnlyEmbeddingInput } from '@tanstack/ai'
+import { getLovableApiKeyFromEnv, withLovableDefaults } from '../utils/client'
+import type {
+  EmbeddingOptions,
+  EmbeddingResult,
+  TokenUsage,
+} from '@tanstack/ai'
+import type OpenAI_SDK from 'openai'
+import type {
+  LovableEmbeddingModel,
+  LovableEmbeddingModelInputModalitiesByName,
+  LovableEmbeddingModelProviderOptionsByName,
+} from '../model-meta'
+import type { LovableEmbeddingProviderOptions } from '../embedding/embedding-provider-options'
+import type { LovableClientConfig } from '../utils/client'
+
+export interface LovableEmbeddingConfig extends LovableClientConfig {}
+
+export class LovableEmbeddingAdapter<
+  TModel extends LovableEmbeddingModel,
+> extends BaseEmbeddingAdapter<
+  TModel,
+  LovableEmbeddingProviderOptions,
+  LovableEmbeddingModelProviderOptionsByName,
+  LovableEmbeddingModelInputModalitiesByName
+> {
+  readonly name = 'lovable' as const
+
+  protected client: OpenAI
+
+  constructor(config: LovableEmbeddingConfig, model: TModel) {
+    super(model, {})
+    this.client = new OpenAI(withLovableDefaults(config))
+  }
+
+  async createEmbeddings(
+    options: EmbeddingOptions<LovableEmbeddingProviderOptions>,
+  ): Promise<EmbeddingResult> {
+    const { model, logger, modelOptions } = options
+    const texts = requireTextOnlyEmbeddingInput(options.input, this.name, model)
+
+    try {
+      const request: OpenAI_SDK.EmbeddingCreateParams = {
+        ...modelOptions,
+        model,
+        input: texts,
+        encoding_format: 'float',
+      }
+      if (options.dimensions !== undefined) {
+        request.dimensions = options.dimensions
+      }
+
+      logger.request(
+        `activity=embed provider=${this.name} model=${model} inputs=${texts.length}`,
+        { provider: this.name, model },
+      )
+
+      const response = await this.client.embeddings.create(request)
+
+      const usage: TokenUsage = {
+        promptTokens: response.usage.prompt_tokens,
+        completionTokens: 0,
+        totalTokens: response.usage.total_tokens,
+      }
+
+      return {
+        id: generateId(this.name),
+        model,
+        embeddings: response.data.map((item) => ({
+          vector: item.embedding,
+          index: item.index,
+        })),
+        usage,
+      }
+    } catch (error: unknown) {
+      logger.errors(`${this.name}.createEmbeddings fatal`, {
+        error: toRunErrorPayload(error, `${this.name}.createEmbeddings failed`),
+        source: `${this.name}.createEmbeddings`,
+      })
+      throw error
+    }
+  }
+}
+
+export function createLovableEmbedding<TModel extends LovableEmbeddingModel>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<LovableEmbeddingConfig, 'apiKey'>,
+): LovableEmbeddingAdapter<TModel> {
+  return new LovableEmbeddingAdapter({ apiKey, ...config }, model)
+}
+
+export function lovableEmbedding<TModel extends LovableEmbeddingModel>(
+  model: TModel,
+  config?: Omit<LovableEmbeddingConfig, 'apiKey'>,
+): LovableEmbeddingAdapter<TModel> {
+  return createLovableEmbedding(model, getLovableApiKeyFromEnv(), config)
+}

--- a/packages/ai-lovable/src/adapters/factory.ts
+++ b/packages/ai-lovable/src/adapters/factory.ts
@@ -1,0 +1,78 @@
+import { getLovableApiKeyFromEnv } from '../utils/client'
+import { LovableTextAdapter } from './text'
+import { LovableResponsesTextAdapter } from './responses-text'
+import type { LovableClientConfig } from '../utils/client'
+import type { LovableTextConfig } from './text'
+import type { LovableResponsesTextConfig } from './responses-text'
+import type { LovableModelId } from '../model-meta'
+
+export type LovableTextApi = 'responses' | 'chat' | 'chat-completions'
+
+/** Config for the branching factory's Responses mode (default, or api: 'responses'). */
+export type LovableResponsesApiConfig = Omit<
+  LovableResponsesTextConfig,
+  'apiKey'
+> & {
+  api?: 'responses'
+}
+
+/** Config for the branching factory's Chat Completions mode (api required). */
+export type LovableChatApiConfig = Omit<LovableTextConfig, 'apiKey'> & {
+  api: 'chat' | 'chat-completions'
+}
+
+type AnyLovableTextAdapter<TModel extends LovableModelId> =
+  | LovableResponsesTextAdapter<TModel>
+  | LovableTextAdapter<TModel>
+
+function stripApi<T extends { api?: unknown }>(config: T): Omit<T, 'api'> {
+  const { api, ...rest } = config
+  void api
+  return rest
+}
+
+function build<TModel extends LovableModelId>(
+  model: TModel,
+  config: LovableClientConfig & { api?: LovableTextApi },
+): AnyLovableTextAdapter<TModel> {
+  if (config.api === 'chat' || config.api === 'chat-completions') {
+    return new LovableTextAdapter(stripApi(config), model)
+  }
+  return new LovableResponsesTextAdapter(stripApi(config), model)
+}
+
+export function createLovableText<TModel extends LovableModelId>(
+  model: TModel,
+  apiKey: string,
+  config?: LovableResponsesApiConfig,
+): LovableResponsesTextAdapter<TModel>
+export function createLovableText<TModel extends LovableModelId>(
+  model: TModel,
+  apiKey: string,
+  config: LovableChatApiConfig,
+): LovableTextAdapter<TModel>
+export function createLovableText<TModel extends LovableModelId>(
+  model: TModel,
+  apiKey: string,
+  config?: LovableResponsesApiConfig | LovableChatApiConfig,
+): AnyLovableTextAdapter<TModel> {
+  return build(model, { ...config, apiKey })
+}
+
+export function lovableText<TModel extends LovableModelId>(
+  model: TModel,
+  config?: LovableResponsesApiConfig,
+): LovableResponsesTextAdapter<TModel>
+export function lovableText<TModel extends LovableModelId>(
+  model: TModel,
+  config: LovableChatApiConfig,
+): LovableTextAdapter<TModel>
+export function lovableText<TModel extends LovableModelId>(
+  model: TModel,
+  config?: LovableResponsesApiConfig | LovableChatApiConfig,
+): AnyLovableTextAdapter<TModel> {
+  return build(model, {
+    ...config,
+    apiKey: getLovableApiKeyFromEnv(),
+  })
+}

--- a/packages/ai-lovable/src/adapters/image.ts
+++ b/packages/ai-lovable/src/adapters/image.ts
@@ -1,0 +1,279 @@
+import OpenAI from 'openai'
+import { resolveMediaPrompt } from '@tanstack/ai'
+import { BaseImageAdapter } from '@tanstack/ai/adapters'
+import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
+import { buildImagesUsage } from '@tanstack/openai-base'
+import { generateId } from '@tanstack/ai-utils'
+import { getLovableApiKeyFromEnv, withLovableDefaults } from '../utils/client'
+import { imagePartToFile } from '../image/image-input-to-file'
+import type {
+  GeneratedImage,
+  ImageGenerationOptions,
+  ImageGenerationResult,
+  ImagePart,
+  MediaInputMetadata,
+} from '@tanstack/ai'
+import type OpenAI_SDK from 'openai'
+import type {
+  LovableImageModel,
+  LovableImageModelInputModalitiesByName,
+  LovableImageModelProviderOptionsByName,
+  LovableImageModelSizeByName,
+} from '../model-meta'
+import type { LovableImageProviderOptions } from '../image/image-provider-options'
+import type { LovableClientConfig } from '../utils/client'
+
+const MAX_EDIT_IMAGES = 16
+
+export interface LovableImageConfig extends LovableClientConfig {
+  /**
+   * Opt into fetching HTTP(S) image URL inputs for image edits. The gateway
+   * `/images/edits` endpoint requires uploaded file bytes, so an HTTP(S) URL
+   * has to be downloaded and buffered in memory. When `false` (the default),
+   * HTTP(S) URL image inputs throw.
+   */
+  allowUrlFetch?: boolean
+}
+
+function supportsImageMask(model: string): boolean {
+  return model.startsWith('openai/')
+}
+
+function generatedImagesFromResponse(
+  data:
+    | Array<{
+        b64_json?: string | null
+        url?: string | null
+        revised_prompt?: string | null
+      }>
+    | undefined
+    | null,
+  emptyMessage: string,
+): Array<GeneratedImage> {
+  const images: Array<GeneratedImage> = (data ?? []).flatMap(
+    (item): Array<GeneratedImage> => {
+      const revisedPromptField =
+        item.revised_prompt !== undefined && item.revised_prompt !== null
+          ? { revisedPrompt: item.revised_prompt }
+          : {}
+      if (item.b64_json) {
+        return [{ b64Json: item.b64_json, ...revisedPromptField }]
+      }
+      if (item.url) {
+        return [{ url: item.url, ...revisedPromptField }]
+      }
+      return []
+    },
+  )
+
+  if (images.length === 0) {
+    throw new Error(emptyMessage)
+  }
+
+  return images
+}
+
+export class LovableImageAdapter<
+  TModel extends LovableImageModel,
+> extends BaseImageAdapter<
+  TModel,
+  LovableImageProviderOptions,
+  LovableImageModelProviderOptionsByName,
+  LovableImageModelSizeByName,
+  LovableImageModelInputModalitiesByName
+> {
+  override readonly kind = 'image' as const
+  readonly name = 'lovable' as const
+
+  protected client: OpenAI
+  private readonly allowUrlFetch: boolean
+
+  constructor(config: LovableImageConfig, model: TModel) {
+    super(model, {})
+    const { allowUrlFetch, ...clientOptions } = config
+    this.client = new OpenAI(withLovableDefaults(clientOptions))
+    this.allowUrlFetch = allowUrlFetch ?? false
+  }
+
+  async generateImages(
+    options: ImageGenerationOptions<LovableImageProviderOptions>,
+  ): Promise<ImageGenerationResult> {
+    const { model, numberOfImages, size, modelOptions } = options
+    const resolved = resolveMediaPrompt(options.prompt)
+    const prompt = resolved.text
+
+    if (resolved.videos.length > 0) {
+      throw new Error(
+        `${this.name}.generateImages does not support video prompt parts (model: ${model}).`,
+      )
+    }
+    if (resolved.audios.length > 0) {
+      throw new Error(
+        `${this.name}.generateImages does not support audio prompt parts (model: ${model}).`,
+      )
+    }
+
+    if (resolved.images.length > 0) {
+      return this.editImages({
+        model,
+        prompt,
+        numberOfImages,
+        size,
+        modelOptions,
+        imageInputs: resolved.images,
+        logger: options.logger,
+      })
+    }
+
+    const request: OpenAI_SDK.Images.ImageGenerateParams = {
+      model,
+      prompt,
+      n: numberOfImages ?? 1,
+      ...(modelOptions ?? {}),
+    }
+    if (size !== undefined) {
+      request.size = size
+    }
+
+    try {
+      options.logger.request(
+        `activity=image provider=${this.name} model=${model} n=${request.n ?? 1} size=${request.size ?? 'default'}`,
+        { provider: this.name, model },
+      )
+      const response = await this.client.images.generate({
+        ...request,
+        stream: false,
+      })
+
+      const images = generatedImagesFromResponse(
+        response.data,
+        `${this.name}: image response contained no images`,
+      )
+      const usage = buildImagesUsage(response.usage)
+
+      return {
+        id: generateId(this.name),
+        model,
+        images,
+        ...(usage ? { usage } : {}),
+      }
+    } catch (error: unknown) {
+      options.logger.errors(`${this.name}.generateImages fatal`, {
+        error: toRunErrorPayload(error, `${this.name}.generateImages failed`),
+        source: `${this.name}.generateImages`,
+      })
+      throw error
+    }
+  }
+
+  private async editImages(args: {
+    model: string
+    prompt: string
+    numberOfImages?: number
+    size?: string
+    modelOptions?: LovableImageProviderOptions
+    imageInputs: ReadonlyArray<ImagePart<MediaInputMetadata>>
+    logger: ImageGenerationOptions<LovableImageProviderOptions>['logger']
+  }): Promise<ImageGenerationResult> {
+    const { model, prompt, numberOfImages, size, modelOptions, logger } = args
+
+    const maskParts = args.imageInputs.filter(
+      (part) => part.metadata?.role === 'mask',
+    )
+    const sourceParts = args.imageInputs.filter(
+      (part) => part.metadata?.role !== 'mask',
+    )
+
+    if (maskParts.length > 0 && !supportsImageMask(model)) {
+      throw new Error(
+        `${this.name}: model "${model}" does not support mask image parts. Use an openai/ image model for masked edits.`,
+      )
+    }
+    if (maskParts.length > 1) {
+      throw new Error(
+        `${this.name}: only one input with metadata.role === 'mask' is supported per request.`,
+      )
+    }
+    if (sourceParts.length === 0) {
+      throw new Error(
+        `${this.name}: the prompt contained only mask image parts; at least one source image is required.`,
+      )
+    }
+    if (sourceParts.length > MAX_EDIT_IMAGES) {
+      throw new Error(
+        `${this.name}: model "${model}" accepts at most ${MAX_EDIT_IMAGES} source image(s); received ${sourceParts.length}.`,
+      )
+    }
+
+    const sourceFiles = await Promise.all(
+      sourceParts.map((part, i) =>
+        imagePartToFile(part, `source-${i}`, this.allowUrlFetch),
+      ),
+    )
+    const [firstSourceFile] = sourceFiles
+    const maskFile = maskParts[0]
+      ? await imagePartToFile(maskParts[0], 'mask', this.allowUrlFetch)
+      : undefined
+
+    const request: OpenAI_SDK.Images.ImageEditParamsNonStreaming = {
+      model,
+      prompt,
+      image:
+        firstSourceFile && sourceFiles.length === 1
+          ? firstSourceFile
+          : sourceFiles,
+      n: numberOfImages ?? 1,
+      stream: false,
+      ...((modelOptions ??
+        {}) as Partial<OpenAI_SDK.Images.ImageEditParamsNonStreaming>),
+    }
+    if (size !== undefined) {
+      request.size = size
+    }
+    if (maskFile) {
+      request.mask = maskFile
+    }
+
+    try {
+      logger.request(
+        `activity=imageEdit provider=${this.name} model=${model} n=${request.n ?? 1} size=${request.size ?? 'default'} sources=${sourceFiles.length}${maskFile ? ' mask' : ''}`,
+        { provider: this.name, model },
+      )
+      const response = await this.client.images.edit(request)
+
+      const images = generatedImagesFromResponse(
+        response.data,
+        `${this.name}: image edit response contained no images`,
+      )
+      const usage = buildImagesUsage(response.usage)
+
+      return {
+        id: generateId(this.name),
+        model,
+        images,
+        ...(usage ? { usage } : {}),
+      }
+    } catch (error: unknown) {
+      logger.errors(`${this.name}.editImages fatal`, {
+        error: toRunErrorPayload(error, `${this.name}.editImages failed`),
+        source: `${this.name}.editImages`,
+      })
+      throw error
+    }
+  }
+}
+
+export function createLovableImage<TModel extends LovableImageModel>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<LovableImageConfig, 'apiKey'>,
+): LovableImageAdapter<TModel> {
+  return new LovableImageAdapter({ apiKey, ...config }, model)
+}
+
+export function lovableImage<TModel extends LovableImageModel>(
+  model: TModel,
+  config?: Omit<LovableImageConfig, 'apiKey'>,
+): LovableImageAdapter<TModel> {
+  return createLovableImage(model, getLovableApiKeyFromEnv(), config)
+}

--- a/packages/ai-lovable/src/adapters/image.ts
+++ b/packages/ai-lovable/src/adapters/image.ts
@@ -4,7 +4,11 @@ import { BaseImageAdapter } from '@tanstack/ai/adapters'
 import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
 import { buildImagesUsage } from '@tanstack/openai-base'
 import { generateId } from '@tanstack/ai-utils'
-import { getLovableApiKeyFromEnv, withLovableDefaults } from '../utils/client'
+import {
+  getLovableApiKeyFromEnv,
+  openaiRequestOptions,
+  withLovableDefaults,
+} from '../utils/client'
 import { imagePartToFile } from '../image/image-input-to-file'
 import type {
   GeneratedImage,
@@ -122,6 +126,7 @@ export class LovableImageAdapter<
         modelOptions,
         imageInputs: resolved.images,
         logger: options.logger,
+        abortSignal: options.abortSignal,
       })
     }
 
@@ -140,10 +145,13 @@ export class LovableImageAdapter<
         `activity=image provider=${this.name} model=${model} n=${request.n ?? 1} size=${request.size ?? 'default'}`,
         { provider: this.name, model },
       )
-      const response = await this.client.images.generate({
-        ...request,
-        stream: false,
-      })
+      const response = await this.client.images.generate(
+        {
+          ...request,
+          stream: false,
+        },
+        openaiRequestOptions(options.abortSignal),
+      )
 
       const images = generatedImagesFromResponse(
         response.data,
@@ -174,8 +182,17 @@ export class LovableImageAdapter<
     modelOptions?: LovableImageProviderOptions
     imageInputs: ReadonlyArray<ImagePart<MediaInputMetadata>>
     logger: ImageGenerationOptions<LovableImageProviderOptions>['logger']
+    abortSignal?: AbortSignal
   }): Promise<ImageGenerationResult> {
-    const { model, prompt, numberOfImages, size, modelOptions, logger } = args
+    const {
+      model,
+      prompt,
+      numberOfImages,
+      size,
+      modelOptions,
+      logger,
+      abortSignal,
+    } = args
 
     const maskParts = args.imageInputs.filter(
       (part) => part.metadata?.role === 'mask',
@@ -207,12 +224,17 @@ export class LovableImageAdapter<
 
     const sourceFiles = await Promise.all(
       sourceParts.map((part, i) =>
-        imagePartToFile(part, `source-${i}`, this.allowUrlFetch),
+        imagePartToFile(part, `source-${i}`, this.allowUrlFetch, abortSignal),
       ),
     )
     const [firstSourceFile] = sourceFiles
     const maskFile = maskParts[0]
-      ? await imagePartToFile(maskParts[0], 'mask', this.allowUrlFetch)
+      ? await imagePartToFile(
+          maskParts[0],
+          'mask',
+          this.allowUrlFetch,
+          abortSignal,
+        )
       : undefined
 
     const request: OpenAI_SDK.Images.ImageEditParamsNonStreaming = {
@@ -239,7 +261,10 @@ export class LovableImageAdapter<
         `activity=imageEdit provider=${this.name} model=${model} n=${request.n ?? 1} size=${request.size ?? 'default'} sources=${sourceFiles.length}${maskFile ? ' mask' : ''}`,
         { provider: this.name, model },
       )
-      const response = await this.client.images.edit(request)
+      const response = await this.client.images.edit(
+        request,
+        openaiRequestOptions(abortSignal),
+      )
 
       const images = generatedImagesFromResponse(
         response.data,

--- a/packages/ai-lovable/src/adapters/responses-text.ts
+++ b/packages/ai-lovable/src/adapters/responses-text.ts
@@ -1,0 +1,66 @@
+import OpenAI from 'openai'
+import { OpenAIBaseResponsesTextAdapter } from '@tanstack/openai-base'
+import { getLovableApiKeyFromEnv, withLovableDefaults } from '../utils/client'
+import type { Modality } from '@tanstack/ai'
+import type {
+  LovableChatModelToolCapabilitiesByName,
+  LovableModelId,
+  ResolveInputModalities,
+  ResolveProviderOptions,
+} from '../model-meta'
+import type { LovableMessageMetadataByModality } from '../message-types'
+import type { ExternalResponsesProviderOptions } from '../text/responses-provider-options'
+import type { LovableClientConfig } from '../utils/client'
+
+export interface LovableResponsesTextConfig extends LovableClientConfig {}
+
+export type LovableResponsesTextProviderOptions =
+  ExternalResponsesProviderOptions
+
+type ResolveToolCapabilities<TModel extends string> =
+  TModel extends keyof LovableChatModelToolCapabilitiesByName
+    ? NonNullable<LovableChatModelToolCapabilitiesByName[TModel]>
+    : readonly []
+
+/**
+ * Lovable AI Gateway Responses text adapter.
+ *
+ * Talks to the OpenAI-compatible Responses API at
+ * `https://ai.gateway.lovable.dev/v1`.
+ */
+export class LovableResponsesTextAdapter<
+  TModel extends LovableModelId,
+  TProviderOptions extends Record<string, any> = ResolveProviderOptions<TModel>,
+  TInputModalities extends ReadonlyArray<Modality> =
+    ResolveInputModalities<TModel>,
+  TToolCapabilities extends ReadonlyArray<string> =
+    ResolveToolCapabilities<TModel>,
+> extends OpenAIBaseResponsesTextAdapter<
+  TModel,
+  TProviderOptions,
+  TInputModalities,
+  LovableMessageMetadataByModality,
+  TToolCapabilities
+> {
+  override readonly kind = 'text' as const
+  override readonly name = 'lovable' as const
+
+  constructor(config: LovableResponsesTextConfig, model: TModel) {
+    super(model, 'lovable', new OpenAI(withLovableDefaults(config)))
+  }
+}
+
+export function createLovableResponsesText<TModel extends LovableModelId>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<LovableResponsesTextConfig, 'apiKey'>,
+): LovableResponsesTextAdapter<TModel> {
+  return new LovableResponsesTextAdapter({ apiKey, ...config }, model)
+}
+
+export function lovableResponsesText<TModel extends LovableModelId>(
+  model: TModel,
+  config?: Omit<LovableResponsesTextConfig, 'apiKey'>,
+): LovableResponsesTextAdapter<TModel> {
+  return createLovableResponsesText(model, getLovableApiKeyFromEnv(), config)
+}

--- a/packages/ai-lovable/src/adapters/summarize.ts
+++ b/packages/ai-lovable/src/adapters/summarize.ts
@@ -1,0 +1,35 @@
+import { ChatStreamSummarizeAdapter } from '@tanstack/ai/adapters'
+import { getLovableApiKeyFromEnv } from '../utils/client'
+import { LovableTextAdapter } from './text'
+import type { InferTextProviderOptions } from '@tanstack/ai/adapters'
+import type { LovableModelId } from '../model-meta'
+import type { LovableClientConfig } from '../utils/client'
+
+export interface LovableSummarizeConfig extends LovableClientConfig {}
+
+export type LovableSummarizeModel = LovableModelId
+
+export function createLovableSummarize<TModel extends LovableSummarizeModel>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<LovableSummarizeConfig, 'apiKey'>,
+): ChatStreamSummarizeAdapter<
+  TModel,
+  InferTextProviderOptions<LovableTextAdapter<TModel>>
+> {
+  return new ChatStreamSummarizeAdapter(
+    new LovableTextAdapter({ apiKey, ...config }, model),
+    model,
+    'lovable',
+  )
+}
+
+export function lovableSummarize<TModel extends LovableSummarizeModel>(
+  model: TModel,
+  config?: Omit<LovableSummarizeConfig, 'apiKey'>,
+): ChatStreamSummarizeAdapter<
+  TModel,
+  InferTextProviderOptions<LovableTextAdapter<TModel>>
+> {
+  return createLovableSummarize(model, getLovableApiKeyFromEnv(), config)
+}

--- a/packages/ai-lovable/src/adapters/text.ts
+++ b/packages/ai-lovable/src/adapters/text.ts
@@ -1,0 +1,49 @@
+import OpenAI from 'openai'
+import { OpenAIBaseChatCompletionsTextAdapter } from '@tanstack/openai-base'
+import { withLovableDefaults } from '../utils/client'
+import type { Modality } from '@tanstack/ai'
+import type {
+  LovableChatModelToolCapabilitiesByName,
+  LovableModelId,
+  ResolveInputModalities,
+  ResolveProviderOptions,
+} from '../model-meta'
+import type { LovableMessageMetadataByModality } from '../message-types'
+import type { LovableClientConfig } from '../utils/client'
+
+type ResolveToolCapabilities<TModel extends string> =
+  TModel extends keyof LovableChatModelToolCapabilitiesByName
+    ? NonNullable<LovableChatModelToolCapabilitiesByName[TModel]>
+    : readonly []
+
+export interface LovableTextConfig extends LovableClientConfig {}
+
+export type { ExternalTextProviderOptions as LovableTextProviderOptions } from '../text/text-provider-options'
+
+/**
+ * Lovable AI Gateway text adapter.
+ *
+ * Talks to the OpenAI-compatible Chat Completions API at
+ * `https://ai.gateway.lovable.dev/v1`.
+ */
+export class LovableTextAdapter<
+  TModel extends LovableModelId,
+  TProviderOptions extends Record<string, any> = ResolveProviderOptions<TModel>,
+  TInputModalities extends ReadonlyArray<Modality> =
+    ResolveInputModalities<TModel>,
+  TToolCapabilities extends ReadonlyArray<string> =
+    ResolveToolCapabilities<TModel>,
+> extends OpenAIBaseChatCompletionsTextAdapter<
+  TModel,
+  TProviderOptions,
+  TInputModalities,
+  LovableMessageMetadataByModality,
+  TToolCapabilities
+> {
+  override readonly kind = 'text' as const
+  override readonly name = 'lovable' as const
+
+  constructor(config: LovableTextConfig, model: TModel) {
+    super(model, 'lovable', new OpenAI(withLovableDefaults(config)))
+  }
+}

--- a/packages/ai-lovable/src/adapters/transcription.ts
+++ b/packages/ai-lovable/src/adapters/transcription.ts
@@ -1,0 +1,219 @@
+import OpenAI from 'openai'
+import { BaseTranscriptionAdapter } from '@tanstack/ai/adapters'
+import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
+import { base64ToArrayBuffer, generateId } from '@tanstack/ai-utils'
+import { getLovableApiKeyFromEnv, withLovableDefaults } from '../utils/client'
+import type {
+  TokenUsage,
+  TranscriptionOptions,
+  TranscriptionResponseFormat,
+  TranscriptionResult,
+} from '@tanstack/ai'
+import type OpenAI_SDK from 'openai'
+import type { LovableTranscriptionModel } from '../model-meta'
+import type { LovableTranscriptionProviderOptions } from '../audio/transcription-provider-options'
+import type { LovableClientConfig } from '../utils/client'
+
+function isPlainFormat(format: string): format is 'json' | 'text' {
+  return format === 'json' || format === 'text'
+}
+
+export interface LovableTranscriptionConfig extends LovableClientConfig {}
+
+function buildTranscriptionUsage(
+  response?: OpenAI_SDK.Audio.TranscriptionCreateResponse,
+): TokenUsage | undefined {
+  const usage = response?.usage
+  if (!usage || usage.type === 'duration') {
+    return undefined
+  }
+
+  const result: TokenUsage = {
+    promptTokens: usage.input_tokens || 0,
+    completionTokens: usage.output_tokens || 0,
+    totalTokens: usage.total_tokens || 0,
+  }
+
+  const inputDetails = usage.input_token_details
+  const promptTokensDetails = {
+    ...(inputDetails?.audio_tokens
+      ? { audioTokens: inputDetails.audio_tokens }
+      : {}),
+    ...(inputDetails?.text_tokens
+      ? { textTokens: inputDetails.text_tokens }
+      : {}),
+  }
+  if (Object.keys(promptTokensDetails).length > 0) {
+    result.promptTokensDetails = promptTokensDetails
+  }
+  if (usage.output_tokens) {
+    result.completionTokensDetails = { textTokens: usage.output_tokens }
+  }
+
+  return result
+}
+
+export class LovableTranscriptionAdapter<
+  TModel extends LovableTranscriptionModel,
+> extends BaseTranscriptionAdapter<
+  TModel,
+  LovableTranscriptionProviderOptions
+> {
+  readonly name = 'lovable' as const
+
+  protected client: OpenAI
+
+  constructor(config: LovableTranscriptionConfig, model: TModel) {
+    super(model, {})
+    this.client = new OpenAI(withLovableDefaults(config))
+  }
+
+  async transcribe(
+    options: TranscriptionOptions<LovableTranscriptionProviderOptions>,
+  ): Promise<TranscriptionResult> {
+    const { model, language } = options
+
+    try {
+      const request = this.buildTranscriptionRequest(options)
+
+      options.logger.request(
+        `activity=transcription provider=${this.name} model=${model}`,
+        { provider: this.name, model },
+      )
+
+      const response = await this.client.audio.transcriptions.create(request)
+      const usage =
+        typeof response === 'string'
+          ? undefined
+          : buildTranscriptionUsage(response)
+
+      return {
+        id: generateId(this.name),
+        model,
+        text: typeof response === 'string' ? response : response.text,
+        ...(language !== undefined && { language }),
+        ...(usage !== undefined && { usage }),
+      }
+    } catch (error: unknown) {
+      options.logger.errors(`${this.name}.transcribe fatal`, {
+        error: toRunErrorPayload(error, `${this.name}.transcribe failed`),
+        source: `${this.name}.transcribe`,
+      })
+      throw error
+    }
+  }
+
+  private buildTranscriptionRequest(
+    options: TranscriptionOptions<LovableTranscriptionProviderOptions>,
+  ): OpenAI_SDK.Audio.TranscriptionCreateParamsNonStreaming {
+    const { model, audio, language, prompt, responseFormat, modelOptions } =
+      options
+    const file = this.prepareAudioFile(audio)
+    const topLevelResponseFormat = responseFormat
+    const effectiveResponseFormat =
+      topLevelResponseFormat ?? modelOptions?.response_format
+
+    if (
+      topLevelResponseFormat !== undefined &&
+      modelOptions?.response_format !== undefined &&
+      topLevelResponseFormat !== modelOptions.response_format
+    ) {
+      throw new Error(
+        `Conflicting response formats: responseFormat="${topLevelResponseFormat}" and modelOptions.response_format="${modelOptions.response_format}". Provide only one.`,
+      )
+    }
+
+    if (
+      effectiveResponseFormat !== undefined &&
+      !isPlainFormat(effectiveResponseFormat)
+    ) {
+      throw new Error(
+        `lovable: model "${model}" only supports json and text response formats; received "${effectiveResponseFormat}".`,
+      )
+    }
+
+    const request: OpenAI_SDK.Audio.TranscriptionCreateParamsNonStreaming = {
+      ...modelOptions,
+      model,
+      file,
+    }
+    delete request.stream
+    if (language !== undefined) {
+      request.language = language
+    }
+    if (prompt !== undefined) {
+      request.prompt = prompt
+    }
+    request.response_format = mapResponseFormat(effectiveResponseFormat)
+
+    return request
+  }
+
+  protected prepareAudioFile(audio: string | File | Blob | ArrayBuffer): File {
+    if (typeof File !== 'undefined' && audio instanceof File) {
+      return audio
+    }
+    if (typeof Blob !== 'undefined' && audio instanceof Blob) {
+      this.ensureFileSupport()
+      return new File([audio], 'audio.mp3', {
+        type: audio.type || 'audio/mpeg',
+      })
+    }
+    if (typeof ArrayBuffer !== 'undefined' && audio instanceof ArrayBuffer) {
+      this.ensureFileSupport()
+      return new File([audio], 'audio.mp3', { type: 'audio/mpeg' })
+    }
+    if (typeof audio === 'string') {
+      this.ensureFileSupport()
+
+      if (audio.startsWith('data:')) {
+        const parts = audio.split(',')
+        const header = parts[0]
+        const base64Data = parts[1] || ''
+        const mimeMatch = header?.match(/data:([^;]+)/)
+        const mimeType = mimeMatch?.[1] || 'audio/mpeg'
+        const bytes = base64ToArrayBuffer(base64Data)
+        const extension = mimeType.split('/')[1] || 'mp3'
+        return new File([bytes], `audio.${extension}`, { type: mimeType })
+      }
+
+      const bytes = base64ToArrayBuffer(audio)
+      return new File([bytes], 'audio.mp3', { type: 'audio/mpeg' })
+    }
+
+    throw new Error('Invalid audio input type')
+  }
+
+  private ensureFileSupport(): void {
+    if (typeof File === 'undefined') {
+      throw new Error(
+        '`File` is not available in this environment. ' +
+          'Use Node.js 20 or newer, or pass a File object directly.',
+      )
+    }
+  }
+}
+
+function mapResponseFormat(
+  format?: TranscriptionResponseFormat,
+): 'json' | 'text' {
+  if (format === 'text') return 'text'
+  return 'json'
+}
+
+export function createLovableTranscription<
+  TModel extends LovableTranscriptionModel,
+>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<LovableTranscriptionConfig, 'apiKey'>,
+): LovableTranscriptionAdapter<TModel> {
+  return new LovableTranscriptionAdapter({ apiKey, ...config }, model)
+}
+
+export function lovableTranscription<TModel extends LovableTranscriptionModel>(
+  model: TModel,
+  config?: Omit<LovableTranscriptionConfig, 'apiKey'>,
+): LovableTranscriptionAdapter<TModel> {
+  return createLovableTranscription(model, getLovableApiKeyFromEnv(), config)
+}

--- a/packages/ai-lovable/src/adapters/transcription.ts
+++ b/packages/ai-lovable/src/adapters/transcription.ts
@@ -2,7 +2,11 @@ import OpenAI from 'openai'
 import { BaseTranscriptionAdapter } from '@tanstack/ai/adapters'
 import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
 import { base64ToArrayBuffer, generateId } from '@tanstack/ai-utils'
-import { getLovableApiKeyFromEnv, withLovableDefaults } from '../utils/client'
+import {
+  getLovableApiKeyFromEnv,
+  openaiRequestOptions,
+  withLovableDefaults,
+} from '../utils/client'
 import type {
   TokenUsage,
   TranscriptionOptions,
@@ -81,7 +85,10 @@ export class LovableTranscriptionAdapter<
         { provider: this.name, model },
       )
 
-      const response = await this.client.audio.transcriptions.create(request)
+      const response = await this.client.audio.transcriptions.create(
+        request,
+        openaiRequestOptions(options.abortSignal),
+      )
       const usage =
         typeof response === 'string'
           ? undefined

--- a/packages/ai-lovable/src/adapters/tts.ts
+++ b/packages/ai-lovable/src/adapters/tts.ts
@@ -1,0 +1,90 @@
+import OpenAI from 'openai'
+import { BaseTTSAdapter } from '@tanstack/ai/adapters'
+import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
+import { arrayBufferToBase64, generateId } from '@tanstack/ai-utils'
+import { getLovableApiKeyFromEnv, withLovableDefaults } from '../utils/client'
+import type { TTSOptions, TTSResult } from '@tanstack/ai'
+import type OpenAI_SDK from 'openai'
+import type { LovableTTSModel } from '../model-meta'
+import type { LovableTTSProviderOptions } from '../audio/tts-provider-options'
+import type { LovableClientConfig } from '../utils/client'
+
+export interface LovableTTSConfig extends LovableClientConfig {}
+
+const CONTENT_TYPES: Record<string, string> = {
+  mp3: 'audio/mpeg',
+  opus: 'audio/opus',
+  aac: 'audio/aac',
+  flac: 'audio/flac',
+  wav: 'audio/wav',
+  pcm: 'audio/pcm',
+}
+
+export class LovableTTSAdapter<
+  TModel extends LovableTTSModel,
+> extends BaseTTSAdapter<TModel, LovableTTSProviderOptions> {
+  readonly name = 'lovable' as const
+
+  protected client: OpenAI
+
+  constructor(config: LovableTTSConfig, model: TModel) {
+    super(model, {})
+    this.client = new OpenAI(withLovableDefaults(config))
+  }
+
+  async generateSpeech(
+    options: TTSOptions<LovableTTSProviderOptions>,
+  ): Promise<TTSResult> {
+    const { model, text, voice, format, speed, modelOptions } = options
+
+    const request: OpenAI_SDK.Audio.SpeechCreateParams = {
+      model,
+      input: text,
+      voice: voice || 'alloy',
+      response_format: format,
+      ...(speed !== undefined && { speed }),
+      ...(modelOptions ?? {}),
+    }
+
+    try {
+      options.logger.request(
+        `activity=tts provider=${this.name} model=${model} format=${request.response_format ?? 'default'} voice=${request.voice}`,
+        { provider: this.name, model },
+      )
+      const response = await this.client.audio.speech.create(request)
+      const arrayBuffer = await response.arrayBuffer()
+      const base64 = arrayBufferToBase64(arrayBuffer)
+      const outputFormat = (request.response_format as string) || 'mp3'
+      const contentType = CONTENT_TYPES[outputFormat] || 'audio/mpeg'
+
+      return {
+        id: generateId(this.name),
+        model,
+        audio: base64,
+        format: outputFormat,
+        contentType,
+      }
+    } catch (error: unknown) {
+      options.logger.errors(`${this.name}.generateSpeech fatal`, {
+        error: toRunErrorPayload(error, `${this.name}.generateSpeech failed`),
+        source: `${this.name}.generateSpeech`,
+      })
+      throw error
+    }
+  }
+}
+
+export function createLovableSpeech<TModel extends LovableTTSModel>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<LovableTTSConfig, 'apiKey'>,
+): LovableTTSAdapter<TModel> {
+  return new LovableTTSAdapter({ apiKey, ...config }, model)
+}
+
+export function lovableSpeech<TModel extends LovableTTSModel>(
+  model: TModel,
+  config?: Omit<LovableTTSConfig, 'apiKey'>,
+): LovableTTSAdapter<TModel> {
+  return createLovableSpeech(model, getLovableApiKeyFromEnv(), config)
+}

--- a/packages/ai-lovable/src/adapters/tts.ts
+++ b/packages/ai-lovable/src/adapters/tts.ts
@@ -2,7 +2,11 @@ import OpenAI from 'openai'
 import { BaseTTSAdapter } from '@tanstack/ai/adapters'
 import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
 import { arrayBufferToBase64, generateId } from '@tanstack/ai-utils'
-import { getLovableApiKeyFromEnv, withLovableDefaults } from '../utils/client'
+import {
+  getLovableApiKeyFromEnv,
+  openaiRequestOptions,
+  withLovableDefaults,
+} from '../utils/client'
 import type { TTSOptions, TTSResult } from '@tanstack/ai'
 import type OpenAI_SDK from 'openai'
 import type { LovableTTSModel } from '../model-meta'
@@ -51,7 +55,10 @@ export class LovableTTSAdapter<
         `activity=tts provider=${this.name} model=${model} format=${request.response_format ?? 'default'} voice=${request.voice}`,
         { provider: this.name, model },
       )
-      const response = await this.client.audio.speech.create(request)
+      const response = await this.client.audio.speech.create(
+        request,
+        openaiRequestOptions(options.abortSignal),
+      )
       const arrayBuffer = await response.arrayBuffer()
       const base64 = arrayBufferToBase64(arrayBuffer)
       const outputFormat = (request.response_format as string) || 'mp3'

--- a/packages/ai-lovable/src/adapters/video.ts
+++ b/packages/ai-lovable/src/adapters/video.ts
@@ -1,0 +1,295 @@
+import OpenAI from 'openai'
+import { resolveMediaPrompt } from '@tanstack/ai'
+import { BaseVideoAdapter, snapToDurationOption } from '@tanstack/ai/adapters'
+import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
+import { arrayBufferToBase64 } from '@tanstack/ai-utils'
+import { getLovableApiKeyFromEnv, withLovableDefaults } from '../utils/client'
+import { imagePartToFile } from '../image/image-input-to-file'
+import {
+  toApiSeconds,
+  validateHighResDuration,
+  validateVideoSeconds,
+  validateVideoSize,
+} from '../video/video-provider-options'
+import type { DurationOptions } from '@tanstack/ai/adapters'
+import type {
+  VideoGenerationOptions,
+  VideoJobResult,
+  VideoStatusResult,
+  VideoUrlResult,
+} from '@tanstack/ai'
+import type OpenAI_SDK from 'openai'
+import type {
+  LovableVideoModel,
+  LovableVideoModelDurationByName,
+  LovableVideoModelInputModalitiesByName,
+  LovableVideoModelProviderOptionsByName,
+  LovableVideoModelSizeByName,
+} from '../model-meta'
+import type {
+  LovableVideoDuration,
+  LovableVideoProviderOptions,
+} from '../video/video-provider-options'
+import type { LovableClientConfig } from '../utils/client'
+
+const LARGE_MEDIA_BUFFER_BYTES = 10 * 1024 * 1024
+const VIDEO_DURATIONS = [
+  4, 6, 8,
+] as const satisfies ReadonlyArray<LovableVideoDuration>
+
+function warnIfLargeMediaBuffer(byteLength: number, source: string): void {
+  if (byteLength <= LARGE_MEDIA_BUFFER_BYTES) return
+  console.warn(
+    `[lovable.${source}] downloaded ${(byteLength / 1024 / 1024).toFixed(1)} MiB into memory before base64 encoding. ` +
+      `Workers/serverless runtimes commonly run out of memory above ~10 MiB. ` +
+      `Consider streaming the video through a CDN or your own storage layer instead.`,
+  )
+}
+
+/**
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export interface LovableVideoConfig extends LovableClientConfig {
+  /**
+   * Opt into fetching HTTP(S) image URL inputs for `input_reference`.
+   * The endpoint requires uploaded file bytes, so an HTTP(S) URL has to be
+   * downloaded and buffered in memory. When `false` (the default), HTTP(S)
+   * URL image inputs throw.
+   */
+  allowUrlFetch?: boolean
+}
+
+/**
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export class LovableVideoAdapter<
+  TModel extends LovableVideoModel,
+> extends BaseVideoAdapter<
+  TModel,
+  LovableVideoProviderOptions,
+  LovableVideoModelProviderOptionsByName,
+  LovableVideoModelSizeByName,
+  LovableVideoModelInputModalitiesByName,
+  LovableVideoModelDurationByName
+> {
+  readonly name = 'lovable' as const
+
+  protected client: OpenAI
+  protected clientConfig: LovableVideoConfig
+
+  constructor(config: LovableVideoConfig, model: TModel) {
+    super({}, model)
+    this.clientConfig = config
+    const { allowUrlFetch: _allowUrlFetch, ...clientOptions } = config
+    this.client = new OpenAI(withLovableDefaults(clientOptions))
+  }
+
+  async createVideoJob(
+    options: VideoGenerationOptions<
+      LovableVideoProviderOptions,
+      LovableVideoModelSizeByName[TModel],
+      LovableVideoModelDurationByName[TModel]
+    >,
+  ): Promise<VideoJobResult> {
+    const { model, size, duration, modelOptions } = options
+
+    const resolvedSize = size ?? modelOptions?.size
+    validateVideoSize(model, resolvedSize)
+    const seconds = duration ?? modelOptions?.seconds
+    validateVideoSeconds(model, seconds)
+    validateHighResDuration(model, resolvedSize, seconds)
+
+    const resolved = resolveMediaPrompt(options.prompt)
+
+    if (resolved.videos.length > 0) {
+      throw new Error(
+        `${this.name}.createVideoJob does not support video prompt parts (model: ${model}).`,
+      )
+    }
+    if (resolved.audios.length > 0) {
+      throw new Error(
+        `${this.name}.createVideoJob does not support audio prompt parts (model: ${model}).`,
+      )
+    }
+    if (resolved.images.length > 1) {
+      throw new Error(
+        `${this.name}: video models accept at most one input_reference image; received ${resolved.images.length}.`,
+      )
+    }
+
+    const request: OpenAI_SDK.Videos.VideoCreateParams = {
+      model,
+      prompt: resolved.text,
+    }
+    const [inputReference] = resolved.images
+    if (inputReference) {
+      request.input_reference = await imagePartToFile(
+        inputReference,
+        'input-reference',
+        this.clientConfig.allowUrlFetch ?? false,
+      )
+    }
+    if (resolvedSize) {
+      // Gateway Veo sizes include 1080p and 4K, which are not in the OpenAI SDK union.
+      request.size = resolvedSize as OpenAI_SDK.Videos.VideoSize
+    }
+    if (seconds !== undefined) {
+      const apiSeconds = toApiSeconds(seconds)
+      if (apiSeconds !== undefined) {
+        // Gateway Veo clips can be 6 seconds. The OpenAI SDK union is 4/8/12.
+        request.seconds = apiSeconds as OpenAI_SDK.Videos.VideoSeconds
+      }
+    }
+
+    try {
+      options.logger.request(
+        `activity=video.create provider=${this.name} model=${model} size=${request.size ?? 'default'} seconds=${request.seconds ?? 'default'}`,
+        { provider: this.name, model },
+      )
+      const response = await this.client.videos.create(request)
+      return { jobId: response.id, model }
+    } catch (error: unknown) {
+      options.logger.errors(`${this.name}.createVideoJob fatal`, {
+        error: toRunErrorPayload(error, `${this.name}.createVideoJob failed`),
+        source: `${this.name}.createVideoJob`,
+      })
+      throw error
+    }
+  }
+
+  async getVideoStatus(jobId: string): Promise<VideoStatusResult> {
+    try {
+      const response = await this.client.videos.retrieve(jobId)
+      return {
+        jobId,
+        status: this.mapStatus(response.status),
+        progress: response.progress,
+        ...(response.error?.message !== undefined && {
+          error: response.error.message,
+        }),
+      }
+    } catch (error: unknown) {
+      if (isHttpStatus(error, 404)) {
+        return { jobId, status: 'failed', error: 'Job not found' }
+      }
+      throw error
+    }
+  }
+
+  async getVideoUrl(jobId: string): Promise<VideoUrlResult> {
+    try {
+      const videoInfo = await this.client.videos.retrieve(jobId)
+      const directUrl = videoResourceUrl(videoInfo)
+      if (directUrl) {
+        return {
+          jobId,
+          url: directUrl,
+          ...(videoInfo.expires_at !== null && {
+            expiresAt: new Date(videoInfo.expires_at),
+          }),
+        }
+      }
+
+      const contentResponse = await this.client.videos.downloadContent(jobId)
+      return dataUrlFromResponse(
+        jobId,
+        contentResponse,
+        'video.downloadContent',
+      )
+    } catch (error: unknown) {
+      if (isHttpStatus(error, 404)) {
+        throw new Error(`Video job not found: ${jobId}`)
+      }
+      if (isHttpStatus(error, 400)) {
+        throw new Error(
+          `Video is not ready for download. Check status first. Job ID: ${jobId}`,
+        )
+      }
+      throw error
+    }
+  }
+
+  override availableDurations(): DurationOptions<LovableVideoDuration> {
+    return { kind: 'discrete', values: VIDEO_DURATIONS }
+  }
+
+  override snapDuration(seconds: number): LovableVideoDuration | undefined {
+    return snapToDurationOption(seconds, this.availableDurations())
+  }
+
+  protected mapStatus(
+    apiStatus: string,
+  ): 'pending' | 'processing' | 'completed' | 'failed' {
+    switch (apiStatus) {
+      case 'queued':
+      case 'pending':
+        return 'pending'
+      case 'processing':
+      case 'in_progress':
+        return 'processing'
+      case 'completed':
+      case 'succeeded':
+        return 'completed'
+      case 'failed':
+      case 'error':
+      case 'cancelled':
+        return 'failed'
+      default:
+        return 'processing'
+    }
+  }
+}
+
+async function dataUrlFromResponse(
+  jobId: string,
+  contentResponse: Response,
+  source: string,
+): Promise<VideoUrlResult> {
+  const videoBlob = await contentResponse.blob()
+  const buffer = await videoBlob.arrayBuffer()
+  warnIfLargeMediaBuffer(buffer.byteLength, source)
+  const base64 = arrayBufferToBase64(buffer)
+  const mimeType = contentResponse.headers.get('content-type') || 'video/mp4'
+  return {
+    jobId,
+    url: `data:${mimeType};base64,${base64}`,
+  }
+}
+
+function videoResourceUrl(video: OpenAI_SDK.Videos.Video): string | undefined {
+  const extra = video as OpenAI_SDK.Videos.Video & { url?: string }
+  if (extra.url && extra.url.length > 0) {
+    return extra.url
+  }
+  return undefined
+}
+
+function isHttpStatus(error: unknown, status: number): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    (error as { status: unknown }).status === status
+  )
+}
+
+/**
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export function createLovableVideo<TModel extends LovableVideoModel>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<LovableVideoConfig, 'apiKey'>,
+): LovableVideoAdapter<TModel> {
+  return new LovableVideoAdapter({ apiKey, ...config }, model)
+}
+
+/**
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export function lovableVideo<TModel extends LovableVideoModel>(
+  model: TModel,
+  config?: Omit<LovableVideoConfig, 'apiKey'>,
+): LovableVideoAdapter<TModel> {
+  return createLovableVideo(model, getLovableApiKeyFromEnv(), config)
+}

--- a/packages/ai-lovable/src/adapters/video.ts
+++ b/packages/ai-lovable/src/adapters/video.ts
@@ -3,7 +3,11 @@ import { resolveMediaPrompt } from '@tanstack/ai'
 import { BaseVideoAdapter, snapToDurationOption } from '@tanstack/ai/adapters'
 import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
 import { arrayBufferToBase64 } from '@tanstack/ai-utils'
-import { getLovableApiKeyFromEnv, withLovableDefaults } from '../utils/client'
+import {
+  getLovableApiKeyFromEnv,
+  openaiRequestOptions,
+  withLovableDefaults,
+} from '../utils/client'
 import { imagePartToFile } from '../image/image-input-to-file'
 import {
   toApiSeconds,
@@ -127,6 +131,7 @@ export class LovableVideoAdapter<
         inputReference,
         'input-reference',
         this.clientConfig.allowUrlFetch ?? false,
+        options.abortSignal,
       )
     }
     if (resolvedSize) {
@@ -146,7 +151,10 @@ export class LovableVideoAdapter<
         `activity=video.create provider=${this.name} model=${model} size=${request.size ?? 'default'} seconds=${request.seconds ?? 'default'}`,
         { provider: this.name, model },
       )
-      const response = await this.client.videos.create(request)
+      const response = await this.client.videos.create(
+        request,
+        openaiRequestOptions(options.abortSignal),
+      )
       return { jobId: response.id, model }
     } catch (error: unknown) {
       options.logger.errors(`${this.name}.createVideoJob fatal`, {
@@ -184,8 +192,8 @@ export class LovableVideoAdapter<
         return {
           jobId,
           url: directUrl,
-          ...(videoInfo.expires_at !== null && {
-            expiresAt: new Date(videoInfo.expires_at),
+          ...(videoInfo.expires_at != null && {
+            expiresAt: new Date(videoInfo.expires_at * 1000),
           }),
         }
       }

--- a/packages/ai-lovable/src/audio/transcription-provider-options.ts
+++ b/packages/ai-lovable/src/audio/transcription-provider-options.ts
@@ -1,6 +1,4 @@
-import type { TranscriptionResponseFormat } from '@tanstack/ai'
-
-export type LovableTranscriptionResponseFormat = TranscriptionResponseFormat
+export type LovableTranscriptionResponseFormat = 'json' | 'text'
 
 export interface LovableTranscriptionProviderOptions {
   temperature?: number

--- a/packages/ai-lovable/src/audio/transcription-provider-options.ts
+++ b/packages/ai-lovable/src/audio/transcription-provider-options.ts
@@ -1,0 +1,9 @@
+import type { TranscriptionResponseFormat } from '@tanstack/ai'
+
+export type LovableTranscriptionResponseFormat = TranscriptionResponseFormat
+
+export interface LovableTranscriptionProviderOptions {
+  temperature?: number
+  response_format?: LovableTranscriptionResponseFormat
+  prompt?: string
+}

--- a/packages/ai-lovable/src/audio/tts-provider-options.ts
+++ b/packages/ai-lovable/src/audio/tts-provider-options.ts
@@ -1,0 +1,21 @@
+export type LovableTTSVoice =
+  | 'alloy'
+  | 'ash'
+  | 'ballad'
+  | 'coral'
+  | 'echo'
+  | 'fable'
+  | 'onyx'
+  | 'nova'
+  | 'sage'
+  | 'shimmer'
+  | 'verse'
+
+export type LovableTTSFormat = 'mp3' | 'opus' | 'aac' | 'flac' | 'wav' | 'pcm'
+
+export interface LovableTTSProviderOptions {
+  /**
+   * Extra voice direction in plain language, for example "speak slowly and warmly".
+   */
+  instructions?: string
+}

--- a/packages/ai-lovable/src/byok.ts
+++ b/packages/ai-lovable/src/byok.ts
@@ -1,0 +1,7 @@
+import { defineByokProvider } from '@tanstack/ai/byok'
+
+export const lovableByok = defineByokProvider({
+  id: 'lovable',
+  label: 'Lovable AI Gateway',
+  env: 'LOVABLE_API_KEY',
+})

--- a/packages/ai-lovable/src/embedding/embedding-provider-options.ts
+++ b/packages/ai-lovable/src/embedding/embedding-provider-options.ts
@@ -1,0 +1,9 @@
+/**
+ * Provider options for Lovable embedding models.
+ *
+ * `dimensions` is a top-level option on `embed()`. `encoding_format` is
+ * pinned to `float` so vectors are always `number[]`.
+ */
+export interface LovableEmbeddingProviderOptions {
+  user?: string
+}

--- a/packages/ai-lovable/src/image/image-input-to-file.ts
+++ b/packages/ai-lovable/src/image/image-input-to-file.ts
@@ -33,6 +33,7 @@ export async function imagePartToFile(
   part: ImagePart<MediaInputMetadata>,
   fallbackName: string,
   allowUrlFetch: boolean,
+  abortSignal?: AbortSignal,
 ): Promise<File> {
   ensureFileSupport()
 
@@ -54,7 +55,10 @@ export async function imagePartToFile(
     )
   }
 
-  const response = await fetch(part.source.value)
+  const response = await fetch(
+    part.source.value,
+    abortSignal ? { signal: abortSignal } : undefined,
+  )
   if (!response.ok) {
     throw new Error(
       `Failed to fetch image input (${response.status} ${response.statusText}): ${part.source.value}`,

--- a/packages/ai-lovable/src/image/image-input-to-file.ts
+++ b/packages/ai-lovable/src/image/image-input-to-file.ts
@@ -1,0 +1,77 @@
+import { base64ToArrayBuffer } from '@tanstack/ai-utils'
+import type { ImagePart, MediaInputMetadata } from '@tanstack/ai'
+
+const DEFAULT_MIME = 'image/png'
+const MIME_TO_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+}
+
+function extForMime(mimeType: string): string {
+  return MIME_TO_EXT[mimeType] ?? mimeType.split('/')[1] ?? 'png'
+}
+
+function ensureFileSupport(): void {
+  if (typeof File === 'undefined') {
+    throw new Error(
+      '`File` is not available in this environment. ' +
+        'Image-conditioned generation requires Node 20+ or a browser context.',
+    )
+  }
+}
+
+/**
+ * Convert a TanStack `ImagePart` into an OpenAI-compatible `File`.
+ *
+ * HTTP(S) URLs are fetched only when `allowUrlFetch` is set. The gateway
+ * edit and `input_reference` endpoints need uploaded bytes, not a URL.
+ */
+export async function imagePartToFile(
+  part: ImagePart<MediaInputMetadata>,
+  fallbackName: string,
+  allowUrlFetch: boolean,
+): Promise<File> {
+  ensureFileSupport()
+
+  if (part.source.type === 'data') {
+    const mimeType = part.source.mimeType || DEFAULT_MIME
+    const bytes = base64ToArrayBuffer(part.source.value)
+    return new File([bytes], `${fallbackName}.${extForMime(mimeType)}`, {
+      type: mimeType,
+    })
+  }
+
+  if (/^https?:\/\//i.test(part.source.value) && !allowUrlFetch) {
+    throw new Error(
+      `lovable: HTTP(S) URL image inputs are not fetched by default because ` +
+        `the edit / input_reference endpoints require uploaded bytes, so ` +
+        `the image would be downloaded and buffered in memory (risking OOM on ` +
+        `constrained runtimes). Pass a data: URI, or set \`allowUrlFetch: true\` ` +
+        `on the adapter config to opt into fetching. URL: ${part.source.value}`,
+    )
+  }
+
+  const response = await fetch(part.source.value)
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch image input (${response.status} ${response.statusText}): ${part.source.value}`,
+    )
+  }
+  const blob = await response.blob()
+  const mimeType =
+    part.source.mimeType || blob.type || inferMimeFromUrl(part.source.value)
+  return new File([blob], `${fallbackName}.${extForMime(mimeType)}`, {
+    type: mimeType,
+  })
+}
+
+function inferMimeFromUrl(url: string): string {
+  const match = url.match(/\.(png|jpe?g|webp|gif)(?:\?|#|$)/i)
+  if (!match || !match[1]) return DEFAULT_MIME
+  const ext = match[1].toLowerCase()
+  if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
+  return `image/${ext}`
+}

--- a/packages/ai-lovable/src/image/image-provider-options.ts
+++ b/packages/ai-lovable/src/image/image-provider-options.ts
@@ -1,0 +1,17 @@
+export type LovableImageSize = '1024x1024' | '1536x1024' | '1024x1536' | 'auto'
+
+export type LovableImageQuality = 'high' | 'medium' | 'low' | 'auto'
+
+export type LovableImageOutputFormat = 'png' | 'jpeg' | 'webp'
+
+export type LovableImageBackground = 'transparent' | 'opaque' | 'auto'
+
+export type LovableImageModeration = 'low' | 'auto'
+
+export interface LovableImageProviderOptions {
+  quality?: LovableImageQuality
+  output_format?: LovableImageOutputFormat
+  background?: LovableImageBackground
+  moderation?: LovableImageModeration
+  user?: string
+}

--- a/packages/ai-lovable/src/index.ts
+++ b/packages/ai-lovable/src/index.ts
@@ -1,0 +1,125 @@
+/**
+ * @module @tanstack/ai-lovable
+ *
+ * Lovable AI Gateway adapter for TanStack AI.
+ */
+
+export {
+  LovableTextAdapter,
+  type LovableTextConfig,
+  type LovableTextProviderOptions,
+} from './adapters/text'
+
+export {
+  createLovableText,
+  lovableText,
+  type LovableTextApi,
+  type LovableResponsesApiConfig,
+  type LovableChatApiConfig,
+} from './adapters/factory'
+
+export {
+  LovableResponsesTextAdapter,
+  createLovableResponsesText,
+  lovableResponsesText,
+  type LovableResponsesTextConfig,
+  type LovableResponsesTextProviderOptions,
+} from './adapters/responses-text'
+
+export {
+  createLovableSummarize,
+  lovableSummarize,
+  type LovableSummarizeConfig,
+  type LovableSummarizeModel,
+} from './adapters/summarize'
+
+export {
+  LovableEmbeddingAdapter,
+  createLovableEmbedding,
+  lovableEmbedding,
+  type LovableEmbeddingConfig,
+} from './adapters/embedding'
+export type { LovableEmbeddingProviderOptions } from './embedding/embedding-provider-options'
+
+export {
+  LovableImageAdapter,
+  createLovableImage,
+  lovableImage,
+  type LovableImageConfig,
+} from './adapters/image'
+export type { LovableImageProviderOptions } from './image/image-provider-options'
+
+/**
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export {
+  LovableVideoAdapter,
+  createLovableVideo,
+  lovableVideo,
+  type LovableVideoConfig,
+} from './adapters/video'
+export type {
+  LovableVideoProviderOptions,
+  LovableVideoSize,
+  LovableHdVideoSize,
+  Lovable4kVideoSize,
+  LovableVideoDuration,
+  LovableVideoSeconds,
+} from './video/video-provider-options'
+
+export {
+  LovableTTSAdapter,
+  createLovableSpeech,
+  lovableSpeech,
+  type LovableTTSConfig,
+} from './adapters/tts'
+export type {
+  LovableTTSProviderOptions,
+  LovableTTSVoice,
+  LovableTTSFormat,
+} from './audio/tts-provider-options'
+
+export {
+  LovableTranscriptionAdapter,
+  createLovableTranscription,
+  lovableTranscription,
+  type LovableTranscriptionConfig,
+} from './adapters/transcription'
+export type { LovableTranscriptionProviderOptions } from './audio/transcription-provider-options'
+
+export {
+  LOVABLE_CHAT_MODELS,
+  LOVABLE_IMAGE_MODELS,
+  LOVABLE_VIDEO_MODELS,
+  LOVABLE_EMBEDDING_MODELS,
+  LOVABLE_TTS_MODELS,
+  LOVABLE_TRANSCRIPTION_MODELS,
+} from './model-meta'
+export type {
+  LovableChatModel,
+  LovableModelId,
+  LovableChatModelProviderOptionsByName,
+  LovableModelInputModalitiesByName,
+  LovableImageModel,
+  LovableVideoModel,
+  LovableEmbeddingModel,
+  LovableTTSModel,
+  LovableTranscriptionModel,
+  ResolveProviderOptions,
+  ResolveInputModalities,
+} from './model-meta'
+
+export type {
+  LovableTextMetadata,
+  LovableImageMetadata,
+  LovableAudioMetadata,
+  LovableVideoMetadata,
+  LovableDocumentMetadata,
+  LovableMessageMetadataByModality,
+} from './message-types'
+
+export {
+  getLovableApiKeyFromEnv,
+  lovableGatewayHeaders,
+  type LovableClientConfig,
+} from './utils/client'

--- a/packages/ai-lovable/src/message-types.ts
+++ b/packages/ai-lovable/src/message-types.ts
@@ -1,0 +1,45 @@
+/**
+ * Metadata for Lovable AI Gateway document content parts.
+ */
+export interface LovableDocumentMetadata {}
+
+/**
+ * Metadata for Lovable AI Gateway text content parts.
+ */
+export interface LovableTextMetadata {}
+
+/**
+ * Metadata for Lovable AI Gateway image content parts.
+ */
+export interface LovableImageMetadata {
+  /**
+   * Specifies the detail level of the image.
+   * - 'auto': Let the model decide based on image size and content
+   * - 'low': Use low resolution processing (faster, cheaper, less detail)
+   * - 'high': Use high resolution processing (slower, more expensive, more detail)
+   *
+   * @default 'auto'
+   */
+  detail?: 'auto' | 'low' | 'high'
+}
+
+/**
+ * Metadata for Lovable AI Gateway audio content parts.
+ */
+export interface LovableAudioMetadata {}
+
+/**
+ * Metadata for Lovable AI Gateway video content parts.
+ */
+export interface LovableVideoMetadata {}
+
+/**
+ * Map of modality types to their Lovable AI Gateway metadata types.
+ */
+export interface LovableMessageMetadataByModality {
+  text: LovableTextMetadata
+  image: LovableImageMetadata
+  audio: LovableAudioMetadata
+  video: LovableVideoMetadata
+  document: LovableDocumentMetadata
+}

--- a/packages/ai-lovable/src/model-meta.ts
+++ b/packages/ai-lovable/src/model-meta.ts
@@ -1,0 +1,161 @@
+import type { LovableEmbeddingProviderOptions } from './embedding/embedding-provider-options'
+import type {
+  LovableImageProviderOptions,
+  LovableImageSize,
+} from './image/image-provider-options'
+import type { LovableTextProviderOptions } from './text/text-provider-options'
+import type {
+  LovableHdVideoSize,
+  LovableVideoDuration,
+  LovableVideoProviderOptions,
+  LovableVideoSize,
+} from './video/video-provider-options'
+
+/**
+ * Chat models listed on https://docs.lovable.dev/features/ai.
+ * Ids use the `google/` and `openai/` form that the gateway accepts.
+ */
+export const LOVABLE_CHAT_MODELS = [
+  'google/gemini-3.7-flash',
+  'google/gemini-3.6-flash',
+  'google/gemini-3.5-flash',
+  'google/gemini-3.1-pro-preview',
+  'google/gemini-3.1-flash-lite',
+  'google/gemini-3-flash-preview',
+  'google/gemini-2.5-pro',
+  'google/gemini-2.5-flash',
+  'google/gemini-2.5-flash-lite',
+  'openai/gpt-5.6-sol',
+  'openai/gpt-5.6-terra',
+  'openai/gpt-5.6-luna',
+  'openai/gpt-5.5-pro',
+  'openai/gpt-5.5',
+  'openai/gpt-5.4-pro',
+  'openai/gpt-5.4',
+  'openai/gpt-5.4-mini',
+  'openai/gpt-5.4-nano',
+  'openai/gpt-5.2',
+  'openai/gpt-5',
+  'openai/gpt-5-mini',
+  'openai/gpt-5-nano',
+] as const
+
+export type LovableChatModel = (typeof LOVABLE_CHAT_MODELS)[number]
+
+/**
+ * A curated chat model id, or any other id the gateway accepts.
+ * Uncurated ids fall back to text-only input and the generic provider options.
+ */
+export type LovableModelId = LovableChatModel | (string & {})
+
+export type LovableChatModelProviderOptionsByName = {
+  [K in LovableChatModel]: LovableTextProviderOptions
+}
+
+export type LovableModelInputModalitiesByName = {
+  [K in LovableChatModel]: readonly ['text', 'image']
+}
+
+export type LovableChatModelToolCapabilitiesByName = {
+  [K in LovableChatModel]: readonly []
+}
+
+export type ResolveProviderOptions<TModel extends string> =
+  TModel extends keyof LovableChatModelProviderOptionsByName
+    ? LovableChatModelProviderOptionsByName[TModel]
+    : LovableTextProviderOptions
+
+export type ResolveInputModalities<TModel extends string> =
+  TModel extends keyof LovableModelInputModalitiesByName
+    ? LovableModelInputModalitiesByName[TModel]
+    : readonly ['text']
+
+export const LOVABLE_IMAGE_MODELS = [
+  'openai/gpt-image-2',
+  'openai/gpt-image-1-mini',
+  'google/gemini-3.1-flash-image',
+  'google/gemini-3.1-flash-lite-image',
+  'google/gemini-3-pro-image',
+  'google/gemini-2.5-flash-image',
+] as const
+
+export type LovableImageModel = (typeof LOVABLE_IMAGE_MODELS)[number]
+
+export type LovableImageModelProviderOptionsByName = {
+  [K in LovableImageModel]: LovableImageProviderOptions
+}
+
+export type LovableImageModelSizeByName = {
+  [K in LovableImageModel]: LovableImageSize
+}
+
+export type LovableImageModelInputModalitiesByName = {
+  [K in LovableImageModel]: readonly ['image']
+}
+
+/**
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export const LOVABLE_VIDEO_MODELS = [
+  'google/veo-3.1-lite',
+  'google/veo-3.1-fast',
+  'google/veo-3.1',
+] as const
+
+/**
+ * @experimental Video generation is an experimental feature and may change.
+ */
+export type LovableVideoModel = (typeof LOVABLE_VIDEO_MODELS)[number]
+
+export type LovableVideoModelProviderOptionsByName = {
+  [K in LovableVideoModel]: LovableVideoProviderOptions
+}
+
+export type LovableVideoModelSizeByName = {
+  'google/veo-3.1-lite': LovableHdVideoSize
+  'google/veo-3.1-fast': LovableVideoSize
+  'google/veo-3.1': LovableVideoSize
+}
+
+export type LovableVideoModelDurationByName = {
+  [K in LovableVideoModel]: LovableVideoDuration
+}
+
+export type LovableVideoModelInputModalitiesByName = {
+  [K in LovableVideoModel]: readonly ['image']
+}
+
+export const LOVABLE_EMBEDDING_MODELS = [
+  'google/gemini-embedding-2',
+  'google/gemini-embedding-001',
+  'openai/text-embedding-3-small',
+  'openai/text-embedding-3-large',
+] as const
+
+export type LovableEmbeddingModel = (typeof LOVABLE_EMBEDDING_MODELS)[number]
+
+export type LovableEmbeddingModelProviderOptionsByName = {
+  [K in LovableEmbeddingModel]: LovableEmbeddingProviderOptions
+}
+
+export type LovableEmbeddingModelInputModalitiesByName = {
+  [K in LovableEmbeddingModel]: readonly ['text']
+}
+
+export const LOVABLE_TTS_MODELS = [
+  'openai/gpt-4o-mini-tts',
+  'google/gemini-2.5-flash-tts',
+  'google/gemini-2.5-pro-tts',
+  'google/gemini-2.5-flash-lite-preview-tts',
+  'google/gemini-3.1-flash-tts-preview',
+] as const
+
+export type LovableTTSModel = (typeof LOVABLE_TTS_MODELS)[number]
+
+export const LOVABLE_TRANSCRIPTION_MODELS = [
+  'openai/gpt-4o-mini-transcribe',
+  'openai/gpt-4o-transcribe',
+] as const
+
+export type LovableTranscriptionModel =
+  (typeof LOVABLE_TRANSCRIPTION_MODELS)[number]

--- a/packages/ai-lovable/src/text/responses-provider-options.ts
+++ b/packages/ai-lovable/src/text/responses-provider-options.ts
@@ -1,0 +1,8 @@
+import type { LovableTextProviderOptions } from './text-provider-options'
+
+export type LovableResponsesProviderOptions = Pick<
+  LovableTextProviderOptions,
+  'temperature' | 'top_p' | 'max_output_tokens' | 'user'
+>
+
+export type ExternalResponsesProviderOptions = LovableResponsesProviderOptions

--- a/packages/ai-lovable/src/text/text-provider-options.ts
+++ b/packages/ai-lovable/src/text/text-provider-options.ts
@@ -1,0 +1,18 @@
+export interface LovableTextProviderOptions {
+  temperature?: number | null
+  top_p?: number | null
+  max_tokens?: number | null
+  max_completion_tokens?: number | null
+  max_output_tokens?: number | null
+  frequency_penalty?: number | null
+  presence_penalty?: number | null
+  stop?: string | null | Array<string>
+  seed?: number | null
+  reasoning?: boolean | Record<string, unknown> | null
+  include_reasoning?: boolean | null
+  response_format?: unknown
+  structured_outputs?: boolean | null
+  user?: string | null
+}
+
+export type ExternalTextProviderOptions = LovableTextProviderOptions

--- a/packages/ai-lovable/src/utils/client.ts
+++ b/packages/ai-lovable/src/utils/client.ts
@@ -1,0 +1,43 @@
+import { getApiKeyFromEnv } from '@tanstack/ai-utils'
+import type { ClientOptions } from 'openai'
+
+export const LOVABLE_DEFAULT_BASE_URL = 'https://ai.gateway.lovable.dev/v1'
+
+export interface LovableClientConfig extends Omit<ClientOptions, 'apiKey'> {
+  apiKey: string
+}
+
+export function getLovableApiKeyFromEnv(): string {
+  try {
+    return getApiKeyFromEnv('LOVABLE_API_KEY')
+  } catch (cause) {
+    throw new Error(
+      'LOVABLE_API_KEY is required. Set it in the environment or pass apiKey to the factory.',
+      { cause },
+    )
+  }
+}
+
+export function lovableGatewayHeaders(apiKey: string): {
+  'Lovable-API-Key': string
+  'X-Lovable-AIG-SDK': string
+} {
+  return {
+    'Lovable-API-Key': apiKey,
+    'X-Lovable-AIG-SDK': 'tanstack-ai',
+  }
+}
+
+export function withLovableDefaults(
+  config: LovableClientConfig,
+): ClientOptions {
+  const { defaultHeaders, ...rest } = config
+  return {
+    ...rest,
+    baseURL: config.baseURL || LOVABLE_DEFAULT_BASE_URL,
+    defaultHeaders: {
+      ...lovableGatewayHeaders(config.apiKey),
+      ...defaultHeaders,
+    },
+  }
+}

--- a/packages/ai-lovable/src/utils/client.ts
+++ b/packages/ai-lovable/src/utils/client.ts
@@ -41,3 +41,10 @@ export function withLovableDefaults(
     },
   }
 }
+
+export function openaiRequestOptions(
+  abortSignal?: AbortSignal,
+): { signal: AbortSignal } | undefined {
+  if (!abortSignal) return undefined
+  return { signal: abortSignal }
+}

--- a/packages/ai-lovable/src/video/video-provider-options.ts
+++ b/packages/ai-lovable/src/video/video-provider-options.ts
@@ -1,0 +1,128 @@
+/**
+ * @experimental Video generation is an experimental feature and may change.
+ */
+
+export type LovableHdVideoSize =
+  | '1280x720'
+  | '720x1280'
+  | '1920x1080'
+  | '1080x1920'
+
+export type Lovable4kVideoSize = '3840x2160' | '2160x3840'
+
+export type LovableVideoSize = LovableHdVideoSize | Lovable4kVideoSize
+
+export type LovableVideoSeconds = '4' | '6' | '8'
+
+export type LovableVideoDuration = 4 | 6 | 8
+
+export interface LovableVideoProviderOptions {
+  size?: LovableVideoSize
+  seconds?: LovableVideoSeconds
+}
+
+const HD_SIZES: ReadonlyArray<LovableHdVideoSize> = [
+  '1280x720',
+  '720x1280',
+  '1920x1080',
+  '1080x1920',
+]
+
+const FOUR_K_SIZES: ReadonlyArray<Lovable4kVideoSize> = [
+  '3840x2160',
+  '2160x3840',
+]
+
+const ALL_SIZES: ReadonlyArray<LovableVideoSize> = [
+  ...HD_SIZES,
+  ...FOUR_K_SIZES,
+]
+
+const HIGH_RES_SIZES: ReadonlySet<string> = new Set([
+  '1920x1080',
+  '1080x1920',
+  '3840x2160',
+  '2160x3840',
+])
+
+const FOUR_K_MODELS: ReadonlySet<string> = new Set([
+  'google/veo-3.1-fast',
+  'google/veo-3.1',
+])
+
+export function is4kVideoSize(size: string): size is Lovable4kVideoSize {
+  return (FOUR_K_SIZES as ReadonlyArray<string>).includes(size)
+}
+
+export function isHighResVideoSize(size: string): boolean {
+  return HIGH_RES_SIZES.has(size)
+}
+
+export function supports4kVideo(model: string): boolean {
+  return FOUR_K_MODELS.has(model)
+}
+
+export function validateVideoSize(
+  model: string,
+  size?: string,
+): asserts size is LovableVideoSize | undefined {
+  if (!size) return
+
+  if (!(ALL_SIZES as ReadonlyArray<string>).includes(size)) {
+    throw new Error(
+      `Size "${size}" is not supported by model "${model}". Supported sizes: ${ALL_SIZES.join(', ')}`,
+    )
+  }
+
+  if (is4kVideoSize(size) && !supports4kVideo(model)) {
+    throw new Error(
+      `Size "${size}" is 4K. Only google/veo-3.1-fast and google/veo-3.1 support 4K.`,
+    )
+  }
+}
+
+export function validateVideoSeconds(
+  model: string,
+  seconds?: number | string,
+): asserts seconds is LovableVideoSeconds | LovableVideoDuration | undefined {
+  if (seconds === undefined) return
+
+  const isValid =
+    typeof seconds === 'string'
+      ? seconds === '4' || seconds === '6' || seconds === '8'
+      : seconds === 4 || seconds === 6 || seconds === 8
+
+  if (!isValid) {
+    throw new Error(
+      `Duration "${seconds}" is not supported by model "${model}". Supported durations: 4, 6, or 8 seconds`,
+    )
+  }
+}
+
+export function validateHighResDuration(
+  model: string,
+  size: string | undefined,
+  seconds: number | string | undefined,
+): void {
+  if (!size || !isHighResVideoSize(size)) return
+
+  const asNumber =
+    seconds === undefined
+      ? undefined
+      : typeof seconds === 'string'
+        ? Number(seconds)
+        : seconds
+
+  if (asNumber !== undefined && asNumber !== 8) {
+    throw new Error(
+      `Model "${model}" requires 8 second clips at 1080p and 4K. Received duration ${seconds}.`,
+    )
+  }
+}
+
+export function toApiSeconds(
+  seconds: number | string | undefined,
+): LovableVideoSeconds | undefined {
+  if (seconds === undefined) return undefined
+  return String(seconds) as LovableVideoSeconds
+}

--- a/packages/ai-lovable/tests/byok.test.ts
+++ b/packages/ai-lovable/tests/byok.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { lovableByok } from '../src/byok'
+
+describe('lovableByok', () => {
+  it('exports a required slug', () => {
+    expect(lovableByok.id).toBe('lovable')
+    expect(lovableByok.label).toBe('Lovable AI Gateway')
+    expect(lovableByok.env).toContain('LOVABLE_API_KEY')
+  })
+})

--- a/packages/ai-lovable/tests/client.test.ts
+++ b/packages/ai-lovable/tests/client.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getLovableApiKeyFromEnv,
+  lovableGatewayHeaders,
+  withLovableDefaults,
+  LOVABLE_DEFAULT_BASE_URL,
+} from '../src/utils/client'
+
+describe('getLovableApiKeyFromEnv', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('reads LOVABLE_API_KEY', () => {
+    vi.stubEnv('LOVABLE_API_KEY', 'lv_key')
+
+    expect(getLovableApiKeyFromEnv()).toBe('lv_key')
+  })
+
+  it('throws when LOVABLE_API_KEY is unset', () => {
+    expect(() => getLovableApiKeyFromEnv()).toThrow(/LOVABLE_API_KEY/)
+  })
+})
+
+describe('lovableGatewayHeaders', () => {
+  it('returns the gateway auth headers', () => {
+    expect(lovableGatewayHeaders('k')).toEqual({
+      'Lovable-API-Key': 'k',
+      'X-Lovable-AIG-SDK': 'tanstack-ai',
+    })
+  })
+})
+
+describe('withLovableDefaults', () => {
+  it('sets the default gateway baseURL and auth headers', () => {
+    expect(withLovableDefaults({ apiKey: 'k' })).toMatchObject({
+      apiKey: 'k',
+      baseURL: LOVABLE_DEFAULT_BASE_URL,
+      defaultHeaders: {
+        'Lovable-API-Key': 'k',
+        'X-Lovable-AIG-SDK': 'tanstack-ai',
+      },
+    })
+  })
+
+  it('keeps an explicit baseURL', () => {
+    expect(
+      withLovableDefaults({
+        apiKey: 'k',
+        baseURL: 'http://127.0.0.1:4010/v1',
+      }),
+    ).toMatchObject({
+      apiKey: 'k',
+      baseURL: 'http://127.0.0.1:4010/v1',
+    })
+  })
+
+  it('lets caller defaultHeaders override SDK identification', () => {
+    const result = withLovableDefaults({
+      apiKey: 'k',
+      defaultHeaders: { 'X-Lovable-AIG-SDK': 'custom' },
+    })
+
+    expect(result.defaultHeaders).toMatchObject({
+      'Lovable-API-Key': 'k',
+      'X-Lovable-AIG-SDK': 'custom',
+    })
+  })
+})

--- a/packages/ai-lovable/tests/client.test.ts
+++ b/packages/ai-lovable/tests/client.test.ts
@@ -18,6 +18,7 @@ describe('getLovableApiKeyFromEnv', () => {
   })
 
   it('throws when LOVABLE_API_KEY is unset', () => {
+    vi.stubEnv('LOVABLE_API_KEY', '')
     expect(() => getLovableApiKeyFromEnv()).toThrow(/LOVABLE_API_KEY/)
   })
 })

--- a/packages/ai-lovable/tests/embedding-adapter.test.ts
+++ b/packages/ai-lovable/tests/embedding-adapter.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import {
+  LovableEmbeddingAdapter,
+  createLovableEmbedding,
+} from '../src/adapters/embedding'
+import type OpenAI from 'openai'
+import type { LovableEmbeddingModel } from '../src/model-meta'
+
+const testLogger = resolveDebugOption(false)
+
+class TestLovableEmbeddingAdapter<
+  TModel extends LovableEmbeddingModel,
+> extends LovableEmbeddingAdapter<TModel> {
+  spyOnEmbeddingsCreate() {
+    return vi.spyOn(this.client.embeddings, 'create')
+  }
+}
+
+function mockResponse(
+  vectors: Array<Array<number>>,
+): OpenAI.CreateEmbeddingResponse {
+  return {
+    object: 'list',
+    model: 'openai/text-embedding-3-small',
+    data: vectors.map((embedding, index) => ({
+      object: 'embedding',
+      embedding,
+      index,
+    })),
+    usage: { prompt_tokens: 7, total_tokens: 7 },
+  }
+}
+
+describe('Lovable embedding adapter', () => {
+  it('creates an adapter with the provided API key', () => {
+    const adapter = createLovableEmbedding(
+      'openai/text-embedding-3-small',
+      'test-api-key',
+    )
+    expect(adapter).toBeInstanceOf(LovableEmbeddingAdapter)
+    expect(adapter.kind).toBe('embedding')
+    expect(adapter.name).toBe('lovable')
+    expect(adapter.model).toBe('openai/text-embedding-3-small')
+  })
+
+  it('sends texts as a batch with encoding_format float', async () => {
+    const adapter = new TestLovableEmbeddingAdapter(
+      { apiKey: 'test' },
+      'openai/text-embedding-3-small',
+    )
+    const spy = adapter.spyOnEmbeddingsCreate()
+    spy.mockResolvedValue(
+      mockResponse([
+        [0.1, 0.2],
+        [0.3, 0.4],
+      ]),
+    )
+
+    const result = await adapter.createEmbeddings({
+      model: 'openai/text-embedding-3-small',
+      input: ['a red guitar', { type: 'text', content: 'a blue drum kit' }],
+      logger: testLogger,
+    })
+
+    expect(spy).toHaveBeenCalledWith({
+      model: 'openai/text-embedding-3-small',
+      input: ['a red guitar', 'a blue drum kit'],
+      encoding_format: 'float',
+    })
+    expect(result.embeddings).toEqual([
+      { vector: [0.1, 0.2], index: 0 },
+      { vector: [0.3, 0.4], index: 1 },
+    ])
+  })
+
+  it('rejects image input', async () => {
+    const adapter = createLovableEmbedding('openai/text-embedding-3-small', 'k')
+    await expect(
+      adapter.createEmbeddings({
+        model: 'openai/text-embedding-3-small',
+        input: [
+          {
+            type: 'image',
+            source: { type: 'url', value: 'https://example.com/a.png' },
+          },
+        ],
+        logger: testLogger,
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/packages/ai-lovable/tests/factory.test.ts
+++ b/packages/ai-lovable/tests/factory.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LovableTextAdapter } from '../src/adapters/text'
+import { LovableResponsesTextAdapter } from '../src/adapters/responses-text'
+import { createLovableText, lovableText } from '../src/adapters/factory'
+
+describe('createLovableText (branching factory)', () => {
+  it('defaults to the Responses adapter', () => {
+    const adapter = createLovableText('openai/gpt-5.5', 'k')
+
+    expect(adapter).toBeInstanceOf(LovableResponsesTextAdapter)
+    expect(adapter.kind).toBe('text')
+    expect(adapter.name).toBe('lovable')
+    expect(adapter.model).toBe('openai/gpt-5.5')
+  })
+
+  it("returns the Responses adapter when api is 'responses'", () => {
+    const adapter = createLovableText('openai/gpt-5.5', 'k', {
+      api: 'responses',
+    })
+
+    expect(adapter).toBeInstanceOf(LovableResponsesTextAdapter)
+  })
+
+  it("returns the Chat Completions adapter when api is 'chat'", () => {
+    const adapter = createLovableText('openai/gpt-5.5', 'k', {
+      api: 'chat',
+    })
+
+    expect(adapter).toBeInstanceOf(LovableTextAdapter)
+  })
+
+  it("returns the Chat Completions adapter when api is 'chat-completions'", () => {
+    const adapter = createLovableText('openai/gpt-5.5', 'k', {
+      api: 'chat-completions',
+    })
+
+    expect(adapter).toBeInstanceOf(LovableTextAdapter)
+  })
+})
+
+describe('lovableText (env-key branching factory)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('reads LOVABLE_API_KEY and defaults to Responses', () => {
+    vi.stubEnv('LOVABLE_API_KEY', 'env-key')
+
+    expect(lovableText('openai/gpt-5.5')).toBeInstanceOf(
+      LovableResponsesTextAdapter,
+    )
+    expect(lovableText('openai/gpt-5.5', { api: 'responses' })).toBeInstanceOf(
+      LovableResponsesTextAdapter,
+    )
+    expect(lovableText('openai/gpt-5.5', { api: 'chat' })).toBeInstanceOf(
+      LovableTextAdapter,
+    )
+  })
+})

--- a/packages/ai-lovable/tests/image-adapter.test.ts
+++ b/packages/ai-lovable/tests/image-adapter.test.ts
@@ -36,22 +36,27 @@ describe('Lovable image adapter', () => {
       data: [{ b64_json: 'abc' }],
     })
 
+    const abortSignal = new AbortController().signal
     const result = await adapter.generateImages({
       model: 'openai/gpt-image-2',
       prompt: 'a red guitar',
       numberOfImages: 1,
       size: '1024x1024',
       logger: testLogger,
+      abortSignal,
     })
 
     expect(result.images[0]?.b64Json).toBe('abc')
-    expect(mockGenerate).toHaveBeenCalledWith({
-      model: 'openai/gpt-image-2',
-      prompt: 'a red guitar',
-      n: 1,
-      size: '1024x1024',
-      stream: false,
-    })
+    expect(mockGenerate).toHaveBeenCalledWith(
+      {
+        model: 'openai/gpt-image-2',
+        prompt: 'a red guitar',
+        n: 1,
+        size: '1024x1024',
+        stream: false,
+      },
+      { signal: abortSignal },
+    )
   })
 
   it('throws when the response contains no usable images', async () => {
@@ -88,6 +93,7 @@ describe('Lovable image adapter', () => {
         .mockResolvedValueOnce(imagesEditResponse)
       const generateSpy = adapter.spyOnImagesGenerate()
 
+      const abortSignal = new AbortController().signal
       const result = await adapter.generateImages({
         model: 'openai/gpt-image-2',
         prompt: [
@@ -102,6 +108,7 @@ describe('Lovable image adapter', () => {
           },
         ],
         logger: testLogger,
+        abortSignal,
       })
 
       expect(generateSpy).not.toHaveBeenCalled()
@@ -110,6 +117,7 @@ describe('Lovable image adapter', () => {
       expect(editArgs.model).toBe('openai/gpt-image-2')
       expect(editArgs.prompt).toBe('Make it cinematic')
       expect(editArgs.image).toBeInstanceOf(File)
+      expect(editSpy.mock.calls[0]![1]).toEqual({ signal: abortSignal })
       expect(result.images[0]!.b64Json).toBe('edited-base64')
     })
 

--- a/packages/ai-lovable/tests/image-adapter.test.ts
+++ b/packages/ai-lovable/tests/image-adapter.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import { LovableImageAdapter, createLovableImage } from '../src/adapters/image'
+import type OpenAI from 'openai'
+import type { LovableImageModel } from '../src/model-meta'
+
+const testLogger = resolveDebugOption(false)
+
+class TestLovableImageAdapter<
+  TModel extends LovableImageModel,
+> extends LovableImageAdapter<TModel> {
+  spyOnImagesGenerate() {
+    return vi.spyOn(this.client.images, 'generate')
+  }
+  spyOnImagesEdit() {
+    return vi.spyOn(this.client.images, 'edit')
+  }
+}
+
+describe('Lovable image adapter', () => {
+  it('creates an adapter with the provided API key', () => {
+    const adapter = createLovableImage('openai/gpt-image-2', 'test-api-key')
+    expect(adapter).toBeInstanceOf(LovableImageAdapter)
+    expect(adapter.kind).toBe('image')
+    expect(adapter.name).toBe('lovable')
+    expect(adapter.model).toBe('openai/gpt-image-2')
+  })
+
+  it('calls images.generate with model, prompt, n, and size', async () => {
+    const adapter = new TestLovableImageAdapter(
+      { apiKey: 'test-api-key' },
+      'openai/gpt-image-2',
+    )
+    const mockGenerate = adapter.spyOnImagesGenerate().mockResolvedValueOnce({
+      created: 0,
+      data: [{ b64_json: 'abc' }],
+    })
+
+    const result = await adapter.generateImages({
+      model: 'openai/gpt-image-2',
+      prompt: 'a red guitar',
+      numberOfImages: 1,
+      size: '1024x1024',
+      logger: testLogger,
+    })
+
+    expect(result.images[0]?.b64Json).toBe('abc')
+    expect(mockGenerate).toHaveBeenCalledWith({
+      model: 'openai/gpt-image-2',
+      prompt: 'a red guitar',
+      n: 1,
+      size: '1024x1024',
+      stream: false,
+    })
+  })
+
+  it('throws when the response contains no usable images', async () => {
+    const adapter = new TestLovableImageAdapter(
+      { apiKey: 'test-api-key' },
+      'openai/gpt-image-2',
+    )
+    adapter
+      .spyOnImagesGenerate()
+      .mockResolvedValueOnce({ created: 0, data: [{}] })
+
+    await expect(
+      adapter.generateImages({
+        model: 'openai/gpt-image-2',
+        prompt: 'A cat',
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/image response contained no images/)
+  })
+
+  describe('image edits', () => {
+    const imagesEditResponse: OpenAI.Images.ImagesResponse = {
+      created: 0,
+      data: [{ b64_json: 'edited-base64' }],
+    }
+
+    it('routes to images.edit when the prompt has image parts', async () => {
+      const adapter = new TestLovableImageAdapter(
+        { apiKey: 'test-api-key' },
+        'openai/gpt-image-2',
+      )
+      const editSpy = adapter
+        .spyOnImagesEdit()
+        .mockResolvedValueOnce(imagesEditResponse)
+      const generateSpy = adapter.spyOnImagesGenerate()
+
+      const result = await adapter.generateImages({
+        model: 'openai/gpt-image-2',
+        prompt: [
+          { type: 'text', content: 'Make it cinematic' },
+          {
+            type: 'image',
+            source: {
+              type: 'data',
+              value: 'aGVsbG8=',
+              mimeType: 'image/png',
+            },
+          },
+        ],
+        logger: testLogger,
+      })
+
+      expect(generateSpy).not.toHaveBeenCalled()
+      expect(editSpy).toHaveBeenCalledTimes(1)
+      const editArgs = editSpy.mock.calls[0]![0]
+      expect(editArgs.model).toBe('openai/gpt-image-2')
+      expect(editArgs.prompt).toBe('Make it cinematic')
+      expect(editArgs.image).toBeInstanceOf(File)
+      expect(result.images[0]!.b64Json).toBe('edited-base64')
+    })
+
+    it('sends a mask file for openai models', async () => {
+      const adapter = new TestLovableImageAdapter(
+        { apiKey: 'test-api-key' },
+        'openai/gpt-image-2',
+      )
+      const editSpy = adapter
+        .spyOnImagesEdit()
+        .mockResolvedValueOnce(imagesEditResponse)
+
+      await adapter.generateImages({
+        model: 'openai/gpt-image-2',
+        prompt: [
+          { type: 'text', content: 'Remove the background' },
+          {
+            type: 'image',
+            source: {
+              type: 'data',
+              value: 'aGVsbG8=',
+              mimeType: 'image/png',
+            },
+          },
+          {
+            type: 'image',
+            source: {
+              type: 'data',
+              value: 'bWFzaw==',
+              mimeType: 'image/png',
+            },
+            metadata: { role: 'mask' },
+          },
+        ],
+        logger: testLogger,
+      })
+
+      expect(editSpy.mock.calls[0]![0].mask).toBeInstanceOf(File)
+    })
+
+    it('rejects mask parts on google image models', async () => {
+      const adapter = new TestLovableImageAdapter(
+        { apiKey: 'test-api-key' },
+        'google/gemini-3.1-flash-image',
+      )
+      const editSpy = adapter.spyOnImagesEdit()
+
+      await expect(
+        adapter.generateImages({
+          model: 'google/gemini-3.1-flash-image',
+          prompt: [
+            { type: 'text', content: 'Remove the background' },
+            {
+              type: 'image',
+              source: {
+                type: 'data',
+                value: 'aGVsbG8=',
+                mimeType: 'image/png',
+              },
+            },
+            {
+              type: 'image',
+              source: {
+                type: 'data',
+                value: 'bWFzaw==',
+                mimeType: 'image/png',
+              },
+              metadata: { role: 'mask' },
+            },
+          ],
+          logger: testLogger,
+        }),
+      ).rejects.toThrow(/does not support mask/)
+      expect(editSpy).not.toHaveBeenCalled()
+    })
+
+    it('throws on an HTTP(S) URL image input by default', async () => {
+      const adapter = new TestLovableImageAdapter(
+        { apiKey: 'test-api-key' },
+        'openai/gpt-image-2',
+      )
+      const editSpy = adapter.spyOnImagesEdit()
+
+      await expect(
+        adapter.generateImages({
+          model: 'openai/gpt-image-2',
+          prompt: [
+            { type: 'text', content: 'Make it cinematic' },
+            {
+              type: 'image',
+              source: { type: 'url', value: 'https://example.com/photo.jpg' },
+            },
+          ],
+          logger: testLogger,
+        }),
+      ).rejects.toThrow(/allowUrlFetch/)
+      expect(editSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/ai-lovable/tests/responses-text-adapter.test.ts
+++ b/packages/ai-lovable/tests/responses-text-adapter.test.ts
@@ -1,0 +1,126 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  afterEach,
+  beforeEach,
+  type Mock,
+} from 'vitest'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import { EventType } from '@tanstack/ai'
+import {
+  createLovableResponsesText as _realCreate,
+  lovableResponsesText as _realFactory,
+} from '../src/adapters/responses-text'
+import type { StreamChunk } from '@tanstack/ai'
+
+const testLogger = resolveDebugOption(false)
+
+vi.mock('openai', () => {
+  return {
+    default: class {
+      responses = {
+        create: vi.fn(),
+      }
+    },
+  }
+})
+
+function createAsyncIterable<T>(chunks: Array<T>): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0
+      return {
+        async next() {
+          if (index < chunks.length) {
+            return { value: chunks[index++]!, done: false }
+          }
+          return { value: undefined as T, done: true }
+        },
+      }
+    },
+  }
+}
+
+let pendingMockCreate: Mock<(...args: Array<unknown>) => unknown> | undefined
+
+function setupMockSdkClient(
+  streamChunks: Array<Record<string, unknown>>,
+): Mock<(...args: Array<unknown>) => unknown> {
+  pendingMockCreate = vi.fn().mockImplementation(() => {
+    return Promise.resolve(createAsyncIterable(streamChunks))
+  })
+  return pendingMockCreate
+}
+
+function applyPendingMock<T extends object>(adapter: T): T {
+  if (pendingMockCreate) {
+    // openai-base keeps the SDK client as a private field; tests inject it
+    // the same way as @tanstack/ai-vercel-gateway.
+    Object.assign(adapter, {
+      client: { responses: { create: pendingMockCreate } },
+    })
+    pendingMockCreate = undefined
+  }
+  return adapter
+}
+
+const createLovableResponsesText: typeof _realCreate = (
+  model,
+  apiKey,
+  config,
+) => applyPendingMock(_realCreate(model, apiKey, config))
+const lovableResponsesText: typeof _realFactory = (model, config) =>
+  applyPendingMock(_realFactory(model, config))
+
+describe('Lovable Responses text adapter', () => {
+  beforeEach(() => {
+    pendingMockCreate = undefined
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('creates a Responses adapter with name lovable', () => {
+    const adapter = createLovableResponsesText('google/gemini-3.7-flash', 'k')
+
+    expect(adapter.kind).toBe('text')
+    expect(adapter.name).toBe('lovable')
+    expect(adapter.model).toBe('google/gemini-3.7-flash')
+  })
+
+  it('creates a Responses adapter from LOVABLE_API_KEY', () => {
+    vi.stubEnv('LOVABLE_API_KEY', 'env-key')
+
+    const adapter = lovableResponsesText('openai/gpt-5.5')
+
+    expect(adapter.kind).toBe('text')
+    expect(adapter.model).toBe('openai/gpt-5.5')
+  })
+
+  it('emits RUN_STARTED then text from a Responses stream', async () => {
+    setupMockSdkClient([{ type: 'response.output_text.delta', delta: 'hi' }])
+    const adapter = createLovableResponsesText('openai/gpt-5.5', 'k')
+    const chunks: Array<StreamChunk> = []
+
+    for await (const chunk of adapter.chatStream({
+      model: 'openai/gpt-5.5',
+      messages: [{ role: 'user', content: 'hi' }],
+      logger: testLogger,
+    })) {
+      chunks.push(chunk)
+    }
+
+    expect(chunks[0]?.type).toBe(EventType.RUN_STARTED)
+    expect(
+      chunks.some(
+        (chunk) =>
+          chunk.type === EventType.TEXT_MESSAGE_CONTENT &&
+          'delta' in chunk &&
+          chunk.delta === 'hi',
+      ),
+    ).toBe(true)
+  })
+})

--- a/packages/ai-lovable/tests/summarize-adapter.test.ts
+++ b/packages/ai-lovable/tests/summarize-adapter.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  createLovableSummarize,
+  lovableSummarize,
+} from '../src/adapters/summarize'
+
+describe('Lovable summarize adapter', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('creates a summarize adapter with kind summarize', () => {
+    const adapter = createLovableSummarize('google/gemini-3.7-flash', 'k')
+
+    expect(adapter.kind).toBe('summarize')
+    expect(adapter.name).toBe('lovable')
+    expect(adapter.model).toBe('google/gemini-3.7-flash')
+  })
+
+  it('creates a summarize adapter from LOVABLE_API_KEY', () => {
+    vi.stubEnv('LOVABLE_API_KEY', 'env-key')
+
+    const adapter = lovableSummarize('openai/gpt-5.5')
+
+    expect(adapter.kind).toBe('summarize')
+    expect(adapter.name).toBe('lovable')
+  })
+})

--- a/packages/ai-lovable/tests/text-adapter.test.ts
+++ b/packages/ai-lovable/tests/text-adapter.test.ts
@@ -1,0 +1,133 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  afterEach,
+  beforeEach,
+  type Mock,
+} from 'vitest'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import { EventType } from '@tanstack/ai'
+import {
+  createLovableText as _realCreateLovableText,
+  lovableText as _realLovableText,
+} from '../src/adapters/factory'
+import type { StreamChunk } from '@tanstack/ai'
+
+const testLogger = resolveDebugOption(false)
+
+vi.mock('openai', () => {
+  return {
+    default: class {
+      chat = {
+        completions: {
+          create: vi.fn(),
+        },
+      }
+    },
+  }
+})
+
+function createAsyncIterable<T>(chunks: Array<T>): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0
+      return {
+        async next() {
+          if (index < chunks.length) {
+            return { value: chunks[index++]!, done: false }
+          }
+          return { value: undefined as T, done: true }
+        },
+      }
+    },
+  }
+}
+
+let pendingMockCreate: Mock<(...args: Array<unknown>) => unknown> | undefined
+
+function setupMockSdkClient(
+  streamChunks: Array<Record<string, unknown>>,
+  nonStreamResponse?: Record<string, unknown>,
+): Mock<(...args: Array<unknown>) => unknown> {
+  pendingMockCreate = vi.fn().mockImplementation((params) => {
+    if (params.stream) {
+      return Promise.resolve(createAsyncIterable(streamChunks))
+    }
+    return Promise.resolve(nonStreamResponse)
+  })
+  return pendingMockCreate
+}
+
+function applyPendingMock<T extends object>(adapter: T): T {
+  if (pendingMockCreate) {
+    // openai-base keeps the SDK client as a private field; tests inject it
+    // the same way as @tanstack/ai-vercel-gateway.
+    Object.assign(adapter, {
+      client: { chat: { completions: { create: pendingMockCreate } } },
+    })
+    pendingMockCreate = undefined
+  }
+  return adapter
+}
+
+const createLovableText = (
+  model: Parameters<typeof _realCreateLovableText>[0],
+  apiKey: string,
+) => applyPendingMock(_realCreateLovableText(model, apiKey, { api: 'chat' }))
+const lovableText = (model: Parameters<typeof _realLovableText>[0]) =>
+  applyPendingMock(_realLovableText(model, { api: 'chat' }))
+
+describe('Lovable text adapter', () => {
+  beforeEach(() => {
+    pendingMockCreate = undefined
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('creates a text adapter with explicit API key', () => {
+    const adapter = createLovableText('google/gemini-3.7-flash', 'k')
+
+    expect(adapter.kind).toBe('text')
+    expect(adapter.name).toBe('lovable')
+    expect(adapter.model).toBe('google/gemini-3.7-flash')
+  })
+
+  it('creates a text adapter from LOVABLE_API_KEY', () => {
+    vi.stubEnv('LOVABLE_API_KEY', 'env-key')
+
+    const adapter = lovableText('openai/gpt-5.5')
+
+    expect(adapter.kind).toBe('text')
+    expect(adapter.model).toBe('openai/gpt-5.5')
+  })
+
+  it('emits RUN_STARTED then text from a one-chunk stream', async () => {
+    setupMockSdkClient([
+      { id: '1', choices: [{ delta: { content: 'hi' }, index: 0 }] },
+    ])
+    const adapter = createLovableText('openai/gpt-5.5', 'k')
+    const chunks: Array<StreamChunk> = []
+
+    for await (const chunk of adapter.chatStream({
+      model: 'openai/gpt-5.5',
+      messages: [{ role: 'user', content: 'hi' }],
+      logger: testLogger,
+    })) {
+      chunks.push(chunk)
+    }
+
+    expect(chunks[0]?.type).toBe(EventType.RUN_STARTED)
+    expect(
+      chunks.some(
+        (chunk) =>
+          chunk.type === EventType.TEXT_MESSAGE_CONTENT &&
+          'delta' in chunk &&
+          chunk.delta === 'hi',
+      ),
+    ).toBe(true)
+  })
+})

--- a/packages/ai-lovable/tests/transcription-adapter.test.ts
+++ b/packages/ai-lovable/tests/transcription-adapter.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import {
+  LovableTranscriptionAdapter,
+  createLovableTranscription,
+} from '../src/adapters/transcription'
+import type { LovableTranscriptionModel } from '../src/model-meta'
+
+const testLogger = resolveDebugOption(false)
+
+class TestLovableTranscriptionAdapter<
+  TModel extends LovableTranscriptionModel,
+> extends LovableTranscriptionAdapter<TModel> {
+  spyOnTranscriptionsCreate() {
+    return vi.spyOn(this.client.audio.transcriptions, 'create')
+  }
+}
+
+describe('Lovable transcription adapter', () => {
+  it('creates an adapter with the provided API key', () => {
+    const adapter = createLovableTranscription(
+      'openai/gpt-4o-mini-transcribe',
+      'test-api-key',
+    )
+    expect(adapter).toBeInstanceOf(LovableTranscriptionAdapter)
+    expect(adapter.name).toBe('lovable')
+    expect(adapter.model).toBe('openai/gpt-4o-mini-transcribe')
+  })
+
+  it('sends the file with json response format by default', async () => {
+    const adapter = new TestLovableTranscriptionAdapter(
+      { apiKey: 'test-api-key' },
+      'openai/gpt-4o-mini-transcribe',
+    )
+    const mockCreate = adapter
+      .spyOnTranscriptionsCreate()
+      .mockResolvedValueOnce({
+        text: 'hello world',
+      })
+
+    const audio = new File([new Uint8Array([1, 2, 3])], 'clip.mp3', {
+      type: 'audio/mpeg',
+    })
+    const result = await adapter.transcribe({
+      model: 'openai/gpt-4o-mini-transcribe',
+      audio,
+      language: 'en',
+      logger: testLogger,
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'openai/gpt-4o-mini-transcribe',
+        file: audio,
+        language: 'en',
+        response_format: 'json',
+      }),
+    )
+    expect(result.text).toBe('hello world')
+  })
+
+  it('rejects verbose_json', async () => {
+    const adapter = new TestLovableTranscriptionAdapter(
+      { apiKey: 'test-api-key' },
+      'openai/gpt-4o-transcribe',
+    )
+    const mockCreate = adapter.spyOnTranscriptionsCreate()
+
+    await expect(
+      adapter.transcribe({
+        model: 'openai/gpt-4o-transcribe',
+        audio: new File([], 'clip.mp3', { type: 'audio/mpeg' }),
+        responseFormat: 'verbose_json',
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/only supports json and text/)
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('throws when top-level and modelOptions response formats conflict', async () => {
+    const adapter = new TestLovableTranscriptionAdapter(
+      { apiKey: 'test-api-key' },
+      'openai/gpt-4o-mini-transcribe',
+    )
+
+    await expect(
+      adapter.transcribe({
+        model: 'openai/gpt-4o-mini-transcribe',
+        audio: new File([], 'clip.mp3', { type: 'audio/mpeg' }),
+        responseFormat: 'json',
+        modelOptions: { response_format: 'text' },
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/Conflicting response formats/)
+  })
+})

--- a/packages/ai-lovable/tests/transcription-adapter.test.ts
+++ b/packages/ai-lovable/tests/transcription-adapter.test.ts
@@ -41,11 +41,13 @@ describe('Lovable transcription adapter', () => {
     const audio = new File([new Uint8Array([1, 2, 3])], 'clip.mp3', {
       type: 'audio/mpeg',
     })
+    const abortSignal = new AbortController().signal
     const result = await adapter.transcribe({
       model: 'openai/gpt-4o-mini-transcribe',
       audio,
       language: 'en',
       logger: testLogger,
+      abortSignal,
     })
 
     expect(mockCreate).toHaveBeenCalledWith(
@@ -55,6 +57,7 @@ describe('Lovable transcription adapter', () => {
         language: 'en',
         response_format: 'json',
       }),
+      { signal: abortSignal },
     )
     expect(result.text).toBe('hello world')
   })

--- a/packages/ai-lovable/tests/tts-adapter.test.ts
+++ b/packages/ai-lovable/tests/tts-adapter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import { LovableTTSAdapter, createLovableSpeech } from '../src/adapters/tts'
+import type { LovableTTSModel } from '../src/model-meta'
+
+const testLogger = resolveDebugOption(false)
+
+class TestLovableTTSAdapter<
+  TModel extends LovableTTSModel,
+> extends LovableTTSAdapter<TModel> {
+  spyOnSpeechCreate() {
+    return vi.spyOn(this.client.audio.speech, 'create')
+  }
+}
+
+describe('Lovable TTS adapter', () => {
+  it('creates an adapter with the provided API key', () => {
+    const adapter = createLovableSpeech(
+      'openai/gpt-4o-mini-tts',
+      'test-api-key',
+    )
+    expect(adapter).toBeInstanceOf(LovableTTSAdapter)
+    expect(adapter.kind).toBe('tts')
+    expect(adapter.name).toBe('lovable')
+    expect(adapter.model).toBe('openai/gpt-4o-mini-tts')
+  })
+
+  it('calls audio.speech.create and returns base64 audio', async () => {
+    const adapter = new TestLovableTTSAdapter(
+      { apiKey: 'test-api-key' },
+      'openai/gpt-4o-mini-tts',
+    )
+    const bytes = new Uint8Array([1, 2, 3])
+    const mockCreate = adapter
+      .spyOnSpeechCreate()
+      .mockResolvedValueOnce(new Response(bytes))
+
+    const result = await adapter.generateSpeech({
+      model: 'openai/gpt-4o-mini-tts',
+      text: 'Hello',
+      voice: 'nova',
+      format: 'mp3',
+      logger: testLogger,
+      modelOptions: { instructions: 'speak slowly and warmly' },
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      model: 'openai/gpt-4o-mini-tts',
+      input: 'Hello',
+      voice: 'nova',
+      response_format: 'mp3',
+      instructions: 'speak slowly and warmly',
+    })
+    expect(result.audio).toBe(Buffer.from(bytes).toString('base64'))
+    expect(result.format).toBe('mp3')
+    expect(result.contentType).toBe('audio/mpeg')
+  })
+})

--- a/packages/ai-lovable/tests/tts-adapter.test.ts
+++ b/packages/ai-lovable/tests/tts-adapter.test.ts
@@ -35,6 +35,7 @@ describe('Lovable TTS adapter', () => {
       .spyOnSpeechCreate()
       .mockResolvedValueOnce(new Response(bytes))
 
+    const abortSignal = new AbortController().signal
     const result = await adapter.generateSpeech({
       model: 'openai/gpt-4o-mini-tts',
       text: 'Hello',
@@ -42,15 +43,19 @@ describe('Lovable TTS adapter', () => {
       format: 'mp3',
       logger: testLogger,
       modelOptions: { instructions: 'speak slowly and warmly' },
+      abortSignal,
     })
 
-    expect(mockCreate).toHaveBeenCalledWith({
-      model: 'openai/gpt-4o-mini-tts',
-      input: 'Hello',
-      voice: 'nova',
-      response_format: 'mp3',
-      instructions: 'speak slowly and warmly',
-    })
+    expect(mockCreate).toHaveBeenCalledWith(
+      {
+        model: 'openai/gpt-4o-mini-tts',
+        input: 'Hello',
+        voice: 'nova',
+        response_format: 'mp3',
+        instructions: 'speak slowly and warmly',
+      },
+      { signal: abortSignal },
+    )
     expect(result.audio).toBe(Buffer.from(bytes).toString('base64'))
     expect(result.format).toBe('mp3')
     expect(result.contentType).toBe('audio/mpeg')

--- a/packages/ai-lovable/tests/video-adapter.test.ts
+++ b/packages/ai-lovable/tests/video-adapter.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import { LovableVideoAdapter, createLovableVideo } from '../src/adapters/video'
+import type OpenAI from 'openai'
+import type { LovableVideoModel } from '../src/model-meta'
+
+const testLogger = resolveDebugOption(false)
+
+class TestLovableVideoAdapter<
+  TModel extends LovableVideoModel,
+> extends LovableVideoAdapter<TModel> {
+  spyOnVideosCreate() {
+    return vi.spyOn(this.client.videos, 'create')
+  }
+}
+
+function queuedVideo(id: string): OpenAI.Videos.Video {
+  return {
+    id,
+    completed_at: null,
+    created_at: 0,
+    error: null,
+    expires_at: null,
+    model: 'sora-2',
+    object: 'video',
+    progress: 0,
+    prompt: null,
+    remixed_from_video_id: null,
+    seconds: '4',
+    size: '1280x720',
+    status: 'queued',
+  }
+}
+
+describe('Lovable video adapter', () => {
+  it('creates an adapter with the provided API key', () => {
+    const adapter = createLovableVideo('google/veo-3.1-lite', 'test-api-key')
+    expect(adapter).toBeInstanceOf(LovableVideoAdapter)
+    expect(adapter.name).toBe('lovable')
+    expect(adapter.model).toBe('google/veo-3.1-lite')
+  })
+
+  it('reports discrete 4, 6, and 8 second durations', () => {
+    const adapter = createLovableVideo('google/veo-3.1-lite', 'k')
+    expect(adapter.availableDurations()).toEqual({
+      kind: 'discrete',
+      values: [4, 6, 8],
+    })
+    expect(adapter.snapDuration(4)).toBe(4)
+    expect(adapter.snapDuration(5)).toBe(4)
+    expect(adapter.snapDuration(8)).toBe(8)
+  })
+
+  it('creates a job with prompt, size, and seconds', async () => {
+    const adapter = new TestLovableVideoAdapter(
+      { apiKey: 'test-api-key' },
+      'google/veo-3.1-lite',
+    )
+    const mockCreate = adapter
+      .spyOnVideosCreate()
+      .mockResolvedValueOnce(queuedVideo('video-job-1'))
+
+    const result = await adapter.createVideoJob({
+      model: 'google/veo-3.1-lite',
+      prompt: 'A cat walking through fog',
+      size: '1280x720',
+      duration: 4,
+      logger: testLogger,
+    })
+
+    expect(result).toEqual({
+      jobId: 'video-job-1',
+      model: 'google/veo-3.1-lite',
+    })
+    expect(mockCreate).toHaveBeenCalledWith({
+      model: 'google/veo-3.1-lite',
+      prompt: 'A cat walking through fog',
+      size: '1280x720',
+      seconds: '4',
+    })
+  })
+
+  it('uploads a single image part as input_reference', async () => {
+    const adapter = new TestLovableVideoAdapter(
+      { apiKey: 'test-api-key' },
+      'google/veo-3.1-lite',
+    )
+    const mockCreate = adapter
+      .spyOnVideosCreate()
+      .mockResolvedValueOnce(queuedVideo('video-job-1'))
+
+    await adapter.createVideoJob({
+      model: 'google/veo-3.1-lite',
+      prompt: [
+        { type: 'text', content: 'Slow cinematic push-in' },
+        {
+          type: 'image',
+          source: { type: 'data', value: 'aGk=', mimeType: 'image/png' },
+        },
+      ],
+      logger: testLogger,
+    })
+
+    const request = mockCreate.mock.calls[0]![0]
+    expect(request.prompt).toBe('Slow cinematic push-in')
+    expect(request.input_reference).toBeInstanceOf(File)
+  })
+
+  it('rejects 4K on Veo 3.1 Lite', async () => {
+    const adapter = new TestLovableVideoAdapter(
+      { apiKey: 'test-api-key' },
+      'google/veo-3.1-lite',
+    )
+    const mockCreate = adapter.spyOnVideosCreate()
+
+    await expect(
+      adapter.createVideoJob({
+        model: 'google/veo-3.1-lite',
+        prompt: 'A city at night',
+        modelOptions: { size: '3840x2160' },
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/4K/)
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-8-second clips at 1080p', async () => {
+    const adapter = new TestLovableVideoAdapter(
+      { apiKey: 'test-api-key' },
+      'google/veo-3.1-fast',
+    )
+    const mockCreate = adapter.spyOnVideosCreate()
+
+    await expect(
+      adapter.createVideoJob({
+        model: 'google/veo-3.1-fast',
+        prompt: 'A city at night',
+        size: '1920x1080',
+        duration: 4,
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/8 second/)
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('throws when more than one image part is provided', async () => {
+    const adapter = new TestLovableVideoAdapter(
+      { apiKey: 'test-api-key' },
+      'google/veo-3.1-lite',
+    )
+    const mockCreate = adapter.spyOnVideosCreate()
+
+    await expect(
+      adapter.createVideoJob({
+        model: 'google/veo-3.1-lite',
+        prompt: [
+          { type: 'text', content: 'x' },
+          {
+            type: 'image',
+            source: { type: 'data', value: 'aGk=', mimeType: 'image/png' },
+          },
+          {
+            type: 'image',
+            source: { type: 'data', value: 'YnllCg==', mimeType: 'image/png' },
+          },
+        ],
+        logger: testLogger,
+      }),
+    ).rejects.toThrow(/at most one input_reference image/)
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/ai-lovable/tests/video-adapter.test.ts
+++ b/packages/ai-lovable/tests/video-adapter.test.ts
@@ -12,6 +12,9 @@ class TestLovableVideoAdapter<
   spyOnVideosCreate() {
     return vi.spyOn(this.client.videos, 'create')
   }
+  spyOnVideosRetrieve() {
+    return vi.spyOn(this.client.videos, 'retrieve')
+  }
 }
 
 function queuedVideo(id: string): OpenAI.Videos.Video {
@@ -60,24 +63,49 @@ describe('Lovable video adapter', () => {
       .spyOnVideosCreate()
       .mockResolvedValueOnce(queuedVideo('video-job-1'))
 
+    const abortSignal = new AbortController().signal
     const result = await adapter.createVideoJob({
       model: 'google/veo-3.1-lite',
       prompt: 'A cat walking through fog',
       size: '1280x720',
       duration: 4,
       logger: testLogger,
+      abortSignal,
     })
 
     expect(result).toEqual({
       jobId: 'video-job-1',
       model: 'google/veo-3.1-lite',
     })
-    expect(mockCreate).toHaveBeenCalledWith({
-      model: 'google/veo-3.1-lite',
-      prompt: 'A cat walking through fog',
-      size: '1280x720',
-      seconds: '4',
-    })
+    expect(mockCreate).toHaveBeenCalledWith(
+      {
+        model: 'google/veo-3.1-lite',
+        prompt: 'A cat walking through fog',
+        size: '1280x720',
+        seconds: '4',
+      },
+      { signal: abortSignal },
+    )
+  })
+
+  it('converts expires_at Unix seconds to a Date', async () => {
+    const adapter = new TestLovableVideoAdapter(
+      { apiKey: 'test-api-key' },
+      'google/veo-3.1-lite',
+    )
+    const expiresAtSeconds = 1_700_000_000
+    const completed: OpenAI.Videos.Video & { url: string } = {
+      ...queuedVideo('video-job-1'),
+      status: 'completed',
+      expires_at: expiresAtSeconds,
+      url: 'https://cdn.example/clip.mp4',
+    }
+    adapter.spyOnVideosRetrieve().mockResolvedValueOnce(completed)
+
+    const result = await adapter.getVideoUrl('video-job-1')
+
+    expect(result.url).toBe('https://cdn.example/clip.mp4')
+    expect(result.expiresAt).toEqual(new Date(expiresAtSeconds * 1000))
   })
 
   it('uploads a single image part as input_reference', async () => {

--- a/packages/ai-lovable/tsconfig.json
+++ b/packages/ai-lovable/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ai-lovable/vite.config.ts
+++ b/packages/ai-lovable/vite.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import { tanstackViteConfig } from '@tanstack/vite-config'
+import packageJson from './package.json'
+
+const config = defineConfig({
+  test: {
+    name: packageJson.name,
+    dir: './',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        'tests/',
+        '**/*.test.ts',
+        '**/*.config.ts',
+        '**/types.ts',
+      ],
+      include: ['src/**/*.ts'],
+    },
+  },
+})
+
+export default mergeConfig(
+  config,
+  tanstackViteConfig({
+    entry: ['./src/index.ts', './src/byok.ts'],
+    srcDir: './src',
+    cjs: false,
+  }),
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2090,6 +2090,31 @@ importers:
         specifier: ^4.2.0
         version: 4.3.6
 
+  packages/ai-lovable:
+    dependencies:
+      '@tanstack/ai-utils':
+        specifier: workspace:^
+        version: link:../ai-utils
+      '@tanstack/openai-base':
+        specifier: workspace:^
+        version: link:../openai-base
+      openai:
+        specifier: ^6.41.0
+        version: 6.41.0(ws@8.21.0)(zod@4.3.6)
+    devDependencies:
+      '@tanstack/ai':
+        specifier: workspace:*
+        version: link:../ai
+      '@vitest/coverage-v8':
+        specifier: 4.1.10
+        version: 4.1.10(vitest@4.1.10)
+      vite:
+        specifier: ^8.2.1
+        version: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
+      zod:
+        specifier: ^4.2.0
+        version: 4.3.6
+
   packages/ai-mcp:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -2934,6 +2959,9 @@ importers:
       '@tanstack/ai-llmgateway':
         specifier: workspace:*
         version: link:../../packages/ai-llmgateway
+      '@tanstack/ai-lovable':
+        specifier: workspace:*
+        version: link:../../packages/ai-lovable
       '@tanstack/ai-mcp':
         specifier: workspace:*
         version: link:../../packages/ai-mcp

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -4,7 +4,7 @@ End-to-end tests for TanStack AI using Playwright and [aimock](https://github.co
 
 **Architecture:** Playwright drives a TanStack Start app (`testing/e2e/`) which routes requests through provider adapters pointing at aimock. Fixtures define mock responses. No real API keys needed. All scenarios (including tool execution flows) use aimock fixtures. Tests run in parallel with per-test `X-Test-Id` isolation.
 
-**Providers tested:** openai, anthropic, gemini, vertex, vertex-grok, vertex-mistral, ollama, groq, grok, openrouter, openrouter-responses, vercel-gateway, vercel-gateway-responses, bedrock, bedrock-responses, openai-compatible, mistral, byteplus, elevenlabs, llmgateway
+**Providers tested:** openai, anthropic, gemini, vertex, vertex-grok, vertex-mistral, ollama, groq, grok, openrouter, openrouter-responses, vercel-gateway, vercel-gateway-responses, lovable, lovable-responses, bedrock, bedrock-responses, openai-compatible, mistral, byteplus, elevenlabs, llmgateway
 
 > **Claude Code (`@tanstack/ai-claude-code`) is excluded from the standard matrix.** It's a harness adapter that spawns the Claude Code runtime as a subprocess, so aimock's per-test `X-Test-Id` header isolation can't be injected into its requests. It's covered by unit tests in the package plus a gated live smoke test in `tests/claude-code.spec.ts` — run it with `CLAUDE_CODE_E2E=1` and an `ANTHROPIC_API_KEY` (or a local `claude login`).
 

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -29,6 +29,7 @@
     "@tanstack/ai-grok": "workspace:*",
     "@tanstack/ai-groq": "workspace:*",
     "@tanstack/ai-llmgateway": "workspace:*",
+    "@tanstack/ai-lovable": "workspace:*",
     "@tanstack/ai-mcp": "workspace:*",
     "@tanstack/ai-memory": "workspace:*",
     "@tanstack/ai-mistral": "workspace:*",

--- a/testing/e2e/src/lib/feature-support.ts
+++ b/testing/e2e/src/lib/feature-support.ts
@@ -22,6 +22,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'openai-compatible',
     'mistral',
     'byteplus',
@@ -41,6 +42,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'openai-compatible',
     'mistral',
     'byteplus',
@@ -74,6 +76,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'openai-compatible',
     'mistral',
     'byteplus',
@@ -95,6 +98,8 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'openrouter-responses',
     'vercel-gateway',
     'vercel-gateway-responses',
+    'lovable',
+    'lovable-responses',
     'openai-compatible',
     'mistral',
     'byteplus',
@@ -113,6 +118,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'openai-compatible',
     'mistral',
     'byteplus',
@@ -132,6 +138,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'openai-compatible',
     'mistral',
     'byteplus',
@@ -151,6 +158,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'openai-compatible',
     'mistral',
     'byteplus',
@@ -170,6 +178,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'openai-compatible',
     'mistral',
     'byteplus',
@@ -188,6 +197,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'openai-compatible',
     'byteplus',
     'llmgateway',
@@ -222,6 +232,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'openai-compatible',
     'byteplus',
     'llmgateway',
@@ -240,6 +251,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'openai-compatible',
     'mistral',
     'byteplus',
@@ -313,6 +325,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'mistral',
     'llmgateway',
   ]),
@@ -330,6 +343,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'bedrock-responses',
     'openrouter',
     'vercel-gateway',
+    'lovable',
     'mistral',
     'llmgateway',
   ]),
@@ -352,11 +366,18 @@ export const matrix: Record<Feature, Set<Provider>> = {
     'ollama',
     'mistral',
     'vercel-gateway',
+    'lovable',
   ]),
   // Gemini excluded: aimock doesn't mock Gemini's Imagen predict endpoint format
   // vercel-gateway uses POST /v1/images/generations, the same path aimock
   // already mocks for openai. Drop this entry if the first run has no fixture.
-  'image-gen': new Set(['openai', 'grok', 'byteplus', 'vercel-gateway']),
+  'image-gen': new Set([
+    'openai',
+    'grok',
+    'byteplus',
+    'vercel-gateway',
+    'lovable',
+  ]),
   // image-to-image (image parts in the generateImage prompt). aimock 1.29
   // mocks OpenAI's multipart `/v1/images/edits` (matches on the `prompt` form
   // field, ignores the binary image/mask fields), so the OpenAI route runs
@@ -369,7 +390,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
   // endpoint (reference images ride an `image` array in the JSON body), so
   // there is no `/v1/images/edits` request for this spec's journal assertion
   // to find. The reference-image mapping is unit-tested instead.
-  'image-to-image': new Set(['openai']),
+  'image-to-image': new Set(['openai', 'lovable']),
   // byteplus excluded: BytePlus has no music/audio generation product —
   // Seed Speech is TTS + ASR only.
   // Vertex excluded for the same media-path reason as embedding: the
@@ -378,8 +399,22 @@ export const matrix: Record<Feature, Set<Provider>> = {
   'audio-gen': new Set(['gemini', 'elevenlabs']),
   // byteplus excluded: no sound-effects endpoint (see audio-gen above).
   'sound-effects': new Set(['elevenlabs']),
-  tts: new Set(['openai', 'gemini', 'grok', 'elevenlabs', 'byteplus']),
-  transcription: new Set(['openai', 'grok', 'groq', 'elevenlabs', 'byteplus']),
+  tts: new Set([
+    'openai',
+    'gemini',
+    'grok',
+    'elevenlabs',
+    'byteplus',
+    'lovable',
+  ]),
+  transcription: new Set([
+    'openai',
+    'grok',
+    'groq',
+    'elevenlabs',
+    'byteplus',
+    'lovable',
+  ]),
   // byteplus excluded: this spec asserts named-speaker segments
   // (`agent`/`customer`), which is OpenAI's `diarized_json` shape. Seed ASR's
   // nearest equivalent is `enable_speaker_info`, whose response shape is
@@ -400,7 +435,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
   // (packages/ai-openrouter/tests/video-adapter.test.ts). Add it here when
   // aimock learns the OpenRouter job endpoints
   // (https://github.com/CopilotKit/aimock/issues/261).
-  'video-gen': new Set(['openai', 'gemini', 'byteplus']),
+  'video-gen': new Set(['openai', 'gemini', 'byteplus', 'lovable']),
   // image-to-video (image parts in the generateVideo prompt). aimock 1.29's
   // `/v1/videos` handler parses Sora's multipart upload (the SDK switches to
   // multipart when `input_reference` carries a File) and matches on the
@@ -413,7 +448,7 @@ export const matrix: Record<Feature, Set<Provider>> = {
   // role inside the task body's `content[]`, so the spec's assertion that a
   // multipart POST /v1/videos carried the prompt can't hold. The role mapping
   // is unit-tested instead.
-  'image-to-video': new Set(['openai']),
+  'image-to-video': new Set(['openai', 'lovable']),
   // Gemini Omni Flash video generation over the Interactions API. Runs
   // through a dedicated aimock mount (see geminiOmniVideoMount in
   // global-setup.ts) — aimock handles synchronous text interactions natively

--- a/testing/e2e/src/lib/media-providers.ts
+++ b/testing/e2e/src/lib/media-providers.ts
@@ -28,6 +28,12 @@ import {
   createBytePlusVideo,
 } from '@tanstack/ai-byteplus'
 import { createVercelGatewayImage } from '@tanstack/ai-vercel-gateway'
+import {
+  createLovableImage,
+  createLovableSpeech,
+  createLovableTranscription,
+  createLovableVideo,
+} from '@tanstack/ai-lovable'
 import type { TranscriptionResponseFormat } from '@tanstack/ai'
 import type { Feature, Provider } from '@/lib/types'
 
@@ -111,6 +117,11 @@ export function createImageAdapter(
         baseURL: openaiUrl(aimockPort),
         defaultHeaders: headers,
       }),
+    lovable: () =>
+      createLovableImage('openai/gpt-image-2', DUMMY_KEY, {
+        baseURL: openaiUrl(aimockPort),
+        defaultHeaders: headers,
+      }),
   }
   const factory = factories[provider]
   if (!factory) throw new Error(`No image adapter for provider: ${provider}`)
@@ -149,6 +160,11 @@ export function createTTSAdapter(
     byteplus: () =>
       createBytePlusSpeech('seed-audio-1.0', DUMMY_KEY, {
         baseURL: llmockBase(aimockPort),
+        defaultHeaders: headers,
+      }),
+    lovable: () =>
+      createLovableSpeech('openai/gpt-4o-mini-tts', DUMMY_KEY, {
+        baseURL: openaiUrl(aimockPort),
         defaultHeaders: headers,
       }),
   }
@@ -191,6 +207,11 @@ export function createTranscriptionAdapter(
     byteplus: () =>
       createBytePlusTranscription('seed-asr', DUMMY_KEY, {
         baseURL: llmockBase(aimockPort),
+        defaultHeaders: headers,
+      }),
+    lovable: () =>
+      createLovableTranscription('openai/gpt-4o-mini-transcribe', DUMMY_KEY, {
+        baseURL: openaiUrl(aimockPort),
         defaultHeaders: headers,
       }),
   }
@@ -239,6 +260,11 @@ export function createVideoAdapter(
     byteplus: () =>
       createBytePlusVideo('seedance-1-0-pro-fast-251015', DUMMY_KEY, {
         baseURL: bytePlusArkUrl(aimockPort),
+        defaultHeaders: headers,
+      }),
+    lovable: () =>
+      createLovableVideo('google/veo-3.1-lite', DUMMY_KEY, {
+        baseURL: openaiUrl(aimockPort),
         defaultHeaders: headers,
       }),
   }

--- a/testing/e2e/src/lib/providers.ts
+++ b/testing/e2e/src/lib/providers.ts
@@ -18,6 +18,7 @@ import {
   createOpenRouterText,
 } from '@tanstack/ai-openrouter'
 import { createVercelGatewayText } from '@tanstack/ai-vercel-gateway'
+import { createLovableText } from '@tanstack/ai-lovable'
 import { createMistralText } from '@tanstack/ai-mistral'
 import { createBytePlusText } from '@tanstack/ai-byteplus'
 import { createLLMGatewayText } from '@tanstack/ai-llmgateway'
@@ -45,6 +46,8 @@ const defaultModels: Record<Provider, string> = {
   'openrouter-responses': 'openai/gpt-4o',
   'vercel-gateway': 'openai/gpt-5.5',
   'vercel-gateway-responses': 'openai/gpt-5.5',
+  lovable: 'openai/gpt-5.5',
+  'lovable-responses': 'openai/gpt-5.5',
   'openai-compatible': 'gpt-4o',
   mistral: 'mistral-large-latest',
   // Structured-output features override this in `features.ts`:
@@ -266,6 +269,22 @@ export function createTextAdapter(
     'vercel-gateway-responses': () =>
       createChatOptions({
         adapter: createVercelGatewayText(model as 'openai/gpt-5.5', DUMMY_KEY, {
+          api: 'responses',
+          baseURL: openaiUrl,
+          defaultHeaders: testHeaders,
+        }),
+      }),
+    lovable: () =>
+      createChatOptions({
+        adapter: createLovableText(model as 'openai/gpt-5.5', DUMMY_KEY, {
+          api: 'chat',
+          baseURL: openaiUrl,
+          defaultHeaders: testHeaders,
+        }),
+      }),
+    'lovable-responses': () =>
+      createChatOptions({
+        adapter: createLovableText(model as 'openai/gpt-5.5', DUMMY_KEY, {
           api: 'responses',
           baseURL: openaiUrl,
           defaultHeaders: testHeaders,

--- a/testing/e2e/src/lib/types.ts
+++ b/testing/e2e/src/lib/types.ts
@@ -16,6 +16,8 @@ export type Provider =
   | 'openrouter-responses'
   | 'vercel-gateway'
   | 'vercel-gateway-responses'
+  | 'lovable'
+  | 'lovable-responses'
   | 'openai-compatible'
   | 'mistral'
   | 'byteplus'
@@ -70,6 +72,8 @@ export const ALL_PROVIDERS: Provider[] = [
   'openrouter-responses',
   'vercel-gateway',
   'vercel-gateway-responses',
+  'lovable',
+  'lovable-responses',
   'openai-compatible',
   'mistral',
   'byteplus',

--- a/testing/e2e/src/routes/api.embedding.ts
+++ b/testing/e2e/src/routes/api.embedding.ts
@@ -5,6 +5,7 @@ import { createGeminiEmbedding } from '@tanstack/ai-gemini'
 import { createMistralEmbedding } from '@tanstack/ai-mistral'
 import { createOllamaEmbedding } from '@tanstack/ai-ollama'
 import { createVercelGatewayEmbedding } from '@tanstack/ai-vercel-gateway'
+import { createLovableEmbedding } from '@tanstack/ai-lovable'
 import type { Provider } from '@/lib/types'
 
 const LLMOCK_BASE = process.env.LLMOCK_URL || 'http://127.0.0.1:4010'
@@ -67,6 +68,11 @@ function createEmbeddingAdapter(
       }),
     'vercel-gateway': () =>
       createVercelGatewayEmbedding('openai/text-embedding-3-small', DUMMY_KEY, {
+        baseURL: openaiUrl(aimockPort),
+        defaultHeaders: headers,
+      }),
+    lovable: () =>
+      createLovableEmbedding('openai/text-embedding-3-small', DUMMY_KEY, {
         baseURL: openaiUrl(aimockPort),
         defaultHeaders: headers,
       }),

--- a/testing/e2e/src/routes/api.summarize.ts
+++ b/testing/e2e/src/routes/api.summarize.ts
@@ -12,6 +12,7 @@ import { grokVertexSummarize } from '@tanstack/ai-grok/vertex'
 import { createLLMGatewaySummarize } from '@tanstack/ai-llmgateway'
 import { createOpenRouterSummarize } from '@tanstack/ai-openrouter'
 import { createVercelGatewaySummarize } from '@tanstack/ai-vercel-gateway'
+import { createLovableSummarize } from '@tanstack/ai-lovable'
 import { HTTPClient } from '@openrouter/sdk'
 import type { Provider } from '@/lib/types'
 
@@ -118,6 +119,11 @@ function createSummarizeAdapter(
       }),
     'vercel-gateway': () =>
       createVercelGatewaySummarize('openai/gpt-5.5', DUMMY_KEY, {
+        baseURL: openaiUrl(aimockPort),
+        defaultHeaders: headers,
+      }),
+    lovable: () =>
+      createLovableSummarize('openai/gpt-5.5', DUMMY_KEY, {
         baseURL: openaiUrl(aimockPort),
         defaultHeaders: headers,
       }),

--- a/testing/e2e/tests/test-matrix.ts
+++ b/testing/e2e/tests/test-matrix.ts
@@ -29,6 +29,8 @@ export const providers: Provider[] = [
   'openrouter-responses',
   'vercel-gateway',
   'vercel-gateway-responses',
+  'lovable',
+  'lovable-responses',
   'openai-compatible',
   'mistral',
   'byteplus',


### PR DESCRIPTION
Install `@tanstack/ai-lovable` and call Google and OpenAI models with one Lovable project key. Chat, embeddings, image, video, speech, and transcription all work. Users can paste `LOVABLE_API_KEY` in the browser through `lovableByok`.

Media calls now honor the activity abort signal. Video `expiresAt` uses Unix seconds from the gateway, converted to milliseconds.

## 🎯 Changes

New package `@tanstack/ai-lovable` talks to `https://ai.gateway.lovable.dev/v1`.

- Chat defaults to the Responses API. Pass `{ api: "chat" }` for Chat Completions.
- Image generate and edit (`POST /v1/images/edits`). Mask parts work on `openai/` image models.
- Video jobs (`POST /v1/videos`, poll, download). Clips are 4, 6, or 8 seconds.
- Embeddings, speech, and transcription on the OpenAI-compatible paths.
- BYOK: `lovableByok` from `@tanstack/ai-lovable/byok`. Env is `LOVABLE_API_KEY`.

Docs live at `docs/adapters/lovable.md`. The e2e matrix now runs Lovable for chat and the media features above.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

**Commands run**

1. `pnpm --filter @tanstack/ai-lovable test:lib` passed (44 tests).
2. `pnpm --filter @tanstack/ai-lovable test:types` and `test:oxlint` passed after the review fixes.
3. `pnpm --filter @tanstack/ai-e2e test:e2e -- --grep "lovable -- (embedding|image-gen|image-to-image|tts|transcription|video-gen|image-to-video)"` passed on the first commit (16 tests; 3 first-attempt hydration flakes, then retry passed).
4. `pnpm test:pr` ran on the first commit. `root:test:knip` and `root:test:docs` failed on untracked local files (`marketing/`, `docs/superpowers/worktrees`). Those files are not in this PR.

**Manual test**

1. Run `pnpm --filter @tanstack/ai-lovable test:lib`.
2. Run `pnpm --filter @tanstack/ai-e2e test:e2e -- --grep "lovable --"`.
3. Copy a snippet from `docs/adapters/lovable.md` and run it against a real `LOVABLE_API_KEY` if you want a live smoke test.

**How this PR makes testing easy**

Unit tests sit in `packages/ai-lovable/tests/`. They cover abort-signal forwarding and video `expires_at` seconds. E2E wiring is in `testing/e2e/src/lib/feature-support.ts` and `media-providers.ts`.

## Risk / rollback

This is a new opt-in package. Existing adapters do not change. Revert the PR to undo.

## Public API change

**Before**

There is no `@tanstack/ai-lovable` package.

**After**

```ts
import { chat, generateImage } from "@tanstack/ai"
import { lovableText, lovableImage } from "@tanstack/ai-lovable"
import { lovableByok } from "@tanstack/ai-lovable/byok"

const stream = chat({
  adapter: lovableText("google/gemini-3.7-flash"),
  messages: [{ role: "user", content: "Hello" }],
})

const image = await generateImage({
  adapter: lovableImage("openai/gpt-image-2"),
  prompt: "a red guitar",
})
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Lovable AI Gateway adapter for chat, Responses, summarization, embeddings, image and video generation, speech synthesis, and transcription.
  * Added Bring Your Own Key support with `LOVABLE_API_KEY`.
  * Added model-aware options, media controls, and environment-based configuration.
  * Added support across the relevant AI capabilities.

* **Documentation**
  * Added setup, authentication, usage, media, BYOK, model, and troubleshooting guidance.
  * Updated adapter listings and integration guidance.

* **Tests**
  * Added coverage for Lovable features, configuration, BYOK, and provider scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->