### PR TITLE
build(adapters): remove unused zod peer dependencies

### DIFF
--- a/.changeset/tame-wolves-rest.md
+++ b/.changeset/tame-wolves-rest.md
@@ -1,0 +1,14 @@
+---
+'@tanstack/ai-anthropic': patch
+'@tanstack/ai-bedrock': patch
+'@tanstack/ai-byteplus': patch
+'@tanstack/ai-grok': patch
+'@tanstack/ai-groq': patch
+'@tanstack/ai-llmgateway': patch
+'@tanstack/ai-lovable': patch
+'@tanstack/ai-mistral': patch
+'@tanstack/ai-openai': patch
+'@tanstack/ai-vercel-gateway': patch
+---
+
+Stop requiring Zod as a peer dependency when the adapters do not import it at runtime.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -15,6 +15,7 @@
     "**/dist",
     "**/docs",
     "packages/ai-fal/src/image/generated/",
+    "scripts/lovable-gateway.models.json",
     "pnpm-lock.yaml",
     ".angular",
     ".github"

--- a/packages/ai-anthropic/package.json
+++ b/packages/ai-anthropic/package.json
@@ -71,8 +71,7 @@
   },
   "peerDependencies": {
     "@anthropic-ai/vertex-sdk": "^0.19.0",
-    "@tanstack/ai": "workspace:^",
-    "zod": "^4.0.0"
+    "@tanstack/ai": "workspace:^"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/vertex-sdk": {

--- a/packages/ai-bedrock/package.json
+++ b/packages/ai-bedrock/package.json
@@ -53,8 +53,7 @@
     "vite": "^8.2.1"
   },
   "peerDependencies": {
-    "@tanstack/ai": "workspace:^",
-    "zod": "^4.0.0"
+    "@tanstack/ai": "workspace:^"
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",

--- a/packages/ai-byteplus/package.json
+++ b/packages/ai-byteplus/package.json
@@ -67,8 +67,7 @@
     "vite": "^8.2.1"
   },
   "peerDependencies": {
-    "@tanstack/ai": "workspace:^",
-    "zod": "^4.0.0"
+    "@tanstack/ai": "workspace:^"
   },
   "dependencies": {
     "@tanstack/ai-utils": "workspace:^",

--- a/packages/ai-grok/package.json
+++ b/packages/ai-grok/package.json
@@ -79,8 +79,7 @@
   },
   "peerDependencies": {
     "@tanstack/ai": "workspace:^",
-    "google-auth-library": "^10.5.0",
-    "zod": "^4.0.0"
+    "google-auth-library": "^10.5.0"
   },
   "peerDependenciesMeta": {
     "google-auth-library": {

--- a/packages/ai-groq/package.json
+++ b/packages/ai-groq/package.json
@@ -66,8 +66,7 @@
     "vite": "^8.2.1"
   },
   "peerDependencies": {
-    "@tanstack/ai": "workspace:^",
-    "zod": "^4.0.0"
+    "@tanstack/ai": "workspace:^"
   },
   "dependencies": {
     "@tanstack/ai-utils": "workspace:^",

--- a/packages/ai-llmgateway/package.json
+++ b/packages/ai-llmgateway/package.json
@@ -64,8 +64,7 @@
   "devDependencies": {
     "@tanstack/ai": "workspace:*",
     "@vitest/coverage-v8": "4.1.10",
-    "vite": "^8.2.1",
-    "zod": "^4.2.0"
+    "vite": "^8.2.1"
   },
   "peerDependencies": {
     "@tanstack/ai": "workspace:^"

--- a/packages/ai-llmgateway/package.json
+++ b/packages/ai-llmgateway/package.json
@@ -68,7 +68,6 @@
     "zod": "^4.2.0"
   },
   "peerDependencies": {
-    "@tanstack/ai": "workspace:^",
-    "zod": "^4.0.0"
+    "@tanstack/ai": "workspace:^"
   }
 }

--- a/packages/ai-lovable/package.json
+++ b/packages/ai-lovable/package.json
@@ -68,8 +68,7 @@
     "zod": "^4.2.0"
   },
   "peerDependencies": {
-    "@tanstack/ai": "workspace:^",
-    "zod": "^4.0.0"
+    "@tanstack/ai": "workspace:^"
   },
   "dependencies": {
     "@tanstack/ai-utils": "workspace:^",

--- a/packages/ai-lovable/package.json
+++ b/packages/ai-lovable/package.json
@@ -64,8 +64,7 @@
   "devDependencies": {
     "@tanstack/ai": "workspace:*",
     "@vitest/coverage-v8": "4.1.10",
-    "vite": "^8.2.1",
-    "zod": "^4.2.0"
+    "vite": "^8.2.1"
   },
   "peerDependencies": {
     "@tanstack/ai": "workspace:^"

--- a/packages/ai-mistral/package.json
+++ b/packages/ai-mistral/package.json
@@ -62,8 +62,7 @@
   },
   "peerDependencies": {
     "@tanstack/ai": "workspace:^",
-    "google-auth-library": "^10.5.0",
-    "zod": "^4.0.0"
+    "google-auth-library": "^10.5.0"
   },
   "peerDependenciesMeta": {
     "google-auth-library": {

--- a/packages/ai-mistral/tests/mistral-adapter.test.ts
+++ b/packages/ai-mistral/tests/mistral-adapter.test.ts
@@ -19,7 +19,6 @@ vi.mock('@mistralai/mistralai', () => {
 })
 
 import type { AdapterYieldChunk, TextOptions, Tool } from '@tanstack/ai'
-import { z } from 'zod'
 import type { MistralTextProviderOptions } from '../src/adapters/text'
 
 const { chat, createChatOptions, maxIterations, toolDefinition } =
@@ -630,11 +629,18 @@ describe('Mistral AG-UI event emission', () => {
     const askUser = toolDefinition({
       name: 'ask_user',
       description: 'Ask the user to choose an option',
-      inputSchema: z.object({
-        mode: z.enum(['canary']).optional(),
-        question: z.string(),
-        nullableNote: z.string().nullable(),
-      }),
+      inputSchema: {
+        type: 'object',
+        properties: {
+          mode: { type: 'string', enum: ['canary'] },
+          question: { type: 'string' },
+          nullableNote: {
+            anyOf: [{ type: 'string' }, { type: 'null' }],
+          },
+        },
+        required: ['question', 'nullableNote'],
+        additionalProperties: false,
+      },
     }).server((input) => {
       executedInput = input
       return { accepted: true }

--- a/packages/ai-mistral/tests/mistral-output-schema-chat.test.ts
+++ b/packages/ai-mistral/tests/mistral-output-schema-chat.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { z } from 'zod'
 
 const { mockComplete } = vi.hoisted(() => ({
   mockComplete: vi.fn<(...args: Array<unknown>) => unknown>(),
@@ -85,10 +84,15 @@ describe('chat({ outputSchema }) with Mistral', () => {
     const result = await chat({
       adapter,
       messages: [{ role: 'user', content: 'Return structured output' }],
-      outputSchema: z.object({
-        mode: z.enum(['canary']).optional(),
-        note: z.string().nullable(),
-      }),
+      outputSchema: {
+        type: 'object',
+        properties: {
+          mode: { type: 'string', enum: ['canary'] },
+          note: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+        },
+        required: ['note'],
+        additionalProperties: false,
+      },
     })
 
     expect(mockComplete).toHaveBeenCalledWith(

--- a/packages/ai-openai/package.json
+++ b/packages/ai-openai/package.json
@@ -75,8 +75,7 @@
     "openai": "^6.41.0"
   },
   "peerDependencies": {
-    "@tanstack/ai": "workspace:^",
-    "zod": "^4.0.0"
+    "@tanstack/ai": "workspace:^"
   },
   "devDependencies": {
     "@tanstack/ai": "workspace:*",

--- a/packages/ai-vercel-gateway/package.json
+++ b/packages/ai-vercel-gateway/package.json
@@ -66,8 +66,7 @@
     "vite": "^8.2.1"
   },
   "peerDependencies": {
-    "@tanstack/ai": "workspace:^",
-    "zod": "^4.0.0"
+    "@tanstack/ai": "workspace:^"
   },
   "dependencies": {
     "@tanstack/ai-utils": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1595,9 +1595,6 @@ importers:
       openai:
         specifier: ^6.41.0
         version: 6.41.0(ws@8.21.0)(zod@4.3.6)
-      zod:
-        specifier: ^4.0.0
-        version: 4.3.6
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 4.1.10
@@ -1617,9 +1614,6 @@ importers:
       openai:
         specifier: ^6.41.0
         version: 6.41.0(ws@8.21.0)(zod@4.3.6)
-      zod:
-        specifier: ^4.0.0
-        version: 4.3.6
     devDependencies:
       '@tanstack/ai':
         specifier: workspace:*
@@ -1931,9 +1925,6 @@ importers:
       openai:
         specifier: ^6.41.0
         version: 6.41.0(ws@8.21.0)(zod@4.3.6)
-      zod:
-        specifier: ^4.0.0
-        version: 4.3.6
     devDependencies:
       '@tanstack/ai':
         specifier: workspace:*
@@ -1981,9 +1972,6 @@ importers:
       openai:
         specifier: ^6.41.0
         version: 6.41.0(ws@8.21.0)(zod@4.3.6)
-      zod:
-        specifier: ^4.0.0
-        version: 4.3.6
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 4.1.10
@@ -2179,9 +2167,6 @@ importers:
       '@tanstack/ai-utils':
         specifier: workspace:*
         version: link:../ai-utils
-      zod:
-        specifier: ^4.0.0
-        version: 4.3.6
     devDependencies:
       '@tanstack/ai':
         specifier: workspace:*
@@ -2701,9 +2686,6 @@ importers:
       openai:
         specifier: ^6.41.0
         version: 6.41.0(ws@8.21.0)(zod@4.3.6)
-      zod:
-        specifier: ^4.0.0
-        version: 4.3.6
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 4.1.10
@@ -11786,6 +11768,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2074,9 +2074,6 @@ importers:
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
-      zod:
-        specifier: ^4.2.0
-        version: 4.3.6
 
   packages/ai-lovable:
     dependencies:
@@ -2099,9 +2096,6 @@ importers:
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@24.10.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.9.0)
-      zod:
-        specifier: ^4.2.0
-        version: 4.3.6
 
   packages/ai-mcp:
     dependencies:

--- a/scripts/lovable-gateway.models.json
+++ b/scripts/lovable-gateway.models.json
@@ -12,8 +12,15 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text", "image", "audio", "video"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -78,8 +85,15 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text", "image", "video"],
-      "output": ["text", "image"]
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
     },
     "pricing": {
       "input": {
@@ -136,8 +150,15 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text", "image", "audio", "video"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -201,8 +222,12 @@
     "context_window": 8192,
     "max_tokens": 16384,
     "modalities": {
-      "input": ["text"],
-      "output": ["audio"]
+      "input": [
+        "text"
+      ],
+      "output": [
+        "audio"
+      ]
     },
     "pricing": {
       "input": {
@@ -240,8 +265,12 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text"],
-      "output": ["audio"]
+      "input": [
+        "text"
+      ],
+      "output": [
+        "audio"
+      ]
     },
     "pricing": {
       "input": {
@@ -279,8 +308,15 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text", "image", "audio", "video"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -370,8 +406,12 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text"],
-      "output": ["audio"]
+      "input": [
+        "text"
+      ],
+      "output": [
+        "audio"
+      ]
     },
     "pricing": {
       "input": {
@@ -409,8 +449,15 @@
     "max_tokens": 65000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text", "image", "audio", "video"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -475,8 +522,15 @@
     "max_tokens": 32768,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text", "image", "video"],
-      "output": ["text", "image"]
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
     },
     "pricing": {
       "input": {
@@ -541,8 +595,15 @@
     "max_tokens": 32768,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text", "image", "video"],
-      "output": ["text", "image"]
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
     },
     "pricing": {
       "input": {
@@ -607,8 +668,15 @@
     "max_tokens": 65000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text", "image", "audio", "video"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -672,8 +740,15 @@
     "context_window": 65536,
     "max_tokens": 4096,
     "modalities": {
-      "input": ["text", "image", "video"],
-      "output": ["text", "image"]
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
     },
     "pricing": {
       "input": {
@@ -738,8 +813,12 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text"],
-      "output": ["audio"]
+      "input": [
+        "text"
+      ],
+      "output": [
+        "audio"
+      ]
     },
     "pricing": {
       "input": {
@@ -777,8 +856,15 @@
     "max_tokens": 64000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text", "image", "audio", "video"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -868,8 +954,15 @@
     "max_tokens": 64000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": ["text", "image", "audio", "video"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -934,8 +1027,15 @@
     "max_tokens": 64000,
     "knowledge": "2026-03",
     "modalities": {
-      "input": ["text", "image", "audio", "video"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1000,8 +1100,12 @@
     "max_tokens": 0,
     "knowledge": "2025-05",
     "modalities": {
-      "input": ["text"],
-      "output": ["text"]
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1029,8 +1133,15 @@
     "max_tokens": 0,
     "knowledge": "2025-11",
     "modalities": {
-      "input": ["text", "image", "audio", "video"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1081,8 +1192,13 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["video"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "video"
+      ]
     },
     "pricing": {
       "video_duration": {
@@ -1110,8 +1226,13 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["video"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "video"
+      ]
     },
     "pricing": {
       "video_duration": {
@@ -1139,8 +1260,13 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["video"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "video"
+      ]
     },
     "pricing": {
       "video_duration": {
@@ -1165,8 +1291,13 @@
     "context_window": 16000,
     "max_tokens": 2000,
     "modalities": {
-      "input": ["text", "audio"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1211,8 +1342,12 @@
     "context_window": 2000,
     "max_tokens": 0,
     "modalities": {
-      "input": ["text"],
-      "output": ["audio"]
+      "input": [
+        "text"
+      ],
+      "output": [
+        "audio"
+      ]
     },
     "pricing": {
       "input": {
@@ -1249,8 +1384,13 @@
     "context_window": 16000,
     "max_tokens": 2000,
     "modalities": {
-      "input": ["text", "audio"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1296,8 +1436,13 @@
     "max_tokens": 128000,
     "knowledge": "2024-09-30",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1381,8 +1526,13 @@
     "max_tokens": 128000,
     "knowledge": "2024-05-30",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1466,8 +1616,13 @@
     "max_tokens": 128000,
     "knowledge": "2024-05-30",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1516,8 +1671,13 @@
     "max_tokens": 128000,
     "knowledge": "2024-10",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1601,8 +1761,13 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1701,8 +1866,13 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1786,8 +1956,13 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1836,8 +2011,13 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -1901,8 +2081,13 @@
     "max_tokens": 128000,
     "knowledge": "2025-12-01",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -2001,8 +2186,13 @@
     "max_tokens": 128000,
     "knowledge": "2025-12-01",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -2066,8 +2256,13 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -2166,8 +2361,13 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -2266,8 +2466,13 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["text"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -2365,8 +2570,13 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["image"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
     },
     "pricing": {
       "input": {
@@ -2411,8 +2621,13 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": ["text", "image"],
-      "output": ["image"]
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
     },
     "pricing": {
       "input": {
@@ -2457,8 +2672,12 @@
     "context_window": 8191,
     "max_tokens": 0,
     "modalities": {
-      "input": ["text"],
-      "output": ["text"]
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {
@@ -2485,8 +2704,12 @@
     "context_window": 8191,
     "max_tokens": 0,
     "modalities": {
-      "input": ["text"],
-      "output": ["text"]
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
     },
     "pricing": {
       "input": {

--- a/scripts/lovable-gateway.models.json
+++ b/scripts/lovable-gateway.models.json
@@ -12,15 +12,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -85,15 +78,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -150,15 +136,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -222,12 +201,8 @@
     "context_window": 8192,
     "max_tokens": 16384,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -265,12 +240,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -308,15 +279,8 @@
     "max_tokens": 65536,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -406,12 +370,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -449,15 +409,8 @@
     "max_tokens": 65000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -522,15 +475,8 @@
     "max_tokens": 32768,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -595,15 +541,8 @@
     "max_tokens": 32768,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -668,15 +607,8 @@
     "max_tokens": 65000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -740,15 +672,8 @@
     "context_window": 65536,
     "max_tokens": 4096,
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
+      "input": ["text", "image", "video"],
+      "output": ["text", "image"]
     },
     "pricing": {
       "input": {
@@ -813,12 +738,8 @@
     "max_tokens": 16384,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -856,15 +777,8 @@
     "max_tokens": 64000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -954,15 +868,8 @@
     "max_tokens": 64000,
     "knowledge": "2025-01",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1027,15 +934,8 @@
     "max_tokens": 64000,
     "knowledge": "2026-03",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1100,12 +1000,8 @@
     "max_tokens": 0,
     "knowledge": "2025-05",
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1133,15 +1029,8 @@
     "max_tokens": 0,
     "knowledge": "2025-11",
     "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image", "audio", "video"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1192,13 +1081,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1226,13 +1110,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1260,13 +1139,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "video"
-      ]
+      "input": ["text", "image"],
+      "output": ["video"]
     },
     "pricing": {
       "video_duration": {
@@ -1291,13 +1165,8 @@
     "context_window": 16000,
     "max_tokens": 2000,
     "modalities": {
-      "input": [
-        "text",
-        "audio"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "audio"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1342,12 +1211,8 @@
     "context_window": 2000,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "audio"
-      ]
+      "input": ["text"],
+      "output": ["audio"]
     },
     "pricing": {
       "input": {
@@ -1384,13 +1249,8 @@
     "context_window": 16000,
     "max_tokens": 2000,
     "modalities": {
-      "input": [
-        "text",
-        "audio"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "audio"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1436,13 +1296,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-09-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1526,13 +1381,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-05-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1616,13 +1466,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-05-30",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1671,13 +1516,8 @@
     "max_tokens": 128000,
     "knowledge": "2024-10",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1761,13 +1601,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1866,13 +1701,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -1956,13 +1786,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2011,13 +1836,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-08-31",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2081,13 +1901,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-12-01",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2186,13 +2001,8 @@
     "max_tokens": 128000,
     "knowledge": "2025-12-01",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2256,13 +2066,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2361,13 +2166,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2466,13 +2266,8 @@
     "max_tokens": 128000,
     "knowledge": "2026-02-16",
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text", "image"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2570,13 +2365,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "image"
-      ]
+      "input": ["text", "image"],
+      "output": ["image"]
     },
     "pricing": {
       "input": {
@@ -2621,13 +2411,8 @@
     "context_window": 0,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "image"
-      ]
+      "input": ["text", "image"],
+      "output": ["image"]
     },
     "pricing": {
       "input": {
@@ -2672,12 +2457,8 @@
     "context_window": 8191,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {
@@ -2704,12 +2485,8 @@
     "context_window": 8191,
     "max_tokens": 0,
     "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+      "input": ["text"],
+      "output": ["text"]
     },
     "pricing": {
       "input": {


### PR DESCRIPTION
These adapters no longer require Zod as a peer. You can install them without Zod when your app does not use Zod.

Follow-up to #1038.

## 🎯 Changes

- Drop the unused `zod` peer from ten adapters that do not import Zod at runtime.
- Keep the Zod peer on packages that still import it (`ai-perplexity`, `ai-code-mode`, `ai-code-mode-snippets`, `ai-sandbox-cloudflare`).
- Keep the Zod **devDependency** on Anthropic and OpenAI. Their tests still import `z`.
- Remove leftover unused Zod **devDependencies** from `ai-llmgateway` and `ai-lovable`.
- Rewrite two Mistral tests onto equivalent JSON Schema so `@tanstack/ai-mistral` does not need Zod in tests.
- Leave `scripts/lovable-gateway.models.json` in the fetch-script form. Ignore that generated file in oxfmt so autofix does not compact the arrays.
- Skip docs. Runtime APIs do not change. The changeset covers the peer drop.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

**Commands run**

1. `oxfmt --check` on the changed `package.json` files, `.oxfmtrc.json`, and the Lovable catalog JSON. Passed. The catalog file is ignored, as intended.
2. `sherif --ignore-dependency typescript`. Passed.
3. `knip --workspace packages/ai-llmgateway --workspace packages/ai-lovable`. Passed.
4. `pnpm install --lockfile-only --ignore-scripts` after the peer and devDependency edits.

Did not run `pnpm test:pr` on this follow-up commit. The original PR CI was green. This commit only edits dependency metadata, the lockfile, oxfmt ignore, and a generated catalog file that now matches `main`.

**Manual test**

1. Open `packages/ai-bedrock/package.json` (or any of the ten adapters).
2. Confirm `peerDependencies` has `@tanstack/ai` and does not have `zod`.
3. Open `packages/ai-llmgateway/package.json` and `packages/ai-lovable/package.json`.
4. Confirm `devDependencies` also does not list `zod`.
5. Open `packages/ai-anthropic/package.json`. Confirm `zod` is still in `devDependencies` (tests import it) and is not a peer.

**How this PR makes testing easy**

The two Mistral tests now pass JSON Schema objects instead of Zod. A reviewer can run those tests without a Zod install on `@tanstack/ai-mistral`. There is no new E2E path. This is a dependency-metadata change.

## Risk / rollback

Low risk. Dropping an unused peer is more permissive. App code that uses Zod for tools already depends on Zod itself.

Rollback: revert the PR.

## Public API change

**Before**

```json
{
  "peerDependencies": {
    "@tanstack/ai": "workspace:^",
    "zod": "^4.0.0"
  }
}
```

**After**

```json
{
  "peerDependencies": {
    "@tanstack/ai": "workspace:^"
  }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Zod is no longer required as a peer dependency for supported AI provider adapters that do not use it at runtime.
  - Simplified package installation and reduced setup requirements across multiple adapter packages.

- **Bug Fixes**
  - Improved handling of nullable and optional JSON Schema fields during tool execution and structured output validation.
  - Preserved strict schema behavior without requiring Zod.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->