### PR TITLE
fix(ai): keep first text delta after a tool call in the same turn

### DIFF
--- a/.changeset/fix-post-tool-first-text-delta.md
+++ b/.changeset/fix-post-tool-first-text-delta.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai': patch
+---
+
+Fix StreamProcessor dropping the first text delta of a post-tool segment. When an assistant turn opened with a tool call and then spoke, the message auto-created by `TOOL_CALL_START` left `hasToolCallsSinceTextStart` set through `TEXT_MESSAGE_START`, so the segment reset fired one delta late and folded away the first `TEXT_MESSAGE_CONTENT` chunk (e.g. losing the first word of the reply). The segment reset now runs on the first post-tool delta regardless of whether the prior segment was empty, and only the flush of a non-empty prior segment stays gated.

--- a/packages/ai/src/activities/chat/stream/processor.ts
+++ b/packages/ai/src/activities/chat/stream/processor.ts
@@ -1307,12 +1307,14 @@ export class StreamProcessor {
     // Detect if this is a NEW text segment (after tool calls) vs continuation
     const isNewSegment =
       state.hasToolCallsSinceTextStart &&
-      previousSegment.length > 0 &&
       this.isNewTextSegment(chunk, previousSegment)
 
     if (isNewSegment) {
       // Emit any accumulated text before starting new segment
-      if (previousSegment !== state.lastEmittedText) {
+      if (
+        previousSegment.length > 0 &&
+        previousSegment !== state.lastEmittedText
+      ) {
         this.emitTextUpdateForMessage(messageId)
       }
       // Reset SEGMENT text accumulation for the new text segment after tool calls

--- a/packages/ai/tests/stream-processor.test.ts
+++ b/packages/ai/tests/stream-processor.test.ts
@@ -1396,6 +1396,39 @@ describe('StreamProcessor', () => {
       expect((textParts[0] as any).content).toBe('Before')
       expect((textParts[1] as any).content).toBe('After')
     })
+
+    // A turn that opens with a tool call and THEN speaks: the assistant
+    // message is auto-created by TOOL_CALL_START, so TEXT_MESSAGE_START hits
+    // the pending-message path and does not reset the post-tool segment flag.
+    // The first TEXT_MESSAGE_CONTENT delta must still survive in the assembled
+    // TextPart (spec: every delta appends) rather than being folded away on the
+    // next delta.
+    it('keeps the first post-tool text delta when the turn opens with a tool call', () => {
+      const processor = new StreamProcessor()
+      processor.prepareAssistantMessage()
+
+      processor.processChunk(ev.runStarted())
+      processor.processChunk(ev.toolStart('tc-1', 'search'))
+      processor.processChunk(ev.toolArgs('tc-1', '{}'))
+      processor.processChunk(ev.toolEnd('tc-1', 'search'))
+      processor.processChunk(ev.toolResult('tc-1', '{"ok":true}'))
+      processor.processChunk(ev.textStart())
+      processor.processChunk(ev.textContent('Hello '))
+      processor.processChunk(ev.textContent('from '))
+      processor.processChunk(ev.textContent('the '))
+      processor.processChunk(ev.textContent('model.'))
+      processor.processChunk(ev.textEnd())
+      processor.processChunk(ev.runFinished('stop'))
+      processor.finalizeStream()
+
+      const textParts = processor
+        .getMessages()
+        .flatMap((m) => m.parts)
+        .filter((p): p is TextPart => p.type === 'text')
+      expect(textParts.map((p) => p.content).join('')).toBe(
+        'Hello from the model.',
+      )
+    })
   })
 
   // ==========================================================================

--- a/scripts/lovable-gateway.models.json
+++ b/scripts/lovable-gateway.models.json
@@ -12,15 +12,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -85,15 +78,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -150,15 +136,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -222,12 +201,8 @@
     "context_window": 8192,
     "max_tokens": 16384,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -265,12 +240,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -308,15 +279,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -406,12 +370,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -449,15 +409,8 @@
     "max_tokens": 65000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -522,15 +475,8 @@
     "max_tokens": 32768,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -595,15 +541,8 @@
     "max_tokens": 32768,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -668,15 +607,8 @@
     "max_tokens": 65000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -740,15 +672,8 @@
     "context_window": 65536,
     "max_tokens": 4096,
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -813,12 +738,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -856,15 +777,8 @@
     "max_tokens": 64000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -954,15 +868,8 @@
     "max_tokens": 64000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1027,15 +934,8 @@
     "max_tokens": 64000,
     "knowledge": "2026-03",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1100,12 +1000,8 @@
     "max_tokens": 0,
     "knowledge": "2025-05",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1133,15 +1029,8 @@
     "max_tokens": 0,
     "knowledge": "2025-11",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1192,13 +1081,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1226,13 +1110,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1260,13 +1139,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1291,13 +1165,8 @@
     "context_window": 16000,
     "max_tokens": 2000,
     "modalities": {
-      "input": [
-        "text",
-        "audio"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "audio"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1342,12 +1211,8 @@
     "context_window": 2000,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -1384,13 +1249,8 @@
     "context_window": 16000,
     "max_tokens": 2000,
     "modalities": {
-      "input": [
-        "text",
-        "audio"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "audio"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1436,13 +1296,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-09-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1526,13 +1381,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-05-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1616,13 +1466,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-05-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1671,13 +1516,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-10",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1761,13 +1601,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1866,13 +1701,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1956,13 +1786,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2011,13 +1836,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2081,13 +1901,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-12-01",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2186,13 +2001,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-12-01",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2256,13 +2066,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2361,13 +2166,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2466,13 +2266,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2570,13 +2365,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "image"
-      ]
+      "input": ["text", "image"],
+      "output": ["image"]
     },
     "pricing": {
       "input": {
@@ -2621,13 +2411,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "image"
-      ]
+      "input": ["text", "image"],
+      "output": ["image"]
     },
     "pricing": {
       "input": {
@@ -2672,12 +2457,8 @@
     "context_window": 8191,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2704,12 +2485,8 @@
     "context_window": 8191,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {

--- a/testing/e2e/fixtures/text-tool-text/tool-text.json
+++ b/testing/e2e/fixtures/text-tool-text/tool-text.json
@@ -1,0 +1,27 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "[tool-text] list the guitars in stock",
+        "sequenceIndex": 0
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "getGuitars",
+            "arguments": "{}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "[tool-text] list the guitars in stock",
+        "sequenceIndex": 1
+      },
+      "response": {
+        "content": "Absolutely, here's our inventory: Fender Stratocaster, Gibson Les Paul, and Martin D-28."
+      }
+    }
+  ]
+}

--- a/testing/e2e/tests/text-tool-text.spec.ts
+++ b/testing/e2e/tests/text-tool-text.spec.ts
@@ -38,5 +38,33 @@ for (const provider of providersFor('text-tool-text')) {
       expect(combined).toContain('Let me check')
       expect(combined).toContain('Fender Stratocaster')
     })
+
+    // No leading text, so the tool call creates the message and the post-tool
+    // TEXT_MESSAGE_START skips the segment reset — the path that used to drop
+    // the reply's first word.
+    test('keeps the first word of the text that follows an opening tool call', async ({
+      page,
+      testId,
+      aimockPort,
+    }) => {
+      await page.goto(
+        featureUrl(provider, 'text-tool-text', testId, aimockPort),
+      )
+
+      await sendMessage(page, '[tool-text] list the guitars in stock')
+      await waitForResponse(page)
+
+      const toolCalls = await getToolCalls(page)
+      expect(toolCalls[0].name).toBe('getGuitars')
+
+      await waitForAssistantText(page, 'Martin D-28')
+
+      const allText = await page
+        .getByTestId('assistant-message')
+        .allInnerTexts()
+      const combined = allText.join(' ')
+      expect(combined).toContain('Absolutely, here')
+      expect(combined).toContain('Martin D-28')
+    })
   })
 }


### PR DESCRIPTION
## 🎯 Changes

When an assistant turn opens with a tool call and then speaks, the first `TEXT_MESSAGE_CONTENT` delta of the post-tool text was dropped from the assembled message. `"Hello from the model."` rendered as `"from the model."`.

### Root cause

`TOOL_CALL_START` auto-creates the assistant message and sets `pendingManualMessageId`. The following `TEXT_MESSAGE_START` then takes the pending-message path (Case 1), which does not run the segment reset the existing-message path (Case 2) does, so `hasToolCallsSinceTextStart` stays set. The content handler's lazy reset was additionally gated on `previousSegment.length > 0`. With an empty prior segment that guard was false, so the stale flag survived to the second delta, whose reset wiped the already-accumulated first delta.

`getState().content` was correct throughout — only the assembled `UIMessage` TextPart lost the word. This breaks the `docs/chat-architecture.md` contract that every `TEXT_MESSAGE_CONTENT` delta appends.

### Fix

Run the segment reset on the first post-tool delta regardless of whether the prior segment is empty; gate only the flush of a non-empty prior segment on `previousSegment.length > 0`.

- Move the `length > 0` guard off the segment-reset condition onto the prior-segment flush.
- Add a unit test for the tool-then-text sequence in `stream-processor.test.ts`.
- Add a `text-tool-text` e2e case for a turn that opens with a tool call.

## ✅ Checklist

- [x] I have followed the steps in the Contributing guide.
- [x] I have tested code changes locally with `pnpm run test:pr`.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: not user-facing — restores behavior already documented in `docs/chat-architecture.md`.
- [x] Changeset: added (`patch`, `@tanstack/ai`).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the first word of a response could be lost after a tool call.
  * Improved preservation of UI resources, structured output, tool results, metadata, and errors during streamed responses.
  * Improved handling of text transitions so repeated or empty segments are not emitted unnecessarily.

* **Tests**
  * Added coverage for tool-first conversations, interleaved streams, and UI-resource persistence.
  * Added end-to-end validation of text immediately following a tool call.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->