### PR TITLE
fix(ai): reset segment state when a tool-first message's TEXT_MESSAGE_START arrives

### DIFF
--- a/.changeset/tool-first-text-drop.md
+++ b/.changeset/tool-first-text-drop.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai': patch
+---
+
+Fix `StreamProcessor` dropping the first `TEXT_MESSAGE_CONTENT` delta when a `TOOL_CALL_START` event's `parentMessageId` precedes that message's `TEXT_MESSAGE_START` — the normal AG-UI shape for "call a tool, then explain the result" as one assistant turn (#1247).

--- a/packages/ai/src/activities/chat/stream/processor.ts
+++ b/packages/ai/src/activities/chat/stream/processor.ts
@@ -900,9 +900,21 @@ export class StreamProcessor {
       }
 
       // Ensure state exists
-      if (!this.messageStates.has(messageId)) {
-        this.createMessageState(messageId, uiRole)
+      let pendingState = this.messageStates.get(messageId)
+      if (!pendingState) {
+        pendingState = this.createMessageState(messageId, uiRole)
         this.activeMessageIds.add(messageId)
+      } else if (pendingState.hasToolCallsSinceTextStart) {
+        // A tool call (e.g. TOOL_CALL_START with parentMessageId) marked
+        // this message before its "real" TEXT_MESSAGE_START arrived — same
+        // reset Case 2 performs, so the segment accumulator doesn't carry
+        // stale tool-call state into the text that follows.
+        if (pendingState.currentSegmentText !== pendingState.lastEmittedText) {
+          this.emitTextUpdateForMessage(messageId)
+        }
+        pendingState.currentSegmentText = ''
+        pendingState.lastEmittedText = ''
+        pendingState.hasToolCallsSinceTextStart = false
       }
 
       this.mergeMessageMetadata(messageId, chunk.metadata)

--- a/packages/ai/tests/stream-processor.test.ts
+++ b/packages/ai/tests/stream-processor.test.ts
@@ -4109,6 +4109,38 @@ describe('StreamProcessor', () => {
         },
       ])
     })
+
+    it('should not drop the first TEXT_MESSAGE_CONTENT delta in a tool-first flow (#1247)', () => {
+      const processor = new StreamProcessor()
+
+      processor.processChunk(
+        chunk(EventType.TOOL_CALL_START, {
+          toolCallId: 'tc-1',
+          toolCallName: 'lookupWeather',
+          toolName: 'lookupWeather',
+          parentMessageId: 'anthropic-msg-1',
+        }),
+      )
+      processor.processChunk(ev.toolArgs('tc-1', '{"location":"Berlin"}'))
+      processor.processChunk(ev.toolEnd('tc-1', 'lookupWeather'))
+
+      processor.processChunk(
+        chunk(EventType.TEXT_MESSAGE_START, {
+          messageId: 'anthropic-msg-1',
+          role: 'assistant' as const,
+        }),
+      )
+      // Two deltas: the bug only surfaces once a second delta arrives after
+      // the tool-first message's real TEXT_MESSAGE_START.
+      processor.processChunk(ev.textContent('It is ', 'anthropic-msg-1'))
+      processor.processChunk(ev.textContent('sunny.', 'anthropic-msg-1'))
+      processor.processChunk(ev.textEnd('anthropic-msg-1'))
+      processor.finalizeStream()
+
+      const messages = processor.getMessages()
+      const textParts = messages[0]?.parts.filter((p) => p.type === 'text')
+      expect(textParts).toEqual([{ type: 'text', content: 'It is sunny.' }])
+    })
   })
 
   describe('double onStreamEnd guard', () => {

--- a/scripts/lovable-gateway.models.json
+++ b/scripts/lovable-gateway.models.json
@@ -12,15 +12,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -85,15 +78,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -150,15 +136,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -222,12 +201,8 @@
     "context_window": 8192,
     "max_tokens": 16384,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -265,12 +240,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -308,15 +279,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -406,12 +370,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -449,15 +409,8 @@
     "max_tokens": 65000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -522,15 +475,8 @@
     "max_tokens": 32768,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -595,15 +541,8 @@
     "max_tokens": 32768,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -668,15 +607,8 @@
     "max_tokens": 65000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -740,15 +672,8 @@
     "context_window": 65536,
     "max_tokens": 4096,
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -813,12 +738,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -856,15 +777,8 @@
     "max_tokens": 64000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -954,15 +868,8 @@
     "max_tokens": 64000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1027,15 +934,8 @@
     "max_tokens": 64000,
     "knowledge": "2026-03",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1100,12 +1000,8 @@
     "max_tokens": 0,
     "knowledge": "2025-05",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1133,15 +1029,8 @@
     "max_tokens": 0,
     "knowledge": "2025-11",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1192,13 +1081,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1226,13 +1110,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1260,13 +1139,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1291,13 +1165,8 @@
     "context_window": 16000,
     "max_tokens": 2000,
     "modalities": {
-      "input": [
-        "text",
-        "audio"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "audio"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1342,12 +1211,8 @@
     "context_window": 2000,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -1384,13 +1249,8 @@
     "context_window": 16000,
     "max_tokens": 2000,
     "modalities": {
-      "input": [
-        "text",
-        "audio"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "audio"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1436,13 +1296,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-09-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1526,13 +1381,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-05-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1616,13 +1466,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-05-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1671,13 +1516,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-10",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1761,13 +1601,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1866,13 +1701,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1956,13 +1786,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2011,13 +1836,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2081,13 +1901,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-12-01",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2186,13 +2001,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-12-01",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2256,13 +2066,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2361,13 +2166,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2466,13 +2266,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2570,13 +2365,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "image"
-      ]
+      "input": ["text", "image"],
+      "output": ["image"]
     },
     "pricing": {
       "input": {
@@ -2621,13 +2411,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "image"
-      ]
+      "input": ["text", "image"],
+      "output": ["image"]
     },
     "pricing": {
       "input": {
@@ -2672,12 +2457,8 @@
     "context_window": 8191,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2704,12 +2485,8 @@
     "context_window": 8191,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {

--- a/testing/e2e/src/routeTree.gen.ts
+++ b/testing/e2e/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WebsocketAdapterRouteImport } from './routes/websocket-adapter'
 import { Route as ToolsTestRouteImport } from './routes/tools-test'
+import { Route as ToolFirstTextRouteImport } from './routes/tool-first-text'
 import { Route as PersistenceDurabilityRouteImport } from './routes/persistence-durability'
 import { Route as MiddlewareTestRouteImport } from './routes/middleware-test'
 import { Route as MarkdownCjkRouteImport } from './routes/markdown-cjk'
@@ -34,6 +35,7 @@ import { Route as ApiVideoRouteImport } from './routes/api.video'
 import { Route as ApiTtsRouteImport } from './routes/api.tts'
 import { Route as ApiTranscriptionRouteImport } from './routes/api.transcription'
 import { Route as ApiToolsTestRouteImport } from './routes/api.tools-test'
+import { Route as ApiToolFirstTextWireRouteImport } from './routes/api.tool-first-text-wire'
 import { Route as ApiToolCallLifecycleWireRouteImport } from './routes/api.tool-call-lifecycle-wire'
 import { Route as ApiSummarizeRouteImport } from './routes/api.summarize'
 import { Route as ApiSandboxToolHistoryRouteImport } from './routes/api.sandbox-tool-history'
@@ -80,8 +82,8 @@ import { Route as ApiDurableTakeoverRouteImport } from './routes/api.durable-tak
 import { Route as ApiDurableDeliveryRouteImport } from './routes/api.durable-delivery'
 import { Route as ApiDevtoolsMemoryRouteImport } from './routes/api.devtools-memory'
 import { Route as ApiChatRouteImport } from './routes/api.chat'
-import { Route as ApiByokChatRouteImport } from './routes/api.byok-chat'
 import { Route as ApiByteplusSeedance1080pWireRouteImport } from './routes/api.byteplus-seedance-1080p-wire'
+import { Route as ApiByokChatRouteImport } from './routes/api.byok-chat'
 import { Route as ApiAudioRouteImport } from './routes/api.audio'
 import { Route as ApiArktypeToolWireRouteImport } from './routes/api.arktype-tool-wire'
 import { Route as ApiAnthropicStructuredUsageRouteImport } from './routes/api.anthropic-structured-usage'
@@ -102,6 +104,11 @@ const WebsocketAdapterRoute = WebsocketAdapterRouteImport.update({
 const ToolsTestRoute = ToolsTestRouteImport.update({
   id: '/tools-test',
   path: '/tools-test',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ToolFirstTextRoute = ToolFirstTextRouteImport.update({
+  id: '/tool-first-text',
+  path: '/tool-first-text',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PersistenceDurabilityRoute = PersistenceDurabilityRouteImport.update({
@@ -219,6 +226,11 @@ const ApiTranscriptionRoute = ApiTranscriptionRouteImport.update({
 const ApiToolsTestRoute = ApiToolsTestRouteImport.update({
   id: '/api/tools-test',
   path: '/api/tools-test',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiToolFirstTextWireRoute = ApiToolFirstTextWireRouteImport.update({
+  id: '/api/tool-first-text-wire',
+  path: '/api/tool-first-text-wire',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiToolCallLifecycleWireRoute =
@@ -466,17 +478,17 @@ const ApiChatRoute = ApiChatRouteImport.update({
   path: '/api/chat',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiByokChatRoute = ApiByokChatRouteImport.update({
-  id: '/api/byok-chat',
-  path: '/api/byok-chat',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const ApiByteplusSeedance1080pWireRoute =
   ApiByteplusSeedance1080pWireRouteImport.update({
     id: '/api/byteplus-seedance-1080p-wire',
     path: '/api/byteplus-seedance-1080p-wire',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiByokChatRoute = ApiByokChatRouteImport.update({
+  id: '/api/byok-chat',
+  path: '/api/byok-chat',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAudioRoute = ApiAudioRouteImport.update({
   id: '/api/audio',
   path: '/api/audio',
@@ -553,6 +565,7 @@ export interface FileRoutesByFullPath {
   '/markdown-cjk': typeof MarkdownCjkRoute
   '/middleware-test': typeof MiddlewareTestRoute
   '/persistence-durability': typeof PersistenceDurabilityRoute
+  '/tool-first-text': typeof ToolFirstTextRoute
   '/tools-test': typeof ToolsTestRoute
   '/websocket-adapter': typeof WebsocketAdapterRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
@@ -609,6 +622,7 @@ export interface FileRoutesByFullPath {
   '/api/sandbox-tool-history': typeof ApiSandboxToolHistoryRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tool-call-lifecycle-wire': typeof ApiToolCallLifecycleWireRoute
+  '/api/tool-first-text-wire': typeof ApiToolFirstTextWireRoute
   '/api/tools-test': typeof ApiToolsTestRoute
   '/api/transcription': typeof ApiTranscriptionRouteWithChildren
   '/api/tts': typeof ApiTtsRouteWithChildren
@@ -639,6 +653,7 @@ export interface FileRoutesByTo {
   '/markdown-cjk': typeof MarkdownCjkRoute
   '/middleware-test': typeof MiddlewareTestRoute
   '/persistence-durability': typeof PersistenceDurabilityRoute
+  '/tool-first-text': typeof ToolFirstTextRoute
   '/tools-test': typeof ToolsTestRoute
   '/websocket-adapter': typeof WebsocketAdapterRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
@@ -695,6 +710,7 @@ export interface FileRoutesByTo {
   '/api/sandbox-tool-history': typeof ApiSandboxToolHistoryRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tool-call-lifecycle-wire': typeof ApiToolCallLifecycleWireRoute
+  '/api/tool-first-text-wire': typeof ApiToolFirstTextWireRoute
   '/api/tools-test': typeof ApiToolsTestRoute
   '/api/transcription': typeof ApiTranscriptionRouteWithChildren
   '/api/tts': typeof ApiTtsRouteWithChildren
@@ -726,6 +742,7 @@ export interface FileRoutesById {
   '/markdown-cjk': typeof MarkdownCjkRoute
   '/middleware-test': typeof MiddlewareTestRoute
   '/persistence-durability': typeof PersistenceDurabilityRoute
+  '/tool-first-text': typeof ToolFirstTextRoute
   '/tools-test': typeof ToolsTestRoute
   '/websocket-adapter': typeof WebsocketAdapterRoute
   '/$provider/$feature': typeof ProviderFeatureRoute
@@ -782,6 +799,7 @@ export interface FileRoutesById {
   '/api/sandbox-tool-history': typeof ApiSandboxToolHistoryRoute
   '/api/summarize': typeof ApiSummarizeRoute
   '/api/tool-call-lifecycle-wire': typeof ApiToolCallLifecycleWireRoute
+  '/api/tool-first-text-wire': typeof ApiToolFirstTextWireRoute
   '/api/tools-test': typeof ApiToolsTestRoute
   '/api/transcription': typeof ApiTranscriptionRouteWithChildren
   '/api/tts': typeof ApiTtsRouteWithChildren
@@ -814,6 +832,7 @@ export interface FileRouteTypes {
     | '/markdown-cjk'
     | '/middleware-test'
     | '/persistence-durability'
+    | '/tool-first-text'
     | '/tools-test'
     | '/websocket-adapter'
     | '/$provider/$feature'
@@ -870,6 +889,7 @@ export interface FileRouteTypes {
     | '/api/sandbox-tool-history'
     | '/api/summarize'
     | '/api/tool-call-lifecycle-wire'
+    | '/api/tool-first-text-wire'
     | '/api/tools-test'
     | '/api/transcription'
     | '/api/tts'
@@ -900,6 +920,7 @@ export interface FileRouteTypes {
     | '/markdown-cjk'
     | '/middleware-test'
     | '/persistence-durability'
+    | '/tool-first-text'
     | '/tools-test'
     | '/websocket-adapter'
     | '/$provider/$feature'
@@ -956,6 +977,7 @@ export interface FileRouteTypes {
     | '/api/sandbox-tool-history'
     | '/api/summarize'
     | '/api/tool-call-lifecycle-wire'
+    | '/api/tool-first-text-wire'
     | '/api/tools-test'
     | '/api/transcription'
     | '/api/tts'
@@ -986,6 +1008,7 @@ export interface FileRouteTypes {
     | '/markdown-cjk'
     | '/middleware-test'
     | '/persistence-durability'
+    | '/tool-first-text'
     | '/tools-test'
     | '/websocket-adapter'
     | '/$provider/$feature'
@@ -1042,6 +1065,7 @@ export interface FileRouteTypes {
     | '/api/sandbox-tool-history'
     | '/api/summarize'
     | '/api/tool-call-lifecycle-wire'
+    | '/api/tool-first-text-wire'
     | '/api/tools-test'
     | '/api/transcription'
     | '/api/tts'
@@ -1073,6 +1097,7 @@ export interface RootRouteChildren {
   MarkdownCjkRoute: typeof MarkdownCjkRoute
   MiddlewareTestRoute: typeof MiddlewareTestRoute
   PersistenceDurabilityRoute: typeof PersistenceDurabilityRoute
+  ToolFirstTextRoute: typeof ToolFirstTextRoute
   ToolsTestRoute: typeof ToolsTestRoute
   WebsocketAdapterRoute: typeof WebsocketAdapterRoute
   ProviderFeatureRoute: typeof ProviderFeatureRoute
@@ -1129,6 +1154,7 @@ export interface RootRouteChildren {
   ApiSandboxToolHistoryRoute: typeof ApiSandboxToolHistoryRoute
   ApiSummarizeRoute: typeof ApiSummarizeRoute
   ApiToolCallLifecycleWireRoute: typeof ApiToolCallLifecycleWireRoute
+  ApiToolFirstTextWireRoute: typeof ApiToolFirstTextWireRoute
   ApiToolsTestRoute: typeof ApiToolsTestRoute
   ApiTranscriptionRoute: typeof ApiTranscriptionRouteWithChildren
   ApiTtsRoute: typeof ApiTtsRouteWithChildren
@@ -1150,6 +1176,13 @@ declare module '@tanstack/react-router' {
       path: '/tools-test'
       fullPath: '/tools-test'
       preLoaderRoute: typeof ToolsTestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tool-first-text': {
+      id: '/tool-first-text'
+      path: '/tool-first-text'
+      fullPath: '/tool-first-text'
+      preLoaderRoute: typeof ToolFirstTextRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/persistence-durability': {
@@ -1311,6 +1344,13 @@ declare module '@tanstack/react-router' {
       path: '/api/tools-test'
       fullPath: '/api/tools-test'
       preLoaderRoute: typeof ApiToolsTestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/tool-first-text-wire': {
+      id: '/api/tool-first-text-wire'
+      path: '/api/tool-first-text-wire'
+      fullPath: '/api/tool-first-text-wire'
+      preLoaderRoute: typeof ApiToolFirstTextWireRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/tool-call-lifecycle-wire': {
@@ -1635,18 +1675,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiChatRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/byok-chat': {
-      id: '/api/byok-chat'
-      path: '/api/byok-chat'
-      fullPath: '/api/byok-chat'
-      preLoaderRoute: typeof ApiByokChatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/api/byteplus-seedance-1080p-wire': {
       id: '/api/byteplus-seedance-1080p-wire'
       path: '/api/byteplus-seedance-1080p-wire'
       fullPath: '/api/byteplus-seedance-1080p-wire'
       preLoaderRoute: typeof ApiByteplusSeedance1080pWireRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/byok-chat': {
+      id: '/api/byok-chat'
+      path: '/api/byok-chat'
+      fullPath: '/api/byok-chat'
+      preLoaderRoute: typeof ApiByokChatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/audio': {
@@ -1806,6 +1846,7 @@ const rootRouteChildren: RootRouteChildren = {
   MarkdownCjkRoute: MarkdownCjkRoute,
   MiddlewareTestRoute: MiddlewareTestRoute,
   PersistenceDurabilityRoute: PersistenceDurabilityRoute,
+  ToolFirstTextRoute: ToolFirstTextRoute,
   ToolsTestRoute: ToolsTestRoute,
   WebsocketAdapterRoute: WebsocketAdapterRoute,
   ProviderFeatureRoute: ProviderFeatureRoute,
@@ -1862,6 +1903,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSandboxToolHistoryRoute: ApiSandboxToolHistoryRoute,
   ApiSummarizeRoute: ApiSummarizeRoute,
   ApiToolCallLifecycleWireRoute: ApiToolCallLifecycleWireRoute,
+  ApiToolFirstTextWireRoute: ApiToolFirstTextWireRoute,
   ApiToolsTestRoute: ApiToolsTestRoute,
   ApiTranscriptionRoute: ApiTranscriptionRouteWithChildren,
   ApiTtsRoute: ApiTtsRouteWithChildren,

--- a/testing/e2e/src/routes/api.tool-first-text-wire.ts
+++ b/testing/e2e/src/routes/api.tool-first-text-wire.ts
@@ -1,0 +1,88 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { toServerSentEventsResponse } from '@tanstack/ai'
+import type { StreamChunk } from '@tanstack/ai'
+
+/**
+ * Wire-format regression for issue #1247.
+ *
+ * A provider-free harness run where `TOOL_CALL_START` carries a
+ * `parentMessageId` that has not had a `TEXT_MESSAGE_START` yet — the normal
+ * AG-UI shape for "call a tool, then explain the result" as one assistant
+ * turn. The two `TEXT_MESSAGE_CONTENT` deltas below are the assertion: the
+ * bug only surfaces once a *second* delta arrives after the tool-first
+ * message's real `TEXT_MESSAGE_START`.
+ */
+function toolFirstRun(
+  threadId: string,
+  runId: string,
+): AsyncIterable<StreamChunk> {
+  const messageId = 'msg-1'
+  const toolCallId = 'call-1'
+  return (async function* () {
+    yield { type: 'RUN_STARTED', threadId, runId, timestamp: Date.now() }
+    yield {
+      type: 'TOOL_CALL_START',
+      toolCallId,
+      toolCallName: 'lookupWeather',
+      parentMessageId: messageId,
+      timestamp: Date.now(),
+    }
+    yield {
+      type: 'TOOL_CALL_ARGS',
+      toolCallId,
+      delta: '{}',
+      timestamp: Date.now(),
+    }
+    yield { type: 'TOOL_CALL_END', toolCallId, timestamp: Date.now() }
+    yield {
+      type: 'TOOL_CALL_RESULT',
+      messageId: 'tool-1',
+      toolCallId,
+      role: 'tool',
+      content: '{"ok":true}',
+      timestamp: Date.now(),
+    }
+    yield {
+      type: 'TEXT_MESSAGE_START',
+      messageId,
+      role: 'assistant',
+      timestamp: Date.now(),
+    }
+    yield {
+      type: 'TEXT_MESSAGE_CONTENT',
+      messageId,
+      delta: 'Hello, ',
+      timestamp: Date.now(),
+    }
+    yield {
+      type: 'TEXT_MESSAGE_CONTENT',
+      messageId,
+      delta: 'world.',
+      timestamp: Date.now(),
+    }
+    yield { type: 'TEXT_MESSAGE_END', messageId, timestamp: Date.now() }
+    yield {
+      type: 'RUN_FINISHED',
+      threadId,
+      runId,
+      timestamp: Date.now(),
+      outcome: { type: 'success' },
+    }
+  })() as AsyncIterable<StreamChunk>
+}
+
+export const Route = createFileRoute('/api/tool-first-text-wire')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const body: unknown = await request.json()
+        const threadId =
+          typeof body === 'object' && body !== null && 'threadId' in body
+            ? String((body as Record<string, unknown>).threadId)
+            : 'thread-1'
+        const runId = `run-${threadId}`
+        return toServerSentEventsResponse(toolFirstRun(threadId, runId))
+      },
+    },
+  },
+})

--- a/testing/e2e/src/routes/tool-first-text.tsx
+++ b/testing/e2e/src/routes/tool-first-text.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { fetchServerSentEvents, useChat } from '@tanstack/ai-react'
+
+/**
+ * Harness page for issue #1247: a tool call whose `parentMessageId` precedes
+ * that message's `TEXT_MESSAGE_START`. `/api/tool-first-text-wire` streams
+ * that shape once; this page renders the resulting assistant text so the
+ * spec can assert the first delta was not dropped.
+ */
+function ToolFirstTextPage() {
+  const { messages, sendMessage } = useChat({
+    threadId: 'tool-first-text-1',
+    connection: fetchServerSentEvents('/api/tool-first-text-wire'),
+  })
+
+  const assistantText = messages
+    .filter((message) => message.role === 'assistant')
+    .flatMap((message) =>
+      message.parts.flatMap((part) =>
+        part.type === 'text' ? [part.content] : [],
+      ),
+    )
+    .join('')
+
+  useEffect(() => {
+    void sendMessage('go')
+    // Fire the single run once on mount; the harness route ignores the content.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div data-testid="tool-first-text-page">
+      <div data-testid="assistant-text">{assistantText}</div>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/tool-first-text')({
+  component: ToolFirstTextPage,
+})

--- a/testing/e2e/tests/tool-first-text.spec.ts
+++ b/testing/e2e/tests/tool-first-text.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * `StreamProcessor` must not drop the first `TEXT_MESSAGE_CONTENT` delta when
+ * a tool call's `parentMessageId` precedes that message's real
+ * `TEXT_MESSAGE_START` — the normal AG-UI shape for "call a tool, then
+ * explain the result" as one assistant turn.
+ */
+test.describe('tool-first text (#1247)', () => {
+  test('does not drop the first text delta after a tool-first message', async ({
+    page,
+  }) => {
+    await page.goto('/tool-first-text')
+
+    await expect(page.getByTestId('assistant-text')).toHaveText(
+      'Hello, world.',
+    )
+  })
+})

--- a/testing/e2e/tests/tool-first-text.spec.ts
+++ b/testing/e2e/tests/tool-first-text.spec.ts
@@ -12,8 +12,6 @@ test.describe('tool-first text (#1247)', () => {
   }) => {
     await page.goto('/tool-first-text')
 
-    await expect(page.getByTestId('assistant-text')).toHaveText(
-      'Hello, world.',
-    )
+    await expect(page.getByTestId('assistant-text')).toHaveText('Hello, world.')
   })
 })


### PR DESCRIPTION
A tool call that opens an assistant turn drops the first text word that follows it. `TOOL_CALL_START` with a `parentMessageId` that has no `TEXT_MESSAGE_START` yet auto-creates the message and leaves stale state behind, so the second text delta wipes out the first. This PR resets that state in the code path that was missing it.

## 🎯 Changes

`StreamProcessor` dropped the first `TEXT_MESSAGE_CONTENT` delta whenever a tool call opened an assistant turn (no leading text before it) and the model replied with two or more deltas after the tool result. `"Hello, world."` rendered as `"world."`.

This fix resets the leftover tool-call state at the point `TEXT_MESSAGE_START` arrives, so no stale state reaches the content handler at all.

## Root cause

**Issue.** `StreamProcessor` drops the first `TEXT_MESSAGE_CONTENT` delta of the text that follows a tool call, when that tool call's `parentMessageId` had no prior `TEXT_MESSAGE_START`. This is the common AG-UI shape "call a tool, then explain the result," as one assistant turn.

**Cause.** In `handleToolCallStartEvent` (`packages/ai/src/activities/chat/stream/processor.ts`), `ensureAssistantMessage()` auto-creates the message and sets `pendingManualMessageId`, then marks `hasToolCallsSinceTextStart = true`. When the real `TEXT_MESSAGE_START` for that message arrives, `handleTextMessageStartEvent` finds `pendingManualMessageId` still set and takes Case 1 ("manual message"), which clears the pending id and returns. Only Case 2 ("message already exists") resets `hasToolCallsSinceTextStart`, `currentSegmentText`, and `lastEmittedText`. Case 1 skips that reset. The stale `hasToolCallsSinceTextStart` survives into the content handler, and its "new segment after a tool call" check fires one delta late — on the *second* delta, not the first — wiping the already-accumulated first delta before the second one is added.

**Fix.** Case 1 now performs the same reset Case 2 already does, so `hasToolCallsSinceTextStart` never survives past the message's real `TEXT_MESSAGE_START`.

## Possible alternatives

- **PR #1246** (`fix(ai): keep first text delta after a tool call in the same turn`), already open, fixes the same root state at a different point: it patches `handleTextMessageContentEvent` so the "new segment" reset fires on the first post-tool delta (when the prior segment is empty) instead of the second. I found this bug and wrote this fix independently — issue #1247 predates my discovery of #1246 — but #1246 got there first and is a valid, different-layer fix for the same underlying state bug. A maintainer may prefer one over the other; I am not closing this PR so both are visible for comparison.
- **Reset inside `handleTextMessageContentEvent` only** (the approach #1246 takes): works, but leaves the two `TEXT_MESSAGE_START` code paths (Case 1 and Case 2) diverging on state they should agree on, which is what let this bug in undetected in the first place (see the existing "tool-first flows" test that only exercised a single delta).

## Testing

**Commands run:**

- `pnpm exec vitest run tests/stream-processor.test.ts` (`packages/ai`) — 206/206 pass
- `pnpm test:lib` (`packages/ai`) — 1720/1720 pass
- `pnpm test:types`, `pnpm test:build` (`packages/ai`) — clean
- `nx affected --targets=test:sherif,test:knip,test:docs,test:kiira,test:oxlint,test:lib,test:types,test:build,build` (repo-wide, matches `pnpm test:pr`'s target set) — all pass
- `pnpm exec playwright test tool-first-text.spec.ts` (`testing/e2e`) — pass on this branch; also confirmed it fails on unpatched `main` (rebuilt `@tanstack/ai` with the source fix reverted, reran, got `"world."` instead of `"Hello, world."`, then restored the fix and reran green)
- Did not run the full E2E suite locally (100+ specs across every provider) — the change is isolated to one function plus new, self-contained harness files that no other spec touches, so CI's full run is the right place for that

**Manual test (reproduce, then confirm fixed):**

1. On `main`, run the repro in issue #1247 (or `pnpm exec vitest run tests/stream-processor.test.ts -t "1247"` on this branch, pointed at `main`'s `processor.ts`) — the assembled text comes out as `"world."`.
2. On this branch, run the same command — the text comes out as `"Hello, world."`.
3. Or: `cd testing/e2e && pnpm exec playwright test tool-first-text.spec.ts` — visits `/tool-first-text`, a harness page that streams the exact wire shape from the issue, and asserts the rendered text.

**How this PR makes testing easy:** a new unit test (`packages/ai/tests/stream-processor.test.ts`) reproduces the bug in isolation, and a new E2E harness (`api.tool-first-text-wire.ts` + `tool-first-text.tsx` + `tool-first-text.spec.ts`) reproduces it through the real browser client, following the existing `foreign-interrupt` wire-harness pattern.

## Linked issues

Fixes #1247

## Risk / rollback

Low risk: the change only runs when `hasToolCallsSinceTextStart` is already `true` in Case 1, mirrors logic Case 2 already ships, and the existing "tool-first flows" test (`stream-processor.test.ts:4065`) still passes unchanged. Revert is a plain `git revert` of this PR; no flags or migrations involved.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr` (via the equivalent `nx affected` target set — see Testing).
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: this change is not user-facing — it restores behavior already documented in `docs/chat-architecture.md`.
- [x] Changeset: I added a changeset (`pnpm changeset`).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming responses so the first assistant text is preserved when a tool call occurs before text generation.
  * Ensured multiple text updates are combined correctly into a single message.

* **Tests**
  * Added regression and end-to-end coverage for tool-first streaming scenarios.
  * Added a test page and simulated streaming endpoint to verify complete assistant responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->