### PR TITLE
feat(ai-gemini): add gemini-3.8-flash

### DIFF
--- a/.changeset/gemini-3-8-flash.md
+++ b/.changeset/gemini-3-8-flash.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/ai-gemini': minor
+---
+
+Add Gemini 3.8 Flash (`gemini-3.8-flash`) with multimodal input, thinking, structured output, caching, built-in tools, and agentic video understanding.
+
+Limit its thinking levels to low, medium, and high in both the standard and Interactions adapters.

--- a/docs/adapters/gemini.md
+++ b/docs/adapters/gemini.md
@@ -37,12 +37,16 @@ Need Gemini on Vertex AI (regional endpoints and Google Cloud credentials)? Use 
 
 ## Basic Usage
 
+Use `gemini-3.8-flash` for chat with multimodal input, thinking, and built-in tools. It also supports structured output and caching.
+
+For Gemini 3.8 Flash, set `modelOptions.thinkingConfig.thinkingLevel` to `LOW`, `MEDIUM`, or `HIGH`. The Interactions adapter uses `modelOptions.generation_config.thinking_level` with `low`, `medium`, or `high`. Gemini 3.8 Flash does not accept the `minimal` thinking level.
+
 ```typescript
 import { chat } from "@tanstack/ai";
 import { geminiText } from "@tanstack/ai-gemini";
 
 const stream = chat({
-  adapter: geminiText("gemini-3.1-pro-preview"),
+  adapter: geminiText("gemini-3.8-flash"),
   messages: [{ role: "user", content: "Hello!" }],
 });
 ```
@@ -143,7 +147,7 @@ export async function POST(request: Request) {
   const file = await uploadGeminiFile("./demo.mp4", { mimeType: "video/mp4" });
 
   const stream = chat({
-    adapter: geminiText("gemini-3.7-flash"),
+    adapter: geminiText("gemini-3.8-flash"),
     messages: [
       {
         role: "user",
@@ -168,7 +172,12 @@ geminiVideoPart(file, { fps: 0.5, startOffset: "30s", endOffset: "90s" });
 
 ### Agentic understanding
 
-Single-pass sampling can miss detail in long or fast-moving videos. Set `processing: "agentic"` to let the model drive: it navigates the timeline and pulls frames, transcripts, and audio on demand. This is GA on `gemini-3.7-flash`, `gemini-3.6-flash`, and `gemini-3.5-flash-lite`.
+Single-pass sampling can miss detail in long or fast-moving videos. Set `processing: "agentic"` to let the model drive: it navigates the timeline and pulls frames, transcripts, and audio on demand. Supported models:
+
+- `gemini-3.8-flash`
+- `gemini-3.7-flash`
+- `gemini-3.6-flash`
+- `gemini-3.5-flash-lite`
 
 ```typescript ignore
 geminiVideoPart(file, { processing: "agentic" });

--- a/docs/config.json
+++ b/docs/config.json
@@ -947,7 +947,7 @@
           "label": "Google Gemini",
           "to": "adapters/gemini",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-09-01"
+          "updatedAt": "2026-09-02"
         },
         {
           "label": "Google Vertex AI",

--- a/examples/ts-react-chat/src/lib/model-selection.ts
+++ b/examples/ts-react-chat/src/lib/model-selection.ts
@@ -67,6 +67,11 @@ export const MODEL_OPTIONS: Array<ModelOption> = [
   // Gemini (stateless `geminiText`)
   {
     provider: 'gemini',
+    model: 'gemini-3.8-flash',
+    label: 'Gemini - 3.8 Flash',
+  },
+  {
+    provider: 'gemini',
     model: 'gemini-3.7-flash',
     label: 'Gemini - 3.7 Flash',
   },
@@ -107,6 +112,11 @@ export const MODEL_OPTIONS: Array<ModelOption> = [
   },
 
   // Gemini Interactions (stateful, experimental — `@tanstack/ai-gemini/experimental`)
+  {
+    provider: 'gemini-interactions',
+    model: 'gemini-3.8-flash',
+    label: 'Gemini Interactions - 3.8 Flash (experimental)',
+  },
   {
     provider: 'gemini-interactions',
     model: 'gemini-3.7-flash',

--- a/examples/ts-react-chat/src/routes/api.structured-output.ts
+++ b/examples/ts-react-chat/src/routes/api.structured-output.ts
@@ -164,10 +164,8 @@ function adapterFor(provider: Provider, model?: string): AnyTextAdapter {
       // for the combination and falls back to the engine's legacy
       // finalization path.
       //
-      // Default is `gemini-3.7-flash`: the newest *stable* (non-preview)
-      // 3.x id, matching the dropdown's first entry. The previous default
-      // (`gemini-3-pro-preview`) was retired by Google and now 404s.
-      return geminiText((baseModel || 'gemini-3.7-flash') as 'gemini-3.7-flash')
+      // Keep the default aligned with the dropdown's first entry.
+      return geminiText((baseModel || 'gemini-3.8-flash') as 'gemini-3.8-flash')
     case 'grok':
       return grokText((model || 'grok-build-0.1') as 'grok-build-0.1')
     case 'groq':

--- a/examples/ts-react-chat/src/routes/generations.structured-output.tsx
+++ b/examples/ts-react-chat/src/routes/generations.structured-output.tsx
@@ -80,6 +80,7 @@ const PROVIDER_MODELS: Record<
   // keys on the exact string, so any drift here silently breaks
   // combined-mode routing.
   gemini: [
+    { value: 'gemini-3.8-flash', label: 'Gemini 3.8 Flash' },
     { value: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash' },
     { value: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash' },
     { value: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },

--- a/packages/ai-gemini/src/experimental/text-interactions/adapter.ts
+++ b/packages/ai-gemini/src/experimental/text-interactions/adapter.ts
@@ -13,6 +13,7 @@ import {
 import { assertUniqueToolNames } from '@tanstack/ai/adapter-internals'
 import type { InternalLogger } from '@tanstack/ai/adapter-internals'
 import type {
+  GeminiChatModelProviderOptionsByName,
   GeminiChatModelToolCapabilitiesByName,
   GeminiModelInputModalitiesByName,
   GeminiModels,
@@ -104,15 +105,31 @@ type ToolCallState = {
 // ===========================
 
 /**
- * Resolve provider options for a specific model. The Interactions API's
- * request shape is the same across all chat-capable Gemini models — the
- * SDK doesn't expose a per-model param union — so this currently falls
- * through to the flat `GeminiTextInteractionsProviderOptions` for every
- * model. The alias exists for parity with `GeminiTextAdapter`, so a
- * per-model map can be slotted in later without changing the adapter
- * signature.
+ * Resolve provider options for a specific model. Reuses the chat-model
+ * options map from `model-meta.ts` so a model's allowed thinking levels are
+ * declared once: the Interactions API takes the same levels as
+ * `generateContent` but lowercased (`low`, not `LOW`). Models whose chat
+ * options carry no `thinkingConfig` resolve to `never`, so `thinking_level`
+ * can't be set on them. Everything else falls through to the flat SDK shape.
  */
-type ResolveProviderOptions = GeminiTextInteractionsProviderOptions
+type InteractionsThinkingLevel<TModel> =
+  TModel extends keyof GeminiChatModelProviderOptionsByName
+    ? GeminiChatModelProviderOptionsByName[TModel] extends {
+        thinkingConfig?: { thinkingLevel?: infer L extends string }
+      }
+      ? Lowercase<L>
+      : never
+    : never
+
+type ResolveProviderOptions<TModel extends GeminiModels> = Omit<
+  GeminiTextInteractionsProviderOptions,
+  'generation_config'
+> & {
+  generation_config?: Omit<
+    NonNullable<GeminiTextInteractionsProviderOptions['generation_config']>,
+    'thinking_level'
+  > & { thinking_level?: InteractionsThinkingLevel<TModel> }
+}
 
 /**
  * Resolve input modalities for a specific model. Reuses the chat-model
@@ -169,7 +186,7 @@ type ResolveToolCapabilities<TModel extends string> =
  */
 export class GeminiTextInteractionsAdapter<
   TModel extends GeminiModels,
-  TProviderOptions extends Record<string, any> = ResolveProviderOptions,
+  TProviderOptions extends Record<string, any> = ResolveProviderOptions<TModel>,
   TInputModalities extends ReadonlyArray<Modality> =
     ResolveInputModalities<TModel>,
   TToolCapabilities extends ReadonlyArray<string> =
@@ -455,7 +472,7 @@ export function createGeminiTextInteractions<TModel extends GeminiModels>(
   config?: Omit<GeminiTextInteractionsConfig, 'apiKey'>,
 ): GeminiTextInteractionsAdapter<
   TModel,
-  ResolveProviderOptions,
+  ResolveProviderOptions<TModel>,
   ResolveInputModalities<TModel>,
   ResolveToolCapabilities<TModel>
 > {
@@ -468,7 +485,7 @@ export function geminiTextInteractions<TModel extends GeminiModels>(
   config?: Omit<GeminiTextInteractionsConfig, 'apiKey'>,
 ): GeminiTextInteractionsAdapter<
   TModel,
-  ResolveProviderOptions,
+  ResolveProviderOptions<TModel>,
   ResolveInputModalities<TModel>,
   ResolveToolCapabilities<TModel>
 > {

--- a/packages/ai-gemini/src/message-types.ts
+++ b/packages/ai-gemini/src/message-types.ts
@@ -92,7 +92,7 @@ export interface GeminiAudioMetadata {
  *
  * - `static` (default): single-pass frame sampling via `generateContent`.
  * - `agentic`: multi-pass "agentic" video understanding, GA on the
- *   `agentic_video`-capable flash models (`gemini-3.7-flash`,
+ *   `agentic_video`-capable flash models (`gemini-3.8-flash`, `gemini-3.7-flash`,
  *   `gemini-3.6-flash`, `gemini-3.5-flash-lite`). The text adapter routes the
  *   request through the Interactions API instead of `generateContent`. With
  *   `agentic`, the sampling rate is expressed in the text prompt (e.g. "watch

--- a/packages/ai-gemini/src/model-meta.ts
+++ b/packages/ai-gemini/src/model-meta.ts
@@ -871,6 +871,49 @@ const GEMINI_OMNI_FLASH_PREVIEW = {
     GeminiCachedContentOptions
 >
 
+const GEMINI_3_8_FLASH = {
+  name: 'gemini-3.8-flash',
+  max_input_tokens: 1_048_576,
+  max_output_tokens: 65_536,
+  knowledge_cutoff: '2026-03-01',
+  supports: {
+    input: ['text', 'image', 'video', 'audio', 'document'],
+    output: ['text'],
+    capabilities: [
+      'agentic_video',
+      'batch_api',
+      'caching',
+      'function_calling',
+      'structured_output',
+      'thinking',
+    ],
+    tools: [
+      'code_execution',
+      'file_search',
+      'google_search',
+      'google_maps',
+      'url_context',
+      'computer_use',
+    ],
+  },
+  pricing: {
+    input: {
+      normal: 0.75,
+      cached: 0.075,
+    },
+    output: {
+      normal: 3.75,
+    },
+  },
+} as const satisfies ModelMeta<
+  GeminiToolConfigOptions &
+    GeminiSafetyOptions &
+    GeminiCommonConfigOptions &
+    GeminiCachedContentOptions &
+    GeminiStructuredOutputOptions &
+    GeminiThinkingOptions<'LOW' | 'MEDIUM' | 'HIGH'>
+>
+
 const GEMINI_3_7_FLASH = {
   name: 'gemini-3.7-flash',
   max_input_tokens: 1_048_576,
@@ -1043,6 +1086,7 @@ const GEMINI_3_5_FLASH_LITE = {
 >
 
 export const GEMINI_MODELS = [
+  GEMINI_3_8_FLASH.name,
   GEMINI_3_7_FLASH.name,
   GEMINI_3_6_FLASH.name,
   GEMINI_3_5_FLASH.name,
@@ -1064,6 +1108,7 @@ export const GEMINI_MODELS = [
  * brittle and keeps the engine's legacy finalization fallback.
  */
 export const GEMINI_COMBINED_TOOLS_AND_SCHEMA_MODELS = new Set<string>([
+  GEMINI_3_8_FLASH.name,
   GEMINI_3_7_FLASH.name,
   GEMINI_3_6_FLASH.name,
   GEMINI_3_5_FLASH.name,
@@ -1221,6 +1266,12 @@ export type GeminiEmbeddingModelInputModalitiesByName = {
 // Manual type map for per-model provider options
 export type GeminiChatModelProviderOptionsByName = {
   // Models with thinking and structured output support
+  [GEMINI_3_8_FLASH.name]: GeminiToolConfigOptions &
+    GeminiSafetyOptions &
+    GeminiCommonConfigOptions &
+    GeminiCachedContentOptions &
+    GeminiStructuredOutputOptions &
+    GeminiThinkingOptions<'LOW' | 'MEDIUM' | 'HIGH'>
   [GEMINI_3_7_FLASH.name]: GeminiToolConfigOptions &
     GeminiSafetyOptions &
     GeminiCommonConfigOptions &
@@ -1294,6 +1345,7 @@ export type GeminiChatModelProviderOptionsByName = {
  * Based on the 'supports.tools' arrays defined for each model.
  */
 export type GeminiChatModelToolCapabilitiesByName = {
+  [GEMINI_3_8_FLASH.name]: typeof GEMINI_3_8_FLASH.supports.tools
   [GEMINI_3_7_FLASH.name]: typeof GEMINI_3_7_FLASH.supports.tools
   [GEMINI_3_6_FLASH.name]: typeof GEMINI_3_6_FLASH.supports.tools
   [GEMINI_3_5_FLASH.name]: typeof GEMINI_3_5_FLASH.supports.tools
@@ -1322,6 +1374,7 @@ export type GeminiChatModelToolCapabilitiesByName = {
  */
 export type GeminiModelInputModalitiesByName = {
   // Models with full multimodal support (text, image, audio, video, document)
+  [GEMINI_3_8_FLASH.name]: typeof GEMINI_3_8_FLASH.supports.input
   [GEMINI_3_7_FLASH.name]: typeof GEMINI_3_7_FLASH.supports.input
   [GEMINI_3_6_FLASH.name]: typeof GEMINI_3_6_FLASH.supports.input
   [GEMINI_3_5_FLASH.name]: typeof GEMINI_3_5_FLASH.supports.input

--- a/packages/ai-gemini/src/text/text-provider-options.ts
+++ b/packages/ai-gemini/src/text/text-provider-options.ts
@@ -222,7 +222,10 @@ Cyclic references are unrolled to a limited degree and, as such, may only be use
   responseJsonSchema?: Schema
 }
 
-export interface GeminiThinkingOptions {
+export interface GeminiThinkingOptions<
+  TThinkingLevel extends keyof typeof ThinkingLevel =
+    keyof typeof ThinkingLevel,
+> {
   /**
    * Config for thinking features. An error will be returned if this field is
    * set for models that don't support thinking.
@@ -248,7 +251,7 @@ export interface GeminiThinkingOptions {
      * The level of thoughts tokens that the model should generate
      * (Gemini 3.x and later).
      */
-    thinkingLevel?: keyof typeof ThinkingLevel
+    thinkingLevel?: TThinkingLevel
   }
 }
 

--- a/packages/ai-gemini/tests/agentic-video.test.ts
+++ b/packages/ai-gemini/tests/agentic-video.test.ts
@@ -47,55 +47,58 @@ const videoMessage = (metadata?: Record<string, unknown>): ModelMessage => ({
   ],
 })
 
-describe('Gemini agentic video routing', () => {
-  beforeEach(() => vi.clearAllMocks())
+describe.each(['gemini-3.8-flash', 'gemini-3.7-flash'] as const)(
+  '%s agentic video routing',
+  (model) => {
+    beforeEach(() => vi.clearAllMocks())
 
-  it('routes processing:"agentic" video parts through the Interactions API', async () => {
-    mocks.interactionsCreateSpy.mockResolvedValue({
-      output_text: 'A guitar is played in a store.',
+    it('routes processing:"agentic" video parts through the Interactions API', async () => {
+      mocks.interactionsCreateSpy.mockResolvedValue({
+        output_text: 'A guitar is played in a store.',
+      })
+
+      const adapter = new GeminiTextAdapter({ apiKey: 'k' }, model)
+      const chunks = await collect(
+        chat({
+          adapter,
+          messages: [videoMessage({ processing: 'agentic' })],
+        }),
+      )
+
+      expect(mocks.interactionsCreateSpy).toHaveBeenCalledTimes(1)
+      expect(mocks.generateContentStreamSpy).not.toHaveBeenCalled()
+
+      const payload = mocks.interactionsCreateSpy.mock.calls[0]![0]
+      expect(payload.model).toBe(model)
+      const videoBlock = payload.input[0].content.find(
+        (c: { type: string }) => c.type === 'video',
+      )
+      expect(videoBlock.processing).toBe('agentic')
+
+      const text = chunks
+        .filter((c) => c.type === 'TEXT_MESSAGE_CONTENT')
+        .map((c) => (c as { delta: string }).delta)
+        .join('')
+      expect(text).toBe('A guitar is played in a store.')
     })
 
-    const adapter = new GeminiTextAdapter({ apiKey: 'k' }, 'gemini-3.7-flash')
-    const chunks = await collect(
-      chat({
-        adapter,
-        messages: [videoMessage({ processing: 'agentic' })],
-      }),
-    )
+    it('routes single-pass video parts through generateContentStream', async () => {
+      mocks.generateContentStreamSpy.mockResolvedValue(
+        createStream([
+          {
+            candidates: [
+              { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+            ],
+            usageMetadata: { totalTokenCount: 1 },
+          },
+        ]),
+      )
 
-    expect(mocks.interactionsCreateSpy).toHaveBeenCalledTimes(1)
-    expect(mocks.generateContentStreamSpy).not.toHaveBeenCalled()
+      const adapter = new GeminiTextAdapter({ apiKey: 'k' }, model)
+      await collect(chat({ adapter, messages: [videoMessage()] }))
 
-    const payload = mocks.interactionsCreateSpy.mock.calls[0]![0]
-    expect(payload.model).toBe('gemini-3.7-flash')
-    const videoBlock = payload.input[0].content.find(
-      (c: { type: string }) => c.type === 'video',
-    )
-    expect(videoBlock.processing).toBe('agentic')
-
-    const text = chunks
-      .filter((c) => c.type === 'TEXT_MESSAGE_CONTENT')
-      .map((c) => (c as { delta: string }).delta)
-      .join('')
-    expect(text).toBe('A guitar is played in a store.')
-  })
-
-  it('routes single-pass video parts through generateContentStream', async () => {
-    mocks.generateContentStreamSpy.mockResolvedValue(
-      createStream([
-        {
-          candidates: [
-            { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
-          ],
-          usageMetadata: { totalTokenCount: 1 },
-        },
-      ]),
-    )
-
-    const adapter = new GeminiTextAdapter({ apiKey: 'k' }, 'gemini-3.7-flash')
-    await collect(chat({ adapter, messages: [videoMessage()] }))
-
-    expect(mocks.generateContentStreamSpy).toHaveBeenCalledTimes(1)
-    expect(mocks.interactionsCreateSpy).not.toHaveBeenCalled()
-  })
-})
+      expect(mocks.generateContentStreamSpy).toHaveBeenCalledTimes(1)
+      expect(mocks.interactionsCreateSpy).not.toHaveBeenCalled()
+    })
+  },
+)

--- a/packages/ai-gemini/tests/model-meta.test.ts
+++ b/packages/ai-gemini/tests/model-meta.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, expectTypeOf } from 'vitest'
-import { GEMINI_TTS_MODELS } from '../src/model-meta'
+import { GEMINI_MODELS, GEMINI_TTS_MODELS } from '../src/model-meta'
+import { createGeminiChat } from '../src'
+import { createGeminiTextInteractions } from '../src/experimental'
 import type {
   GeminiChatModelProviderOptionsByName,
   GeminiModelInputModalitiesByName,
@@ -13,6 +15,7 @@ import type {
   GeminiCachedContentOptions,
 } from '../src/text/text-provider-options'
 import type { GeminiMessageMetadataByModality } from '../src/message-types'
+import type { InferTextProviderOptions } from '@tanstack/ai/adapters'
 import type {
   AudioPart,
   ConstrainedModelMessage,
@@ -51,6 +54,38 @@ type BaseOptions = GeminiToolConfigOptions &
   GeminiCachedContentOptions
 
 describe('Gemini Model Provider Options Type Assertions', () => {
+  it('registers gemini-3.8-flash with thinking, structured output, and multimodal input', () => {
+    const adapter = createGeminiChat('gemini-3.8-flash', 'test-key')
+    expect(GEMINI_MODELS).toContain('gemini-3.8-flash')
+    expect(adapter.supportsCombinedToolsAndSchema()).toBe(true)
+    expectTypeOf<
+      GeminiChatModelProviderOptionsByName['gemini-3.8-flash']
+    >().toEqualTypeOf<
+      BaseOptions &
+        GeminiThinkingOptions<'LOW' | 'MEDIUM' | 'HIGH'> &
+        GeminiStructuredOutputOptions
+    >()
+    expectTypeOf<
+      GeminiModelInputModalitiesByName['gemini-3.8-flash'][number]
+    >().toEqualTypeOf<'text' | 'image' | 'video' | 'audio' | 'document'>()
+  })
+
+  it('restricts gemini-3.8-flash thinking levels in both adapters', () => {
+    const adapter = createGeminiChat('gemini-3.8-flash', 'test-key')
+    const interactions = createGeminiTextInteractions(
+      'gemini-3.8-flash',
+      'test-key',
+    )
+    type Options = InferTextProviderOptions<typeof adapter>
+    type InteractionsOptions = InferTextProviderOptions<typeof interactions>
+    expectTypeOf<
+      NonNullable<Options['thinkingConfig']>['thinkingLevel']
+    >().toEqualTypeOf<'LOW' | 'MEDIUM' | 'HIGH' | undefined>()
+    expectTypeOf<
+      NonNullable<InteractionsOptions['generation_config']>['thinking_level']
+    >().toEqualTypeOf<'low' | 'medium' | 'high' | undefined>()
+  })
+
   describe('Models WITH thinking support', () => {
     it('gemini-3.1-pro-preview should support thinking options', () => {
       type Model = 'gemini-3.1-pro-preview'

--- a/packages/ai-gemini/tests/text-interactions-adapter.test.ts
+++ b/packages/ai-gemini/tests/text-interactions-adapter.test.ts
@@ -204,9 +204,9 @@ describe('GeminiTextInteractionsAdapter', () => {
     )
 
     const adapter = createAdapter()
-    const providerOptions: GeminiTextInteractionsProviderOptions = {
+    const providerOptions = {
       previous_interaction_id: 'int_1',
-    }
+    } satisfies GeminiTextInteractionsProviderOptions
 
     await collectChunks(
       chat({
@@ -252,13 +252,13 @@ describe('GeminiTextInteractionsAdapter', () => {
     )
 
     const adapter = createAdapter()
-    const providerOptions: GeminiTextInteractionsProviderOptions = {
+    const providerOptions = {
       generation_config: {
         temperature: 0.6,
         top_p: 0.95,
         max_output_tokens: 512,
       },
-    }
+    } satisfies GeminiTextInteractionsProviderOptions
 
     await collectChunks(
       chat({
@@ -319,7 +319,7 @@ describe('GeminiTextInteractionsAdapter', () => {
         ],
         modelOptions: {
           previous_interaction_id: 'int_prev',
-        } as GeminiTextInteractionsProviderOptions,
+        } satisfies GeminiTextInteractionsProviderOptions,
       }),
     )
 
@@ -751,7 +751,7 @@ describe('GeminiTextInteractionsAdapter', () => {
         // the function_result.
         modelOptions: {
           previous_interaction_id: 'int_prev',
-        } as GeminiTextInteractionsProviderOptions,
+        } satisfies GeminiTextInteractionsProviderOptions,
       }),
     )
 

--- a/packages/ai-gemini/tests/tools-per-model-type-safety.test.ts
+++ b/packages/ai-gemini/tests/tools-per-model-type-safety.test.ts
@@ -42,6 +42,24 @@ const userTool = toolDefinition({
 }).server(async ({ msg }) => msg)
 
 describe('Gemini per-model tool gating', () => {
+  it('gemini-3.8-flash accepts the Gemini 3.7 Flash tool set', () => {
+    const adapter = geminiText('gemini-3.8-flash')
+    typedTools(adapter, [
+      userTool,
+      codeExecutionTool(),
+      fileSearchTool({ fileSearchStoreNames: [] }),
+      googleSearchTool(),
+      googleMapsTool(),
+      urlContextTool(),
+      computerUseTool({
+        environment: Environment.ENVIRONMENT_BROWSER,
+        excludedPredefinedFunctions: [],
+      }),
+      // @ts-expect-error - gemini-3.8-flash does not support google_search_retrieval
+      googleSearchRetrievalTool(),
+    ])
+  })
+
   it('gemini-3.1-pro-preview accepts code_execution, file_search, google_search, url_context', () => {
     const adapter = geminiText('gemini-3.1-pro-preview')
     const fileSearchConfig: Parameters<typeof fileSearchTool>[0] = {

--- a/testing/e2e/fixtures/chat/gemini-3-8-flash.json
+++ b/testing/e2e/fixtures/chat/gemini-3-8-flash.json
@@ -1,0 +1,13 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "model": "gemini-3.8-flash",
+        "userMessage": "[gemini-3.8-flash] recommend a guitar"
+      },
+      "response": {
+        "content": "I'd recommend the Fender Stratocaster."
+      }
+    }
+  ]
+}

--- a/testing/e2e/tests/gemini-3-8-flash.spec.ts
+++ b/testing/e2e/tests/gemini-3-8-flash.spec.ts
@@ -1,0 +1,54 @@
+import { chat } from '@tanstack/ai'
+import { createGeminiChat } from '@tanstack/ai-gemini'
+import { createGeminiTextInteractions } from '@tanstack/ai-gemini/experimental'
+import { vertexText } from '@tanstack/ai-vertex'
+import { vertexE2eConfig } from '../src/lib/vertex-e2e'
+import { test, expect } from './fixtures'
+
+const model = 'gemini-3.8-flash'
+
+const adapters = [
+  {
+    name: 'Gemini',
+    create: (baseUrl: string, headers: Record<string, string>) =>
+      createGeminiChat(model, 'e2e-dummy', {
+        httpOptions: { baseUrl, headers },
+      }),
+  },
+  {
+    name: 'Gemini Interactions',
+    create: (baseUrl: string, headers: Record<string, string>) =>
+      createGeminiTextInteractions(model, 'e2e-dummy', {
+        httpOptions: { baseUrl, headers },
+      }),
+  },
+  {
+    name: 'Vertex',
+    create: (baseUrl: string, headers: Record<string, string>) =>
+      vertexText(model, vertexE2eConfig(baseUrl, headers)),
+  },
+]
+
+for (const { name, create } of adapters) {
+  test(`${name} streams with gemini-3.8-flash on the wire`, async ({
+    aimockPort,
+    testId,
+  }) => {
+    const baseUrl = `http://127.0.0.1:${aimockPort}`
+    const adapter = create(baseUrl, { 'X-Test-Id': testId })
+    let text = ''
+    let finished = false
+    for await (const chunk of chat({
+      adapter,
+      messages: [
+        { role: 'user', content: '[gemini-3.8-flash] recommend a guitar' },
+      ],
+    })) {
+      expect(chunk.type).not.toBe('RUN_ERROR')
+      if (chunk.type === 'TEXT_MESSAGE_CONTENT') text += chunk.delta
+      if (chunk.type === 'RUN_FINISHED') finished = true
+    }
+    expect(text).toContain('Fender Stratocaster')
+    expect(finished).toBe(true)
+  })
+}


### PR DESCRIPTION
## 🎯 Changes

Adds `gemini-3.8-flash` to the Gemini adapter’s model metadata and type maps, with multimodal input, built-in tools, thinking, structured output, caching, and agentic video support.

Thinking levels are limited to low, medium, and high. The Interactions adapter derives its thinking levels from the shared chat-model metadata.

The React chat examples now list 3.8 Flash and use it as the default Gemini model for structured output. Includes updated docs and a minor changeset.

Pricing uses the current promotional rates: $0.75 input, $0.075 cached input, and $3.75 output per million tokens, through December 31, 2026.

Sources: [model card](https://deepmind.google/models/model-cards/gemini-3-8-flash/), [API documentation](https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash), and [pricing](https://ai.google.dev/gemini-api/docs/pricing#gemini-3.8-flash).

Validation: `pnpm run test:pr` and all three focused Gemini 3.8 E2E tests pass. The full E2E run had one failure in the Bedrock multi-turn structured-output test.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Gemini 3.8 Flash model.
  * Supports multimodal inputs, structured output, caching, built-in tools, computer use, and agentic video understanding.
  * Added Gemini 3.8 Flash to model selection and structured-output examples.
  * Added configurable thinking levels: low, medium, and high.
* **Documentation**
  * Updated Gemini usage and video-understanding examples to use Gemini 3.8 Flash.
  * Added guidance for thinking-level configuration and supported video models.
* **Tests**
  * Added coverage for streaming, model capabilities, tool support, and agentic video routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->