### PR TITLE
fix(ai-client): resolve BYOK provider from merged send body

### DIFF
--- a/.changeset/byok-merged-provider.md
+++ b/.changeset/byok-merged-provider.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-client': patch
+---
+
+Resolve BYOK request headers from the merged send body `provider`. A per-call `sendOptions.body.provider` now selects the same key as the wire `forwardedProps`.

--- a/docs/api/ai-angular.md
+++ b/docs/api/ai-angular.md
@@ -56,7 +56,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client` (minus internal state cal
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field. Reactive — accepts a plain value, an Angular `Signal`, or a zero-arg getter; changes sync automatically via `effect`
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire. Reactive (same forms as `forwardedProps`)
 - `byok?` - Optional BYOK keyring from `defineByok`. On each send the client prepares the resolved provider and stamps `x-byok-*` request headers. Keys never go in the body
-- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise `forwardedProps.provider` then `body.provider` are used. If no slug resolves, the send throws instead of attaching every stored key
+- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise the merged `provider` from `forwardedProps`, `body`, and per-call `sendMessage` `body` is used. Later sources win. If no slug resolves, the send throws instead of attaching every stored key
 - `context?` - Typed client-local runtime context passed to client tool implementations. Reactive (same forms). This value is not serialized to the server
 - `live?` - Enable live subscription mode (auto-subscribes/unsubscribes). Reactive (same forms)
 - `outputSchema?` - Standard-schema-compatible schema (Zod, Valibot, ArkType, or JSON Schema). When provided, adds typed `partial` and `final` signals to the return value

--- a/docs/api/ai-client.md
+++ b/docs/api/ai-client.md
@@ -99,7 +99,7 @@ goes away. Users of the framework hooks need no change.
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works — values are merged into `forwardedProps` on the wire and mirrored under the legacy `data` field for backward compatibility
 - `byok?` - Optional BYOK keyring from [`defineByok`](#definebyok). On each send the client prepares the resolved provider and stamps `x-byok-*` request headers. Keys never go in the body
-- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise `forwardedProps.provider` then `body.provider` are used. If no slug resolves, the send throws instead of attaching every stored key
+- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise the merged `provider` from `forwardedProps`, `body`, and per-call `sendMessage` `body` is used. Later sources win. If no slug resolves, the send throws instead of attaching every stored key
 - `context?` - Typed client-local runtime context passed to client tool implementations. This value is not serialized to the server
 - `tools?` - Registered `.client()` tool implementations. The client automatically executes matching tools when the model calls them
 - `onResponse?` - Callback when response is received

--- a/docs/api/ai-preact.md
+++ b/docs/api/ai-preact.md
@@ -77,7 +77,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client`:
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field (e.g., `{ provider: 'openai', model: 'gpt-5.5' }`)
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire
 - `byok?` - Optional BYOK keyring from `defineByok`. On each send the client prepares the resolved provider and stamps `x-byok-*` request headers. Keys never go in the body
-- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise `forwardedProps.provider` then `body.provider` are used. If no slug resolves, the send throws instead of attaching every stored key
+- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise the merged `provider` from `forwardedProps`, `body`, and per-call `sendMessage` `body` is used. Later sources win. If no slug resolves, the send throws instead of attaching every stored key
 - `context?` - Typed client-local runtime context passed to client tool implementations. This value is not serialized to the server
 - `onResponse?` - Callback when response is received
 - `onChunk?` - Callback when stream chunk is received

--- a/docs/api/ai-react.md
+++ b/docs/api/ai-react.md
@@ -87,7 +87,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client`:
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field (e.g., `{ provider: 'openai', model: 'gpt-5.5' }`)
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire
 - `byok?` - Optional BYOK keyring from `defineByok`. On each send the client prepares the resolved provider and stamps `x-byok-*` request headers. Keys never go in the body
-- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise `forwardedProps.provider` then `body.provider` are used. If no slug resolves, the send throws instead of attaching every stored key
+- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise the merged `provider` from `forwardedProps`, `body`, and per-call `sendMessage` `body` is used. Later sources win. If no slug resolves, the send throws instead of attaching every stored key
 - `context?` - Typed client-local runtime context passed to client tool implementations. This value is not serialized to the server
 - `onResponse?` - Callback when response is received
 - `onChunk?` - Callback when stream chunk is received

--- a/docs/api/ai-solid.md
+++ b/docs/api/ai-solid.md
@@ -78,7 +78,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client`:
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field (e.g., `{ provider: 'openai', model: 'gpt-5.5' }`)
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire
 - `byok?` - Optional BYOK keyring from `defineByok`. On each send the client prepares the resolved provider and stamps `x-byok-*` request headers. Keys never go in the body
-- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise `forwardedProps.provider` then `body.provider` are used. If no slug resolves, the send throws instead of attaching every stored key
+- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise the merged `provider` from `forwardedProps`, `body`, and per-call `sendMessage` `body` is used. Later sources win. If no slug resolves, the send throws instead of attaching every stored key
 - `context?` - Typed client-local runtime context passed to client tool implementations. This value is not serialized to the server
 - `onResponse?` - Callback when response is received
 - `onChunk?` - Callback when stream chunk is received

--- a/docs/api/ai-svelte.md
+++ b/docs/api/ai-svelte.md
@@ -76,7 +76,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client` (minus internal state cal
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field (e.g., `{ provider: 'openai', model: 'gpt-5.5' }`)
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire
 - `byok?` - Optional BYOK keyring from `defineByok`. On each send the client prepares the resolved provider and stamps `x-byok-*` request headers. Keys never go in the body
-- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise `forwardedProps.provider` then `body.provider` are used. If no slug resolves, the send throws instead of attaching every stored key
+- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise the merged `provider` from `forwardedProps`, `body`, and per-call `sendMessage` `body` is used. Later sources win. If no slug resolves, the send throws instead of attaching every stored key
 - `context?` - Typed client-local runtime context passed to client tool implementations. This value is not serialized to the server
 - `live?` - Enable live subscription mode (subscribes on creation)
 - `onResponse?` - Callback when response is received

--- a/docs/api/ai-vue.md
+++ b/docs/api/ai-vue.md
@@ -74,7 +74,7 @@ Extends `ChatClientOptions` from `@tanstack/ai-client` (minus internal state cal
 - `forwardedProps?` - Arbitrary client-controlled JSON forwarded to the server in the AG-UI `RunAgentInput.forwardedProps` field (reactive -- changes are synced automatically via `watch`)
 - `body?` - **Deprecated.** Use `forwardedProps` instead. Still works for backward compatibility; values are merged into `forwardedProps` on the wire (reactive)
 - `byok?` - Optional BYOK keyring from `defineByok`. On each send the client prepares the resolved provider and stamps `x-byok-*` request headers. Keys never go in the body
-- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise `forwardedProps.provider` then `body.provider` are used. If no slug resolves, the send throws instead of attaching every stored key
+- `byokProvider?` - Optional function that returns the provider slug for this chat. If it returns a slug, only that key is prepared and sent. Otherwise the merged `provider` from `forwardedProps`, `body`, and per-call `sendMessage` `body` is used. Later sources win. If no slug resolves, the send throws instead of attaching every stored key
 - `context?` - Typed client-local runtime context passed to client tool implementations (reactive). This value is not serialized to the server
 - `live?` - Enable live subscription mode (auto-subscribes/unsubscribes)
 - `onResponse?` - Callback when response is received

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -2261,8 +2261,7 @@ export class ChatClient<
       if (this.byok) {
         const provider = resolveByokProviderId(
           this.byokProvider,
-          this.forwardedPropsOption.provider,
-          this.bodyOption.provider,
+          mergedBody.provider,
         )
         byokHeaders = await prepareResolvedByokHeaders(this.byok, provider)
       }

--- a/packages/ai-client/src/types.ts
+++ b/packages/ai-client/src/types.ts
@@ -883,8 +883,9 @@ export interface ChatClientBaseOptions<
 
   /**
    * Optional provider id for this chat. If it returns a provider slug,
-   * only that key is prepared and sent. Otherwise `forwardedProps.provider`
-   * then `body.provider` are used. If no slug resolves, the send throws
+   * only that key is prepared and sent. Otherwise the merged `provider`
+   * from `forwardedProps`, `body`, and per-call `sendMessage` `body` is
+   * used. Later sources win. If no slug resolves, the send throws
    * instead of attaching every stored key.
    */
   byokProvider?: () => string | undefined

--- a/packages/ai-client/tests/byok-chat-client.test.ts
+++ b/packages/ai-client/tests/byok-chat-client.test.ts
@@ -87,6 +87,34 @@ describe('ChatClient byok', () => {
     expect(record.headers).not.toHaveProperty('x-byok-anthropic')
   })
 
+  it('stamps BYOK headers for per-call body.provider', async () => {
+    const byok = defineByok({ storage: memoryStorage() })
+    await byok.update('openai', OPENAI_KEY)
+    await byok.update('anthropic', 'sk-anthropic-secret')
+    const record: {
+      headers?: Record<string, string>
+      data?: Record<string, unknown>
+    } = {}
+    const client = new ChatClient({
+      connection: recordingConnection(record),
+      byok,
+      forwardedProps: { provider: 'openai', model: 'gpt-5.5' },
+    })
+
+    await client.sendMessage('Hello', undefined, {
+      body: { provider: 'anthropic' },
+    })
+
+    expect(record.headers).toEqual({
+      'x-byok-anthropic': 'sk-anthropic-secret',
+    })
+    expect(record.headers).not.toHaveProperty('x-byok-openai')
+    expect(record.data).toEqual({
+      provider: 'anthropic',
+      model: 'gpt-5.5',
+    })
+  })
+
   it('throws and does not connect when no provider slug resolves', async () => {
     const byok = defineByok({ storage: memoryStorage() })
     await byok.update('openai', OPENAI_KEY)


### PR DESCRIPTION
BYOK headers used the configured `provider` only. A per-call `sendOptions.body.provider` changed the wire `forwardedProps`, but the request still sent `x-byok-*` for the old provider.

This PR resolves the BYOK slug from `mergedBody.provider`. The `byokProvider` callback still wins if it returns a slug.

## 🎯 Changes

- `ChatClient` reads BYOK `provider` from the same merged body as `forwardedProps`.
- Regression test: configured `openai` plus per-call `anthropic` stamps `x-byok-anthropic`.
- API docs and `byokProvider` JSDoc now describe that merge.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

I did not run `pnpm test:pr` on this follow-up. I ran `pnpm exec nx test:lib ai-client -- byok-chat-client.test.ts` (9 passed) and `pnpm exec nx test:types ai-client`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

Patch on `@tanstack/ai-client`.

## Testing

Commands run:

1. `pnpm exec nx test:lib ai-client -- byok-chat-client.test.ts` — 9 passed.
2. `pnpm exec nx test:types ai-client` — passed.
3. `pnpm exec nx test:oxlint ai-client` — 0 errors (on the previous branch; same hunks).

Manual test:

1. On `main`, enable BYOK with keys for `openai` and `anthropic`. Set `forwardedProps: { provider: 'openai' }`. Send `sendMessage('hi', { body: { provider: 'anthropic' } })`. The POST `forwardedProps.provider` is `anthropic`. The header is `x-byok-openai`.
2. On this branch, the same send uses `x-byok-anthropic`.

This PR makes testing easy with `packages/ai-client/tests/byok-chat-client.test.ts`.

## Linked issues

Follow-up to #1227. CodeRabbit flagged the leftover BYOK mismatch after `sendOptions.body` started reaching the wire.

## Risk / rollback

Low. `byokProvider()` still wins over the merged body. Revert the PR to undo.

`reload()` still uses chat-level `provider` only. That matches `reload()` not replaying per-call body.

## Public API change

No new caller API. Existing BYOK plus per-call `body.provider` now stamp matching headers.

**Before**

```ts
await sendMessage("Hello", {
  body: { provider: "anthropic" },
})
// forwardedProps.provider is "anthropic"
// header is still x-byok-openai when the chat was configured for openai
```

**After**

```ts
await sendMessage("Hello", {
  body: { provider: "anthropic" },
})
// forwardedProps.provider is "anthropic"
// header is x-byok-anthropic
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BYOK provider selection now respects per-request provider overrides.
  * Provider values are resolved consistently across forwarded properties, configured request data, and per-call message data, with later values taking precedence.
  * Requests send only the credentials associated with the resolved provider while preserving other forwarded values.

* **Documentation**
  * Updated framework and client API documentation to describe the revised provider resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->