### PR TITLE
fix(ai-bedrock): forward Converse cache token counts to TokenUsage

### DIFF
--- a/.changeset/bedrock-converse-cache-usage.md
+++ b/.changeset/bedrock-converse-cache-usage.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-bedrock': patch
+---
+
+Forward Bedrock Converse cache token counts to `TokenUsage`.
+
+`cacheReadInputTokens` and `cacheWriteInputTokens` from the Converse `metadata.usage` event now land on `promptTokensDetails.cachedTokens` and `promptTokensDetails.cacheWriteTokens`, in `chatStream`, `structuredOutput`, and `structuredOutputStream`. Bedrock's `inputTokens` counts only the uncached part of the input, so without these fields a cached request looked like a near-zero-input call. Both fields are omitted when Bedrock omits them.

--- a/docs/adapters/bedrock.md
+++ b/docs/adapters/bedrock.md
@@ -161,6 +161,10 @@ const adapter = createBedrockText(
 )
 ```
 
+### Token usage
+
+`onUsage` and `RUN_FINISHED.usage` report Bedrock's counts as `promptTokens`, `completionTokens`, and `totalTokens`. When a request hits or writes a prompt cache, the cache counts arrive on `promptTokensDetails.cachedTokens` and `promptTokensDetails.cacheWriteTokens`. Bedrock counts only the uncached part of the input in `promptTokens`, so add the two cache counts to it to get the full input size.
+
 ## Chat Completions API (`api: 'chat'`)
 
 Set `api: 'chat'` to use Bedrock's OpenAI-compatible Chat Completions endpoint. Returns a `bedrock` adapter.

--- a/docs/config.json
+++ b/docs/config.json
@@ -1064,7 +1064,7 @@
           "label": "Amazon Bedrock",
           "to": "adapters/bedrock",
           "addedAt": "2026-06-25",
-          "updatedAt": "2026-08-23"
+          "updatedAt": "2026-09-02"
         },
         {
           "label": "BytePlus",

--- a/packages/ai-bedrock/src/adapters/converse-text.ts
+++ b/packages/ai-bedrock/src/adapters/converse-text.ts
@@ -8,6 +8,7 @@ import {
   processConverseStream,
   throwIfConverseStreamError,
 } from '../converse/stream-processor'
+import { buildConverseUsage } from '../converse/usage'
 import {
   STRUCTURED_TOOL_NAME,
   buildStructuredToolConfig,
@@ -29,6 +30,7 @@ import type {
   Modality,
   AdapterYieldChunk,
   TextOptions,
+  TokenUsage,
   Tool,
 } from '@tanstack/ai'
 import type {
@@ -265,13 +267,7 @@ export class BedrockConverseTextAdapter<
       return {
         data: structured,
         rawText: JSON.stringify(structured),
-        ...(usage && {
-          usage: {
-            promptTokens: usage.inputTokens ?? 0,
-            completionTokens: usage.outputTokens ?? 0,
-            totalTokens: usage.totalTokens ?? 0,
-          },
-        }),
+        ...(usage && { usage: buildConverseUsage(usage) }),
       }
     } catch (error: unknown) {
       chatOptions.logger.errors(`${this.name}.structuredOutput fatal`, {
@@ -303,9 +299,7 @@ export class BedrockConverseTextAdapter<
     let finishReason: 'stop' | 'length' | 'content_filter' = 'stop'
     // Usage arrives on the trailing `metadata` event, after the finish signal,
     // so it is captured during iteration and folded into RUN_FINISHED below.
-    let usage:
-      | { promptTokens: number; completionTokens: number; totalTokens: number }
-      | undefined
+    let usage: TokenUsage | undefined
 
     try {
       chatOptions.logger.request(
@@ -384,11 +378,7 @@ export class BedrockConverseTextAdapter<
         if ('metadata' in ev) {
           const u = ev.metadata?.usage
           if (u) {
-            usage = {
-              promptTokens: u.inputTokens ?? 0,
-              completionTokens: u.outputTokens ?? 0,
-              totalTokens: u.totalTokens ?? 0,
-            }
+            usage = buildConverseUsage(u)
           }
           continue
         }

--- a/packages/ai-bedrock/src/converse/stream-processor.ts
+++ b/packages/ai-bedrock/src/converse/stream-processor.ts
@@ -1,5 +1,6 @@
 import { EventType } from '@tanstack/ai'
-import type { AdapterYieldChunk } from '@tanstack/ai'
+import { buildConverseUsage } from './usage'
+import type { AdapterYieldChunk, TokenUsage } from '@tanstack/ai'
 import type { ConverseStreamOutput } from '@aws-sdk/client-bedrock-runtime'
 
 /**
@@ -89,9 +90,7 @@ export async function* processConverseStream(
   // Usage + finish-reason are captured during iteration and folded into the
   // single terminal RUN_FINISHED, matching openai-base's deferred-finish
   // contract (usage may arrive after the finish signal).
-  let usage:
-    | { promptTokens: number; completionTokens: number; totalTokens: number }
-    | undefined
+  let usage: TokenUsage | undefined
   let finishReason: NonNullable<AdapterYieldChunk['finishReason']> | undefined
 
   // Lazily emit RUN_STARTED exactly once, before the first content event.
@@ -257,11 +256,7 @@ export async function* processConverseStream(
     if ('metadata' in ev) {
       const u = ev.metadata?.usage
       if (u) {
-        usage = {
-          promptTokens: u.inputTokens ?? 0,
-          completionTokens: u.outputTokens ?? 0,
-          totalTokens: u.totalTokens ?? 0,
-        }
+        usage = buildConverseUsage(u)
       }
       continue
     }

--- a/packages/ai-bedrock/src/converse/usage.ts
+++ b/packages/ai-bedrock/src/converse/usage.ts
@@ -1,0 +1,32 @@
+import { buildBaseUsage } from '@tanstack/ai'
+import type { TokenUsage } from '@tanstack/ai'
+import type { TokenUsage as ConverseTokenUsage } from '@aws-sdk/client-bedrock-runtime'
+
+/**
+ * Build normalized {@link TokenUsage} from a Converse `usage` object.
+ *
+ * `inputTokens` is the uncached part of the input only. Cache reads and writes
+ * come as separate fields and go on `promptTokensDetails`, same as the Anthropic
+ * and OpenAI builders. Zero is kept, unlike those builders. Bedrock leaves the
+ * fields out when no checkpoint applied and sends 0 when one did (a served
+ * checkpoint writes 0), so absent and zero are different results.
+ */
+export function buildConverseUsage(usage: ConverseTokenUsage): TokenUsage {
+  const result = buildBaseUsage({
+    promptTokens: usage.inputTokens ?? 0,
+    completionTokens: usage.outputTokens ?? 0,
+    totalTokens: usage.totalTokens ?? 0,
+  })
+
+  const cachedTokens = usage.cacheReadInputTokens
+  const cacheWriteTokens = usage.cacheWriteInputTokens
+  const promptTokensDetails = {
+    ...(cachedTokens !== undefined ? { cachedTokens } : {}),
+    ...(cacheWriteTokens !== undefined ? { cacheWriteTokens } : {}),
+  }
+  if (Object.keys(promptTokensDetails).length > 0) {
+    result.promptTokensDetails = promptTokensDetails
+  }
+
+  return result
+}

--- a/packages/ai-bedrock/tests/converse/adapter.test.ts
+++ b/packages/ai-bedrock/tests/converse/adapter.test.ts
@@ -170,6 +170,43 @@ describe('BedrockConverseTextAdapter', () => {
     expect(JSON.parse(res.rawText)).toEqual({ n: 5 })
   })
 
+  it('forwards cache counts from the structuredOutput usage', async () => {
+    const a = new StubAdapter({ apiKey: 'k' }, 'us.amazon.nova-pro-v1:0')
+    a.nonStreamOutput = {
+      output: {
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                toolUseId: 's',
+                name: 'structured_output',
+                input: { n: 5 },
+              },
+            },
+          ],
+        },
+      },
+      usage: {
+        inputTokens: 3,
+        outputTokens: 4,
+        totalTokens: 8416,
+        cacheReadInputTokens: 8409,
+        cacheWriteInputTokens: 0,
+      },
+    } as unknown as ConverseCommandOutput
+    const res = await a.structuredOutput({
+      chatOptions: textOptions({ messages: [{ role: 'user', content: 'go' }] }),
+      outputSchema: { type: 'object', properties: { n: { type: 'number' } } },
+    })
+    expect(res.usage).toEqual({
+      promptTokens: 3,
+      completionTokens: 4,
+      totalTokens: 8416,
+      promptTokensDetails: { cachedTokens: 8409, cacheWriteTokens: 0 },
+    })
+  })
+
   it('streams structured output through structuredOutputStream', async () => {
     const a = new StubAdapter({ apiKey: 'k' }, 'us.amazon.nova-pro-v1:0')
     a.streamEvents = [
@@ -260,6 +297,52 @@ describe('BedrockConverseTextAdapter', () => {
         }
       ).usage,
     ).toEqual({ promptTokens: 7, completionTokens: 11, totalTokens: 18 })
+  })
+
+  it('forwards cache counts from the structuredOutputStream metadata usage', async () => {
+    const a = new StubAdapter({ apiKey: 'k' }, 'us.amazon.nova-pro-v1:0')
+    a.streamEvents = [
+      { messageStart: { role: 'assistant' } },
+      {
+        contentBlockStart: {
+          start: { toolUse: { toolUseId: 's', name: 'structured_output' } },
+          contentBlockIndex: 0,
+        },
+      },
+      {
+        contentBlockDelta: {
+          delta: { toolUse: { input: '{"n":5}' } },
+          contentBlockIndex: 0,
+        },
+      },
+      { contentBlockStop: { contentBlockIndex: 0 } },
+      { messageStop: { stopReason: 'tool_use' } },
+      {
+        metadata: {
+          usage: {
+            inputTokens: 3,
+            outputTokens: 4,
+            totalTokens: 8416,
+            cacheReadInputTokens: 8409,
+            cacheWriteInputTokens: 0,
+          },
+        },
+      } as unknown as ConverseStreamOutput,
+    ]
+    const events: Array<AdapterYieldChunk> = []
+    for await (const c of a.structuredOutputStream({
+      chatOptions: textOptions({ messages: [{ role: 'user', content: 'go' }] }),
+      outputSchema: { type: 'object', properties: { n: { type: 'number' } } },
+    })) {
+      events.push(c)
+    }
+    const finished = events.find((e) => e.type === EventType.RUN_FINISHED)
+    expect((finished as { usage?: unknown }).usage).toEqual({
+      promptTokens: 3,
+      completionTokens: 4,
+      totalTokens: 8416,
+      promptTokensDetails: { cachedTokens: 8409, cacheWriteTokens: 0 },
+    })
   })
 
   it('omits usage from the structuredOutputStream RUN_FINISHED when no metadata event arrives (#1278)', async () => {

--- a/packages/ai-bedrock/tests/converse/stream-processor.test.ts
+++ b/packages/ai-bedrock/tests/converse/stream-processor.test.ts
@@ -175,6 +175,34 @@ describe('processConverseStream', () => {
     }
   })
 
+  it('forwards cache read/write counts as promptTokensDetails', async () => {
+    const events = await collect(
+      { contentBlockDelta: { delta: { text: 'hi' }, contentBlockIndex: 0 } },
+      { messageStop: { stopReason: 'end_turn' } },
+      {
+        metadata: {
+          // inputTokens is the uncached part only; the cached prefix comes as
+          // its own fields.
+          usage: {
+            inputTokens: 3,
+            outputTokens: 4,
+            totalTokens: 8416,
+            cacheReadInputTokens: 0,
+            cacheWriteInputTokens: 8409,
+          },
+        },
+      },
+    )
+    const finished = events.find((e) => e.type === EventType.RUN_FINISHED)
+    expect((finished as { usage?: unknown }).usage).toEqual({
+      promptTokens: 3,
+      completionTokens: 4,
+      totalTokens: 8416,
+      // Zero is a real value here. The checkpoint was served, not missing.
+      promptTokensDetails: { cachedTokens: 0, cacheWriteTokens: 8409 },
+    })
+  })
+
   it('drains a tool call that never received contentBlockStop (truncated stream)', async () => {
     const events = await collect(
       {


### PR DESCRIPTION
Bedrock Converse drops prompt-cache read and write counts from usage responses. Cached requests can therefore appear to use only a few input tokens. This change maps both counters to the existing `promptTokensDetails` fields.

## 🎯 Changes

- Add `buildConverseUsage()` to normalize Bedrock Converse usage.
- Use the helper in `chatStream`, `structuredOutput`, and `structuredOutputStream`.
- Preserve reported zero values. Omit `promptTokensDetails` only when Bedrock omits both cache fields.
- Document the usage shape and add a patch changeset for `@tanstack/ai-bedrock`.

The adapter cannot create `cachePoint` blocks yet. That request-side feature belongs in a separate PR.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Root cause

**Issue.** `onUsage` and `RUN_FINISHED.usage` omit the cache counters when Bedrock returns them. Callers therefore see only the uncached input count.

**Cause.** Three Converse response paths copy only `inputTokens`, `outputTokens`, and `totalTokens` from `metadata.usage`. Bedrock reports cache reads and writes as separate fields.

During prompt caching, [`inputTokens` contains only uncached input](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html). The full input count is:

```text
inputTokens + cacheReadInputTokens + cacheWriteInputTokens
```

**Fix.** `buildConverseUsage()` maps the two cache fields to `promptTokensDetails.cachedTokens` and `promptTokensDetails.cacheWriteTokens`. All three response paths now use this function.

The function preserves zero values. Bedrock can report `cacheWriteInputTokens: 0` for a cache hit, which differs from an omitted field.

## Possible alternatives

- **Use `providerUsageDetails`.** The adapter could store both fields under their Bedrock names. This would not populate AG-UI `cachedInputTokens` or the OpenTelemetry cache attributes.
- **Map each response path separately.** Each path could add the fields to its existing usage object. This would duplicate the same mapping in three places.

## Testing

**Commands run.**

- `pnpm test:pr`: passed.
- `pnpm nx run @tanstack/ai-bedrock:test:lib`: 10 test files and 95 tests passed.
- `pnpm --filter @tanstack/ai-e2e test:e2e`: not run.

The E2E suite cannot replay the Bedrock Converse binary event stream. This limitation is documented under "Bedrock Converse coverage gap" in `testing/e2e/README.md`.

**Independent repro.**

I wrote a temporary Vitest test for the three affected paths and ran it twice: once against `packages/ai-bedrock/src` extracted from `main` at `416a4e34`, once against this branch.

Command, from the repository root:

```sh
pnpm --filter @tanstack/ai-bedrock exec vitest run tests/_repro/cache-token-repro.test.ts
```

`main` at `416a4e34`:

```text
× preserves cache read and write counts on the finish event
× preserves cache counts for non-streaming structured output
× preserves cache counts for streaming structured output
AssertionError: expected { promptTokens: 3, …(2) } to match object { promptTokensDetails: { …(2) } }

Test Files  1 failed (1)
Tests       3 failed (3)
```

This branch at `7c9364a3`:

```text
Test Files  1 passed (1)
Tests       3 passed (3)
```

A real request produced these values:

```text
cache write:
{ inputTokens: 3, outputTokens: 4, totalTokens: 8416,
  cacheReadInputTokens: 0, cacheWriteInputTokens: 8409 }

cache hit:
{ inputTokens: 3, outputTokens: 4, totalTokens: 8416,
  cacheReadInputTokens: 8409, cacheWriteInputTokens: 0 }
```

**Manual test.**

This test requires AWS credentials and a Claude model that supports prompt caching.

1. On `main`, subclass `BedrockConverseTextAdapter`.
2. Append a `cachePoint` to `system` in `buildInput`.
3. Call `chat()` twice with a system prompt longer than 4,096 tokens.
4. Read `onUsage` after each call.
5. Repeat the test on this branch.

On `main`, `promptTokensDetails` is absent. On this branch, the second call includes `cachedTokens` and `cacheWriteTokens`.

**How this PR makes testing easy.**

`tests/converse/stream-processor.test.ts` covers the normal streaming path. `tests/converse/adapter.test.ts` covers both structured-output paths without AWS credentials.

## Risk / rollback

Risk is low. This change populates an existing optional field only when Bedrock returns cache counters. Request construction does not change.

Revert this PR to restore the previous behavior.

## Public API change

Callers can now read Bedrock cache usage from the existing `TokenUsage` fields.

**Before**

```ts
onUsage(_ctx, usage) {
  usage.promptTokens // 3
  usage.promptTokensDetails // undefined
}
```

**After**

```ts
onUsage(_ctx, usage) {
  usage.promptTokens // 3
  usage.promptTokensDetails
  // { cachedTokens: 8409, cacheWriteTokens: 0 }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Bedrock Converse now reports prompt-cache token usage, including cached and cache-write token counts, across chat and structured output responses.
  - Cache token fields are included when available and omitted when Bedrock does not provide them.

- **Documentation**
  - Added guidance on Bedrock token usage fields and calculating total input tokens.

- **Tests**
  - Added coverage for cache token reporting in streaming and non-streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->