### PR TITLE
feat(gemini): agentic video understanding (GA)

### DIFF
--- a/.changeset/gemini-agentic-video-understanding.md
+++ b/.changeset/gemini-agentic-video-understanding.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-gemini': minor
+---
+
+Add agentic video understanding to the Gemini text adapter.
+
+Set `metadata.processing: 'agentic'` on a video content part to route the request through the Gemini Interactions API for multi-pass "agentic" video understanding (GA on `gemini-3.7-flash`, `gemini-3.6-flash`, and `gemini-3.5-flash-lite`). Omit it for the default single-pass `generateContent` sampling. New `uploadGeminiFile()` and `geminiVideoPart()` helpers cover the Files API upload + poll-until-ACTIVE flow, and the three models now carry an `agentic_video` capability.

--- a/docs/adapters/gemini.md
+++ b/docs/adapters/gemini.md
@@ -129,6 +129,53 @@ export async function POST(request: Request) {
 }
 ```
 
+## Video Understanding
+
+Ask questions about a video: "what happens at 0:30?", "summarize the demo", "list every product shown". Upload the file once, then chat about it.
+
+Video is too large to inline as base64, so upload it to the Gemini Files API first. `uploadGeminiFile()` uploads the file and waits until it is ready to use. `geminiVideoPart()` turns that upload into a message content part.
+
+```typescript
+import { chat, toServerSentEventsResponse } from "@tanstack/ai";
+import { geminiText, uploadGeminiFile, geminiVideoPart } from "@tanstack/ai-gemini";
+
+export async function POST(request: Request) {
+  const file = await uploadGeminiFile("./demo.mp4", { mimeType: "video/mp4" });
+
+  const stream = chat({
+    adapter: geminiText("gemini-3.7-flash"),
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", content: "Summarize this video and cite timestamps." },
+          geminiVideoPart(file),
+        ],
+      },
+    ],
+  });
+
+  return toServerSentEventsResponse(stream);
+}
+```
+
+By default Gemini samples the video at 1 frame per second. Tune that single-pass sampling through the part metadata:
+
+```typescript ignore
+// Watch a 30s-90s clip at half a frame per second.
+geminiVideoPart(file, { fps: 0.5, startOffset: "30s", endOffset: "90s" });
+```
+
+### Agentic understanding
+
+Single-pass sampling can miss detail in long or fast-moving videos. Set `processing: "agentic"` to let the model drive: it navigates the timeline and pulls frames, transcripts, and audio on demand. This is GA on `gemini-3.7-flash`, `gemini-3.6-flash`, and `gemini-3.5-flash-lite`.
+
+```typescript ignore
+geminiVideoPart(file, { processing: "agentic" });
+```
+
+With `agentic`, the adapter routes the request through Gemini's Interactions API, and you express the sampling rate in your prompt ("watch it at 2 fps") instead of through `fps`. It is deeper but slower, since it re-analyzes the video on each turn.
+
 ## Stateful Conversations — Interactions API (Experimental)
 
 Gemini's [Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (currently in Beta) offers server-side conversation state — the Gemini equivalent of OpenAI's Responses API. Instead of replaying the full message history on every turn, you pass a `previous_interaction_id` and the server retains the transcript. This also improves cache hit rates for repeated prefixes.

--- a/docs/config.json
+++ b/docs/config.json
@@ -941,7 +941,7 @@
           "label": "Google Gemini",
           "to": "adapters/gemini",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-08-19"
+          "updatedAt": "2026-09-01"
         },
         {
           "label": "Google Vertex AI",

--- a/packages/ai-gemini/src/adapters/text.ts
+++ b/packages/ai-gemini/src/adapters/text.ts
@@ -28,6 +28,7 @@ import type {
   GoogleGenAI,
   Part,
   ThinkingLevel,
+  VideoMetadata,
 } from '@google/genai'
 import type {
   ContentPart,
@@ -40,8 +41,112 @@ import type { ExternalTextProviderOptions } from '../text/text-provider-options'
 import type {
   GeminiMessageMetadataByModality,
   GeminiToolCallMetadata,
+  GeminiVideoMetadata,
+  GeminiVideoProcessing,
 } from '../message-types'
 import type { GeminiClientConfig } from '../utils/client'
+
+/**
+ * Fallback MIME types for URL-sourced media parts that don't specify one.
+ */
+const DEFAULT_MEDIA_MIME_TYPES = {
+  image: 'image/jpeg',
+  audio: 'audio/mp3',
+  video: 'video/mp4',
+  document: 'application/pdf',
+} as const
+
+/**
+ * Content block shape for an Interactions API `input` step. The installed
+ * @google/genai types predate the video `processing` field, so we model the
+ * subset we emit and cast at the call site.
+ */
+type InteractionContent =
+  | { type: 'text'; text: string }
+  | {
+      type: 'video'
+      uri?: string
+      data?: string
+      mime_type?: string
+      processing?: GeminiVideoProcessing
+    }
+  | {
+      type: 'image' | 'audio' | 'document'
+      uri?: string
+      data?: string
+      mime_type?: string
+    }
+
+interface InteractionStep {
+  type: 'user_input' | 'model_output'
+  content: Array<InteractionContent>
+}
+
+/** True when any message carries a video part requesting agentic processing. */
+function hasAgenticVideo(messages: Array<ModelMessage>): boolean {
+  return messages.some(
+    (msg) =>
+      Array.isArray(msg.content) &&
+      msg.content.some(
+        (part) =>
+          part.type === 'video' &&
+          (part.metadata as GeminiVideoMetadata | undefined)?.processing ===
+            'agentic',
+      ),
+  )
+}
+
+/** Convert a single content part to an Interactions API content block. */
+function contentPartToInteraction(part: ContentPart): InteractionContent {
+  if (part.type === 'text') {
+    return { type: 'text', text: part.content }
+  }
+
+  const source = part.source
+  const mimeType =
+    source.type === 'data'
+      ? source.mimeType
+      : (source.mimeType ?? DEFAULT_MEDIA_MIME_TYPES[part.type])
+  const base =
+    source.type === 'data'
+      ? { data: source.value, mime_type: mimeType }
+      : { uri: source.value, mime_type: mimeType }
+
+  if (part.type === 'video') {
+    const processing = (part.metadata as GeminiVideoMetadata | undefined)
+      ?.processing
+    return { type: 'video', ...base, ...(processing && { processing }) }
+  }
+  return { type: part.type, ...base }
+}
+
+/**
+ * Build the Interactions API `input` from chat messages. Each user/assistant
+ * message becomes a `user_input` / `model_output` step wrapping its content
+ * blocks — the wrapping the Python SDK performs implicitly but the JS SDK
+ * does not. Tool messages are skipped (unsupported on this path).
+ */
+function buildInteractionsInput(
+  messages: Array<ModelMessage>,
+): Array<InteractionStep> {
+  const steps: Array<InteractionStep> = []
+  for (const msg of messages) {
+    if (msg.role === 'tool') continue
+    const stepType = msg.role === 'assistant' ? 'model_output' : 'user_input'
+    const content: Array<InteractionContent> = []
+    if (Array.isArray(msg.content)) {
+      for (const part of msg.content) {
+        content.push(contentPartToInteraction(part))
+      }
+    } else if (msg.content) {
+      content.push({ type: 'text', text: msg.content })
+    }
+    if (content.length > 0) {
+      steps.push({ type: stepType, content })
+    }
+  }
+  return steps
+}
 
 /**
  * Configuration for Gemini text adapter
@@ -122,6 +227,13 @@ export class GeminiTextAdapter<
   async *chatStream(
     options: TextOptions<GeminiTextProviderOptions>,
   ): AsyncIterable<AdapterYieldChunk> {
+    // Agentic video understanding is only exposed through the Interactions API,
+    // not generateContent. Detect it and take that path instead.
+    if (hasAgenticVideo(options.messages)) {
+      yield* this.interactionsStream(options)
+      return
+    }
+
     const mappedOptions = this.mapCommonOptionsToGemini(options)
     const { logger } = options
 
@@ -150,6 +262,114 @@ export class GeminiTextAdapter<
             : 'An unknown error occurred during the chat stream.',
         // Forward the provider's structured error body when present (see
         // toRunErrorRawEvent); omitted otherwise.
+        ...(rawEvent !== undefined && { rawEvent }),
+        error: {
+          message:
+            error instanceof Error
+              ? error.message
+              : 'An unknown error occurred during the chat stream.',
+        },
+      }
+    }
+  }
+
+  /**
+   * Agentic video-understanding path via the Interactions API.
+   *
+   * The Interactions API (unlike `generateContent`) requires message parts to
+   * be wrapped in `user_input` / `model_output` steps, and it accepts the
+   * `processing: 'agentic'` video flag. This is a non-streaming call whose
+   * single text result is re-emitted as AG-UI stream chunks.
+   */
+  private async *interactionsStream(
+    options: TextOptions<GeminiTextProviderOptions>,
+  ): AsyncIterable<AdapterYieldChunk> {
+    const model = options.model
+    const { logger } = options
+    const runId = options.runId ?? generateId(this.name)
+    const threadId = options.threadId ?? generateId(this.name)
+    const messageId = generateId(this.name)
+
+    try {
+      logger.request(
+        `activity=chat provider=gemini model=${model} messages=${options.messages.length} mode=interactions-agentic-video`,
+        { provider: 'gemini', model },
+      )
+
+      const normalizedPrompts = normalizeSystemPrompts(options.systemPrompts)
+      const systemInstruction =
+        normalizedPrompts.length > 0
+          ? normalizedPrompts.map((p) => p.content).join('\n')
+          : undefined
+
+      const input = buildInteractionsInput(options.messages)
+
+      // The installed @google/genai (2.10.0) Interactions `VideoContent` type
+      // predates the `processing` field, so the structurally-built input is
+      // cast at the call boundary. The SDK forwards it to the wire unchanged.
+      const interaction = await this.client.interactions.create({
+        model,
+        ...(systemInstruction !== undefined && {
+          system_instruction: systemInstruction,
+        }),
+        input: input as never,
+      })
+
+      const text = interaction.output_text ?? ''
+
+      yield {
+        type: EventType.RUN_STARTED,
+        runId,
+        threadId,
+        model,
+        timestamp: Date.now(),
+        parentRunId: options.parentRunId,
+      }
+      yield {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId,
+        model,
+        timestamp: Date.now(),
+        role: 'assistant',
+      }
+      if (text) {
+        yield {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId,
+          model,
+          timestamp: Date.now(),
+          delta: text,
+          content: text,
+        }
+      }
+      yield {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId,
+        model,
+        timestamp: Date.now(),
+      }
+      yield {
+        type: EventType.RUN_FINISHED,
+        runId,
+        threadId,
+        model,
+        timestamp: Date.now(),
+        finishReason: 'stop',
+      }
+    } catch (error) {
+      const rawEvent = toRunErrorRawEvent(error)
+      logger.errors('gemini.interactionsStream fatal', {
+        error,
+        source: 'gemini.interactionsStream',
+      })
+      yield {
+        type: EventType.RUN_ERROR,
+        model,
+        timestamp: Date.now(),
+        message:
+          error instanceof Error
+            ? error.message
+            : 'An unknown error occurred during the chat stream.',
         ...(rawEvent !== undefined && { rawEvent }),
         error: {
           message:
@@ -595,29 +815,42 @@ export class GeminiTextAdapter<
       case 'audio':
       case 'video':
       case 'document': {
-        if (part.source.type === 'data') {
-          return {
-            inlineData: {
-              data: part.source.value,
-              mimeType: part.source.mimeType,
-            },
-          }
-        } else {
-          // For URL sources, use provided mimeType or fall back to reasonable defaults
-          const defaultMimeType = {
-            image: 'image/jpeg',
-            audio: 'audio/mp3',
-            video: 'video/mp4',
-            document: 'application/pdf',
-          }[part.type]
+        const geminiPart: Part =
+          part.source.type === 'data'
+            ? {
+                inlineData: {
+                  data: part.source.value,
+                  mimeType: part.source.mimeType,
+                },
+              }
+            : {
+                fileData: {
+                  fileUri: part.source.value,
+                  // For URL sources, use provided mimeType or fall back to
+                  // reasonable defaults.
+                  mimeType:
+                    part.source.mimeType ?? DEFAULT_MEDIA_MIME_TYPES[part.type],
+                },
+              }
 
-          return {
-            fileData: {
-              fileUri: part.source.value,
-              mimeType: part.source.mimeType ?? defaultMimeType,
-            },
+        // Apply single-pass video sampling controls (fps / clip offsets) from
+        // the part metadata. `processing: 'agentic'` is handled separately via
+        // the Interactions API and never reaches this generateContent path.
+        if (part.type === 'video') {
+          const meta = part.metadata as GeminiVideoMetadata | undefined
+          const videoMetadata: VideoMetadata = {
+            ...(meta?.fps !== undefined && { fps: meta.fps }),
+            ...(meta?.startOffset !== undefined && {
+              startOffset: meta.startOffset,
+            }),
+            ...(meta?.endOffset !== undefined && { endOffset: meta.endOffset }),
+          }
+          if (Object.keys(videoMetadata).length > 0) {
+            geminiPart.videoMetadata = videoMetadata
           }
         }
+
+        return geminiPart
       }
       default: {
         const _exhaustiveCheck: never = part

--- a/packages/ai-gemini/src/files/index.ts
+++ b/packages/ai-gemini/src/files/index.ts
@@ -1,0 +1,114 @@
+import { FileState } from '@google/genai'
+import { createGeminiClient, getGeminiApiKeyFromEnv } from '../utils'
+import type { GeminiVideoMetadata } from '../message-types'
+import type { VideoPart } from '@tanstack/ai'
+
+/**
+ * A file uploaded to the Gemini Files API and ready to reference in a message.
+ */
+export interface GeminiUploadedFile {
+  /** Resource name, e.g. `"files/abc123"`. */
+  name: string
+  /** File URI to reference from message content (as a `url` source). */
+  uri: string
+  /** MIME type reported by the Files API. */
+  mimeType: string
+}
+
+/**
+ * Options for {@link uploadGeminiFile}.
+ */
+export interface GeminiUploadFileOptions {
+  /**
+   * API key. Falls back to `GOOGLE_API_KEY` / `GEMINI_API_KEY` from the
+   * environment when omitted.
+   */
+  apiKey?: string
+  /**
+   * MIME type of the file (e.g. `"video/mp4"`). Recommended so the Files API
+   * processes and serves the file with the correct type.
+   */
+  mimeType?: string
+  /** Poll interval while the file is `PROCESSING`, in ms. Default `5000`. */
+  pollIntervalMs?: number
+  /** Max time to wait for processing, in ms. Default `300000` (5 min). */
+  timeoutMs?: number
+}
+
+/**
+ * Upload a file via the Gemini Files API and wait until it is `ACTIVE`.
+ *
+ * Large media (notably video) must be uploaded rather than inlined as base64;
+ * the Files API processes uploads asynchronously. This wraps the upload +
+ * poll-until-ready loop and returns a reference you can drop into message
+ * content as a `url` source (see {@link geminiVideoPart}).
+ *
+ * @throws if the upload has no URI, or processing fails or times out.
+ */
+export async function uploadGeminiFile(
+  file: string | Blob,
+  options: GeminiUploadFileOptions = {},
+): Promise<GeminiUploadedFile> {
+  const {
+    apiKey = getGeminiApiKeyFromEnv(),
+    mimeType,
+    pollIntervalMs = 5000,
+    timeoutMs = 300_000,
+  } = options
+
+  const client = createGeminiClient({ apiKey })
+
+  let uploaded = await client.files.upload({
+    file,
+    ...(mimeType && { config: { mimeType } }),
+  })
+
+  const fileName = uploaded.name
+  if (!fileName) {
+    throw new Error('Gemini file upload did not return a file name.')
+  }
+
+  const deadline = Date.now() + timeoutMs
+  while (uploaded.state === FileState.PROCESSING) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Gemini file processing timed out after ${timeoutMs}ms (${fileName}).`,
+      )
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+    uploaded = await client.files.get({ name: fileName })
+  }
+
+  if (uploaded.state === FileState.FAILED) {
+    throw new Error(
+      `Gemini file processing failed: ${uploaded.error?.message ?? String(uploaded.state)}`,
+    )
+  }
+  if (!uploaded.uri) {
+    throw new Error('Gemini file upload did not return a URI.')
+  }
+
+  return {
+    name: fileName,
+    uri: uploaded.uri,
+    mimeType: uploaded.mimeType ?? mimeType ?? 'application/octet-stream',
+  }
+}
+
+/**
+ * Build a TanStack AI video content part from an uploaded Gemini file.
+ *
+ * Pass `metadata` to control understanding — e.g.
+ * `{ processing: 'agentic' }` to route through the agentic Interactions path,
+ * or `{ fps, startOffset, endOffset }` for single-pass sampling controls.
+ */
+export function geminiVideoPart(
+  file: GeminiUploadedFile,
+  metadata?: GeminiVideoMetadata,
+): VideoPart<GeminiVideoMetadata> {
+  return {
+    type: 'video',
+    source: { type: 'url', value: file.uri, mimeType: file.mimeType },
+    ...(metadata && { metadata }),
+  }
+}

--- a/packages/ai-gemini/src/index.ts
+++ b/packages/ai-gemini/src/index.ts
@@ -60,6 +60,14 @@ export type {
 // having to add `@google/genai` to their own dependencies.
 export { HarmBlockThreshold, HarmCategory } from '@google/genai'
 
+// Files API helpers — upload + poll a file (e.g. video) until it is ACTIVE
+export {
+  uploadGeminiFile,
+  geminiVideoPart,
+  type GeminiUploadedFile,
+  type GeminiUploadFileOptions,
+} from './files/index'
+
 // Embedding adapter - for embedding vectors
 export {
   GeminiEmbeddingAdapter,
@@ -168,6 +176,7 @@ export type {
   GeminiImageMetadata,
   GeminiAudioMetadata,
   GeminiVideoMetadata,
+  GeminiVideoProcessing,
   GeminiDocumentMetadata,
   GeminiMessageMetadataByModality,
 } from './message-types'

--- a/packages/ai-gemini/src/message-types.ts
+++ b/packages/ai-gemini/src/message-types.ts
@@ -88,6 +88,19 @@ export interface GeminiAudioMetadata {
 }
 
 /**
+ * How Gemini processes a video for understanding.
+ *
+ * - `static` (default): single-pass frame sampling via `generateContent`.
+ * - `agentic`: multi-pass "agentic" video understanding, GA on the
+ *   `agentic_video`-capable flash models (`gemini-3.7-flash`,
+ *   `gemini-3.6-flash`, `gemini-3.5-flash-lite`). The text adapter routes the
+ *   request through the Interactions API instead of `generateContent`. With
+ *   `agentic`, the sampling rate is expressed in the text prompt (e.g. "watch
+ *   it at 0.5 fps"), not via `fps`.
+ */
+export type GeminiVideoProcessing = 'agentic' | 'static'
+
+/**
  * Metadata for Gemini video content parts.
  */
 export interface GeminiVideoMetadata {
@@ -98,6 +111,30 @@ export interface GeminiVideoMetadata {
    * @see https://ai.google.dev/gemini-api/docs/vision#video-requirements
    */
   mimeType?: GeminiVideoMimeType
+  /**
+   * How the model processes this video for understanding. When set, the
+   * adapter routes the request through the Gemini Interactions API. Omit for
+   * the default single-pass `generateContent` behavior.
+   */
+  processing?: GeminiVideoProcessing
+  /**
+   * Frame-rate sampling density (frames per second) for single-pass
+   * (`generateContent`) understanding. Valid range (0, 24]; defaults to 1.0
+   * on the server. Ignored when `processing` is `agentic`.
+   *
+   * @see https://ai.google.dev/gemini-api/docs/vision#customize-frame-rate
+   */
+  fps?: number
+  /**
+   * Clip start offset, as a decimal number of seconds with an `s` suffix
+   * (e.g. `"10.5s"`). Restricts understanding to a segment of the video.
+   */
+  startOffset?: string
+  /**
+   * Clip end offset, as a decimal number of seconds with an `s` suffix
+   * (e.g. `"45s"`). Restricts understanding to a segment of the video.
+   */
+  endOffset?: string
 }
 
 /**

--- a/packages/ai-gemini/src/model-meta.ts
+++ b/packages/ai-gemini/src/model-meta.ts
@@ -14,6 +14,7 @@ interface ModelMeta<TProviderOptions = unknown> {
     input: Array<'text' | 'image' | 'audio' | 'video' | 'document'>
     output: Array<'text' | 'image' | 'audio' | 'video'>
     capabilities?: Array<
+      | 'agentic_video'
       | 'audio_generation'
       | 'batch_api'
       | 'caching'
@@ -879,6 +880,7 @@ const GEMINI_3_7_FLASH = {
     input: ['text', 'image', 'video', 'audio', 'document'],
     output: ['text'],
     capabilities: [
+      'agentic_video',
       'batch_api',
       'caching',
       'function_calling',
@@ -923,6 +925,7 @@ const GEMINI_3_6_FLASH = {
     input: ['text', 'image', 'video', 'audio', 'document'],
     output: ['text'],
     capabilities: [
+      'agentic_video',
       'batch_api',
       'caching',
       'function_calling',
@@ -1006,6 +1009,7 @@ const GEMINI_3_5_FLASH_LITE = {
     input: ['text', 'image', 'video', 'audio', 'document'],
     output: ['text'],
     capabilities: [
+      'agentic_video',
       'batch_api',
       'caching',
       'function_calling',

--- a/packages/ai-gemini/tests/agentic-video.test.ts
+++ b/packages/ai-gemini/tests/agentic-video.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { chat } from '@tanstack/ai'
+import type { AdapterYieldChunk, ModelMessage } from '@tanstack/ai'
+import { GeminiTextAdapter } from '../src/adapters/text'
+
+// Mock @google/genai with both the generateContent* surface (single-pass) and
+// the interactions surface (agentic), so we can assert which one a given
+// message routes to.
+const mocks = vi.hoisted(() => ({
+  generateContentStreamSpy: vi.fn(),
+  interactionsCreateSpy: vi.fn(),
+}))
+
+vi.mock('@google/genai', async () => {
+  const actual = await vi.importActual<any>('@google/genai')
+  const { generateContentStreamSpy, interactionsCreateSpy } = mocks
+  class MockGoogleGenAI {
+    public models = { generateContentStream: generateContentStreamSpy }
+    get interactions() {
+      return { create: interactionsCreateSpy }
+    }
+    constructor(_options: { apiKey: string }) {}
+  }
+  return { ...actual, GoogleGenAI: MockGoogleGenAI }
+})
+
+const createStream = (chunks: Array<Record<string, unknown>>) =>
+  (async function* () {
+    for (const chunk of chunks) yield chunk
+  })()
+
+const collect = async (stream: AsyncIterable<AdapterYieldChunk>) => {
+  const chunks: Array<AdapterYieldChunk> = []
+  for await (const chunk of stream) chunks.push(chunk)
+  return chunks
+}
+
+const videoMessage = (metadata?: Record<string, unknown>): ModelMessage => ({
+  role: 'user',
+  content: [
+    { type: 'text', content: 'What happens in this video?' },
+    {
+      type: 'video',
+      source: { type: 'url', value: 'files/abc', mimeType: 'video/mp4' },
+      ...(metadata && { metadata }),
+    },
+  ],
+})
+
+describe('Gemini agentic video routing', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('routes processing:"agentic" video parts through the Interactions API', async () => {
+    mocks.interactionsCreateSpy.mockResolvedValue({
+      output_text: 'A guitar is played in a store.',
+    })
+
+    const adapter = new GeminiTextAdapter({ apiKey: 'k' }, 'gemini-3.7-flash')
+    const chunks = await collect(
+      chat({
+        adapter,
+        messages: [videoMessage({ processing: 'agentic' })],
+      }),
+    )
+
+    expect(mocks.interactionsCreateSpy).toHaveBeenCalledTimes(1)
+    expect(mocks.generateContentStreamSpy).not.toHaveBeenCalled()
+
+    const payload = mocks.interactionsCreateSpy.mock.calls[0]![0]
+    expect(payload.model).toBe('gemini-3.7-flash')
+    const videoBlock = payload.input[0].content.find(
+      (c: { type: string }) => c.type === 'video',
+    )
+    expect(videoBlock.processing).toBe('agentic')
+
+    const text = chunks
+      .filter((c) => c.type === 'TEXT_MESSAGE_CONTENT')
+      .map((c) => (c as { delta: string }).delta)
+      .join('')
+    expect(text).toBe('A guitar is played in a store.')
+  })
+
+  it('routes single-pass video parts through generateContentStream', async () => {
+    mocks.generateContentStreamSpy.mockResolvedValue(
+      createStream([
+        {
+          candidates: [
+            { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+          ],
+          usageMetadata: { totalTokenCount: 1 },
+        },
+      ]),
+    )
+
+    const adapter = new GeminiTextAdapter({ apiKey: 'k' }, 'gemini-3.7-flash')
+    await collect(chat({ adapter, messages: [videoMessage()] }))
+
+    expect(mocks.generateContentStreamSpy).toHaveBeenCalledTimes(1)
+    expect(mocks.interactionsCreateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -38,6 +38,7 @@ Each test iterates over supported providers using `providersFor('feature')`:
 | tts                      | 3         | `tests/tts.spec.ts`                      |
 | transcription            | 3         | `tests/transcription.spec.ts`            |
 | audio-gen                | 1         | `tests/audio-gen.spec.ts`                |
+| video-understanding      | 1         | `tests/video-understanding.spec.ts`      |
 
 ### Tools-test page
 

--- a/testing/e2e/global-setup.ts
+++ b/testing/e2e/global-setup.ts
@@ -103,6 +103,15 @@ export default async function globalSetup() {
   // text tests.
   mock.mount('/omni-video', geminiOmniVideoMount())
 
+  // Agentic video understanding (standard Gemini chat adapter). A video part
+  // with metadata.processing:'agentic' routes through the non-streaming
+  // interactions.create(), which reads `output_text`. aimock's native
+  // interactions handler defaults to streaming SSE (keyed off `stream !==
+  // false`), so it can't serve create(). This dedicated prefix returns a
+  // completed JSON interaction instead. See the video-understanding provider
+  // block in src/lib/providers.ts.
+  mock.mount('/vu-interactions', geminiVideoUnderstandingMount())
+
   // Anthropic server_tool_use bug reproduction (issue #604). aimock can't
   // natively synthesize `server_tool_use` / `web_fetch_tool_result` content
   // blocks, so this mount hand-crafts the raw SSE Claude would emit when a
@@ -940,6 +949,47 @@ function geminiOmniVideoMount(): Mountable {
       }
 
       return false
+    },
+  }
+}
+
+/**
+ * Mounts the agentic video-understanding interaction under a dedicated
+ * `/vu-interactions` prefix (the video-understanding provider points its baseUrl
+ * there). The standard Gemini adapter's agentic path calls the non-streaming
+ * `interactions.create()` and reads `output_text`; aimock's native handler
+ * would stream SSE instead. This returns a completed JSON interaction with the
+ * text the spec asserts on.
+ */
+function geminiVideoUnderstandingMount(): Mountable {
+  return {
+    async handleRequest(
+      req: http.IncomingMessage,
+      res: http.ServerResponse,
+      // aimock strips the mount prefix ('/vu-interactions'), so pathname
+      // looks like '/v1beta/interactions'.
+      pathname: string,
+    ): Promise<boolean> {
+      if (pathname !== '/v1beta/interactions' || req.method !== 'POST') {
+        return false
+      }
+      const body = await readJsonRequestBody(req)
+      const model =
+        typeof body?.model === 'string' ? body.model : 'gemini-3.7-flash'
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.end(
+        JSON.stringify({
+          id: 'aimock-vu-1',
+          object: 'interaction',
+          status: 'completed',
+          model,
+          output_text:
+            'The video shows a guitar being played in a music store. A ' +
+            'musician demonstrates the instrument with a bright, clear tone.',
+        }),
+      )
+      return true
     },
   }
 }

--- a/testing/e2e/src/lib/feature-support.ts
+++ b/testing/e2e/src/lib/feature-support.ts
@@ -465,6 +465,11 @@ export const matrix: Record<Feature, Set<Provider>> = {
   // the adapter (geminiTextInteractions, behind @tanstack/ai-gemini/experimental).
   // byteplus excluded for the same reason: Ark's chat endpoint is stateless.
   'stateful-interactions': new Set(['gemini']),
+  // Gemini-only. Agentic video understanding: a video content part with
+  // metadata.processing: 'agentic' makes geminiText route through the
+  // Interactions API (aimock serves synchronous text interactions natively;
+  // it extracts the text prompt and ignores the video block when matching).
+  'video-understanding': new Set(['gemini']),
 }
 
 export function isSupported(provider: Provider, feature: Feature): boolean {

--- a/testing/e2e/src/lib/features.ts
+++ b/testing/e2e/src/lib/features.ts
@@ -176,4 +176,8 @@ export const featureConfigs: Record<Feature, FeatureConfig> = {
     tools: [],
     modelOptions: {},
   },
+  'video-understanding': {
+    tools: [],
+    modelOptions: {},
+  },
 }

--- a/testing/e2e/src/lib/providers.ts
+++ b/testing/e2e/src/lib/providers.ts
@@ -154,6 +154,23 @@ export function createTextAdapter(
     })
   }
 
+  // Agentic video understanding uses the standard Gemini chat adapter, but a
+  // video part with metadata.processing:'agentic' makes it route through the
+  // Interactions API (POST /v1beta/interactions). aimock defaults that endpoint
+  // to streaming SSE, which the non-streaming interactions.create() can't read,
+  // so this feature gets a dedicated mount prefix that returns a completed JSON
+  // interaction. Keeps stateful-interactions on the native handler untouched.
+  if (provider === 'gemini' && feature === 'video-understanding') {
+    return createChatOptions({
+      adapter: createGeminiChat(model as 'gemini-2.5-flash', DUMMY_KEY, {
+        httpOptions: {
+          baseUrl: `${base}/vu-interactions`,
+          headers: testHeaders,
+        },
+      }),
+    })
+  }
+
   const factories: Record<Provider, () => { adapter: AnyTextAdapter }> = {
     openai: () =>
       createChatOptions({

--- a/testing/e2e/src/lib/types.ts
+++ b/testing/e2e/src/lib/types.ts
@@ -56,6 +56,7 @@ export type Feature =
   | 'image-to-video'
   | 'interactions-video'
   | 'stateful-interactions'
+  | 'video-understanding'
 
 export const ALL_PROVIDERS: Provider[] = [
   'openai',
@@ -114,4 +115,5 @@ export const ALL_FEATURES: Feature[] = [
   'image-to-video',
   'interactions-video',
   'stateful-interactions',
+  'video-understanding',
 ]

--- a/testing/e2e/src/routes/$provider/$feature.tsx
+++ b/testing/e2e/src/routes/$provider/$feature.tsx
@@ -25,6 +25,11 @@ import { EmbeddingUI } from '@/components/EmbeddingUI'
 
 const VALID_MODES = new Set<Mode>(['sse', 'http-stream', 'fetcher'])
 
+// A tiny MP4 `ftyp` box. aimock ignores the bytes and matches on the text
+// prompt, so any base64 works — this just gives the video-understanding
+// message a real video content part to route on.
+const AGENTIC_VIDEO_DATA = 'AAAAIGZ0eXBpc29tAAACAGlzb21pc28y'
+
 export const Route = createFileRoute('/$provider/$feature')({
   component: FeaturePage,
   validateSearch: (search: Record<string, unknown>) => {
@@ -479,6 +484,26 @@ function ChatFeature({
           // keys. Asserted by per-call-body.spec.ts.
           if (text.startsWith('[per-call-body]')) {
             sendMessage(text, { body: { perCallBodyMarker: testId } })
+            return
+          }
+          // Agentic video understanding: attach a video part flagged
+          // `processing: 'agentic'` so geminiText routes through the
+          // Interactions API instead of generateContent.
+          if (feature === 'video-understanding') {
+            sendMessage({
+              content: [
+                { type: 'text', content: text },
+                {
+                  type: 'video',
+                  source: {
+                    type: 'data',
+                    value: AGENTIC_VIDEO_DATA,
+                    mimeType: 'video/mp4',
+                  },
+                  metadata: { processing: 'agentic' },
+                },
+              ],
+            })
             return
           }
           sendMessage(text)

--- a/testing/e2e/tests/video-understanding.spec.ts
+++ b/testing/e2e/tests/video-understanding.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from './fixtures'
+import {
+  sendMessage,
+  waitForResponse,
+  getLastAssistantMessage,
+  featureUrl,
+} from './helpers'
+import { providersFor } from './test-matrix'
+
+// Agentic video understanding (geminiText). The route attaches a video content
+// part flagged `processing: 'agentic'`, so the adapter routes the turn through
+// Gemini's Interactions API instead of generateContent. aimock serves the
+// synchronous interaction natively: it extracts the text prompt, ignores the
+// video block, matches the fixture, and returns `output_text`.
+//
+// This is the integration assertion (the whole stack wires up and renders). The
+// routing itself (interactions.create vs generateContentStream) is pinned by
+// unit tests in `packages/ai-gemini/tests/agentic-video.test.ts`.
+for (const provider of providersFor('video-understanding')) {
+  test.describe(`${provider} -- video-understanding`, () => {
+    test('answers a question about an attached video', async ({
+      page,
+      testId,
+      aimockPort,
+    }) => {
+      await page.goto(
+        featureUrl(provider, 'video-understanding', testId, aimockPort),
+      )
+
+      await sendMessage(page, '[video-understanding] describe this video')
+      await waitForResponse(page)
+
+      const response = await getLastAssistantMessage(page)
+      expect(response).toContain('guitar')
+    })
+  })
+}

--- a/testing/panel/src/components/Header.tsx
+++ b/testing/panel/src/components/Header.tsx
@@ -227,6 +227,24 @@ export default function Header() {
           </Link>
 
           <Link
+            to="/video-understanding"
+            onClick={() => setIsOpen(false)}
+            className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-800 transition-colors mb-2"
+            activeProps={{
+              className:
+                'flex items-center gap-3 p-3 rounded-lg bg-indigo-600 hover:bg-indigo-700 transition-colors mb-2',
+            }}
+          >
+            <Video size={20} />
+            <div className="flex items-center gap-2">
+              <span className="font-medium">Video Understanding</span>
+              <span className="text-xs px-1.5 py-0.5 bg-yellow-500/20 text-yellow-400 rounded">
+                Exp
+              </span>
+            </div>
+          </Link>
+
+          <Link
             to="/tts"
             onClick={() => setIsOpen(false)}
             className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-800 transition-colors mb-2"

--- a/testing/panel/src/routeTree.gen.ts
+++ b/testing/panel/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as VideoUnderstandingRouteImport } from './routes/video-understanding'
 import { Route as VideoRouteImport } from './routes/video'
 import { Route as TtsRouteImport } from './routes/tts'
 import { Route as TranscriptionRouteImport } from './routes/transcription'
@@ -22,6 +23,8 @@ import { Route as ImageRouteImport } from './routes/image'
 import { Route as CompactionRouteImport } from './routes/compaction'
 import { Route as AddonManagerRouteImport } from './routes/addon-manager'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ApiVideoUnderstandingUploadRouteImport } from './routes/api.video-understanding-upload'
+import { Route as ApiVideoUnderstandingRouteImport } from './routes/api.video-understanding'
 import { Route as ApiVideoRouteImport } from './routes/api.video'
 import { Route as ApiTtsRouteImport } from './routes/api.tts'
 import { Route as ApiTranscriptionRouteImport } from './routes/api.transcription'
@@ -40,6 +43,11 @@ import { Route as ApiCompactionChatRouteImport } from './routes/api.compaction-c
 import { Route as ApiChatRouteImport } from './routes/api.chat'
 import { Route as ApiAddonChatRouteImport } from './routes/api.addon-chat'
 
+const VideoUnderstandingRoute = VideoUnderstandingRouteImport.update({
+  id: '/video-understanding',
+  path: '/video-understanding',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const VideoRoute = VideoRouteImport.update({
   id: '/video',
   path: '/video',
@@ -103,6 +111,17 @@ const AddonManagerRoute = AddonManagerRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiVideoUnderstandingUploadRoute =
+  ApiVideoUnderstandingUploadRouteImport.update({
+    id: '/api/video-understanding-upload',
+    path: '/api/video-understanding-upload',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiVideoUnderstandingRoute = ApiVideoUnderstandingRouteImport.update({
+  id: '/api/video-understanding',
+  path: '/api/video-understanding',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiVideoRoute = ApiVideoRouteImport.update({
@@ -205,6 +224,7 @@ export interface FileRoutesByFullPath {
   '/transcription': typeof TranscriptionRoute
   '/tts': typeof TtsRoute
   '/video': typeof VideoRoute
+  '/video-understanding': typeof VideoUnderstandingRoute
   '/api/addon-chat': typeof ApiAddonChatRoute
   '/api/chat': typeof ApiChatRoute
   '/api/compaction-chat': typeof ApiCompactionChatRoute
@@ -222,6 +242,8 @@ export interface FileRoutesByFullPath {
   '/api/transcription': typeof ApiTranscriptionRoute
   '/api/tts': typeof ApiTtsRoute
   '/api/video': typeof ApiVideoRoute
+  '/api/video-understanding': typeof ApiVideoUnderstandingRoute
+  '/api/video-understanding-upload': typeof ApiVideoUnderstandingUploadRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -237,6 +259,7 @@ export interface FileRoutesByTo {
   '/transcription': typeof TranscriptionRoute
   '/tts': typeof TtsRoute
   '/video': typeof VideoRoute
+  '/video-understanding': typeof VideoUnderstandingRoute
   '/api/addon-chat': typeof ApiAddonChatRoute
   '/api/chat': typeof ApiChatRoute
   '/api/compaction-chat': typeof ApiCompactionChatRoute
@@ -254,6 +277,8 @@ export interface FileRoutesByTo {
   '/api/transcription': typeof ApiTranscriptionRoute
   '/api/tts': typeof ApiTtsRoute
   '/api/video': typeof ApiVideoRoute
+  '/api/video-understanding': typeof ApiVideoUnderstandingRoute
+  '/api/video-understanding-upload': typeof ApiVideoUnderstandingUploadRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -270,6 +295,7 @@ export interface FileRoutesById {
   '/transcription': typeof TranscriptionRoute
   '/tts': typeof TtsRoute
   '/video': typeof VideoRoute
+  '/video-understanding': typeof VideoUnderstandingRoute
   '/api/addon-chat': typeof ApiAddonChatRoute
   '/api/chat': typeof ApiChatRoute
   '/api/compaction-chat': typeof ApiCompactionChatRoute
@@ -287,6 +313,8 @@ export interface FileRoutesById {
   '/api/transcription': typeof ApiTranscriptionRoute
   '/api/tts': typeof ApiTtsRoute
   '/api/video': typeof ApiVideoRoute
+  '/api/video-understanding': typeof ApiVideoUnderstandingRoute
+  '/api/video-understanding-upload': typeof ApiVideoUnderstandingUploadRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -304,6 +332,7 @@ export interface FileRouteTypes {
     | '/transcription'
     | '/tts'
     | '/video'
+    | '/video-understanding'
     | '/api/addon-chat'
     | '/api/chat'
     | '/api/compaction-chat'
@@ -321,6 +350,8 @@ export interface FileRouteTypes {
     | '/api/transcription'
     | '/api/tts'
     | '/api/video'
+    | '/api/video-understanding'
+    | '/api/video-understanding-upload'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -336,6 +367,7 @@ export interface FileRouteTypes {
     | '/transcription'
     | '/tts'
     | '/video'
+    | '/video-understanding'
     | '/api/addon-chat'
     | '/api/chat'
     | '/api/compaction-chat'
@@ -353,6 +385,8 @@ export interface FileRouteTypes {
     | '/api/transcription'
     | '/api/tts'
     | '/api/video'
+    | '/api/video-understanding'
+    | '/api/video-understanding-upload'
   id:
     | '__root__'
     | '/'
@@ -368,6 +402,7 @@ export interface FileRouteTypes {
     | '/transcription'
     | '/tts'
     | '/video'
+    | '/video-understanding'
     | '/api/addon-chat'
     | '/api/chat'
     | '/api/compaction-chat'
@@ -385,6 +420,8 @@ export interface FileRouteTypes {
     | '/api/transcription'
     | '/api/tts'
     | '/api/video'
+    | '/api/video-understanding'
+    | '/api/video-understanding-upload'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -401,6 +438,7 @@ export interface RootRouteChildren {
   TranscriptionRoute: typeof TranscriptionRoute
   TtsRoute: typeof TtsRoute
   VideoRoute: typeof VideoRoute
+  VideoUnderstandingRoute: typeof VideoUnderstandingRoute
   ApiAddonChatRoute: typeof ApiAddonChatRoute
   ApiChatRoute: typeof ApiChatRoute
   ApiCompactionChatRoute: typeof ApiCompactionChatRoute
@@ -418,10 +456,19 @@ export interface RootRouteChildren {
   ApiTranscriptionRoute: typeof ApiTranscriptionRoute
   ApiTtsRoute: typeof ApiTtsRoute
   ApiVideoRoute: typeof ApiVideoRoute
+  ApiVideoUnderstandingRoute: typeof ApiVideoUnderstandingRoute
+  ApiVideoUnderstandingUploadRoute: typeof ApiVideoUnderstandingUploadRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/video-understanding': {
+      id: '/video-understanding'
+      path: '/video-understanding'
+      fullPath: '/video-understanding'
+      preLoaderRoute: typeof VideoUnderstandingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/video': {
       id: '/video'
       path: '/video'
@@ -511,6 +558,20 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/video-understanding-upload': {
+      id: '/api/video-understanding-upload'
+      path: '/api/video-understanding-upload'
+      fullPath: '/api/video-understanding-upload'
+      preLoaderRoute: typeof ApiVideoUnderstandingUploadRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/video-understanding': {
+      id: '/api/video-understanding'
+      path: '/api/video-understanding'
+      fullPath: '/api/video-understanding'
+      preLoaderRoute: typeof ApiVideoUnderstandingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/video': {
@@ -649,6 +710,7 @@ const rootRouteChildren: RootRouteChildren = {
   TranscriptionRoute: TranscriptionRoute,
   TtsRoute: TtsRoute,
   VideoRoute: VideoRoute,
+  VideoUnderstandingRoute: VideoUnderstandingRoute,
   ApiAddonChatRoute: ApiAddonChatRoute,
   ApiChatRoute: ApiChatRoute,
   ApiCompactionChatRoute: ApiCompactionChatRoute,
@@ -666,6 +728,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiTranscriptionRoute: ApiTranscriptionRoute,
   ApiTtsRoute: ApiTtsRoute,
   ApiVideoRoute: ApiVideoRoute,
+  ApiVideoUnderstandingRoute: ApiVideoUnderstandingRoute,
+  ApiVideoUnderstandingUploadRoute: ApiVideoUnderstandingUploadRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/testing/panel/src/routes/api.video-understanding-upload.ts
+++ b/testing/panel/src/routes/api.video-understanding-upload.ts
@@ -1,0 +1,63 @@
+import * as os from 'node:os'
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+import { createFileRoute } from '@tanstack/react-router'
+import { uploadGeminiFile } from '@tanstack/ai-gemini'
+
+/**
+ * Upload a video (multipart form field `file`) to the Gemini Files API and wait
+ * until it is ACTIVE. Returns `{ uri, mimeType, name }` for the client to pass
+ * back with subsequent chat turns.
+ *
+ * The incoming blob is written to a temp file first — the Files API upload is
+ * most reliable from a path, and it keeps the 24MB body off the heap longer
+ * than necessary.
+ */
+export const Route = createFileRoute('/api/video-understanding-upload')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        let tmpPath: string | undefined
+        try {
+          const formData = await request.formData()
+          const file = formData.get('file')
+          if (!(file instanceof File)) {
+            return Response.json(
+              { error: 'Expected a `file` field with a video.' },
+              { status: 400 },
+            )
+          }
+
+          const bytes = Buffer.from(await file.arrayBuffer())
+          const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_')
+          tmpPath = path.join(os.tmpdir(), `vu-${process.pid}-${safeName}`)
+          fs.writeFileSync(tmpPath, bytes)
+
+          const uploaded = await uploadGeminiFile(tmpPath, {
+            mimeType: file.type || 'video/mp4',
+          })
+
+          console.log(`>> video-understanding upload -> ${uploaded.uri}`)
+          return Response.json(uploaded)
+        } catch (error: any) {
+          console.error(
+            '[API Route] video-understanding upload error:',
+            error?.message,
+          )
+          return Response.json(
+            { error: error?.message ?? 'Upload failed' },
+            { status: 500 },
+          )
+        } finally {
+          if (tmpPath) {
+            try {
+              fs.unlinkSync(tmpPath)
+            } catch {
+              // best-effort cleanup
+            }
+          }
+        }
+      },
+    },
+  },
+})

--- a/testing/panel/src/routes/api.video-understanding.ts
+++ b/testing/panel/src/routes/api.video-understanding.ts
@@ -1,0 +1,108 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
+import { geminiText, geminiVideoPart } from '@tanstack/ai-gemini'
+import type {
+  GeminiUploadedFile,
+  GeminiVideoMetadata,
+} from '@tanstack/ai-gemini'
+import type { ContentPart, ModelMessage } from '@tanstack/ai'
+
+// Agentic understanding routes through the Interactions API; single-pass
+// understanding uses generateContent. Both run on the same GA flash model.
+const AGENTIC_MODEL = 'gemini-3.7-flash'
+const SINGLE_PASS_MODEL = 'gemini-3.7-flash'
+
+const SYSTEM_PROMPT =
+  'You are a helpful assistant that answers questions about the video the user ' +
+  'has shared. Be concise and specific, and cite timestamps when relevant.'
+
+/** Extract plain text from a wire message (string content or text parts). */
+function messageText(msg: any): string {
+  if (typeof msg?.content === 'string') return msg.content
+  const parts = Array.isArray(msg?.content)
+    ? msg.content
+    : Array.isArray(msg?.parts)
+      ? msg.parts
+      : []
+  return parts
+    .filter((p: any) => p?.type === 'text' && p.content)
+    .map((p: any) => p.content)
+    .join('\n')
+}
+
+/**
+ * Rebuild the conversation for the adapter, attaching the uploaded video to the
+ * first user turn so it stays in context for every turn (the full history is
+ * re-sent each request).
+ */
+function buildMessages(
+  wireMessages: Array<any>,
+  video: GeminiUploadedFile | undefined,
+  videoMetadata: GeminiVideoMetadata,
+): Array<ModelMessage> {
+  let videoAttached = false
+  return wireMessages.map((msg): ModelMessage => {
+    const role: ModelMessage['role'] =
+      msg.role === 'assistant' ? 'assistant' : 'user'
+    const text = messageText(msg)
+
+    if (role === 'user' && video && !videoAttached) {
+      videoAttached = true
+      const content: Array<ContentPart> = [
+        geminiVideoPart(video, videoMetadata),
+        { type: 'text', content: text },
+      ]
+      return { role, content }
+    }
+    return { role, content: text }
+  })
+}
+
+export const Route = createFileRoute('/api/video-understanding')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const abortController = new AbortController()
+        const body = await request.json()
+        const data = body.data || {}
+        const mode: 'agentic' | 'single-pass' =
+          data.mode === 'agentic' ? 'agentic' : 'single-pass'
+        const video: GeminiUploadedFile | undefined = data.video
+
+        try {
+          const videoMetadata: GeminiVideoMetadata =
+            mode === 'agentic' ? { processing: 'agentic' } : { fps: 1 }
+
+          const messages = buildMessages(
+            body.messages ?? [],
+            video,
+            videoMetadata,
+          )
+
+          const model = mode === 'agentic' ? AGENTIC_MODEL : SINGLE_PASS_MODEL
+          console.log(
+            `>> video-understanding chat mode=${mode} model=${model} hasVideo=${Boolean(video)}`,
+          )
+
+          const stream = chat({
+            adapter: geminiText(model),
+            systemPrompts: [SYSTEM_PROMPT],
+            messages,
+            abortController,
+          })
+
+          return toServerSentEventsResponse(stream, { abortController })
+        } catch (error: any) {
+          console.error(
+            '[API Route] video-understanding error:',
+            error?.message,
+          )
+          return new Response(
+            JSON.stringify({ error: error?.message ?? 'Unknown error' }),
+            { status: 500, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+      },
+    },
+  },
+})

--- a/testing/panel/src/routes/video-understanding.tsx
+++ b/testing/panel/src/routes/video-understanding.tsx
@@ -1,0 +1,243 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { fetchServerSentEvents, useChat } from '@tanstack/ai-react'
+import { useMemo, useRef, useState } from 'react'
+import { Loader2, Send, Upload, Video } from 'lucide-react'
+
+export const Route = createFileRoute('/video-understanding')({
+  component: VideoUnderstanding,
+})
+
+type Mode = 'agentic' | 'single-pass'
+
+interface UploadedVideo {
+  uri: string
+  mimeType: string
+  name: string
+}
+
+function getMessageText(parts: Array<any>): string {
+  return parts
+    .filter((part) => part.type === 'text' && part.content)
+    .map((part) => part.content)
+    .join('')
+}
+
+function VideoUnderstanding() {
+  const [mode, setMode] = useState<Mode>('single-pass')
+  const [input, setInput] = useState('')
+  const [video, setVideo] = useState<UploadedVideo | null>(null)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const body = useMemo(() => ({ video, mode }), [video, mode])
+
+  const { messages, sendMessage, isLoading } = useChat({
+    connection: fetchServerSentEvents('/api/video-understanding'),
+    body,
+  })
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setUploadError(null)
+    setUploading(true)
+    setVideo(null)
+    setPreviewUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev)
+      return URL.createObjectURL(file)
+    })
+
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+      const res = await fetch('/api/video-understanding-upload', {
+        method: 'POST',
+        body: formData,
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'Upload failed')
+      setVideo(json as UploadedVideo)
+    } catch (err: any) {
+      setUploadError(err?.message ?? 'Upload failed')
+      setPreviewUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev)
+        return null
+      })
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!input.trim() || isLoading || !video) return
+    sendMessage(input)
+    setInput('')
+  }
+
+  const canChat = Boolean(video) && !uploading
+
+  return (
+    <div className="flex h-[calc(100vh-72px)] bg-gray-900 text-gray-100">
+      {/* Left — video + controls */}
+      <div className="w-2/5 flex flex-col border-r border-indigo-500/20 p-6 gap-4 overflow-y-auto">
+        <div className="flex items-center gap-2 text-indigo-400">
+          <Video size={20} />
+          <h1 className="text-lg font-semibold">Video Understanding</h1>
+        </div>
+
+        {/* Video preview / upload dropzone */}
+        {previewUrl ? (
+          <video
+            src={previewUrl}
+            controls
+            className="w-full rounded-lg border border-gray-700 bg-black"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="flex flex-col items-center justify-center gap-2 w-full h-48 rounded-lg border-2 border-dashed border-gray-600 text-gray-400 hover:border-indigo-500 hover:text-indigo-400 transition-colors"
+          >
+            <Upload size={28} />
+            <span className="text-sm">Click to upload a video</span>
+          </button>
+        )}
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="video/*"
+          onChange={handleUpload}
+          className="hidden"
+        />
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            className="flex items-center gap-2 rounded-lg bg-gray-800 px-3 py-2 text-sm hover:bg-gray-700 disabled:opacity-50"
+          >
+            <Upload size={16} />
+            {video ? 'Replace video' : 'Choose video'}
+          </button>
+          {uploading && (
+            <span className="flex items-center gap-2 text-sm text-indigo-400">
+              <Loader2 size={16} className="animate-spin" />
+              Uploading & processing…
+            </span>
+          )}
+          {video && !uploading && (
+            <span className="text-sm text-green-400 truncate">
+              Ready: {video.name}
+            </span>
+          )}
+        </div>
+        {uploadError && (
+          <p className="text-sm text-red-400">Upload error: {uploadError}</p>
+        )}
+
+        {/* Mode toggle */}
+        <div>
+          <label className="text-sm text-gray-400 mb-2 block">
+            Processing mode
+          </label>
+          <div className="flex gap-2">
+            {(['single-pass', 'agentic'] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMode(m)}
+                className={`flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                  mode === m
+                    ? 'bg-indigo-600 text-white'
+                    : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+                }`}
+              >
+                {m === 'agentic' ? 'Agentic' : 'Single-pass'}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-gray-500 mt-2">
+            {mode === 'agentic'
+              ? 'Interactions API · processing: "agentic" on gemini-3.7-flash. Deeper, but slower — re-analyzes the video each turn.'
+              : 'generateContent on gemini-3.7-flash (1 fps). Fast, good for multi-turn chat.'}
+          </p>
+        </div>
+      </div>
+
+      {/* Right — chat */}
+      <div className="w-3/5 flex flex-col">
+        <div className="flex-1 overflow-y-auto p-6 flex flex-col gap-4">
+          {messages.length === 0 && (
+            <p className="text-gray-500 text-sm">
+              {video
+                ? 'Ask a question about the video below.'
+                : 'Upload a video to start chatting about it.'}
+            </p>
+          )}
+          {messages.map(({ id, role, parts }) => {
+            const text = getMessageText(parts)
+            return (
+              <div
+                key={id}
+                className={`rounded-lg px-4 py-3 text-sm whitespace-pre-wrap max-w-[85%] ${
+                  role === 'assistant'
+                    ? 'bg-gray-800 border border-indigo-500/20 self-start'
+                    : 'bg-indigo-600/20 border border-indigo-500/30 self-end'
+                }`}
+              >
+                <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">
+                  {role}
+                </div>
+                {text || (
+                  <span className="text-gray-500 italic">
+                    {isLoading ? 'thinking…' : '(no content)'}
+                  </span>
+                )}
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Composer */}
+        <form
+          onSubmit={handleSubmit}
+          className="border-t border-gray-800 p-4 flex items-end gap-3"
+        >
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                handleSubmit(e)
+              }
+            }}
+            rows={2}
+            placeholder={
+              canChat ? 'Ask about the video…' : 'Upload a video first…'
+            }
+            disabled={!canChat}
+            className="flex-1 resize-none rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none disabled:opacity-50"
+          />
+          <button
+            type="submit"
+            disabled={!canChat || isLoading || !input.trim()}
+            className="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-3 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {isLoading ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Send size={16} />
+            )}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Ask questions about a video with the Gemini adapter. Attach a video part, then chat about it: "what happens at 0:30?", "summarize the demo". Set `metadata.processing: 'agentic'` for multi-pass agentic understanding, now GA on `gemini-3.7-flash`, `gemini-3.6-flash`, and `gemini-3.5-flash-lite`.

## 🎯 Changes

- Route a video part with `processing: 'agentic'` through the Interactions API. Single-pass video keeps the `generateContent` path.
- Add an `agentic_video` capability to the three GA flash models. Remove the old EAP model.
- Add `uploadGeminiFile()` (Files API upload, then poll until ACTIVE) and `geminiVideoPart()` helpers.
- Extend `GeminiVideoMetadata` with `processing`, `fps`, `startOffset`, and `endOffset`.
- Add a unit test, an e2e feature, docs, a `testing/panel` demo, and a changeset.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

Commands run (all pass):

1. `pnpm nx affected -t test:types,test:lib,test:oxlint,build`
2. `pnpm test:sherif`, `pnpm nx affected -t test:knip`, `pnpm test:docs`
3. e2e: `video-understanding.spec.ts` passes, and `stateful-interactions.spec.ts` still passes (no regression).

I did not run the literal `pnpm run test:pr`. Its `react-native`, `dts`, `maintainer`, and `ai-review` meta-targets need secrets that are not set here. I ran the rest of that target set by hand (the list above), so the checkbox stays unchecked.

Manual test:

1. Set `GEMINI_API_KEY` and start the panel: `pnpm --filter stream-processor-panel dev`.
2. Open the Video Understanding page.
3. Upload a short video and ask a question about it.
4. Toggle Agentic, then ask again. The agentic answer routes through the Interactions API.

How this PR makes testing easy: `packages/ai-gemini/tests/agentic-video.test.ts` pins the routing (agentic goes to `interactions.create`, single-pass to `generateContent`). `testing/e2e/tests/video-understanding.spec.ts` drives the feature end to end against aimock.

## Risk / rollback

Low. The change is additive. Without `processing: 'agentic'`, video keeps the current single-pass path. To undo, revert the PR.

## Public API change

New exports on `@tanstack/ai-gemini`: `uploadGeminiFile`, `geminiVideoPart`, and the `GeminiVideoProcessing` type, plus a `processing` field on video metadata.

**Before**

```ts
// No first-class video understanding on the Gemini adapter.
```

**After**

```ts
import { chat } from '@tanstack/ai'
import { geminiText, uploadGeminiFile, geminiVideoPart } from '@tanstack/ai-gemini'

const file = await uploadGeminiFile('./demo.mp4', { mimeType: 'video/mp4' })

const stream = chat({
  adapter: geminiText('gemini-3.7-flash'),
  messages: [
    {
      role: 'user',
      content: [
        { type: 'text', content: 'Summarize this video.' },
        geminiVideoPart(file, { processing: 'agentic' }),
      ],
    },
  ],
})
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added video understanding for Gemini, including video uploads and conversational questions.
  - Added single-pass and agentic processing modes with configurable video sampling and time ranges.
  - Added an interactive video-understanding panel with upload preview, progress, and chat.
  - Added support for agentic video understanding on compatible Gemini models.

- **Documentation**
  - Added Gemini video-understanding usage examples and configuration guidance.

- **Tests**
  - Added automated coverage for standard and agentic video processing flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->