### PR TITLE
docs: fix fal size parameter typo

### DIFF
--- a/docs/adapters/fal.md
+++ b/docs/adapters/fal.md
@@ -138,7 +138,7 @@ const result = await generateImage({
 
 ## Image Size Options
 
-The fal adapter supports a flexible `size` paramater that maps either to `image_size` or to `aspect_ratio` and `resolution` parameters:
+The fal adapter supports a flexible `size` parameter that maps either to `image_size` or to `aspect_ratio` and `resolution` parameters:
 
 |  | `size` | Maps To |
 |--------|---------|---------|


### PR DESCRIPTION
## 🎯 Changes

Correct the spelling of "parameter" in the fal adapter's image size documentation.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] Code tests do not apply to this documentation-only change; `pnpm test:docs` passes.
- [x] I fully understand the code in this pull request, including the AI-assisted preparation.
- [x] Docs: I updated `docs/` for this change.
- [x] Changeset: this PR does not change a published package.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the image size options documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->