### PR TITLE
fix(ai): preserve required runtime context in createChatOptions return type

### DIFF
--- a/.changeset/create-chat-options-context.md
+++ b/.changeset/create-chat-options-context.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai': patch
+---
+
+fix: `createChatOptions` now preserves the runtime-context requirement on its return type. When tools or middleware declare a required context, the input already enforces `context` via `RuntimeContextOption`, but the return type declared it optional — so spreading the result into `chat()` failed to typecheck (`Type 'undefined' is not assignable to type '...'`). The return type now applies the same `RuntimeContextOption` conditional as the parameter, so the documented spread pattern compiles with context-typed tools. Type-level only; runtime is unchanged.

--- a/packages/ai/src/activities/chat/index.ts
+++ b/packages/ai/src/activities/chat/index.ts
@@ -623,12 +623,12 @@ export function createChatOptions<
     TStream,
     InferredContext<TTools, TMiddleware>
   >,
-  'tools' | 'middleware' | 'interrupts'
+  'tools' | 'middleware' | 'interrupts' | 'context'
 > & {
   tools?: TTools
   interrupts?: TInterrupts
   middleware?: ExactMiddlewareOption<TTools, TContext, TInterrupts, TMiddleware>
-} {
+} & RuntimeContextOption<TTools, TMiddleware, TContext> {
   return options
 }
 

--- a/packages/ai/tests/type-check.test.ts
+++ b/packages/ai/tests/type-check.test.ts
@@ -224,9 +224,15 @@ describe('TextActivityOptions type checking', () => {
       context: { userId: 'u-1', tenantId: 't-1' },
     })
 
-    expectTypeOf<NonNullable<typeof options.context>>().toEqualTypeOf<
-      ToolContext & MiddlewareContext
-    >()
+    // The returned `context` is required (not `... | undefined`): createChatOptions
+    // required it on input, so it must preserve that on output. If it were optional,
+    // this fails — `ToolContext & MiddlewareContext | undefined` does not extend the
+    // non-optional target.
+    expectTypeOf(options.context).toExtend<ToolContext & MiddlewareContext>()
+
+    // The regression this guards: the documented pattern of spreading the pre-built
+    // options into chat(), which requires a defined context for these typed consumers.
+    chat({ ...options, messages: [{ role: 'user', content: 'Hello' }] })
 
     createChatOptions({
       adapter: mockAdapter,


### PR DESCRIPTION
## 🎯 Changes

`createChatOptions` requires you to pass `context` when a tool or middleware declares one, but its return type marks `context` optional — so you can't spread the result back into `chat()`, which is the whole point of the helper.

```ts
const tool = toolDefinition({
  name: 'whoami',
  description: 'reads context',
  inputSchema: z.object({}),
}).server<{ userId: string }>((_input, ctx) => ctx.context.userId)

const options = createChatOptions({
  adapter: openaiText('gpt-5.5'),
  tools: [tool],
  context: { userId: 'u1' }, // ✅ required here
})

// ❌ Type 'undefined' is not assignable to type '{ userId: string }'
chat({ ...options, messages: [] })
```

The parameter type enforces the requirement via `RuntimeContextOption`, but the return type falls back to `context?: TContext`, so the spread carries `context?: { userId: string }` into `chat()` — which needs it defined for this tool.

The fix applies that same `RuntimeContextOption<TTools, TMiddleware, TContext>` conditional to the return type of `createChatOptions` (`packages/ai/src/activities/chat/index.ts`). Two lines; the implementation is still `return options`, so it's type-level only:

- tools/middleware require a context → returned `context` is required (was optional — the bug)
- context-free tools → `context` stays optional (unchanged)

It went unnoticed because the one test that exercised a context-typed tool (`packages/ai/tests/type-check.test.ts`) asserted the result through `NonNullable<typeof options.context>`, which papered over the optionality; every other call site (docs, `testing/`) is context-free and spreads fine on the optional branch.

I updated that test to check the returned `context` directly (dropping the `NonNullable`) and to spread into `chat()`. Without the fix, that spread fails with the error above.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed TypeScript errors when passing options created by `createChatOptions` into `chat()`.
  - Context is now correctly marked as required when configured tools or middleware need it.
  - Context types are now preserved and combined accurately for typed consumers.

- **Tests**
  - Added coverage for spreading pre-built chat options into `chat()` with context-dependent tools and middleware.

- **Release**
  - Patch-level update; runtime behavior is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->