### PR TITLE
fix(local-process): handle EPIPE error when writing to closed stdin

### DIFF
--- a/.changeset/local-process-stdin-error-listener.md
+++ b/.changeset/local-process-stdin-error-listener.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-sandbox-local-process': patch
+---
+
+fix: stop an uncaught EPIPE when a write goes to a child that closed its stdin

--- a/packages/ai-sandbox-local-process/src/handle.ts
+++ b/packages/ai-sandbox-local-process/src/handle.ts
@@ -891,6 +891,11 @@ export class LocalProcessHandle implements SandboxHandle {
       detached: spawnDetached,
     })
     this.track(child)
+    // Node reports a failed write twice: to the `write` callback below, and
+    // as an `error` event on this socket. An unhandled `error` event throws
+    // and stops the host process. `stdin.write` still rejects with the same
+    // error.
+    child.stdin.on('error', () => {})
     if (opts?.signal) {
       opts.signal.addEventListener(
         'abort',

--- a/packages/ai-sandbox-local-process/tests/local-process.test.ts
+++ b/packages/ai-sandbox-local-process/tests/local-process.test.ts
@@ -228,6 +228,48 @@ describe('local-process killTree — POSIX child.kill(signal) branch', () => {
   )
 })
 
+describe('local-process stdin errors', () => {
+  posixOnly(
+    'a write to a child that closed its stdin rejects without an uncaught error (skipped on Windows: named pipes do not report EPIPE the same way)',
+    async () => {
+      const sbx = await fresh()
+      // `exec 0<&-` makes the child close its own stdin while it keeps running:
+      // the write end stays open, and no process holds the read end.
+      const proc = await sbx.process.spawn('exec 0<&- ; echo closed ; sleep 30')
+      // The shell echoes after it closes fd 0. An earlier write only fills the
+      // pipe buffer and resolves, which would prove nothing.
+      let closed = false
+      for await (const chunk of proc.stdout) {
+        if (chunk.includes('closed')) {
+          closed = true
+          break
+        }
+      }
+      expect(closed).toBe(true)
+
+      const uncaught: Array<Error> = []
+      const onUncaught = (error: Error): void => {
+        uncaught.push(error)
+      }
+      process.on('uncaughtException', onUncaught)
+      try {
+        await expect(proc.stdin.write('probe\n')).rejects.toThrow(/EPIPE/)
+        // Node emits the socket's `error` event on a `nextTick` after the
+        // callback, and that queue always drains before a `setImmediate`.
+        await new Promise((resolve) => setImmediate(resolve))
+      } finally {
+        process.off('uncaughtException', onUncaught)
+      }
+
+      expect(uncaught).toEqual([])
+
+      await proc.kill()
+      await sbx.destroy()
+    },
+    30_000,
+  )
+})
+
 describe('local-process + spawnNdjson (real agent-CLI streaming)', () => {
   it('streams NDJSON events emitted by a spawned process', async () => {
     const sbx = await fresh()

--- a/packages/ai-sandbox-local-process/tests/local-process.test.ts
+++ b/packages/ai-sandbox-local-process/tests/local-process.test.ts
@@ -233,38 +233,42 @@ describe('local-process stdin errors', () => {
     'a write to a child that closed its stdin rejects without an uncaught error (skipped on Windows: named pipes do not report EPIPE the same way)',
     async () => {
       const sbx = await fresh()
-      // `exec 0<&-` makes the child close its own stdin while it keeps running:
-      // the write end stays open, and no process holds the read end.
-      const proc = await sbx.process.spawn('exec 0<&- ; echo closed ; sleep 30')
-      // The shell echoes after it closes fd 0. An earlier write only fills the
-      // pipe buffer and resolves, which would prove nothing.
-      let closed = false
-      for await (const chunk of proc.stdout) {
-        if (chunk.includes('closed')) {
-          closed = true
-          break
-        }
-      }
-      expect(closed).toBe(true)
-
-      const uncaught: Array<Error> = []
-      const onUncaught = (error: Error): void => {
-        uncaught.push(error)
-      }
-      process.on('uncaughtException', onUncaught)
+      // `finally`: the `sleep 30` below outlives a failed assertion otherwise.
       try {
-        await expect(proc.stdin.write('probe\n')).rejects.toThrow(/EPIPE/)
-        // Node emits the socket's `error` event on a `nextTick` after the
-        // callback, and that queue always drains before a `setImmediate`.
-        await new Promise((resolve) => setImmediate(resolve))
+        // `exec 0<&-` makes the child close its own stdin while it keeps
+        // running: the write end stays open, and no process holds the read end.
+        const proc = await sbx.process.spawn(
+          'exec 0<&- ; echo closed ; sleep 30',
+        )
+        // The shell echoes after it closes fd 0. An earlier write only fills the
+        // pipe buffer and resolves, which would prove nothing.
+        let closed = false
+        for await (const chunk of proc.stdout) {
+          if (chunk.includes('closed')) {
+            closed = true
+            break
+          }
+        }
+        expect(closed).toBe(true)
+
+        const uncaught: Array<Error> = []
+        const onUncaught = (error: Error): void => {
+          uncaught.push(error)
+        }
+        process.on('uncaughtException', onUncaught)
+        try {
+          await expect(proc.stdin.write('probe\n')).rejects.toThrow(/EPIPE/)
+          // Node emits the socket's `error` event on a `nextTick` after the
+          // callback, and that queue always drains before a `setImmediate`.
+          await new Promise((resolve) => setImmediate(resolve))
+        } finally {
+          process.off('uncaughtException', onUncaught)
+        }
+
+        expect(uncaught).toEqual([])
       } finally {
-        process.off('uncaughtException', onUncaught)
+        await sbx.destroy()
       }
-
-      expect(uncaught).toEqual([])
-
-      await proc.kill()
-      await sbx.destroy()
     },
     30_000,
   )


### PR DESCRIPTION
## 🎯 Changes

Fixes #1292 .

`spawnProcess` has no `error` listener to `child.stdin`. Node reports a failed write twice. It calls the `write` callback, and it also emits an `error` event on the socket. An unhandled `error` event throws, and that exception stops the host process.

This PR adds en error listener to `child.stdin` in `spawnProcess`. 

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented uncaught errors when writing to a local process after it closes its standard input.
  * Writes now report the expected `EPIPE` error without interrupting the host process.

* **Tests**
  * Added coverage verifying safe handling of closed process input streams on POSIX systems.
  * Improved test cleanup to ensure local processes are stopped even when assertions fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->