### PR TITLE
fix(ai-bedrock): forward usage from Converse structuredOutputStream()

### DIFF
--- a/.changeset/bedrock-structured-stream-usage.md
+++ b/.changeset/bedrock-structured-stream-usage.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-bedrock': patch
+---
+
+fix: forward usage from Converse structuredOutputStream()
+
+`ConverseTextAdapter.structuredOutputStream()` iterated the Converse event stream without a `metadata` branch, so the trailing usage event was ignored and `RUN_FINISHED` carried no token counts on the streaming structured-output path. The normal chat path (`processConverseStream`) and the non-stream `structuredOutput()` already handled it; this brings the third path in line.

--- a/packages/ai-bedrock/src/adapters/converse-text.ts
+++ b/packages/ai-bedrock/src/adapters/converse-text.ts
@@ -301,6 +301,11 @@ export class BedrockConverseTextAdapter<
     let hasEmittedTextMessageStart = false
     let accumulatedRaw = ''
     let finishReason: 'stop' | 'length' | 'content_filter' = 'stop'
+    // Usage arrives on the trailing `metadata` event, after the finish signal,
+    // so it is captured during iteration and folded into RUN_FINISHED below.
+    let usage:
+      | { promptTokens: number; completionTokens: number; totalTokens: number }
+      | undefined
 
     try {
       chatOptions.logger.request(
@@ -373,6 +378,18 @@ export class BedrockConverseTextAdapter<
               : stopReason === 'content_filtered'
                 ? 'content_filter'
                 : 'stop'
+          continue
+        }
+
+        if ('metadata' in ev) {
+          const u = ev.metadata?.usage
+          if (u) {
+            usage = {
+              promptTokens: u.inputTokens ?? 0,
+              completionTokens: u.outputTokens ?? 0,
+              totalTokens: u.totalTokens ?? 0,
+            }
+          }
           continue
         }
       }
@@ -451,6 +468,7 @@ export class BedrockConverseTextAdapter<
         model: chatOptions.model,
         timestamp: Date.now(),
         finishReason,
+        ...(usage && { usage }),
       }
     } catch (error: unknown) {
       if (!hasEmittedRunStarted) {

--- a/packages/ai-bedrock/tests/converse/adapter.test.ts
+++ b/packages/ai-bedrock/tests/converse/adapter.test.ts
@@ -212,6 +212,89 @@ describe('BedrockConverseTextAdapter', () => {
     ).toBe('stop')
   })
 
+  it('folds trailing metadata usage into the structuredOutputStream RUN_FINISHED (#1278)', async () => {
+    const a = new StubAdapter({ apiKey: 'k' }, 'us.amazon.nova-pro-v1:0')
+    a.streamEvents = [
+      { messageStart: { role: 'assistant' } },
+      {
+        contentBlockStart: {
+          start: { toolUse: { toolUseId: 's', name: 'structured_output' } },
+          contentBlockIndex: 0,
+        },
+      },
+      {
+        contentBlockDelta: {
+          delta: { toolUse: { input: '{"n":5}' } },
+          contentBlockIndex: 0,
+        },
+      },
+      { contentBlockStop: { contentBlockIndex: 0 } },
+      { messageStop: { stopReason: 'tool_use' } },
+      // SDK boundary: the metadata event requires `metrics` too — narrow the
+      // canned shape through `unknown` rather than spell out every field.
+      {
+        metadata: {
+          usage: { inputTokens: 7, outputTokens: 11, totalTokens: 18 },
+        },
+      } as unknown as ConverseStreamOutput,
+    ]
+    const events: Array<AdapterYieldChunk> = []
+    for await (const c of a.structuredOutputStream({
+      chatOptions: textOptions({ messages: [{ role: 'user', content: 'go' }] }),
+      outputSchema: { type: 'object', properties: { n: { type: 'number' } } },
+    })) {
+      events.push(c)
+    }
+    const finished = events.filter((e) => e.type === EventType.RUN_FINISHED)
+    expect(finished).toHaveLength(1)
+    // Usage arrives on the trailing metadata event, after messageStop, yet is
+    // folded into the single terminal RUN_FINISHED.
+    expect(
+      (
+        finished[0] as {
+          usage?: {
+            promptTokens: number
+            completionTokens: number
+            totalTokens: number
+          }
+        }
+      ).usage,
+    ).toEqual({ promptTokens: 7, completionTokens: 11, totalTokens: 18 })
+  })
+
+  it('omits usage from the structuredOutputStream RUN_FINISHED when no metadata event arrives (#1278)', async () => {
+    const a = new StubAdapter({ apiKey: 'k' }, 'us.amazon.nova-pro-v1:0')
+    a.streamEvents = [
+      { messageStart: { role: 'assistant' } },
+      {
+        contentBlockStart: {
+          start: { toolUse: { toolUseId: 's', name: 'structured_output' } },
+          contentBlockIndex: 0,
+        },
+      },
+      {
+        contentBlockDelta: {
+          delta: { toolUse: { input: '{"n":5}' } },
+          contentBlockIndex: 0,
+        },
+      },
+      { contentBlockStop: { contentBlockIndex: 0 } },
+      { messageStop: { stopReason: 'tool_use' } },
+    ]
+    const events: Array<AdapterYieldChunk> = []
+    for await (const c of a.structuredOutputStream({
+      chatOptions: textOptions({ messages: [{ role: 'user', content: 'go' }] }),
+      outputSchema: { type: 'object', properties: { n: { type: 'number' } } },
+    })) {
+      events.push(c)
+    }
+    const finished = events.filter((e) => e.type === EventType.RUN_FINISHED)
+    expect(finished).toHaveLength(1)
+    // A run with no usage signal must stay distinguishable from a zero-cost
+    // one: the key is absent, not a zero-filled object.
+    expect(finished[0]).not.toHaveProperty('usage')
+  })
+
   it('rejects a non-forced tool-use block in structuredOutput', async () => {
     const a = new StubAdapter({ apiKey: 'k' }, 'us.amazon.nova-pro-v1:0')
     // The model emitted a different (hallucinated/leftover) tool — its input


### PR DESCRIPTION
`chat({ outputSchema, stream: true })` against Bedrock Converse emits a `RUN_FINISHED` chunk with no `usage`. A consumer that meters cost from that field sees a successful structured call with no token counts. This PR reads the trailing Converse `metadata` event and puts the token counts on `RUN_FINISHED`.

## 🎯 Changes

`BedrockConverseTextAdapter.structuredOutputStream()` now handles the Converse `metadata` event. The captured counts are spread onto the terminal `RUN_FINISHED`.

The branch has two commits. The first is the fix alone. The second adds the unit test, so a reviewer can check out `968e6d8` and watch the new test fail.

Two paths in this package already do this. The new branch mirrors them:

- `processConverseStream` in `packages/ai-bedrock/src/converse/stream-processor.ts` (the normal chat path)
- the non-stream `structuredOutput()` in the same file, fixed by #1077

When no `metadata` event arrives, the `usage` key stays absent. An unmetered run stays distinguishable from a zero-cost run.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [ ] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

The docs box is not ticked, and no `docs/` file changed. `docs/chat/stream-events.md` already documents `usage` on `RUN_FINISHED`. This PR makes Bedrock Converse match that documented contract.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Root cause

**Issue.** Streaming structured output on Bedrock Converse reports no token usage. It affects every caller of `chat({ outputSchema, stream: true })` with a Bedrock Converse adapter. The plain streaming chat path reports usage correctly.

**Cause.** The event loop in `structuredOutputStream()` (`packages/ai-bedrock/src/adapters/converse-text.ts`) handles `contentBlockDelta` and `messageStop` only. Converse sends token usage on a trailing `metadata` event, after the finish signal. That event fell through the loop, so the terminal `RUN_FINISHED` was built from `finishReason` alone.

**Fix.** A `metadata` branch captures `ev.metadata.usage` into a local variable during iteration. `RUN_FINISHED` spreads that variable with `...(usage && { usage })`.

## Possible alternatives

- **Middleware `onUsage`.** A consumer can read usage through `onUsage` in middleware. It does not correct `RUN_FINISHED`, so code that reads `chunk.usage` still gets nothing.
- **Delegate to `processConverseStream`.** The structured path can reuse the chat stream processor. That processor emits tool-call events and maps `stopReason` differently, so the structured contract would change. The diff is much larger than the bug.
- **Correct it in `packages/ai` core.** Core cannot add what it never receives. The adapter drops the counts before core sees them.

## Testing

**Commands run**

- `pnpm test:pr` — pass. It runs `test:sherif`, `test:knip`, `test:docs`, `test:kiira`, `test:oxlint`, `test:lib`, `test:types`, `test:build` and `build`.
- `pnpm --filter @tanstack/ai-e2e test:e2e` — 646 pass, 1 skip. One failure, `durable-takeover.spec.ts:543`, also fails on clean `main` at c675499 with the same assertion. It is not caused by this branch.
- No E2E test was added. `testing/e2e/README.md` records that aimock cannot replay the Converse binary event stream, and sends that coverage to `packages/ai-bedrock/tests/converse/`.

**Repro on clean `main` (c675499), before the fix**

The repro drives the adapter `sendStream` seam with one canned Converse event stream. No credentials and no network are needed. The plain chat path is the control.

```
FAIL tests/repro-usage.test.ts > reports the same usage on the streaming structured-output path
AssertionError: expected undefined to deeply equal { promptTokens: 593, …(2) }
- Expected: { "completionTokens": 56, "promptTokens": 593, "totalTokens": 649 }
+ Received: undefined
Test Files  1 failed | 10 passed (11)
Tests  1 failed | 91 passed (92)
```

**Same repro on this branch, after the fix**

```
RUN v4.1.10 packages/ai-bedrock
Test Files  1 passed (1)
Tests  2 passed (2)
```

**Manual test**

1. Configure a Bedrock Converse adapter with valid AWS credentials.
2. Call `chat({ adapter, messages, outputSchema, stream: true })` and iterate the stream.
3. Log `chunk.usage` on the `RUN_FINISHED` chunk. On `main` it is `undefined`.
4. Repeat step 2 without `outputSchema`. Usage is present on `main`.
5. Install this branch and repeat step 2. Usage is now present on both calls.

Measured against `eu.anthropic.claude-sonnet-5` over Converse:

| call | before | after |
| --- | --- | --- |
| `chat({ stream: true })` | `{ 41, 18, 59 }` | `{ 41, 18, 59 }` |
| `chat({ outputSchema, stream: true })` | `undefined` | `{ 593, 56, 649 }` |

The higher prompt count on the structured call is expected. The forced-tool JSON schema is injected.

**How this PR makes testing easy**

Commit `70fa0d3` adds two cases to `packages/ai-bedrock/tests/converse/adapter.test.ts`. They use the `StubAdapter` already in that file, so no credentials and no network are needed.

1. Run `pnpm --filter @tanstack/ai-bedrock test:lib`. All 92 tests pass.
2. Run `git revert --no-commit 968e6d8`, then repeat step 1. The first new case fails.

The fix is the first commit and the test is the second. A reviewer can check out `968e6d8` to see the branch state before the test.

## Linked issues

Fixes #1276

## Risk / rollback

Risk is low. The change adds one branch inside one method and one optional field on one event. No other path reads the new local variable. To roll back, revert this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming structured-output responses now include accurate prompt, completion, and total token counts when usage metadata is provided.
  * Final response events no longer report empty token usage when metadata is unavailable.

* **Tests**
  * Added coverage for token usage handling in streaming structured-output responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->