### PR TITLE
feat(ai-gemini): add Gemini Omni 1.1 Flash (gemini-omni-1.1-flash)

### DIFF
--- a/.changeset/gemini-omni-1-1-flash.md
+++ b/.changeset/gemini-omni-1-1-flash.md
@@ -4,4 +4,4 @@
 
 Add Gemini Omni 1.1 Flash (`gemini-omni-1.1-flash`) as the GA Interactions video model.
 
-`geminiVideo('gemini-omni-1.1-flash')` uses the existing Interactions video path. `gemini-omni-flash-preview` stays as a deprecated alias until it shuts down on 2026-09-30. `modelOptions.resolution` maps onto `response_format.resolution` (`360p` | `720p` | `1080p` | `4k`, default 720p). Duration stays 3–10 seconds per call.
+`geminiVideo('gemini-omni-1.1-flash')` uses the existing Interactions video path. `gemini-omni-flash-preview` stays as a deprecated alias until it shuts down on 2026-09-30. Omni `size` is an `aspectRatio_resolution` template (`'16:9'` or `'16:9_1080p'`) that maps onto `response_format.aspect_ratio` and `response_format.resolution` (`360p` | `720p` | `1080p` | `4k`, default 720p). Duration stays 3–10 seconds per call.

--- a/.changeset/gemini-omni-1-1-flash.md
+++ b/.changeset/gemini-omni-1-1-flash.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-gemini': patch
+---
+
+Add Gemini Omni 1.1 Flash (`gemini-omni-1.1-flash`) as the GA Interactions video model.
+
+`geminiVideo('gemini-omni-1.1-flash')` uses the existing Interactions video path. `gemini-omni-flash-preview` stays as a deprecated alias until it shuts down on 2026-09-30. `modelOptions.resolution` maps onto `response_format.resolution` (`360p` | `720p` | `1080p` | `4k`, default 720p). Duration stays 3–10 seconds per call.

--- a/docs/config.json
+++ b/docs/config.json
@@ -520,7 +520,7 @@
           "label": "Video Generation",
           "to": "media/video-generation",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-08-20"
+          "updatedAt": "2026-08-31"
         },
         {
           "label": "Generation Hooks",

--- a/docs/media/video-generation.md
+++ b/docs/media/video-generation.md
@@ -609,7 +609,7 @@ fal is the exception: `duration` is typed from `@fal-ai/client`'s
 
 #### Gemini Omni Flash (Interactions API) Model Options
 
-Gemini Omni Flash (`gemini-omni-flash-preview`) is Google's multimodal
+Gemini Omni Flash (`gemini-omni-1.1-flash`) is Google's multimodal
 video-generation model with conversational editing. It only serves the
 [Interactions API](https://ai.google.dev/gemini-api/docs/omni), and the same
 `geminiVideo()` adapter routes it automatically:
@@ -620,8 +620,8 @@ video-generation model with conversational editing. It only serves the
   When Google delivers by reference instead, the Files API URI passes through
   and needs your API key to download, like Veo.
 
-Clips are 720p at 24 FPS. `duration` accepts any value in the **3 to 10 second**
-range (fractional seconds included), defaulting to 10 seconds when omitted:
+`duration` accepts any value in the **3 to 10 second** range (fractional
+seconds included), defaulting to 10 seconds when omitted:
 
 - `availableDurations()` reports
   `{ kind: 'range', min: 3, max: 10, unit: 'seconds' }`.
@@ -629,24 +629,35 @@ range (fractional seconds included), defaulting to 10 seconds when omitted:
 - `snapDuration(n)` snaps raw seconds into the range, clamping to its bounds and
   rounding to whole seconds.
 
-The `size` option maps onto the interaction's output aspect ratio:
+The `size` option maps onto the interaction's output aspect ratio
+(`'16:9'` default, or `'9:16'`). Pass `modelOptions.resolution` to set
+`response_format.resolution`:
+
+- `'360p'`
+- `'720p'` (default)
+- `'1080p'` (upscaled)
+- `'4k'` (upscaled)
 
 ```typescript ignore
 import { generateVideo, getVideoJobStatus } from "@tanstack/ai";
 import { geminiVideo } from "@tanstack/ai-gemini";
 
-const adapter = geminiVideo("gemini-omni-flash-preview");
+const adapter = geminiVideo("gemini-omni-1.1-flash");
 
 const { jobId } = await generateVideo({
   adapter,
   prompt: "A woman playing violin outdoors at golden hour",
   size: "9:16", // aspect ratio: '16:9' (default) or '9:16'
   duration: 6, // 3-10 seconds; omit for the 10s default
+  modelOptions: { resolution: "1080p" }, // '360p' | '720p' | '1080p' | '4k'
 });
 
 const status = await getVideoJobStatus({ adapter, jobId });
 // status.url → 'data:video/mp4;base64,…' once completed
 ```
+
+`gemini-omni-flash-preview` still type-checks as a deprecated alias until
+it shuts down on 2026-09-30. Use `gemini-omni-1.1-flash` in new code.
 
 Image and video prompt parts are sent to the interaction as content blocks,
 grouped as images, then videos, then the text prompt (Omni doesn't use Veo's
@@ -668,7 +679,7 @@ edits the video while preserving everything you didn't mention:
 import { generateVideo } from "@tanstack/ai";
 import { geminiVideo } from "@tanstack/ai-gemini";
 
-const adapter = geminiVideo("gemini-omni-flash-preview");
+const adapter = geminiVideo("gemini-omni-1.1-flash");
 
 // Turn 1: generate
 const first = await generateVideo({

--- a/docs/media/video-generation.md
+++ b/docs/media/video-generation.md
@@ -629,14 +629,9 @@ seconds included), defaulting to 10 seconds when omitted:
 - `snapDuration(n)` snaps raw seconds into the range, clamping to its bounds and
   rounding to whole seconds.
 
-The `size` option maps onto the interaction's output aspect ratio
-(`'16:9'` default, or `'9:16'`). Pass `modelOptions.resolution` to set
-`response_format.resolution`:
-
-- `'360p'`
-- `'720p'` (default)
-- `'1080p'` (upscaled)
-- `'4k'` (upscaled)
+The `size` option is an `aspectRatio_resolution` template, same shape as
+grok and byteplus video. Bare `'16:9'` / `'9:16'` uses the 720p default.
+Add a suffix for the other tiers (`'360p'`, `'1080p'`, `'4k'`):
 
 ```typescript ignore
 import { generateVideo, getVideoJobStatus } from "@tanstack/ai";
@@ -647,9 +642,8 @@ const adapter = geminiVideo("gemini-omni-1.1-flash");
 const { jobId } = await generateVideo({
   adapter,
   prompt: "A woman playing violin outdoors at golden hour",
-  size: "9:16", // aspect ratio: '16:9' (default) or '9:16'
+  size: "9:16_1080p", // '16:9' | '9:16', optional _360p/_720p/_1080p/_4k
   duration: 6, // 3-10 seconds; omit for the 10s default
-  modelOptions: { resolution: "1080p" }, // '360p' | '720p' | '1080p' | '4k'
 });
 
 const status = await getVideoJobStatus({ adapter, jobId });

--- a/examples/ts-react-media/src/components/OmniStudio.tsx
+++ b/examples/ts-react-media/src/components/OmniStudio.tsx
@@ -17,7 +17,7 @@ import type { MediaPromptPart } from '@tanstack/ai/client'
 import { generateVideoFn } from '@/lib/server-functions'
 import { readMediaFile, toImagePart, toVideoPart } from '@/lib/media'
 
-const OMNI_MODEL = 'gemini-omni-flash-preview'
+const OMNI_MODEL = 'gemini-omni-1.1-flash'
 /** Omni bills per second of generated video. */
 const PRICE_PER_SECOND = 0.1
 

--- a/examples/ts-react-media/src/components/VideoGenerator.tsx
+++ b/examples/ts-react-media/src/components/VideoGenerator.tsx
@@ -115,7 +115,7 @@ export default function VideoGenerator({
   const omniInRun =
     selectedModel === 'all'
       ? geminiModels.length > 0
-      : selectedModel.startsWith('gemini-omni-flash-preview')
+      : selectedModel.startsWith('gemini-omni')
 
   // Each card runs its own generation, so the form is busy while any of them
   // reports that it is.

--- a/examples/ts-react-media/src/lib/models.ts
+++ b/examples/ts-react-media/src/lib/models.ts
@@ -187,18 +187,18 @@ export const VIDEO_MODELS = [
     provider: 'fal' as const,
   },
   {
-    id: 'gemini-omni-flash-preview',
-    name: 'Gemini Omni Flash (Text-to-Video)',
+    id: 'gemini-omni-1.1-flash',
+    name: 'Gemini Omni 1.1 Flash (Text-to-Video)',
     description:
-      'Google multimodal video generation with conversational editing, via the Interactions API (3-10s, 720p)',
+      'Google multimodal video generation with conversational editing, via the Interactions API (3-10s, 360p/720p/1080p/4k)',
     mode: 'text-to-video' as const,
     provider: 'gemini' as const,
   },
   {
-    id: 'gemini-omni-flash-preview/image-to-video',
-    name: 'Gemini Omni Flash (Image-to-Video)',
+    id: 'gemini-omni-1.1-flash/image-to-video',
+    name: 'Gemini Omni 1.1 Flash (Image-to-Video)',
     description:
-      'Animate an image with Gemini Omni Flash via the Interactions API',
+      'Animate an image with Gemini Omni 1.1 Flash via the Interactions API',
     mode: 'image-to-video' as const,
     provider: 'gemini' as const,
   },

--- a/examples/ts-react-media/src/lib/server-functions.ts
+++ b/examples/ts-react-media/src/lib/server-functions.ts
@@ -447,12 +447,12 @@ function videoStreamForModel(data: VideoRequest): AsyncIterable<StreamChunk> {
     // Gemini Omni Flash (Interactions API, GEMINI_API_KEY). One model
     // serves both UI entries; it accepts text, image, AND video prompt
     // parts (sent as interaction content blocks: images, then videos,
-    // then text). Clips are 3–10s at 720p (default 10s when `duration`
-    // is omitted); `size` is the output aspect ratio. Passing
+    // then text). Clips are 3–10s (default 10s when `duration` is
+    // omitted); `size` is the output aspect ratio. Passing
     // `previous_interaction_id` chains a prompt onto a prior generation
     // for conversational editing.
-    case 'gemini-omni-flash-preview':
-    case 'gemini-omni-flash-preview/image-to-video': {
+    case 'gemini-omni-1.1-flash':
+    case 'gemini-omni-1.1-flash/image-to-video': {
       const prompt = asOmniPrompt(data.prompt)
       if (
         data.model.endsWith('/image-to-video') &&
@@ -466,7 +466,7 @@ function videoStreamForModel(data: VideoRequest): AsyncIterable<StreamChunk> {
       return generateVideo({
         stream: true,
         pollingInterval: VIDEO_POLL_INTERVAL_MS,
-        adapter: geminiVideo('gemini-omni-flash-preview'),
+        adapter: geminiVideo('gemini-omni-1.1-flash'),
         prompt,
         size: aspectRatio ?? '16:9',
         ...(duration !== undefined ? { duration } : {}),

--- a/packages/ai-gemini/src/adapters/video.ts
+++ b/packages/ai-gemini/src/adapters/video.ts
@@ -9,6 +9,7 @@ import { createGeminiClient, getGeminiApiKeyFromEnv } from '../utils'
 import {
   getGeminiVideoDurationOptions,
   isInteractionsVideoModel,
+  parseGeminiOmniVideoSize,
 } from '../video/video-provider-options'
 import type { DurationOptions } from '@tanstack/ai/adapters'
 import type {
@@ -36,7 +37,6 @@ import type {
   GeminiVideoModelProviderOptionsByName,
   GeminiVideoModelSizeByName,
   GeminiVideoProviderOptions,
-  GeminiVideoSize,
 } from '../video/video-provider-options'
 import type { GeminiClientConfig } from '../utils/client'
 
@@ -237,7 +237,8 @@ function interactionUsageToTokenUsage(
  * prompt parts are sent as interaction content blocks, grouped as images,
  * then videos, then the text prompt (interleaving is not preserved); pass
  * `modelOptions.previous_interaction_id` to conversationally edit a prior
- * Omni generation. `modelOptions.resolution` maps onto
+ * Omni generation. `size` is an `aspectRatio_resolution` template
+ * (`'16:9'` or `'16:9_1080p'`); the optional suffix maps onto
  * `response_format.resolution` (`'360p' | '720p' | '1080p' | '4k'`,
  * default 720p).
  *
@@ -267,7 +268,7 @@ export class GeminiVideoAdapter<
   async createVideoJob(
     options: VideoGenerationOptions<
       GeminiVideoModelProviderOptionsByName[TModel],
-      GeminiVideoSize,
+      GeminiVideoModelSizeByName[TModel],
       GeminiVideoModelDurationByName[TModel]
     >,
   ): Promise<VideoJobResult> {
@@ -342,13 +343,14 @@ export class GeminiVideoAdapter<
   private async createInteractionsVideoJob(
     options: VideoGenerationOptions<
       GeminiVideoModelProviderOptionsByName[TModel],
-      GeminiVideoSize,
+      GeminiVideoModelSizeByName[TModel],
       GeminiVideoModelDurationByName[TModel]
     >,
   ): Promise<VideoJobResult> {
     const { prompt, size, duration, logger } = options
-    const { resolution, ...passthroughModelOptions } =
-      (options.modelOptions as GeminiOmniVideoProviderOptions | undefined) ?? {}
+    const modelOptions = options.modelOptions as
+      | GeminiOmniVideoProviderOptions
+      | undefined
 
     try {
       const resolved = resolveMediaPrompt(prompt)
@@ -387,24 +389,29 @@ export class GeminiVideoAdapter<
       }
 
       // Aspect ratio, clip length, and resolution ride on `response_format`.
-      // Duration is a `"<seconds>s"` string, accepted anywhere in the 3–10s
-      // range (fractional included) and defaulting to 10s when omitted.
-      // Resolution is `'360p' | '720p' | '1080p' | '4k'` and defaults to
-      // 720p when omitted — https://ai.google.dev/gemini-api/docs/omni
+      // Duration is a `"<seconds>s"` string. Resolution comes from the
+      // optional `size` suffix (`'16:9_1080p'`), defaulting to 720p when
+      // omitted — https://ai.google.dev/gemini-api/docs/omni
+      const parsedSize =
+        size !== undefined ? parseGeminiOmniVideoSize(size) : undefined
       const responseFormat =
-        size !== undefined || duration !== undefined || resolution !== undefined
+        parsedSize !== undefined || duration !== undefined
           ? {
               response_format: {
                 type: 'video' as const,
-                ...(size !== undefined && { aspect_ratio: size }),
+                ...(parsedSize !== undefined && {
+                  aspect_ratio: parsedSize.aspectRatio,
+                  ...(parsedSize.resolution !== undefined && {
+                    resolution: parsedSize.resolution,
+                  }),
+                }),
                 ...(duration !== undefined && { duration: `${duration}s` }),
-                ...(resolution !== undefined && { resolution }),
               },
             }
           : {}
 
       const interaction = await this.client.interactions.create({
-        ...passthroughModelOptions,
+        ...modelOptions,
         model: this.model,
         input: [{ type: 'user_input', content }],
         response_modalities: ['video'],

--- a/packages/ai-gemini/src/adapters/video.ts
+++ b/packages/ai-gemini/src/adapters/video.ts
@@ -228,15 +228,18 @@ function interactionUsageToTokenUsage(
  * requires the API key (`x-goog-api-key` header or `?key=` query
  * parameter) to download.
  *
- * **Gemini Omni Flash** (`gemini-omni-flash-preview`) only serves the
- * Interactions API: `createVideoJob` creates a background interaction with
+ * **Gemini Omni Flash** (`gemini-omni-1.1-flash`, plus the deprecated
+ * `gemini-omni-flash-preview` alias) only serves the Interactions API:
+ * `createVideoJob` creates a background interaction with
  * `response_modalities: ['video']`, `getVideoStatus` polls it by id, and
  * `getVideoUrl` returns the inline base64 MP4 as a `data:` URL (or the
  * Files API URI when the server delivers by reference). Image and video
  * prompt parts are sent as interaction content blocks, grouped as images,
  * then videos, then the text prompt (interleaving is not preserved); pass
  * `modelOptions.previous_interaction_id` to conversationally edit a prior
- * Omni generation.
+ * Omni generation. `modelOptions.resolution` maps onto
+ * `response_format.resolution` (`'360p' | '720p' | '1080p' | '4k'`,
+ * default 720p).
  *
  * @experimental Video generation is an experimental feature and may change.
  */
@@ -344,9 +347,8 @@ export class GeminiVideoAdapter<
     >,
   ): Promise<VideoJobResult> {
     const { prompt, size, duration, logger } = options
-    const modelOptions = options.modelOptions as
-      | GeminiOmniVideoProviderOptions
-      | undefined
+    const { resolution, ...passthroughModelOptions } =
+      (options.modelOptions as GeminiOmniVideoProviderOptions | undefined) ?? {}
 
     try {
       const resolved = resolveMediaPrompt(prompt)
@@ -384,23 +386,25 @@ export class GeminiVideoAdapter<
         )
       }
 
-      // Aspect ratio and clip length ride on `response_format`. Duration is
-      // a `"<seconds>s"` string, accepted anywhere in the 3–10s range
-      // (fractional included) and defaulting to 10s when omitted — verified
-      // against the live API; the docs don't publish the range constraints.
+      // Aspect ratio, clip length, and resolution ride on `response_format`.
+      // Duration is a `"<seconds>s"` string, accepted anywhere in the 3–10s
+      // range (fractional included) and defaulting to 10s when omitted.
+      // Resolution is `'360p' | '720p' | '1080p' | '4k'` and defaults to
+      // 720p when omitted — https://ai.google.dev/gemini-api/docs/omni
       const responseFormat =
-        size !== undefined || duration !== undefined
+        size !== undefined || duration !== undefined || resolution !== undefined
           ? {
               response_format: {
                 type: 'video' as const,
                 ...(size !== undefined && { aspect_ratio: size }),
                 ...(duration !== undefined && { duration: `${duration}s` }),
+                ...(resolution !== undefined && { resolution }),
               },
             }
           : {}
 
       const interaction = await this.client.interactions.create({
-        ...modelOptions,
+        ...passthroughModelOptions,
         model: this.model,
         input: [{ type: 'user_input', content }],
         response_modalities: ['video'],
@@ -659,6 +663,12 @@ export class GeminiVideoAdapter<
   }
 }
 
+/** @deprecated Shuts down 2026-09-30. Use `gemini-omni-1.1-flash`. */
+export function createGeminiVideo(
+  model: 'gemini-omni-flash-preview',
+  apiKey: string,
+  config?: Omit<GeminiVideoConfig, 'apiKey'>,
+): GeminiVideoAdapter<'gemini-omni-flash-preview'>
 /**
  * Creates a Gemini video adapter with an explicit API key.
  * Type resolution happens here at the call site.
@@ -685,10 +695,20 @@ export function createGeminiVideo<TModel extends GeminiVideoModel>(
   model: TModel,
   apiKey: string,
   config?: Omit<GeminiVideoConfig, 'apiKey'>,
+): GeminiVideoAdapter<TModel>
+export function createGeminiVideo<TModel extends GeminiVideoModel>(
+  model: TModel,
+  apiKey: string,
+  config?: Omit<GeminiVideoConfig, 'apiKey'>,
 ): GeminiVideoAdapter<TModel> {
   return new GeminiVideoAdapter({ apiKey, ...config }, model)
 }
 
+/** @deprecated Shuts down 2026-09-30. Use `gemini-omni-1.1-flash`. */
+export function geminiVideo(
+  model: 'gemini-omni-flash-preview',
+  config?: Omit<GeminiVideoConfig, 'apiKey'>,
+): GeminiVideoAdapter<'gemini-omni-flash-preview'>
 /**
  * Creates a Gemini video adapter with automatic API key detection from environment variables.
  * Type resolution happens here at the call site.
@@ -719,6 +739,10 @@ export function createGeminiVideo<TModel extends GeminiVideoModel>(
  * const status = await getVideoJobStatus({ adapter, jobId });
  * ```
  */
+export function geminiVideo<TModel extends GeminiVideoModel>(
+  model: TModel,
+  config?: Omit<GeminiVideoConfig, 'apiKey'>,
+): GeminiVideoAdapter<TModel>
 export function geminiVideo<TModel extends GeminiVideoModel>(
   model: TModel,
   config?: Omit<GeminiVideoConfig, 'apiKey'>,

--- a/packages/ai-gemini/src/index.ts
+++ b/packages/ai-gemini/src/index.ts
@@ -108,11 +108,13 @@ export {
   GEMINI_VIDEO_DURATIONS,
   getGeminiVideoDurationOptions,
   isInteractionsVideoModel,
+  parseGeminiOmniVideoSize,
 } from './video/video-provider-options'
 export type {
   GeminiInteractionsVideoModel,
   GeminiOmniVideoProviderOptions,
   GeminiOmniVideoResolution,
+  GeminiOmniVideoSize,
   GeminiVideoModel,
   GeminiVideoModelDurationByName,
   GeminiVideoModelInputModalitiesByName,

--- a/packages/ai-gemini/src/index.ts
+++ b/packages/ai-gemini/src/index.ts
@@ -112,6 +112,7 @@ export {
 export type {
   GeminiInteractionsVideoModel,
   GeminiOmniVideoProviderOptions,
+  GeminiOmniVideoResolution,
   GeminiVideoModel,
   GeminiVideoModelDurationByName,
   GeminiVideoModelInputModalitiesByName,

--- a/packages/ai-gemini/src/model-meta.ts
+++ b/packages/ai-gemini/src/model-meta.ts
@@ -807,11 +807,44 @@ const VEO_3_1_LITE_PREVIEW = {
 >
 
 /**
- * Gemini Omni Flash — multimodal video generation with conversational
- * editing. Serves only the Interactions API (`generateContent` rejects it),
- * so it routes through the interactions-based path of the video adapter,
- * not Veo's `:predictLongRunning` flow. Pricing is per second of generated
- * video ($0.10/sec). 720p / 24 FPS, 3–10 second clips (default 10s).
+ * Gemini Omni 1.1 Flash — GA. Multimodal video generation with
+ * conversational editing. Serves only the Interactions API
+ * (`generateContent` rejects it), so it routes through the
+ * interactions-based path of the video adapter, not Veo's
+ * `:predictLongRunning` flow. Pricing is per second of generated video
+ * ($0.10/sec). 360p / 720p (default) / 1080p / 4k at 24 FPS, 3–10 second
+ * clips (default 10s).
+ * @see https://ai.google.dev/gemini-api/docs/models/gemini-omni-flash
+ * @experimental Omni video generation is an experimental feature and may change.
+ */
+const GEMINI_OMNI_1_1_FLASH = {
+  name: 'gemini-omni-1.1-flash',
+  max_input_tokens: 1_048_576,
+  max_output_tokens: 1,
+  supports: {
+    input: ['text', 'image', 'video'],
+    output: ['video', 'audio'],
+  },
+  pricing: {
+    input: {
+      normal: 0,
+    },
+    output: {
+      normal: 0.1,
+    },
+  },
+} as const satisfies ModelMeta<
+  GeminiToolConfigOptions &
+    GeminiSafetyOptions &
+    GeminiCommonConfigOptions &
+    GeminiCachedContentOptions
+>
+
+/**
+ * @deprecated `gemini-omni-flash-preview` shuts down on 2026-09-30. Use the
+ * GA id `gemini-omni-1.1-flash` instead. Kept in the model union so existing
+ * code still compiles until shutdown.
+ * @see https://ai.google.dev/gemini-api/docs/models/gemini-omni-flash
  * @experimental Omni video generation is an experimental feature and may change.
  */
 const GEMINI_OMNI_FLASH_PREVIEW = {
@@ -1143,15 +1176,19 @@ export const GEMINI_VIDEO_MODELS = [
   VEO_3_1_PREVIEW.name,
   VEO_3_1_FAST_PREVIEW.name,
   VEO_3_1_LITE_PREVIEW.name,
+  GEMINI_OMNI_1_1_FLASH.name,
+  // Deprecated alias — shuts down 2026-09-30.
   GEMINI_OMNI_FLASH_PREVIEW.name,
 ] as const
 
 /**
  * Video models served by the Interactions API rather than Veo's
- * `:predictLongRunning` operations flow.
+ * `:predictLongRunning` operations flow. GA id first; the trailing
+ * `-preview` id is a shutdown alias kept so existing code compiles.
  * @experimental Omni video generation is an experimental feature and may change.
  */
 export const GEMINI_INTERACTIONS_VIDEO_MODELS = [
+  GEMINI_OMNI_1_1_FLASH.name,
   GEMINI_OMNI_FLASH_PREVIEW.name,
 ] as const
 

--- a/packages/ai-gemini/src/video/video-provider-options.ts
+++ b/packages/ai-gemini/src/video/video-provider-options.ts
@@ -41,14 +41,47 @@ export function isInteractionsVideoModel(
 }
 
 /**
- * Supported aspect ratios for Gemini video generation. This is the `size`
- * value for the Gemini video adapter — both Veo and Omni Flash express
- * output shape as an aspect ratio (plus an optional `resolution` in
- * `modelOptions`), not pixel dimensions.
+ * Aspect ratios for Gemini video generation. Veo `size` is this union.
+ * Omni `size` also accepts an `aspectRatio_resolution` suffix
+ * (`'16:9_1080p'`), same template as grok / byteplus video.
  *
  * @experimental Video generation is an experimental feature and may change.
  */
 export type GeminiVideoSize = '16:9' | '9:16'
+
+/**
+ * Omni Flash output resolution. Used as the optional suffix on `size`
+ * (`'16:9_1080p'`). Default 720p when omitted.
+ *
+ * @experimental Omni video generation is an experimental feature and may change.
+ */
+export type GeminiOmniVideoResolution = '360p' | '720p' | '1080p' | '4k'
+
+/**
+ * Omni Flash `size`: bare aspect ratio or `aspectRatio_resolution`.
+ *
+ * @experimental Omni video generation is an experimental feature and may change.
+ */
+export type GeminiOmniVideoSize =
+  | GeminiVideoSize
+  | `${GeminiVideoSize}_${GeminiOmniVideoResolution}`
+
+/**
+ * Splits an Omni `size` into aspect ratio and optional resolution.
+ * `'16:9_1080p'` → `{ aspectRatio: '16:9', resolution: '1080p' }`.
+ * `'9:16'` → `{ aspectRatio: '9:16' }`.
+ */
+export function parseGeminiOmniVideoSize(
+  size: string,
+): { aspectRatio: string; resolution?: string } | undefined {
+  const match = /^(\d+:\d+)(?:_(.+))?$/.exec(size)
+  const [, aspectRatio, resolution] = match ?? []
+  if (aspectRatio === undefined) return undefined
+  return {
+    aspectRatio,
+    ...(resolution !== undefined && { resolution }),
+  }
+}
 
 /**
  * Provider-specific options for Gemini Veo video generation.
@@ -85,9 +118,9 @@ export type GeminiVideoProviderOptions = Omit<
  *   and polls it through the `generateVideo` jobs API
  * - `response_modalities` / `response_format` — the adapter requests video
  *   output and maps the top-level `size` option onto
- *   `response_format.aspect_ratio`, `duration` onto
- *   `response_format.duration`, and `modelOptions.resolution` onto
- *   `response_format.resolution`
+ *   `response_format.aspect_ratio` (and `response_format.resolution` when
+ *   the size carries a suffix) and `duration` onto
+ *   `response_format.duration`
  * - `tools` / `response_mime_type` — not applicable to video generation
  *
  * Notable passthroughs:
@@ -99,8 +132,6 @@ export type GeminiVideoProviderOptions = Omit<
  *
  * @experimental Omni video generation is an experimental feature and may change.
  */
-export type GeminiOmniVideoResolution = '360p' | '720p' | '1080p' | '4k'
-
 export type GeminiOmniVideoProviderOptions = Omit<
   Interactions.CreateModelInteractionParamsNonStreaming,
   | 'model'
@@ -111,14 +142,7 @@ export type GeminiOmniVideoProviderOptions = Omit<
   | 'response_format'
   | 'response_mime_type'
   | 'tools'
-> & {
-  /**
-   * Output resolution. Mapped onto `response_format.resolution`.
-   * Default 720p when omitted (the API default). 1080p and 4k are upscaled.
-   * @see https://ai.google.dev/gemini-api/docs/omni#output-resolution
-   */
-  resolution?: GeminiOmniVideoResolution
-}
+>
 
 /**
  * Model-specific provider options mapping.
@@ -132,12 +156,15 @@ export type GeminiVideoModelProviderOptionsByName = {
 }
 
 /**
- * Model-specific size (aspect ratio) mapping.
+ * Model-specific size mapping. Veo is aspect ratio only. Omni accepts the
+ * `aspectRatio_resolution` template (`'16:9_1080p'`).
  *
  * @experimental Video generation is an experimental feature and may change.
  */
 export type GeminiVideoModelSizeByName = {
-  [TModel in GeminiVideoModel]: GeminiVideoSize
+  [TModel in GeminiVideoModel]: TModel extends GeminiInteractionsVideoModel
+    ? GeminiOmniVideoSize
+    : GeminiVideoSize
 }
 
 /**

--- a/packages/ai-gemini/src/video/video-provider-options.ts
+++ b/packages/ai-gemini/src/video/video-provider-options.ts
@@ -43,7 +43,7 @@ export function isInteractionsVideoModel(
 /**
  * Supported aspect ratios for Gemini video generation. This is the `size`
  * value for the Gemini video adapter — both Veo and Omni Flash express
- * output shape as an aspect ratio (plus an optional `resolution` in Veo's
+ * output shape as an aspect ratio (plus an optional `resolution` in
  * `modelOptions`), not pixel dimensions.
  *
  * @experimental Video generation is an experimental feature and may change.
@@ -85,7 +85,9 @@ export type GeminiVideoProviderOptions = Omit<
  *   and polls it through the `generateVideo` jobs API
  * - `response_modalities` / `response_format` — the adapter requests video
  *   output and maps the top-level `size` option onto
- *   `response_format.aspect_ratio`
+ *   `response_format.aspect_ratio`, `duration` onto
+ *   `response_format.duration`, and `modelOptions.resolution` onto
+ *   `response_format.resolution`
  * - `tools` / `response_mime_type` — not applicable to video generation
  *
  * Notable passthroughs:
@@ -97,6 +99,8 @@ export type GeminiVideoProviderOptions = Omit<
  *
  * @experimental Omni video generation is an experimental feature and may change.
  */
+export type GeminiOmniVideoResolution = '360p' | '720p' | '1080p' | '4k'
+
 export type GeminiOmniVideoProviderOptions = Omit<
   Interactions.CreateModelInteractionParamsNonStreaming,
   | 'model'
@@ -107,7 +111,14 @@ export type GeminiOmniVideoProviderOptions = Omit<
   | 'response_format'
   | 'response_mime_type'
   | 'tools'
->
+> & {
+  /**
+   * Output resolution. Mapped onto `response_format.resolution`.
+   * Default 720p when omitted (the API default). 1080p and 4k are upscaled.
+   * @see https://ai.google.dev/gemini-api/docs/omni#output-resolution
+   */
+  resolution?: GeminiOmniVideoResolution
+}
 
 /**
  * Model-specific provider options mapping.
@@ -156,6 +167,7 @@ export type GeminiVideoModelDurationByName = {
   'veo-3.1-generate-preview': 4 | 6 | 8
   'veo-3.1-fast-generate-preview': 4 | 6 | 8
   'veo-3.1-lite-generate-preview': 4 | 6 | 8
+  'gemini-omni-1.1-flash': number
   'gemini-omni-flash-preview': number
 }
 
@@ -182,6 +194,12 @@ export const GEMINI_VIDEO_DURATIONS: {
   'veo-3.1-generate-preview': { kind: 'discrete', values: [4, 6, 8] },
   'veo-3.1-fast-generate-preview': { kind: 'discrete', values: [4, 6, 8] },
   'veo-3.1-lite-generate-preview': { kind: 'discrete', values: [4, 6, 8] },
+  'gemini-omni-1.1-flash': {
+    kind: 'range',
+    min: 3,
+    max: 10,
+    unit: 'seconds',
+  },
   'gemini-omni-flash-preview': {
     kind: 'range',
     min: 3,

--- a/packages/ai-gemini/tests/video-adapter.test.ts
+++ b/packages/ai-gemini/tests/video-adapter.test.ts
@@ -158,9 +158,15 @@ describe('Gemini Video Adapter', () => {
         4 | 6 | 8 | undefined
       >()
 
-      const omni = createGeminiVideo('gemini-omni-flash-preview', 'test-key')
+      const omni = createGeminiVideo('gemini-omni-1.1-flash', 'test-key')
       type OmniCreate = Parameters<typeof generateVideo<typeof omni>>[0]
       expectTypeOf<OmniCreate['duration']>().toEqualTypeOf<number | undefined>()
+
+      const preview = createGeminiVideo('gemini-omni-flash-preview', 'test-key')
+      type PreviewCreate = Parameters<typeof generateVideo<typeof preview>>[0]
+      expectTypeOf<PreviewCreate['duration']>().toEqualTypeOf<
+        number | undefined
+      >()
     })
   })
 
@@ -644,9 +650,14 @@ function createInteractionsClientStub(
   }
 }
 
-class StubbedGeminiOmniVideoAdapter extends GeminiVideoAdapter<'gemini-omni-flash-preview'> {
-  constructor(stub: InteractionsClientStub) {
-    super({ apiKey: 'test-key' }, 'gemini-omni-flash-preview')
+class StubbedGeminiOmniVideoAdapter<
+  TModel extends GeminiVideoModel = 'gemini-omni-1.1-flash',
+> extends GeminiVideoAdapter<TModel> {
+  constructor(
+    stub: InteractionsClientStub,
+    model: TModel = 'gemini-omni-1.1-flash' as TModel,
+  ) {
+    super({ apiKey: 'test-key' }, model)
     this.client = stub as unknown as GoogleGenAI
   }
 }
@@ -654,7 +665,7 @@ class StubbedGeminiOmniVideoAdapter extends GeminiVideoAdapter<'gemini-omni-flas
 describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
   describe('durations', () => {
     it('reports the 3-10 second range and clamps raw seconds into it', () => {
-      const adapter = createGeminiVideo('gemini-omni-flash-preview', 'test-key')
+      const adapter = createGeminiVideo('gemini-omni-1.1-flash', 'test-key')
       expect(adapter.availableDurations()).toEqual({
         kind: 'range',
         min: 3,
@@ -667,13 +678,17 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
     })
 
     it('types duration as number (continuous range) at compile time', () => {
-      const omni = createGeminiVideo('gemini-omni-flash-preview', 'test-key')
+      const omni = createGeminiVideo('gemini-omni-1.1-flash', 'test-key')
       expectTypeOf(omni.snapDuration).returns.toEqualTypeOf<
         number | undefined
       >()
       type OmniOptions = Parameters<typeof omni.createVideoJob>[0]
       expectTypeOf<OmniOptions['duration']>().toEqualTypeOf<
         number | undefined
+      >()
+      type OmniModelOptions = NonNullable<OmniOptions['modelOptions']>
+      expectTypeOf<OmniModelOptions['resolution']>().toEqualTypeOf<
+        '360p' | '720p' | '1080p' | '4k' | undefined
       >()
     })
   })
@@ -684,7 +699,7 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
       const adapter = new StubbedGeminiOmniVideoAdapter(stub)
 
       const result = await adapter.createVideoJob({
-        model: 'gemini-omni-flash-preview',
+        model: 'gemini-omni-1.1-flash',
         prompt: 'a sunset over the ocean',
         size: '9:16',
         duration: 8,
@@ -693,10 +708,10 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
 
       expect(result).toEqual({
         jobId: 'v1_omni-job-123',
-        model: 'gemini-omni-flash-preview',
+        model: 'gemini-omni-1.1-flash',
       })
       expect(stub.interactions.create).toHaveBeenCalledWith({
-        model: 'gemini-omni-flash-preview',
+        model: 'gemini-omni-1.1-flash',
         input: [
           {
             type: 'user_input',
@@ -718,14 +733,14 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
       const adapter = new StubbedGeminiOmniVideoAdapter(stub)
 
       await adapter.createVideoJob({
-        model: 'gemini-omni-flash-preview',
+        model: 'gemini-omni-1.1-flash',
         prompt: 'make the violin invisible',
         modelOptions: { previous_interaction_id: 'v1_prior-turn' },
         logger: testLogger,
       })
 
       expect(stub.interactions.create).toHaveBeenCalledWith({
-        model: 'gemini-omni-flash-preview',
+        model: 'gemini-omni-1.1-flash',
         previous_interaction_id: 'v1_prior-turn',
         input: [
           {
@@ -743,7 +758,7 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
       const adapter = new StubbedGeminiOmniVideoAdapter(stub)
 
       await adapter.createVideoJob({
-        model: 'gemini-omni-flash-preview',
+        model: 'gemini-omni-1.1-flash',
         prompt: [
           {
             type: 'image',
@@ -789,7 +804,7 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
 
       await expect(
         adapter.createVideoJob({
-          model: 'gemini-omni-flash-preview',
+          model: 'gemini-omni-1.1-flash',
           prompt: [
             { type: 'text', content: 'sync to this' },
             {
@@ -815,7 +830,7 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
 
       await expect(
         adapter.createVideoJob({
-          model: 'gemini-omni-flash-preview',
+          model: 'gemini-omni-1.1-flash',
           prompt: 'a sunset',
           logger: testLogger,
         }),
@@ -829,7 +844,7 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
       for (const duration of [2, 15]) {
         await expect(
           adapter.createVideoJob({
-            model: 'gemini-omni-flash-preview',
+            model: 'gemini-omni-1.1-flash',
             prompt: 'a sunset',
             duration,
             logger: testLogger,
@@ -844,7 +859,7 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
       const adapter = new StubbedGeminiOmniVideoAdapter(stub)
 
       await adapter.createVideoJob({
-        model: 'gemini-omni-flash-preview',
+        model: 'gemini-omni-1.1-flash',
         prompt: 'a sunset',
         duration: 4.5,
         logger: testLogger,
@@ -853,6 +868,76 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
       expect(stub.interactions.create).toHaveBeenCalledWith(
         expect.objectContaining({
           response_format: { type: 'video', duration: '4.5s' },
+        }),
+      )
+    })
+
+    it('maps modelOptions.resolution onto response_format.resolution', async () => {
+      const stub = createInteractionsClientStub()
+      const adapter = new StubbedGeminiOmniVideoAdapter(stub)
+
+      await adapter.createVideoJob({
+        model: 'gemini-omni-1.1-flash',
+        prompt: 'a drone shot of a mountain landscape',
+        size: '16:9',
+        duration: 6,
+        modelOptions: { resolution: '1080p' },
+        logger: testLogger,
+      })
+
+      const payload = stub.interactions.create.mock.calls[0]?.[0] as {
+        resolution?: unknown
+        response_format: Record<string, unknown>
+      }
+      expect(payload.resolution).toBeUndefined()
+      expect(payload.response_format).toEqual({
+        type: 'video',
+        aspect_ratio: '16:9',
+        duration: '6s',
+        resolution: '1080p',
+      })
+    })
+
+    it('sends resolution alone on response_format when size and duration are omitted', async () => {
+      const stub = createInteractionsClientStub()
+      const adapter = new StubbedGeminiOmniVideoAdapter(stub)
+
+      await adapter.createVideoJob({
+        model: 'gemini-omni-1.1-flash',
+        prompt: 'a sunset',
+        modelOptions: { resolution: '4k' },
+        logger: testLogger,
+      })
+
+      expect(stub.interactions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          response_format: { type: 'video', resolution: '4k' },
+        }),
+      )
+    })
+
+    it('routes the deprecated preview id through the same Interactions path', async () => {
+      const stub = createInteractionsClientStub()
+      const adapter = new StubbedGeminiOmniVideoAdapter(
+        stub,
+        'gemini-omni-flash-preview',
+      )
+
+      const result = await adapter.createVideoJob({
+        model: 'gemini-omni-flash-preview',
+        prompt: 'a sunset',
+        logger: testLogger,
+      })
+
+      expect(result).toEqual({
+        jobId: 'v1_omni-job-123',
+        model: 'gemini-omni-flash-preview',
+      })
+      expect(stub.interactions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gemini-omni-flash-preview',
+          response_modalities: ['video'],
+          background: true,
         }),
       )
     })

--- a/packages/ai-gemini/tests/video-adapter.test.ts
+++ b/packages/ai-gemini/tests/video-adapter.test.ts
@@ -9,9 +9,13 @@ import {
 import {
   GEMINI_VIDEO_DURATIONS,
   getGeminiVideoDurationOptions,
+  parseGeminiOmniVideoSize,
 } from '../src/video/video-provider-options'
 import type { GenerateVideosOperation, GoogleGenAI } from '@google/genai'
-import type { GeminiVideoModel } from '../src/video/video-provider-options'
+import type {
+  GeminiOmniVideoSize,
+  GeminiVideoModel,
+} from '../src/video/video-provider-options'
 
 const testLogger = resolveDebugOption(false)
 
@@ -157,10 +161,16 @@ describe('Gemini Video Adapter', () => {
       expectTypeOf<VeoCreate['duration']>().toEqualTypeOf<
         4 | 6 | 8 | undefined
       >()
+      expectTypeOf<VeoCreate['size']>().toEqualTypeOf<
+        '16:9' | '9:16' | undefined
+      >()
 
       const omni = createGeminiVideo('gemini-omni-1.1-flash', 'test-key')
       type OmniCreate = Parameters<typeof generateVideo<typeof omni>>[0]
       expectTypeOf<OmniCreate['duration']>().toEqualTypeOf<number | undefined>()
+      expectTypeOf<OmniCreate['size']>().toEqualTypeOf<
+        GeminiOmniVideoSize | undefined
+      >()
 
       const preview = createGeminiVideo('gemini-omni-flash-preview', 'test-key')
       type PreviewCreate = Parameters<typeof generateVideo<typeof preview>>[0]
@@ -686,9 +696,8 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
       expectTypeOf<OmniOptions['duration']>().toEqualTypeOf<
         number | undefined
       >()
-      type OmniModelOptions = NonNullable<OmniOptions['modelOptions']>
-      expectTypeOf<OmniModelOptions['resolution']>().toEqualTypeOf<
-        '360p' | '720p' | '1080p' | '4k' | undefined
+      expectTypeOf<OmniOptions['size']>().toEqualTypeOf<
+        GeminiOmniVideoSize | undefined
       >()
     })
   })
@@ -872,48 +881,37 @@ describe('Gemini Omni Flash Video Adapter (Interactions API)', () => {
       )
     })
 
-    it('maps modelOptions.resolution onto response_format.resolution', async () => {
+    it('splits size "aspectRatio_resolution" onto response_format', async () => {
       const stub = createInteractionsClientStub()
       const adapter = new StubbedGeminiOmniVideoAdapter(stub)
 
       await adapter.createVideoJob({
         model: 'gemini-omni-1.1-flash',
         prompt: 'a drone shot of a mountain landscape',
-        size: '16:9',
+        size: '16:9_1080p',
         duration: 6,
-        modelOptions: { resolution: '1080p' },
-        logger: testLogger,
-      })
-
-      const payload = stub.interactions.create.mock.calls[0]?.[0] as {
-        resolution?: unknown
-        response_format: Record<string, unknown>
-      }
-      expect(payload.resolution).toBeUndefined()
-      expect(payload.response_format).toEqual({
-        type: 'video',
-        aspect_ratio: '16:9',
-        duration: '6s',
-        resolution: '1080p',
-      })
-    })
-
-    it('sends resolution alone on response_format when size and duration are omitted', async () => {
-      const stub = createInteractionsClientStub()
-      const adapter = new StubbedGeminiOmniVideoAdapter(stub)
-
-      await adapter.createVideoJob({
-        model: 'gemini-omni-1.1-flash',
-        prompt: 'a sunset',
-        modelOptions: { resolution: '4k' },
         logger: testLogger,
       })
 
       expect(stub.interactions.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          response_format: { type: 'video', resolution: '4k' },
+          response_format: {
+            type: 'video',
+            aspect_ratio: '16:9',
+            duration: '6s',
+            resolution: '1080p',
+          },
         }),
       )
+    })
+
+    it('parses the Omni size template', () => {
+      expect(parseGeminiOmniVideoSize('16:9_1080p')).toEqual({
+        aspectRatio: '16:9',
+        resolution: '1080p',
+      })
+      expect(parseGeminiOmniVideoSize('9:16')).toEqual({ aspectRatio: '9:16' })
+      expect(parseGeminiOmniVideoSize('not-a-size')).toBeUndefined()
     })
 
     it('routes the deprecated preview id through the same Interactions path', async () => {

--- a/packages/ai/skills/ai-core/media-generation/SKILL.md
+++ b/packages/ai/skills/ai-core/media-generation/SKILL.md
@@ -525,8 +525,8 @@ Gemini Omni Flash (`geminiVideo('gemini-omni-1.1-flash')`) is served by
 the Interactions API instead of Veo's operations flow — same adapter, routed
 by model. `duration` is any number of seconds in the 3–10
 range (fractional ok, default 10 — availableDurations() reports the range),
-`size` is the aspect ratio (`'16:9' | '9:16'`), `modelOptions.resolution` is
-`'360p' | '720p' | '1080p' | '4k'` (default 720p), and the finished video arrives
+`size` is an `aspectRatio_resolution` template (`'16:9'` or `'16:9_1080p'`;
+suffix `'360p' | '720p' | '1080p' | '4k'`, default 720p), and the finished video arrives
 **inline** as a `data:video/mp4;base64,…` URL (no key needed to use it).
 Image/video prompt parts are sent as interaction content blocks, grouped
 as images, then videos, then text (no

--- a/packages/ai/skills/ai-core/media-generation/SKILL.md
+++ b/packages/ai/skills/ai-core/media-generation/SKILL.md
@@ -521,23 +521,26 @@ const { jobId } = await generateVideo({
 // (x-goog-api-key header or ?key= query parameter).
 ```
 
-Gemini Omni Flash (`geminiVideo('gemini-omni-flash-preview')`) is served by
+Gemini Omni Flash (`geminiVideo('gemini-omni-1.1-flash')`) is served by
 the Interactions API instead of Veo's operations flow — same adapter, routed
-by model. Clips are 720p; `duration` is any number of seconds in the 3–10
+by model. `duration` is any number of seconds in the 3–10
 range (fractional ok, default 10 — availableDurations() reports the range),
-`size` is the aspect ratio (`'16:9' | '9:16'`), and the finished video arrives
+`size` is the aspect ratio (`'16:9' | '9:16'`), `modelOptions.resolution` is
+`'360p' | '720p' | '1080p' | '4k'` (default 720p), and the finished video arrives
 **inline** as a `data:video/mp4;base64,…` URL (no key needed to use it).
 Image/video prompt parts are sent as interaction content blocks, grouped
 as images, then videos, then text (no
 `metadata.role` routing); `data` sources go inline, `url` sources pass
 through as-is (never downloaded — use Gemini Files API URIs for remote
 media). For conversational editing, pass a prior generation's `jobId` as
-`modelOptions.previous_interaction_id` with a prompt describing the change:
+`modelOptions.previous_interaction_id` with a prompt describing the change.
+`gemini-omni-flash-preview` remains a deprecated alias until it shuts down
+on 2026-09-30.
 
 ```typescript
 import { geminiVideo } from '@tanstack/ai-gemini'
 
-const omni = geminiVideo('gemini-omni-flash-preview')
+const omni = geminiVideo('gemini-omni-1.1-flash')
 const first = await generateVideo({
   adapter: omni,
   prompt: 'A violinist outdoors',

--- a/testing/e2e/global-setup.ts
+++ b/testing/e2e/global-setup.ts
@@ -822,7 +822,7 @@ function geminiOmniVideoMount(): Mountable {
             id: JOB_ID,
             object: 'interaction',
             status: 'in_progress',
-            model: 'gemini-omni-flash-preview',
+            model: 'gemini-omni-1.1-flash',
           }),
         )
         return true
@@ -837,7 +837,7 @@ function geminiOmniVideoMount(): Mountable {
             id: pollMatch[1],
             object: 'interaction',
             status: 'completed',
-            model: 'gemini-omni-flash-preview',
+            model: 'gemini-omni-1.1-flash',
             usage: {
               total_input_tokens: 12,
               total_output_tokens: 57920,

--- a/testing/e2e/src/lib/media-providers.ts
+++ b/testing/e2e/src/lib/media-providers.ts
@@ -236,7 +236,7 @@ export function createVideoAdapter(
     if (provider !== 'gemini') {
       throw new Error(`No interactions-video adapter for provider: ${provider}`)
     }
-    return createGeminiVideo('gemini-omni-flash-preview', DUMMY_KEY, {
+    return createGeminiVideo('gemini-omni-1.1-flash', DUMMY_KEY, {
       httpOptions: { baseUrl: `${llmockBase(aimockPort)}/omni-video`, headers },
     })
   }

--- a/testing/e2e/tests/interactions-video.spec.ts
+++ b/testing/e2e/tests/interactions-video.spec.ts
@@ -7,7 +7,7 @@ import {
 } from './helpers'
 import { providersFor } from './test-matrix'
 
-// Gemini Omni Flash (gemini-omni-flash-preview) video generation over the
+// Gemini Omni Flash (gemini-omni-1.1-flash) video generation over the
 // Interactions API: create a background interaction → poll it by id →
 // receive the finished clip as inline base64 the adapter surfaces as a
 // data:video/mp4 URL. Backed by the geminiOmniVideoMount in global-setup.ts.


### PR DESCRIPTION
Call `geminiVideo('gemini-omni-1.1-flash')` to generate video with Google's GA Omni model. Pass `size: '9:16_1080p'` for resolution, same `aspectRatio_resolution` template as grok and byteplus. The preview id still compiles until it shuts down on 2026-09-30.

## 🎯 Changes

Google GA'd Gemini Omni 1.1 Flash on 2026-08-27. Daily model-metadata sync does not cover native Gemini video ids, so this is a first-party adapter change.

- Add `gemini-omni-1.1-flash` to `GEMINI_VIDEO_MODELS` and `GEMINI_INTERACTIONS_VIDEO_MODELS`.
- Keep `gemini-omni-flash-preview` as a deprecated alias so existing callers compile until shutdown.
- Route the GA id through the existing Interactions video path. No second adapter.
- Omni `size` is `'16:9' | '9:16'` or `'16:9_1080p'` (suffix `360p` | `720p` | `1080p` | `4k`, default 720p). That maps onto `response_format.aspect_ratio` and `response_format.resolution`.
- Duration stays 3 to 10 seconds per call.

Docs, `examples/ts-react-media`, E2E `interactions-video`, and the media-generation skill now use the GA id. Patch changeset for `@tanstack/ai-gemini`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

**Commands run**

1. `pnpm test:pr` passed on the first commit.
2. After the size-template change: `pnpm --filter @tanstack/ai-gemini exec vitest run tests/video-adapter.test.ts` passed (49 tests), `pnpm --filter @tanstack/ai-gemini test:types` passed, `pnpm --filter @tanstack/ai-gemini test:oxlint` passed (pre-existing `any` warnings only).
3. E2E `interactions-video` did not get a clean local run. Port 3010 was already serving another worktree. A later run against this branch loaded the UI, then died on a fillPrompt flake (DOM had the prompt, Generate stayed disabled). That is not a model-id failure.

**Manual test**

1. Call `geminiVideo('gemini-omni-1.1-flash')` and `generateVideo({ adapter, prompt: 'A violinist outdoors', size: '9:16_1080p' })`.
2. Make sure that the create request is a background Interactions job with `model: 'gemini-omni-1.1-flash'` and `response_format.resolution` `'1080p'`.
3. Pass `size: '16:9'` with no suffix and make sure that resolution is omitted (API default 720p).
4. Call `geminiVideo('gemini-omni-flash-preview')` and make sure that it still type-checks and uses the same Interactions path.
5. Optional: open `examples/ts-react-media` Omni Studio and generate a clip with `GEMINI_API_KEY` set.

**How this PR makes testing easy**

- Unit tests in `packages/ai-gemini/tests/video-adapter.test.ts` cover the GA id, the preview alias, and `size: '16:9_1080p'`.
- `examples/ts-react-media` uses `gemini-omni-1.1-flash`.
- E2E `testing/e2e/tests/interactions-video.spec.ts` now creates `geminiVideo('gemini-omni-1.1-flash')`.

## Linked issues

Closes #1272

## Risk / rollback

Low. The preview id still works. If the GA id is wrong at Google, callers keep the alias until 2026-09-30. Revert the PR to undo.

## Public API change

**Before**

```ts
const adapter = geminiVideo('gemini-omni-flash-preview')
await generateVideo({ adapter, prompt: 'A violinist outdoors', size: '9:16' })
```

**After**

```ts
const adapter = geminiVideo('gemini-omni-1.1-flash')
await generateVideo({
  adapter,
  prompt: 'A violinist outdoors',
  size: '9:16_1080p',
})
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the GA Gemini Omni 1.1 Flash video model.
  * Video size now supports aspect ratio and resolution options, including 360p, 720p, 1080p, and 4K.
  * Added support for configurable video resolution while preserving 3–10 second clip durations.
  * Existing preview model identifiers remain available as deprecated aliases through September 30, 2026.

* **Documentation**
  * Updated video-generation guides, examples, and model descriptions with the new model and sizing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->