### PR TITLE
fix(ai-client): do not end append on an intermediate tool_calls RUN_FINISHED

### DIFF
--- a/.changeset/quiet-append-drain.md
+++ b/.changeset/quiet-append-drain.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/ai': patch
+'@tanstack/ai-client': patch
+---
+
+Keep `append()` pending until the HTTP response is fully processed, including later `RUN_FINISHED` events in the same agent loop.

--- a/docs/api/ai-client.md
+++ b/docs/api/ai-client.md
@@ -176,7 +176,7 @@ export async function POST(request: Request) {
 
 Appends a message to the conversation. If you pass a `UIMessage`, `append` copies `uiMessage.metadata` onto the stored message.
 
-`append()` resolves after the full HTTP response is processed. A `RUN_FINISHED` with `finishReason: "tool_calls"` does not end the wait when the agent loop continues in that response.
+`append()` resolves after the full HTTP response is processed when this call starts the stream. If a stream is already in progress, this call queues the send and the returned promise can resolve before that queued response is processed. A `RUN_FINISHED` with `finishReason: "tool_calls"` does not end the wait when the agent loop continues in that response.
 
 ```typescript
 import { client } from "./client";

--- a/docs/api/ai-client.md
+++ b/docs/api/ai-client.md
@@ -176,6 +176,8 @@ export async function POST(request: Request) {
 
 Appends a message to the conversation. If you pass a `UIMessage`, `append` copies `uiMessage.metadata` onto the stored message.
 
+`append()` resolves after the full HTTP response is processed. A `RUN_FINISHED` with `finishReason: "tool_calls"` does not end the wait when the agent loop continues in that response.
+
 ```typescript
 import { client } from "./client";
 import type { UIMessage } from "@tanstack/ai-client";

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -164,6 +164,16 @@ function resolveTransport(transport: {
   throw new Error('ChatClient: either `connection` or `fetcher` is required.')
 }
 
+function connectionDrainsOnSend(connection: ConnectionAdapter): boolean {
+  return 'connect' in connection
+}
+
+function isIntermediateToolTurn(chunk: StreamChunk): boolean {
+  if (chunk.type !== 'RUN_FINISHED') return false
+  if (chunk.outcome?.type === 'interrupt') return false
+  return tanstackMetadata(chunk)?.finishReason === 'tool_calls'
+}
+
 export interface NormalizedQueueConfig {
   whenBusy: WhenBusy
   drain: 'fifo' | 'batch'
@@ -416,6 +426,12 @@ export class ChatClient<
   private continuationPending = false
   private subscriptionAbortController: AbortController | null = null
   private processingResolve: (() => void) | null = null
+  /**
+   * `connect()` adapters push the full HTTP body into the subscribe queue, then
+   * wait until that queue is idle. After `send()` returns, every chunk from this
+   * request has been processed. Subscribe/send sockets do not drain that way.
+   */
+  private connectionDrainsOnSend = false
   private errorReportedGeneration: number | null = null
   private streamGeneration = 0
   private continuationGeneration = 0
@@ -518,7 +534,9 @@ export class ChatClient<
     this.byokProvider = options.byokProvider
     this.context = options.context
     this.queueConfig = normalizeQueueOption(options.queue)
-    this.connection = normalizeConnectionAdapter(resolveTransport(options))
+    const transport = resolveTransport(options)
+    this.connectionDrainsOnSend = connectionDrainsOnSend(transport)
+    this.connection = normalizeConnectionAdapter(transport)
 
     // Build client tools map
     this.clientToolsRef = { current: new Map() }
@@ -1140,7 +1158,9 @@ export class ChatClient<
       this.clearedStreamTracker.onSessionRunError()
     }
     this.setSessionGenerating(this.activeRunIds.size > 0)
-    if (options?.resolveProcessing !== false) {
+    const skipProcessingResolve =
+      chunk.type === 'RUN_FINISHED' && isIntermediateToolTurn(chunk)
+    if (options?.resolveProcessing !== false && !skipProcessingResolve) {
       this.resolveProcessing()
     }
   }
@@ -2344,6 +2364,14 @@ export class ChatClient<
         return false
       }
 
+      // connect() send() already waited until the subscribe queue was idle.
+      // Kick the processing wait so a stream that ends on tool_calls (no
+      // interrupt / stop) cannot hang. Subscribe/send sockets still wait for
+      // a request-ending terminal below.
+      if (this.connectionDrainsOnSend) {
+        this.resolveProcessing()
+      }
+
       // Wait for subscription loop to finish processing all chunks
       await processingComplete
 
@@ -3045,12 +3073,12 @@ export class ChatClient<
       this.resetSessionGenerating()
       this.setIsSubscribed(false)
       this.setConnectionStatus('disconnected')
-      this.connection = normalizeConnectionAdapter(
-        resolveTransport({
-          connection: options.connection,
-          fetcher: options.fetcher,
-        }),
-      )
+      const transport = resolveTransport({
+        connection: options.connection,
+        fetcher: options.fetcher,
+      })
+      this.connectionDrainsOnSend = connectionDrainsOnSend(transport)
+      this.connection = normalizeConnectionAdapter(transport)
 
       if (wasSubscribed) {
         this.subscribe()

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -171,6 +171,10 @@ function connectionDrainsOnSend(connection: ConnectionAdapter): boolean {
 function isIntermediateToolTurn(chunk: StreamChunk): boolean {
   if (chunk.type !== 'RUN_FINISHED') return false
   if (chunk.outcome?.type === 'interrupt') return false
+  const extra = chunk as StreamChunk & { finishReason?: unknown }
+  if (extra.finishReason !== undefined) {
+    return extra.finishReason === 'tool_calls'
+  }
   return tanstackMetadata(chunk)?.finishReason === 'tool_calls'
 }
 

--- a/packages/ai-client/src/connection-adapters.ts
+++ b/packages/ai-client/src/connection-adapters.ts
@@ -1058,18 +1058,19 @@ export function normalizeConnectionAdapter(
   async function waitUntilSubscriberIdle(
     abortSignal?: AbortSignal,
   ): Promise<void> {
+    // Idle means the subscriber is waiting for the next chunk, so the
+    // previous chunk has left processIncomingChunk. Empty waiters with an
+    // empty buffer is in-flight delivery, not idle.
     const idle = () =>
       activeBuffer.length === 0 &&
       (activeWaiters.length > 0 || abortSignal?.aborted)
     for (let i = 0; i < 16 && !abortSignal?.aborted; i++) {
       if (idle()) return
-      if (activeBuffer.length === 0 && activeWaiters.length === 0) return
       await Promise.resolve()
     }
     let macrotaskWaits = 0
     while (!abortSignal?.aborted) {
       if (idle()) return
-      if (activeBuffer.length === 0 && activeWaiters.length === 0) return
       await new Promise<void>((resolve) => setTimeout(resolve, 0))
       macrotaskWaits++
       if (activeWaiters.length === 0 && macrotaskWaits >= 32) return

--- a/packages/ai-client/src/connection-adapters.ts
+++ b/packages/ai-client/src/connection-adapters.ts
@@ -1055,6 +1055,28 @@ export function normalizeConnectionAdapter(
     }
   }
 
+  async function waitUntilSubscriberIdle(
+    abortSignal?: AbortSignal,
+  ): Promise<void> {
+    let lastBuffer = activeBuffer.length
+    let stalledTicks = 0
+    while (!abortSignal?.aborted) {
+      if (activeBuffer.length === 0 && activeWaiters.length > 0) {
+        return
+      }
+      if (activeBuffer.length < lastBuffer) {
+        stalledTicks = 0
+      } else {
+        stalledTicks++
+      }
+      lastBuffer = activeBuffer.length
+      if (activeWaiters.length === 0 && stalledTicks >= 8) {
+        return
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    }
+  }
+
   return {
     subscribe(abortSignal?: AbortSignal): AsyncIterable<StreamChunk> {
       // Transfer ownership to the latest subscriber so only one active
@@ -1161,6 +1183,8 @@ export function normalizeConnectionAdapter(
           }
         }
         throw err
+      } finally {
+        await waitUntilSubscriberIdle(abortSignal)
       }
     },
     // Expose joinRun only when the underlying connection is resumable. Require

--- a/packages/ai-client/src/connection-adapters.ts
+++ b/packages/ai-client/src/connection-adapters.ts
@@ -1058,22 +1058,21 @@ export function normalizeConnectionAdapter(
   async function waitUntilSubscriberIdle(
     abortSignal?: AbortSignal,
   ): Promise<void> {
-    let lastBuffer = activeBuffer.length
-    let stalledTicks = 0
+    const idle = () =>
+      activeBuffer.length === 0 &&
+      (activeWaiters.length > 0 || abortSignal?.aborted)
+    for (let i = 0; i < 16 && !abortSignal?.aborted; i++) {
+      if (idle()) return
+      if (activeBuffer.length === 0 && activeWaiters.length === 0) return
+      await Promise.resolve()
+    }
+    let macrotaskWaits = 0
     while (!abortSignal?.aborted) {
-      if (activeBuffer.length === 0 && activeWaiters.length > 0) {
-        return
-      }
-      if (activeBuffer.length < lastBuffer) {
-        stalledTicks = 0
-      } else {
-        stalledTicks++
-      }
-      lastBuffer = activeBuffer.length
-      if (activeWaiters.length === 0 && stalledTicks >= 8) {
-        return
-      }
+      if (idle()) return
+      if (activeBuffer.length === 0 && activeWaiters.length === 0) return
       await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      macrotaskWaits++
+      if (activeWaiters.length === 0 && macrotaskWaits >= 32) return
     }
   }
 
@@ -1183,9 +1182,8 @@ export function normalizeConnectionAdapter(
           }
         }
         throw err
-      } finally {
-        await waitUntilSubscriberIdle(abortSignal)
       }
+      await waitUntilSubscriberIdle(abortSignal)
     },
     // Expose joinRun only when the underlying connection is resumable. Require
     // a real function — `'joinRun' in connection` is true for

--- a/packages/ai-client/tests/chat-client.test.ts
+++ b/packages/ai-client/tests/chat-client.test.ts
@@ -2306,6 +2306,60 @@ describe('ChatClient', () => {
       expect(messages[0]?.id).toBeTruthy()
       expect(messages[0]?.createdAt).toBeInstanceOf(Date)
     })
+
+    it('keeps append pending through an intermediate tool_calls RUN_FINISHED until the interrupt', async () => {
+      const adapter: ConnectConnectionAdapter = {
+        async *connect(_messages, _data, _signal, ctx) {
+          const runId = ctx?.runId ?? 'run-1'
+          const threadId = ctx?.threadId ?? 'thread-1'
+          yield {
+            type: EventType.RUN_STARTED,
+            runId,
+            threadId,
+            timestamp: Date.now(),
+          }
+          yield withTanstackMetadata(
+            {
+              type: EventType.RUN_FINISHED,
+              runId,
+              threadId,
+              timestamp: Date.now(),
+            },
+            { finishReason: 'tool_calls' },
+          )
+          yield {
+            type: EventType.RUN_STARTED,
+            runId: 'provider-2',
+            threadId,
+            timestamp: Date.now(),
+          }
+          yield {
+            type: EventType.RUN_FINISHED,
+            runId: 'provider-2',
+            threadId,
+            timestamp: Date.now(),
+            outcome: {
+              type: 'interrupt',
+              interrupts: [{ id: 'interrupt-1', reason: 'client_tool_input' }],
+            },
+          }
+        },
+      }
+      const client = new ChatClient({
+        connection: adapter,
+        threadId: 'thread-1',
+      })
+
+      await client.append({
+        role: 'user',
+        content: 'Notify me',
+      })
+
+      expect(client.getPendingInterrupts()).toEqual([
+        expect.objectContaining({ id: 'interrupt-1' }),
+      ])
+      expect(client.getResumeState()?.runId).toBeTruthy()
+    })
   })
 
   describe('reload', () => {

--- a/packages/ai-client/tests/chat-client.test.ts
+++ b/packages/ai-client/tests/chat-client.test.ts
@@ -2318,15 +2318,13 @@ describe('ChatClient', () => {
             threadId,
             timestamp: Date.now(),
           }
-          yield withTanstackMetadata(
-            {
-              type: EventType.RUN_FINISHED,
-              runId,
-              threadId,
-              timestamp: Date.now(),
-            },
-            { finishReason: 'tool_calls' },
-          )
+          yield {
+            type: EventType.RUN_FINISHED,
+            runId,
+            threadId,
+            timestamp: Date.now(),
+            metadata: { tanstack: { finishReason: 'tool_calls' } },
+          }
           yield {
             type: EventType.RUN_STARTED,
             runId: 'provider-2',

--- a/packages/ai-client/tests/chat-client.test.ts
+++ b/packages/ai-client/tests/chat-client.test.ts
@@ -2358,6 +2358,61 @@ describe('ChatClient', () => {
       ])
       expect(client.getResumeState()?.runId).toBeTruthy()
     })
+
+    it('keeps append pending when intermediate tool_calls is a direct finishReason', async () => {
+      const adapter: ConnectConnectionAdapter = {
+        async *connect(_messages, _data, _signal, ctx) {
+          const runId = ctx?.runId ?? 'run-1'
+          const threadId = ctx?.threadId ?? 'thread-1'
+          yield {
+            type: EventType.RUN_STARTED,
+            runId,
+            threadId,
+            timestamp: Date.now(),
+          }
+          yield {
+            type: EventType.RUN_FINISHED,
+            runId,
+            threadId,
+            timestamp: Date.now(),
+            finishReason: 'tool_calls',
+          }
+          await Promise.resolve()
+          yield {
+            type: EventType.RUN_STARTED,
+            runId: 'provider-2',
+            threadId,
+            timestamp: Date.now(),
+          }
+          yield {
+            type: EventType.RUN_FINISHED,
+            runId: 'provider-2',
+            threadId,
+            timestamp: Date.now(),
+            outcome: {
+              type: 'interrupt',
+              interrupts: [
+                { id: 'interrupt-direct', reason: 'client_tool_input' },
+              ],
+            },
+          }
+        },
+      }
+      const client = new ChatClient({
+        connection: adapter,
+        threadId: 'thread-1',
+      })
+
+      await client.append({
+        role: 'user',
+        content: 'Notify me',
+      })
+
+      expect(client.getPendingInterrupts()).toEqual([
+        expect.objectContaining({ id: 'interrupt-direct' }),
+      ])
+      expect(client.getResumeState()?.runId).toBeTruthy()
+    })
   })
 
   describe('reload', () => {

--- a/packages/ai/src/activities/chat/stream/processor.ts
+++ b/packages/ai/src/activities/chat/stream/processor.ts
@@ -212,6 +212,7 @@ export class StreamProcessor {
   private finishReason: string | null = null
   private hasError = false
   private isDone = false
+  private streamEndEmitted = false
 
   // Recording
   private recording: ChunkRecording | null = null
@@ -741,6 +742,14 @@ export class StreamProcessor {
     return null
   }
 
+  private resumeAssistantState(id: string, state: MessageStreamState): void {
+    this.activeMessageIds.add(id)
+    if (state.isComplete || this.isDone) {
+      state.isComplete = false
+      this.isDone = false
+    }
+  }
+
   /**
    * Ensure an active assistant message exists, creating one if needed.
    * Used for backward compat when events arrive without prior TEXT_MESSAGE_START.
@@ -758,7 +767,7 @@ export class StreamProcessor {
     if (preferredId) {
       const state = this.getMessageState(preferredId)
       if (state) {
-        this.activeMessageIds.add(preferredId)
+        this.resumeAssistantState(preferredId, state)
         return { messageId: preferredId, state }
       }
     }
@@ -768,7 +777,7 @@ export class StreamProcessor {
     if (activeId) {
       const state = this.getMessageState(activeId)
       if (state) {
-        this.activeMessageIds.add(activeId)
+        this.resumeAssistantState(activeId, state)
         return { messageId: activeId, state }
       }
     }
@@ -2429,7 +2438,8 @@ export class StreamProcessor {
     }
 
     // Emit stream end for the last assistant message
-    if (lastAssistantMessage) {
+    if (lastAssistantMessage && !this.streamEndEmitted) {
+      this.streamEndEmitted = true
       this.events.onStreamEnd?.(lastAssistantMessage)
     }
   }
@@ -2548,6 +2558,7 @@ export class StreamProcessor {
     this.finishReason = null
     this.hasError = false
     this.isDone = false
+    this.streamEndEmitted = false
     this.chunkStrategy.reset?.()
   }
 

--- a/packages/ai/src/activities/chat/stream/processor.ts
+++ b/packages/ai/src/activities/chat/stream/processor.ts
@@ -1647,8 +1647,14 @@ export class StreamProcessor {
     }
 
     if (this.activeRuns.size === 0) {
-      this.isDone = true
       this.completeAllToolCalls()
+      const isIntermediateToolTurn =
+        this.finishReason === 'tool_calls' &&
+        chunk.outcome?.type !== 'interrupt'
+      if (isIntermediateToolTurn) {
+        return
+      }
+      this.isDone = true
       this.finalizeStream()
     }
   }
@@ -2344,6 +2350,7 @@ export class StreamProcessor {
    * @see docs/chat-architecture.md#single-shot-text-response — Finalization step
    */
   finalizeStream(): void {
+    this.isDone = true
     let lastAssistantMessage: UIMessage | undefined
 
     // Finalize ALL active messages

--- a/packages/ai/src/activities/chat/stream/processor.ts
+++ b/packages/ai/src/activities/chat/stream/processor.ts
@@ -729,6 +729,15 @@ export class StreamProcessor {
         return id
       }
     }
+    // finalizeStream() clears activeMessageIds but keeps messageStates.
+    // Leftover reasoning after an early RUN_FINISHED must resume that
+    // assistant. A new user turn calls prepareAssistantMessage(), which
+    // clears messageStates first.
+    for (const [id, state] of [...this.messageStates].reverse()) {
+      if (state.role === 'assistant') {
+        return id
+      }
+    }
     return null
   }
 
@@ -748,14 +757,20 @@ export class StreamProcessor {
     // Try to find state by preferred ID
     if (preferredId) {
       const state = this.getMessageState(preferredId)
-      if (state) return { messageId: preferredId, state }
+      if (state) {
+        this.activeMessageIds.add(preferredId)
+        return { messageId: preferredId, state }
+      }
     }
 
     // Try active assistant message
     const activeId = this.getActiveAssistantMessageId()
     if (activeId) {
       const state = this.getMessageState(activeId)
-      if (state) return { messageId: activeId, state }
+      if (state) {
+        this.activeMessageIds.add(activeId)
+        return { messageId: activeId, state }
+      }
     }
 
     // Check if a message with preferredId already exists (reconnect/resume case).

--- a/packages/ai/tests/stream-processor.test.ts
+++ b/packages/ai/tests/stream-processor.test.ts
@@ -4605,6 +4605,35 @@ describe('StreamProcessor', () => {
       expect(processor.getState().done).toBe(true)
     })
 
+    it('appends leftover reasoning after a stop RUN_FINISHED onto the same thinking part', () => {
+      const processor = new StreamProcessor()
+      processor.prepareAssistantMessage()
+
+      processor.processChunk(ev.runStarted())
+      processor.processChunk(ev.stepStarted('step-1'))
+      processor.processChunk(
+        ev.reasoningContent(
+          'The user is asking for a beginner guitar recommen.',
+        ),
+      )
+      processor.processChunk(ev.runFinished('stop'))
+      processor.processChunk(ev.reasoningContent(' $1,299.'))
+
+      const messages = processor.getMessages()
+      expect(messages).toHaveLength(1)
+      const thinkingParts = messages[0]!.parts.filter(
+        (part) => part.type === 'thinking',
+      )
+      expect(thinkingParts).toHaveLength(1)
+      const thinkingPart = thinkingParts[0]
+      if (thinkingPart?.type !== 'thinking') {
+        throw new Error('expected a thinking part')
+      }
+      expect(thinkingPart.content).toBe(
+        'The user is asking for a beginner guitar recommen. $1,299.',
+      )
+    })
+
     it('does not fire onStreamEnd on a sequential tool_calls terminal', () => {
       const events = spyEvents()
       const processor = new StreamProcessor({ events })

--- a/packages/ai/tests/stream-processor.test.ts
+++ b/packages/ai/tests/stream-processor.test.ts
@@ -2976,7 +2976,9 @@ describe('StreamProcessor', () => {
       expect(state.toolCalls.size).toBe(1)
       expect(state.toolCallOrder).toEqual(['tc-1'])
       expect(state.finishReason).toBe('tool_calls')
-      expect(state.done).toBe(true)
+      expect(state.done).toBe(false)
+      processor.finalizeStream()
+      expect(processor.getState().done).toBe(true)
     })
 
     it('should return independent copies (mutations do not affect internal state)', () => {
@@ -4603,6 +4605,26 @@ describe('StreamProcessor', () => {
       expect(processor.getState().done).toBe(true)
     })
 
+    it('does not fire onStreamEnd on a sequential tool_calls terminal', () => {
+      const events = spyEvents()
+      const processor = new StreamProcessor({ events })
+
+      processor.processChunk(ev.runStarted('run-1'))
+      processor.processChunk(ev.textStart('msg-1'))
+      processor.processChunk(ev.textContent('calling', 'msg-1'))
+      processor.processChunk(ev.runFinished('tool_calls', 'run-1'))
+
+      expect(events.onStreamEnd).not.toHaveBeenCalled()
+      expect(processor.getState().done).toBe(false)
+
+      processor.processChunk(ev.runStarted('run-2'))
+      processor.processChunk(ev.textContent(' done', 'msg-1'))
+      processor.processChunk(ev.runFinished('stop', 'run-2'))
+
+      expect(events.onStreamEnd).toHaveBeenCalledTimes(1)
+      expect(processor.getState().done).toBe(true)
+    })
+
     it('single run should finalize normally (backward compat)', () => {
       const events = spyEvents()
       const processor = new StreamProcessor({ events })
@@ -4656,6 +4678,8 @@ describe('StreamProcessor', () => {
       expect(processor.getState().toolCalls.get('tc-a')?.state).toBe(
         'input-complete',
       )
+      expect(processor.getState().done).toBe(false)
+      processor.finalizeStream()
       expect(processor.getState().done).toBe(true)
     })
 

--- a/packages/ai/tests/stream-processor.test.ts
+++ b/packages/ai/tests/stream-processor.test.ts
@@ -4634,6 +4634,35 @@ describe('StreamProcessor', () => {
       )
     })
 
+    it('flushes leftover text after a stop RUN_FINISHED and fires onStreamEnd once', () => {
+      const events = spyEvents()
+      const processor = new StreamProcessor({ events })
+      processor.prepareAssistantMessage()
+
+      processor.processChunk(ev.runStarted())
+      processor.processChunk(ev.textStart('msg-1'))
+      processor.processChunk(ev.textContent('Hello', 'msg-1'))
+      processor.processChunk(ev.runFinished('stop'))
+
+      expect(events.onStreamEnd).toHaveBeenCalledTimes(1)
+      expect(processor.getState().done).toBe(true)
+
+      processor.processChunk(ev.textContent(' world', 'msg-1'))
+      expect(processor.getState().done).toBe(false)
+      processor.processChunk(ev.textEnd('msg-1'))
+      processor.finalizeStream()
+
+      const textPart = processor
+        .getMessages()[0]!
+        .parts.find((part) => part.type === 'text')
+      if (textPart?.type !== 'text') {
+        throw new Error('expected a text part')
+      }
+      expect(textPart.content).toBe('Hello world')
+      expect(events.onStreamEnd).toHaveBeenCalledTimes(1)
+      expect(processor.getState().done).toBe(true)
+    })
+
     it('does not fire onStreamEnd on a sequential tool_calls terminal', () => {
       const events = spyEvents()
       const processor = new StreamProcessor({ events })

--- a/scripts/lovable-gateway.models.json
+++ b/scripts/lovable-gateway.models.json
@@ -12,15 +12,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -85,15 +78,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -150,15 +136,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -222,12 +201,8 @@
     "context_window": 8192,
     "max_tokens": 16384,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -265,12 +240,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -308,15 +279,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -406,12 +370,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -449,15 +409,8 @@
     "max_tokens": 65000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -522,15 +475,8 @@
     "max_tokens": 32768,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -595,15 +541,8 @@
     "max_tokens": 32768,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -668,15 +607,8 @@
     "max_tokens": 65000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -740,15 +672,8 @@
     "context_window": 65536,
     "max_tokens": 4096,
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -813,12 +738,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -856,15 +777,8 @@
     "max_tokens": 64000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -954,15 +868,8 @@
     "max_tokens": 64000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1027,15 +934,8 @@
     "max_tokens": 64000,
     "knowledge": "2026-03",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1100,12 +1000,8 @@
     "max_tokens": 0,
     "knowledge": "2025-05",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1133,15 +1029,8 @@
     "max_tokens": 0,
     "knowledge": "2025-11",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1192,13 +1081,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1226,13 +1110,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1260,13 +1139,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1291,13 +1165,8 @@
     "context_window": 16000,
     "max_tokens": 2000,
     "modalities": {
-      "input": [
-        "text",
-        "audio"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "audio"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1342,12 +1211,8 @@
     "context_window": 2000,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -1384,13 +1249,8 @@
     "context_window": 16000,
     "max_tokens": 2000,
     "modalities": {
-      "input": [
-        "text",
-        "audio"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "audio"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1436,13 +1296,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-09-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1526,13 +1381,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-05-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1616,13 +1466,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-05-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1671,13 +1516,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-10",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1761,13 +1601,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1866,13 +1701,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1956,13 +1786,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2011,13 +1836,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2081,13 +1901,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-12-01",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2186,13 +2001,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-12-01",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2256,13 +2066,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2361,13 +2166,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2466,13 +2266,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2570,13 +2365,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "image"
-      ]
+      "input": ["text", "image"],
+      "output": ["image"]
     },
     "pricing": {
       "input": {
@@ -2621,13 +2411,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "image"
-      ]
+      "input": ["text", "image"],
+      "output": ["image"]
     },
     "pricing": {
       "input": {
@@ -2672,12 +2457,8 @@
     "context_window": 8191,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2704,12 +2485,8 @@
     "context_window": 8191,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {

--- a/testing/e2e/src/lib/tools-test-tools.ts
+++ b/testing/e2e/src/lib/tools-test-tools.ts
@@ -253,6 +253,11 @@ export const SCENARIO_LIST = [
     label: 'Client Tool Input Error',
     category: 'basic',
   },
+  {
+    id: 'invalid-client-tool-retry',
+    label: 'Invalid Client Tool Retry (Regression #1192)',
+    category: 'race',
+  },
   // Race condition / event flow scenarios
   {
     id: 'sequential-client-tools',
@@ -312,6 +317,7 @@ export function getToolsForScenario(scenario: string) {
     case 'client-tool-reasoning':
     case 'client-tool-stop':
     case 'client-tool-input-error':
+    case 'invalid-client-tool-retry':
       return [clientToolDefinitions.show_notification]
 
     case 'server-context':

--- a/testing/e2e/src/routes/api.tools-test.ts
+++ b/testing/e2e/src/routes/api.tools-test.ts
@@ -20,6 +20,7 @@ const providerFreeScenarios = new Set([
   'client-server-context',
   'client-tool-stop',
   'client-tool-input-error',
+  'invalid-client-tool-retry',
   'malformed-tool-arguments',
   'provider-rejected-tool-call',
 ])
@@ -49,13 +50,20 @@ function createProviderFreeAdapter(scenario: string): AnyTextAdapter {
             state: undefined,
             toolName: 'check_status',
           }
-        : scenario === 'client-tool-input-error'
+        : scenario === 'client-tool-input-error' ||
+            scenario === 'invalid-client-tool-retry'
           ? {
               arguments: '{"message":42,"type":"info"}',
               initialText: 'Showing a notification.',
               input: { message: 42, type: 'info' },
-              name: 'client-tool-input-error-test',
-              responseText: 'Unexpected client continuation.',
+              name:
+                scenario === 'invalid-client-tool-retry'
+                  ? 'invalid-client-tool-retry-test'
+                  : 'client-tool-input-error-test',
+              responseText:
+                scenario === 'invalid-client-tool-retry'
+                  ? 'Recovered after client tool input retry.'
+                  : 'Unexpected client continuation.',
               result: undefined,
               state: undefined,
               toolName: 'show_notification',
@@ -104,9 +112,12 @@ function createProviderFreeAdapter(scenario: string): AnyTextAdapter {
       const runId = options.runId ?? 'runtime-context-run'
       const threadId = options.threadId ?? 'runtime-context-thread'
       const messageId = `${runId}-message`
-      const hasToolResult = options.messages.some(
+      const toolResultCount = options.messages.filter(
         (message) => message.role === 'tool',
-      )
+      ).length
+      const hasToolResult = toolResultCount > 0
+      const retryClientTool =
+        scenario === 'invalid-client-tool-retry' && toolResultCount === 1
 
       yield {
         type: EventType.RUN_STARTED,
@@ -116,8 +127,17 @@ function createProviderFreeAdapter(scenario: string): AnyTextAdapter {
         timestamp: Date.now(),
       }
 
-      if (!hasToolResult) {
-        const toolCallId = `${scenario}-tool-call`
+      if (!hasToolResult || retryClientTool) {
+        const toolCallId =
+          scenario === 'invalid-client-tool-retry'
+            ? `${scenario}-tool-call-${toolResultCount + 1}`
+            : `${scenario}-tool-call`
+        const toolArguments = retryClientTool
+          ? '{"message":"done","type":"info"}'
+          : config.arguments
+        const toolInput = retryClientTool
+          ? { message: 'done', type: 'info' }
+          : config.input
 
         yield {
           type: EventType.TEXT_MESSAGE_START,
@@ -150,7 +170,7 @@ function createProviderFreeAdapter(scenario: string): AnyTextAdapter {
         yield {
           type: EventType.TOOL_CALL_ARGS,
           toolCallId,
-          delta: config.arguments,
+          delta: toolArguments,
           model,
           timestamp: Date.now(),
         }
@@ -159,7 +179,7 @@ function createProviderFreeAdapter(scenario: string): AnyTextAdapter {
           toolCallId,
           toolCallName: config.toolName,
           toolName: config.toolName,
-          ...(config.input === undefined ? {} : { input: config.input }),
+          ...(toolInput === undefined ? {} : { input: toolInput }),
           ...(config.result === undefined
             ? {}
             : { result: config.result, state: config.state }),

--- a/testing/e2e/tests/tools-test/client-tool.spec.ts
+++ b/testing/e2e/tests/tools-test/client-tool.spec.ts
@@ -20,6 +20,48 @@ import {
  */
 
 test.describe('Client Tool E2E Tests', () => {
+  test('invalid client-tool input retries then runs the interrupt', async ({
+    page,
+    testId,
+    aimockPort,
+  }) => {
+    const requests: Array<string> = []
+    page.on('request', (request) => {
+      if (
+        request.method() === 'POST' &&
+        request.url().includes('/api/tools-test')
+      ) {
+        requests.push(request.url())
+      }
+    })
+
+    await selectScenario(page, 'invalid-client-tool-retry', testId, aimockPort)
+    await runTest(page)
+    await waitForTestComplete(page, 15000, 2)
+
+    const metadata = await getMetadata(page)
+    expect(requests).toHaveLength(2)
+    expect(metadata.executionCompleteCount).toBe('1')
+
+    const toolCalls = await getToolCalls(page)
+    expect(toolCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ state: 'error' }),
+        expect.objectContaining({
+          name: 'show_notification',
+          state: 'complete',
+        }),
+      ]),
+    )
+
+    const responseText = (await getMessages(page))
+      .flatMap((message) => message.parts)
+      .filter((part) => part.type === 'text')
+      .map((part) => part.content)
+      .join(' ')
+    expect(responseText).toContain('Recovered after client tool input retry.')
+  })
+
   test('single client tool executes and completes', async ({
     page,
     testId,


### PR DESCRIPTION
`append()` used to return on the first `RUN_FINISHED` with `finishReason: "tool_calls"` while a later interrupt was still in the same HTTP body. This PR keeps per-iteration run events. It waits until that response is fully processed.

Drain then processed leftover `REASONING_MESSAGE_CONTENT` after an early `RUN_FINISHED`. That opened a second thinking part and failed the reasoning E2E. The processor now resumes the last assistant so those deltas stay on one thinking part.

## 🎯 Changes

#1201 collapsed the public stream to one `RUN_STARTED` / `RUN_FINISHED` pair for the whole agent loop. This PR does not do that.

A tool-calling `chat()` response can look like this:

1. `RUN_FINISHED` with `finishReason: "tool_calls"` (the model turn ended, the loop continues)
2. More events, then a later `RUN_FINISHED` with an interrupt

`ChatClient.append()` treated step 1 as the end of the request. A caller that disposed the client then dropped the interrupt.

This PR:

- Does not resolve `append()` on an intermediate `tool_calls` terminal (direct `finishReason` or `metadata.tanstack.finishReason`)
- Does not fire `onStreamEnd` on that terminal
- Drains the `connect()` subscribe queue after a successful `send()`, including in-flight `processIncomingChunk`
- Resumes the last assistant after `finalizeStream()` so leftover reasoning and text stay on one message
- Fires `onStreamEnd` at most once

`chat()` still emits one `RUN_STARTED` / `RUN_FINISHED` pair per provider iteration.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Root cause

**Issue.** `ChatClient.append()` can finish too early when one HTTP response contains more than one `RUN_FINISHED`. The later interrupt never installs if the caller disposes the client after `append()`. Drain then made leftover reasoning after an early `RUN_FINISHED` show as a second thinking block.

**Cause.** `updateRunLifecycle()` resolves the processing wait on every `RUN_FINISHED`. `StreamProcessor.handleRunFinishedEvent()` also calls `finalizeStream()` when `activeRuns` is empty. Sequential iterations hit that empty set after the first `tool_calls` terminal. `finalizeStream()` clears `activeMessageIds` but keeps `messageStates`. Leftover `REASONING_MESSAGE_CONTENT` then called `ensureAssistantMessage()` with no active id and opened a new thinking part. `waitUntilSubscriberIdle()` also treated empty waiters as idle while `processIncomingChunk` was still in flight.

**Fix.** Skip processing-resolve and `onStreamEnd` when `finishReason` is `tool_calls` and the outcome is not an interrupt. After `connect()` `send()` reads the body, wait until the subscriber is waiting for the next chunk. After `finalizeStream()`, resume the last assistant from `messageStates` so leftover reasoning appends. Reset `isComplete` and `isDone` on that resume.

## Possible alternatives

- **One public run for the whole agent loop (PR #1201).** That changes the public stream for every consumer. This PR supersedes that approach and keeps the current per-iteration events.
- **Wait only in `ChatClient`, leave the processor as-is.** `onFinish` and status `ready` still fire on the first `tool_calls` terminal. Drain then still splits thinking after an early `RUN_FINISHED`.
- **Relax the reasoning E2E to allow two thinking blocks.** That hides a user-visible split. This PR keeps one thinking part.
- **Make busy `append()` await the queued send.** That changes queue semantics. This PR only documents the existing queue path.

## Testing

**Commands run.**

1. `vitest run tests/stream-processor.test.ts` in `packages/ai`: 208 passed.
2. `vitest run tests/chat-client.test.ts tests/chat-client-hidden-tab-yield.test.ts` in `packages/ai-client`: 128 passed.
3. `oxfmt` on the changed files: pass.
4. `pnpm test:pr` was not run. Full E2E was not run locally after this review commit (CI E2E is the gate).

**Manual test.**

1. Stream a tool-calling response that emits `RUN_FINISHED` (`tool_calls`), then a later interrupt `RUN_FINISHED` in the same HTTP body.
2. `await append(...)`, then read pending interrupts.
3. On unfixed `main`, interrupts are empty if you inspect immediately after `append()`.
4. On this branch, the interrupt is present before `append()` returns.
5. Run the reasoning E2E (`anthropic` / `gemini` / `vertex`). There must be one `thinking-block`, and it must contain `beginner`.

**How this PR makes testing easy.**

- Unit: `packages/ai-client/tests/chat-client.test.ts` (metadata `tool_calls` and direct `finishReason` interrupt waits)
- Unit: `packages/ai/tests/stream-processor.test.ts` (leftover reasoning, leftover text, single `onStreamEnd`)
- Unit: `packages/ai-client/tests/chat-client-hidden-tab-yield.test.ts` (hidden tab does not get a drain macrotask)
- E2E: `testing/e2e/tests/tools-test/client-tool.spec.ts` (`invalid-client-tool-retry`)
- E2E: `testing/e2e/tests/reasoning.spec.ts` (`shows thinking block and final answer`)

## Linked issues

Fixes #1192
Supersedes #1201

## Risk / rollback

Low. Callers that already waited for the last event see the same result. Callers that treated the first `tool_calls` `RUN_FINISHED` as "request done" now wait longer. Leftover reasoning after an early `RUN_FINISHED` now appends to the same assistant instead of opening a new message. Revert this PR to undo.

## Public API change

Same call. `append()` now waits for the full HTTP response when this call starts the stream.

**Before**

```ts
await client.append({ role: 'user', content: 'Notify me' })
// can return after the first tool_calls RUN_FINISHED
```

**After**

```ts
await client.append({ role: 'user', content: 'Notify me' })
// returns after the full response, including a later interrupt
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `append()` now waits for the complete response and agent loop, including intermediate tool-call steps.
  - Improved handling of streamed tool calls and client-tool interruptions, preserving resume state.
  - Invalid client-tool input can now retry and recover correctly.
  - Prevented leftover reasoning or text content from being lost during stream completion.
  - Ensured stream completion is reported only once.

- **Documentation**
  - Clarified `append()` completion behavior and intermediate tool-call events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->