### PR TITLE
fix(openai-base): replay reasoning items on Responses tool loops

### DIFF
--- a/.changeset/smart-crabs-fry.md
+++ b/.changeset/smart-crabs-fry.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/openai-base": patch
+'@tanstack/openai-base': patch
 ---
 
 Replay Responses reasoning item ids on the next tool-loop turn so function_call items keep their required reasoning partner.

--- a/.changeset/smart-crabs-fry.md
+++ b/.changeset/smart-crabs-fry.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/openai-base": patch
+---
+
+Replay Responses reasoning item ids on the next tool-loop turn so function_call items keep their required reasoning partner.

--- a/packages/openai-base/src/adapters/responses-text.ts
+++ b/packages/openai-base/src/adapters/responses-text.ts
@@ -837,6 +837,14 @@ export abstract class OpenAIBaseResponsesTextAdapter<
     let hasEmittedTextMessageStart = false
     let reasoningMessageId: string | undefined
     let hasClosedReasoning = false
+    // Responses pairs a function_call with the preceding reasoning item.
+    // The next turn must send that item back or the API 400s (#1212).
+    let reasoningItemId: string | undefined
+    const captureReasoningItemId = (item: { type?: string; id?: string }) => {
+      if (item.type === 'reasoning' && item.id) {
+        reasoningItemId = item.id
+      }
+    }
     // Track whether we've emitted a terminal RUN_FINISHED so the
     // end-of-stream fallback below knows to synthesise one when the upstream
     // cuts off without a response.completed event.
@@ -899,12 +907,14 @@ export abstract class OpenAIBaseResponsesTextAdapter<
           model: currentModel,
           timestamp,
           content: accumulatedReasoning,
+          ...(reasoningItemId && { signature: reasoningItemId }),
         }
       }
       reasoningMessageId = undefined
       stepId = null
       hasClosedReasoning = false
       accumulatedReasoning = ''
+      reasoningItemId = undefined
     }
 
     const emitReasoningDelta = function* (
@@ -997,6 +1007,7 @@ export abstract class OpenAIBaseResponsesTextAdapter<
           hasEmittedTextMessageStart = false
           reasoningMessageId = undefined
           hasClosedReasoning = false
+          reasoningItemId = undefined
           stepId = null
           accumulatedContent = ''
           accumulatedReasoning = ''
@@ -1224,6 +1235,7 @@ export abstract class OpenAIBaseResponsesTextAdapter<
         // handle output_item.added to capture function call metadata (name)
         if (chunk.type === 'response.output_item.added') {
           const item = chunk.item
+          captureReasoningItemId(item)
           if (item.type === 'function_call' && item.id) {
             // Track the item as soon as we see it so subsequent arg deltas
             // aren't logged as orphans, but only emit TOOL_CALL_START when
@@ -1388,6 +1400,7 @@ export abstract class OpenAIBaseResponsesTextAdapter<
         // whose START + END therefore never fired).
         if (chunk.type === 'response.output_item.done') {
           const item = chunk.item
+          captureReasoningItemId(item)
           if (item.type === 'function_call' && item.id) {
             const metadata = toolCallMetadata.get(item.id) ?? {
               callId: item.call_id || item.id,
@@ -1510,6 +1523,7 @@ export abstract class OpenAIBaseResponsesTextAdapter<
           // below still routes the run's finishReason to 'tool_calls' —
           // leaving consumers waiting for tool results they never saw start.
           for (const item of chunk.response.output) {
+            captureReasoningItemId(item)
             if (item.type !== 'function_call' || !item.id) continue
             const metadata = toolCallMetadata.get(item.id) ?? {
               callId: item.call_id || item.id,
@@ -1832,6 +1846,20 @@ export abstract class OpenAIBaseResponsesTextAdapter<
 
       // Handle assistant messages
       if (message.role === 'assistant') {
+        // Replay reasoning items before the function_call they belong to.
+        // A reasoning model stamps `id: rs_…` on the thinking signature;
+        // omitting that item is a 400 (#1212).
+        for (const thinking of message.thinking ?? []) {
+          if (!thinking.signature) continue
+          result.push({
+            type: 'reasoning',
+            id: thinking.signature,
+            summary: thinking.content
+              ? [{ type: 'summary_text', text: thinking.content }]
+              : [],
+          })
+        }
+
         // If the assistant message has tool calls, add them as FunctionToolCall objects
         // Responses API expects arguments as a string (JSON string)
         if (message.toolCalls && message.toolCalls.length > 0) {

--- a/packages/openai-base/tests/responses-text.test.ts
+++ b/packages/openai-base/tests/responses-text.test.ts
@@ -2579,6 +2579,136 @@ describe('OpenAIBaseResponsesTextAdapter', () => {
       )
     })
 
+    it('round-trips a reasoning item id with its function_call (#1212)', async () => {
+      const firstTurn = [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp-rs-1',
+            model: 'test-model',
+            status: 'in_progress',
+          },
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            type: 'reasoning',
+            id: 'rs_required_1',
+            summary: [],
+          },
+        },
+        {
+          type: 'response.reasoning_text.delta',
+          delta: 'Need the weather tool.',
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 1,
+          item: {
+            type: 'function_call',
+            id: 'fc_item_rs',
+            call_id: 'call_rs',
+            name: 'lookup_weather',
+            arguments: '',
+          },
+        },
+        {
+          type: 'response.function_call_arguments.done',
+          item_id: 'fc_item_rs',
+          output_index: 1,
+          arguments: '{"location":"Berlin"}',
+        },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp-rs-1',
+            model: 'test-model',
+            status: 'completed',
+            output: [
+              {
+                type: 'reasoning',
+                id: 'rs_required_1',
+                summary: [
+                  { type: 'summary_text', text: 'Need the weather tool.' },
+                ],
+              },
+              {
+                type: 'function_call',
+                id: 'fc_item_rs',
+                call_id: 'call_rs',
+                name: 'lookup_weather',
+                arguments: '{"location":"Berlin"}',
+              },
+            ],
+            usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+          },
+        },
+      ]
+      const secondTurn = [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp-rs-2',
+            model: 'test-model',
+            status: 'in_progress',
+          },
+        },
+        {
+          type: 'response.output_text.delta',
+          item_id: 'msg_rs',
+          output_index: 0,
+          content_index: 0,
+          delta: 'Sunny',
+        },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp-rs-2',
+            model: 'test-model',
+            status: 'completed',
+            output: [],
+            usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+          },
+        },
+      ]
+
+      mockResponsesCreate = vi
+        .fn()
+        .mockResolvedValueOnce(createAsyncIterable(firstTurn))
+        .mockResolvedValueOnce(createAsyncIterable(secondTurn))
+      const execute = vi.fn().mockReturnValue({ temperature: 72 })
+
+      for await (const _chunk of chat({
+        adapter: new TestResponsesAdapter(testConfig, 'test-model'),
+        messages: [{ role: 'user', content: 'How is the weather?' }],
+        tools: [{ ...weatherTool, execute }],
+      })) {
+        // consume both agent-loop turns
+      }
+
+      expect(execute).toHaveBeenCalledOnce()
+      expect(mockResponsesCreate).toHaveBeenCalledTimes(2)
+
+      const secondInput = mockResponsesCreate.mock.calls[1]![0].input as Array<{
+        type: string
+        id?: string
+      }>
+      const reasoningIndex = secondInput.findIndex(
+        (item) => item.type === 'reasoning' && item.id === 'rs_required_1',
+      )
+      const functionCallIndex = secondInput.findIndex(
+        (item) => item.type === 'function_call' && item.id === 'fc_item_rs',
+      )
+      expect(reasoningIndex).toBeGreaterThanOrEqual(0)
+      expect(functionCallIndex).toBeGreaterThan(reasoningIndex)
+      expect(secondInput[reasoningIndex]).toEqual({
+        type: 'reasoning',
+        id: 'rs_required_1',
+        summary: [{ type: 'summary_text', text: 'Need the weather tool.' }],
+      })
+    })
+
     it('converts a multimodal tool result to a structured function_call_output', async () => {
       const streamChunks = [
         {


### PR DESCRIPTION
On reasoning models, a Responses tool loop can fail with HTTP 400 after the tool runs. The second turn sends the `function_call` without its paired `reasoning` item (`rs_…`). This PR stores that item id on `thinking[].signature` and sends the reasoning item before the function call.

Fixes #1212

## 🎯 Changes

- Capture the Responses `reasoning` item id from `output_item.added`, `output_item.done`, and `response.completed`.
- Put that id on `STEP_FINISHED.signature` so `chat()` keeps it on `ModelMessage.thinking`.
- Replay `{ type: 'reasoning', id }` before `function_call` in `convertMessagesToInput`.
- Add a `chat()` unit test that drives two turns and asserts the second request includes `rs_required_1` before `fc_item_rs`.
- Docs stay the same. The public call site does not change.
- Patch changeset for `@tanstack/openai-base`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-step tool interactions by preserving reasoning item IDs across turns.
  * Prevented errors when function calls require their associated reasoning item.
  * Ensured reasoning information is replayed in the correct order before related function calls.
* **Tests**
  * Added coverage verifying reasoning items and function calls are correctly replayed in subsequent requests.
* **Release**
  * Prepared a patch release for the OpenAI base integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->