### PR TITLE
feat(ai-lovable): restrict model ids to the curated lists

### DIFF
--- a/.changeset/strict-lovable-model-ids.md
+++ b/.changeset/strict-lovable-model-ids.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-lovable': minor
+---
+
+`LovableModelId` is now the curated `LovableChatModel` union. The `(string & {})` escape hatch is removed, so TypeScript rejects uncurated model ids in `lovableText`, `createLovableText`, `lovableResponsesText`, `createLovableResponsesText`, and the summarize factories. The other modalities (image, video, embedding, TTS, transcription) were already limited to their curated lists.

--- a/docs/adapters/lovable.md
+++ b/docs/adapters/lovable.md
@@ -239,7 +239,7 @@ See [Bring Your Own Key](../advanced/byok) for the client store and a save UI.
 
 ## Models
 
-Pass any model id the gateway accepts. Curated ids get type metadata.
+Pass a model id from the curated lists. TypeScript rejects an id that is not on a list.
 
 Chat:
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -987,7 +987,7 @@
           "label": "Lovable AI Gateway",
           "to": "adapters/lovable",
           "addedAt": "2026-08-24",
-          "updatedAt": "2026-08-24"
+          "updatedAt": "2026-08-25"
         },
         {
           "label": "OpenAI-Compatible",

--- a/packages/ai-lovable/src/model-meta.ts
+++ b/packages/ai-lovable/src/model-meta.ts
@@ -43,10 +43,9 @@ export const LOVABLE_CHAT_MODELS = [
 export type LovableChatModel = (typeof LOVABLE_CHAT_MODELS)[number]
 
 /**
- * A curated chat model id, or any other id the gateway accepts.
- * Uncurated ids fall back to text-only input and the generic provider options.
+ * A curated chat model id from `LOVABLE_CHAT_MODELS`.
  */
-export type LovableModelId = LovableChatModel | (string & {})
+export type LovableModelId = LovableChatModel
 
 export type LovableChatModelProviderOptionsByName = {
   [K in LovableChatModel]: LovableTextProviderOptions

--- a/packages/ai-lovable/tests/model-id-type-safety.test.ts
+++ b/packages/ai-lovable/tests/model-id-type-safety.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Model-id type-safety tests for the Lovable adapters.
+ *
+ * Positive cases: curated model ids compile cleanly.
+ * Negative cases: uncurated ids produce a `@ts-expect-error`.
+ */
+import { describe, it } from 'vitest'
+import {
+  createLovableEmbedding,
+  createLovableImage,
+  createLovableResponsesText,
+  createLovableSpeech,
+  createLovableSummarize,
+  createLovableText,
+  createLovableTranscription,
+  createLovableVideo,
+} from '../src'
+
+describe('Lovable model-id gating', () => {
+  it('accepts curated model ids', () => {
+    createLovableText('google/gemini-3.7-flash', 'k')
+    createLovableResponsesText('openai/gpt-5.5', 'k')
+    createLovableSummarize('openai/gpt-5.5', 'k')
+    createLovableImage('openai/gpt-image-2', 'k')
+    createLovableVideo('google/veo-3.1-lite', 'k')
+    createLovableEmbedding('openai/text-embedding-3-small', 'k')
+    createLovableSpeech('openai/gpt-4o-mini-tts', 'k')
+    createLovableTranscription('openai/gpt-4o-mini-transcribe', 'k')
+  })
+
+  it('rejects uncurated model ids', () => {
+    // @ts-expect-error - not a curated chat model
+    createLovableText('openai/not-a-model', 'k')
+    // @ts-expect-error - not a curated chat model
+    createLovableResponsesText('openai/not-a-model', 'k')
+    // @ts-expect-error - not a curated chat model
+    createLovableSummarize('openai/not-a-model', 'k')
+    // @ts-expect-error - not a curated image model
+    createLovableImage('openai/not-a-model', 'k')
+    // @ts-expect-error - not a curated video model
+    createLovableVideo('openai/not-a-model', 'k')
+    // @ts-expect-error - not a curated embedding model
+    createLovableEmbedding('openai/not-a-model', 'k')
+    // @ts-expect-error - not a curated TTS model
+    createLovableSpeech('openai/not-a-model', 'k')
+    // @ts-expect-error - not a curated transcription model
+    createLovableTranscription('openai/not-a-model', 'k')
+  })
+})


### PR DESCRIPTION
TypeScript now rejects a Lovable model id that is not on a curated list. `LovableModelId` was `LovableChatModel | (string & {})`, so the text, responses-text, and summarize factories accepted any string. This PR removes the escape hatch. The other modalities (image, video, embedding, TTS, transcription) already used their curated unions only.

## 🎯 Changes

- `LovableModelId` is now the `LovableChatModel` union from `LOVABLE_CHAT_MODELS`.
- A new type-safety test (`packages/ai-lovable/tests/model-id-type-safety.test.ts`) pins the gating: every modality factory rejects an uncurated id with `@ts-expect-error`, and curated ids compile.
- `docs/adapters/lovable.md` now says model ids come from the curated lists.
- Changeset: **minor** for `@tanstack/ai-lovable`. All packages are 0.x, where a minor is the breaking bump. Tell me if you want a major instead.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

**Commands run.**

- `pnpm test:pr`: green (sherif, knip, docs links, kiira, oxlint, unit tests, typecheck, build artifacts, build).
- `pnpm --filter @tanstack/ai-lovable test:lib`: 12 files, 46 tests pass.
- `nx run-many --targets=test:types --projects=examples/**,testing/**`: green, so every call site in the examples and the E2E app still compiles.
- Skipped new E2E coverage. The change is compile-time only. There is no runtime behavior for Playwright to observe. The type-safety test and the call-site typechecks are the coverage.

**Manual test.**

1. Open `packages/ai-lovable/tests/model-id-type-safety.test.ts`.
2. Delete one `@ts-expect-error` comment in the "rejects uncurated model ids" block.
3. Run `pnpm --filter @tanstack/ai-lovable test:types`. The check fails, which shows the gate is live.

**How this PR makes testing easy.** The new type-safety test covers all eight factories (text, responses-text, summarize, image, video, embedding, TTS, transcription) with one positive and one negative case each.

## Risk / rollback

This is a breaking type change for callers that pass an uncurated model id to `lovableText`, `createLovableText`, `lovableResponsesText`, `createLovableResponsesText`, or the summarize factories. Those callers get a compile error and must switch to a curated id. Runtime behavior does not change. Rollback: revert the PR.

## Public API change

**Before**

```ts
import { lovableText } from "@tanstack/ai-lovable"

// Any string compiled and fell back to text-only metadata.
const adapter = lovableText("openai/some-uncurated-model")
```

**After**

```ts
import { lovableText } from "@tanstack/ai-lovable"

// Only ids from LOVABLE_CHAT_MODELS compile.
const adapter = lovableText("google/gemini-3.7-flash")

// Type error: not a curated chat model.
const bad = lovableText("openai/some-uncurated-model")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lovable model IDs are now restricted to curated, supported model lists.
  - TypeScript provides clearer validation and rejects unlisted model IDs across Lovable text, response, summarization, image, video, embedding, speech, and transcription features.

- **Documentation**
  - Updated model documentation to reflect curated model ID requirements.
  - Refreshed the Lovable AI Gateway documentation date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->