### PR TITLE
fix(ai): preserve tuple item schemas in structured output conversion

### DIFF
--- a/.changeset/ai-tuple-item-maps.md
+++ b/.changeset/ai-tuple-item-maps.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai': patch
+---
+
+Preserve draft-07 tuple `items` arrays during structured-output conversion.
+
+Keep a single widening map for homogeneous arrays so `undoNullWidening` applies it to every element.

--- a/packages/ai/src/activities/chat/tools/schema-converter.ts
+++ b/packages/ai/src/activities/chat/tools/schema-converter.ts
@@ -99,6 +99,26 @@ function pruneMap(map: NullWideningMap): NullWideningMap | undefined {
   return Object.keys(map).length > 0 ? map : undefined
 }
 
+function coerceArrayItems(items: JSONSchema | Array<JSONSchema>): {
+  schema: JSONSchema | Array<JSONSchema>
+  itemMap: NullWideningMap | Array<NullWideningMap> | undefined
+} {
+  if (Array.isArray(items)) {
+    const nested = items.map((item) =>
+      makeStructuredOutputCompatible(item, item.required || []),
+    )
+    const itemMaps = nested.map((entry) => entry.nullWidening ?? {})
+    return {
+      schema: nested.map((entry) => entry.schema),
+      itemMap: itemMaps.some((entry) => Object.keys(entry).length > 0)
+        ? itemMaps
+        : undefined,
+    }
+  }
+  const nested = makeStructuredOutputCompatible(items, items.required || [])
+  return { schema: nested.schema, itemMap: nested.nullWidening }
+}
+
 /**
  * Transform a JSON schema to be compatible with OpenAI's structured output requirements.
  * OpenAI requires:
@@ -146,18 +166,15 @@ function makeStructuredOutputCompatible(
         widenedHere = wasOptional
         childMap = nested.nullWidening
       } else if (prop.type === 'array' && prop.items) {
-        const items = Array.isArray(prop.items) ? prop.items[0] : prop.items
-        const nestedItems = items
-          ? makeStructuredOutputCompatible(items, items.required || [])
-          : undefined
+        const nestedItems = coerceArrayItems(prop.items)
         properties[propName] = {
           ...prop,
-          items: nestedItems ? nestedItems.schema : prop.items,
+          items: nestedItems.schema,
           ...(wasOptional ? { type: ['array', 'null'] } : {}),
         }
         widenedHere = wasOptional
-        childMap = nestedItems?.nullWidening
-          ? { items: nestedItems.nullWidening }
+        childMap = nestedItems.itemMap
+          ? { items: nestedItems.itemMap }
           : undefined
       } else if (wasOptional) {
         // Make optional fields nullable by adding null to the type. Mark
@@ -188,17 +205,13 @@ function makeStructuredOutputCompatible(
     if (Object.keys(propertyMaps).length > 0) map.properties = propertyMaps
   }
 
-  // Handle array types with object items
+  // Handle array item schemas. A tuple (`items: [a, b, …]`) keeps every
+  // position. A homogeneous schema stays a single items map so
+  // `undoNullWidening` applies it to every element.
   if (result.type === 'array' && result.items) {
-    const items = Array.isArray(result.items) ? result.items[0] : result.items
-    if (items) {
-      const nestedItems = makeStructuredOutputCompatible(
-        items,
-        items.required || [],
-      )
-      result.items = nestedItems.schema
-      if (nestedItems.nullWidening) map.items = nestedItems.nullWidening
-    }
+    const nestedItems = coerceArrayItems(result.items)
+    result.items = nestedItems.schema
+    if (nestedItems.itemMap) map.items = nestedItems.itemMap
   }
 
   return { schema: result, nullWidening: pruneMap(map) }

--- a/packages/ai/tests/tuple-array-null-widening.test.ts
+++ b/packages/ai/tests/tuple-array-null-widening.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { undoNullWidening } from '@tanstack/ai-utils'
+import { convertSchemaForStructuredOutput } from '../src/activities/chat/tools/schema-converter'
+
+const bboxItems = [
+  { type: 'number', minimum: -180 },
+  { type: 'number', minimum: -90 },
+  { type: 'number', maximum: 180 },
+  { type: 'number', maximum: 90 },
+]
+
+describe('structured-output tuple items', () => {
+  it('keeps every positional schema on an array property', () => {
+    const { jsonSchema } = convertSchemaForStructuredOutput({
+      type: 'object',
+      properties: {
+        bbox: { type: 'array', items: bboxItems },
+      },
+      required: ['bbox'],
+    })
+
+    expect(jsonSchema?.properties?.bbox?.items).toEqual(bboxItems)
+  })
+
+  it('records a positional map for a tuple of optional objects', () => {
+    const { jsonSchema, nullWideningMap } = convertSchemaForStructuredOutput({
+      type: 'array',
+      items: [
+        {
+          type: 'object',
+          properties: { west: { type: 'string' } },
+          required: [],
+        },
+        {
+          type: 'object',
+          properties: { east: { type: 'string' } },
+          required: [],
+        },
+      ],
+    })
+
+    expect(Array.isArray(jsonSchema?.items)).toBe(true)
+    expect(nullWideningMap).toEqual({
+      items: [
+        { properties: { west: { widened: true } } },
+        { properties: { east: { widened: true } } },
+      ],
+    })
+  })
+})
+
+describe('structured-output homogeneous array maps', () => {
+  it('un-widens every element, not only index 0', () => {
+    const outputSchema = z.object({
+      list: z.array(z.object({ a: z.string().optional() })),
+    })
+
+    const { nullWideningMap } = convertSchemaForStructuredOutput(outputSchema)
+    expect(
+      undoNullWidening(
+        { list: [{ a: null }, { a: null }, { a: null }] },
+        nullWideningMap,
+      ),
+    ).toEqual({ list: [{}, {}, {}] })
+  })
+})


### PR DESCRIPTION
`convertSchemaForStructuredOutput` kept only `items[0]` for draft-07 tuples, so later positions were dropped. This PR maps every tuple position. Homogeneous arrays still use one widening map, so `undoNullWidening` applies it to every element (jsve’s note on #1210).

## Changes

- Keep every positional schema in a tuple `items` array, including tuples nested in object properties.
- Keep a single `items` map for homogeneous arrays. A list-shaped map would un-widen only index 0.
- Docs: no new public API. Structured-output conversion now matches JSON Schema for tuple `items`.
- Changeset: `.changeset/ai-tuple-item-maps.md` for `@tanstack/ai`.

Follow-up to #1210, which fixed the same tuple drop in `@tanstack/openai-base`.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Root cause

**Issue.** A structured-output schema with a bbox tuple (`items: [{ minimum: -180 }, …]`) kept only the first position.

**Cause.** Both array branches in `makeStructuredOutputCompatible` used `Array.isArray(items) ? items[0] : items`.

**Fix.** Map every tuple entry. Store a list of maps for tuples and one map for a homogeneous `items` schema.

## Possible alternatives

- **Fold this into #1210.** That PR is openai-base only. This converter is `@tanstack/ai`.
- **Always store a list of maps.** That is jsve’s bug: a homogeneous array would un-widen only index 0.

## Testing

**Commands run**

1. `pnpm --filter @tanstack/ai... build` — passed
2. `pnpm --filter @tanstack/ai exec vitest run tests/tuple-array-null-widening.test.ts tests/chat-structured-output-null-normalization.test.ts` — 12 passed
3. `pnpm --filter @tanstack/ai test:types` — passed
4. `pnpm --filter @tanstack/ai test:oxlint` — passed (existing `any` warnings only)
5. `pnpm test:pr` — not run
6. E2E — not run. Coverage is unit tests on the converter.

**Manual test**

1. On `main`, pass `{ type: 'object', properties: { bbox: { type: 'array', items: [{ type: 'number', minimum: -180 }, { type: 'number', minimum: -90 }] } }, required: ['bbox'] }` to `convertSchemaForStructuredOutput`. `items` becomes the first number schema only.
2. On this branch, `items` stays a two-entry array.

Gate 1 on `main`:

```text
FAIL: items is not an array {"type":"number","minimum":-180}
```

On this branch:

```text
PASS: tuple items stayed an array
```

**How this PR makes testing easy.** `packages/ai/tests/tuple-array-null-widening.test.ts` covers tuples and jsve’s 3-element homogeneous round trip.

## Linked issues

Related: #1210, #1208

## Risk / rollback

Low. Tuple structured-output schemas keep every position. Homogeneous arrays keep the old single-map behavior. Revert the PR to undo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed structured outputs so tuple-based array schemas preserve every positional definition.
  * Corrected handling of optional tuple elements and homogeneous arrays when removing widened null values.

* **Tests**
  * Added coverage for tuple schema preservation and null handling across array elements.

* **Chores**
  * Documented a patch release for the AI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->