### PR TITLE
feat: add Groq, Mistral, BytePlus, and ElevenLabs models from modelschemas

### DIFF
--- a/.changeset/sync-models.md
+++ b/.changeset/sync-models.md
@@ -1,0 +1,8 @@
+---
+'@tanstack/ai-byteplus': patch
+'@tanstack/ai-elevenlabs': patch
+'@tanstack/ai-groq': patch
+'@tanstack/ai-mistral': patch
+---
+
+Update model metadata from modelschemas

--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Fetch and sync model metadata
         run: pnpm generate:models
+        env:
+          MODELSCHEMAS_API_KEY: ${{ secrets.MODELSCHEMAS_API_KEY }}
 
       - name: Check for package changes
         id: changes
@@ -64,13 +66,13 @@ jobs:
 
           if [ -z "$EXISTING_PR" ] || [ "$EXISTING_PR" = "null" ]; then
             BODY=$(cat <<'PRBODY'
-          Automated daily sync of model metadata from OpenRouter and Vercel AI Gateway.
+          Automated daily sync of model metadata from modelschemas, OpenRouter, and Vercel AI Gateway.
 
           - Fetches the latest model list from OpenRouter (chat + `GET /api/v1/videos/models`)
           - Fetches the latest model list from Vercel AI Gateway
           - Fetches the latest model list from Lovable AI Gateway
           - Converts to the internal adapter format
-          - Syncs provider-specific model metadata for affected packages
+          - Inserts new native-provider models from modelschemas (`@modelschemas/client`)
           - Creates a patch changeset for all changed packages
           PRBODY
           )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ For deeper architecture details (adapter system, isomorphic tools, framework int
 
 1. Fetches OpenRouter, Vercel AI Gateway, and Lovable AI Gateway catalogs (OpenRouter adapter + gateway packages).
 2. Regenerates `packages/ai-openrouter/src/model-meta.ts` and the Vercel Gateway model list.
-3. Inserts **new** native-provider models into `packages/ai-openai`, `ai-anthropic`, `ai-gemini`, and `ai-grok` from [modelschemas](https://modelschemas.com) (`@modelschemas/client`). Native ids and activities come from each provider catalog. Pricing, modalities, and `supported_parameters` come from the modelschemas OpenRouter catalog when that row exists.
+3. Inserts **new** native-provider models from [modelschemas](https://modelschemas.com) (`@modelschemas/client`) into `ai-openai`, `ai-anthropic`, `ai-gemini`, `ai-grok`, `ai-groq`, `ai-mistral`, `ai-byteplus`, and `ai-elevenlabs`. Native ids and activities come from each provider catalog. For OpenAI, Anthropic, Gemini, and Grok, pricing and `supported_parameters` come from the modelschemas OpenRouter catalog when that row exists. BytePlus and ElevenLabs use the native catalog as-is.
 4. Writes a patch changeset for the packages that changed.
 
 Reads against modelschemas work without a key (60 req/h per IP). Set `MODELSCHEMAS_API_KEY` on the workflow when you want the higher limit.
@@ -63,7 +63,8 @@ Rules the generator follows:
 
 - Keep OpenRouter routing aliases (ids that start with `~`) in the OpenRouter catalog. Users can pass `chat({ model: '~anthropic/claude-haiku-latest' })`. The generated constant name maps `~` to `_`.
 - Do **not** copy those aliases into native provider files (`ai-openai`, `ai-anthropic`, `ai-gemini`, `ai-grok`). Those adapters only accept the provider's own ids.
-- For a new native-provider model, write id, modalities, and pricing. Infer features from catalog `supported_parameters` when that field exists. Do **not** copy another model's tool list (`computer_use`, `google_search`, `x_search`, and similar). Skip a native id until the modelschemas OpenRouter catalog has a matching row (native catalogs often omit pricing and modalities).
+- For a new native-provider model, write id, modalities, and pricing. Infer features from catalog `supported_parameters` when that field exists. Do **not** copy another model's tool list (`computer_use`, `google_search`, `x_search`, and similar). OpenAI, Anthropic, Gemini, and Grok skip a native id until the modelschemas OpenRouter catalog has a matching row. BytePlus, ElevenLabs, Groq, and Mistral insert from the native catalog even when OpenRouter has no row.
+- ElevenLabs is id-literal arrays (`ELEVENLABS_TTS_MODELS` and friends), not ModelMeta constants. Voice-conversion (`*_sts_*`) ids are skipped. BytePlus video and image duration/size tables stay hand-curated.
 - Anthropic first-party ids use dashes (`claude-fable-5-1`). OpenRouter uses dots (`claude-fable-5.1`). The generator takes the modelschemas native id (already hyphenated) and does not copy the dotted OpenRouter slug into `ai-anthropic`. Dated Anthropic snapshots (`claude-haiku-4-5-20251001`) are skipped; the undated alias is the public id.
 - Write a row in the provider's `*ChatModelToolCapabilitiesByName` map for every new chat model, even when `supports.tools` is still `[]`. Missing that row makes `ResolveToolCapabilities` fall back to `readonly []`.
 - For new Anthropic models, infer the provider-options mix from the catalog: no sampling parameters → `AnthropicMaxTokensOptions`; reasoning params without sampling → adaptive-or-disabled thinking.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,19 +52,21 @@ For deeper architecture details (adapter system, isomorphic tools, framework int
 
 `pnpm generate:models` is the maintainer command behind the daily **Sync Model Metadata** workflow (branch `automated/sync-models`). It:
 
-1. Fetches OpenRouter, Vercel AI Gateway, and Lovable AI Gateway catalogs.
+1. Fetches OpenRouter, Vercel AI Gateway, and Lovable AI Gateway catalogs (OpenRouter adapter + gateway packages).
 2. Regenerates `packages/ai-openrouter/src/model-meta.ts` and the Vercel Gateway model list.
-3. Inserts **new** native-provider models into `packages/ai-openai`, `ai-anthropic`, `ai-gemini`, and `ai-grok`.
+3. Inserts **new** native-provider models into `packages/ai-openai`, `ai-anthropic`, `ai-gemini`, and `ai-grok` from [modelschemas](https://modelschemas.com) (`@modelschemas/client`). Native ids and activities come from each provider catalog. Pricing, modalities, and `supported_parameters` come from the modelschemas OpenRouter catalog when that row exists.
 4. Writes a patch changeset for the packages that changed.
+
+Reads against modelschemas work without a key (60 req/h per IP). Set `MODELSCHEMAS_API_KEY` on the workflow when you want the higher limit.
 
 Rules the generator follows:
 
 - Keep OpenRouter routing aliases (ids that start with `~`) in the OpenRouter catalog. Users can pass `chat({ model: '~anthropic/claude-haiku-latest' })`. The generated constant name maps `~` to `_`.
 - Do **not** copy those aliases into native provider files (`ai-openai`, `ai-anthropic`, `ai-gemini`, `ai-grok`). Those adapters only accept the provider's own ids.
-- For a new native-provider model, write id, modalities, and pricing. Infer features from OpenRouter `supported_parameters` when that field exists. Do **not** copy another model's tool list (`computer_use`, `google_search`, `x_search`, and similar).
-- Anthropic first-party ids use dashes (`claude-fable-5-1`). OpenRouter uses dots (`claude-fable-5.1`). The generator hyphenates Anthropic ids on insert. Do not copy the dotted OpenRouter slug into `ai-anthropic`.
+- For a new native-provider model, write id, modalities, and pricing. Infer features from catalog `supported_parameters` when that field exists. Do **not** copy another model's tool list (`computer_use`, `google_search`, `x_search`, and similar). Skip a native id until the modelschemas OpenRouter catalog has a matching row (native catalogs often omit pricing and modalities).
+- Anthropic first-party ids use dashes (`claude-fable-5-1`). OpenRouter uses dots (`claude-fable-5.1`). The generator takes the modelschemas native id (already hyphenated) and does not copy the dotted OpenRouter slug into `ai-anthropic`. Dated Anthropic snapshots (`claude-haiku-4-5-20251001`) are skipped; the undated alias is the public id.
 - Write a row in the provider's `*ChatModelToolCapabilitiesByName` map for every new chat model, even when `supports.tools` is still `[]`. Missing that row makes `ResolveToolCapabilities` fall back to `readonly []`.
-- For new Anthropic models, infer the provider-options mix from the catalog: no sampling parameters → `AnthropicMaxTokensOptions`; `reasoning.mandatory` → `AnthropicAdaptiveOnlyThinkingOptions` plus `AnthropicOutputConfigOptions`.
+- For new Anthropic models, infer the provider-options mix from the catalog: no sampling parameters → `AnthropicMaxTokensOptions`; reasoning params without sampling → adaptive-or-disabled thinking.
 - Leave curated tools and flags on existing models alone. Edit those by hand after the sync PR opens.
 
 Do not rebase or hand-edit `automated/sync-models`. The next scheduled run force-pushes that branch from `main`. Merge generator fixes to `main` first, then let the workflow rebuild the sync PR.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.30.0",
     "@faker-js/faker": "^10.1.0",
+    "@modelschemas/client": "0.1.0",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@tanstack/ai": "workspace:*",
     "@tanstack/ai-grok-build": "workspace:*",

--- a/packages/ai-byteplus/src/model-meta.ts
+++ b/packages/ai-byteplus/src/model-meta.ts
@@ -28,6 +28,30 @@ import type { BytePlusTextProviderOptions } from './text/text-provider-options'
  * advertises an empty tool set. Typing it as `never` makes passing another
  * provider's `ProviderTool` to a BytePlus adapter a compile-time error.
  */
+const DEEPSEEK_V4_FLASH_GA_260731 = {
+  name: 'deepseek-v4-flash-ga-260731',
+  context_window: 1_048_576,
+  max_output_tokens: 393_216,
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
+const DEEPSEEK_V4_PRO_GA_260813 = {
+  name: 'deepseek-v4-pro-ga-260813',
+  context_window: 1_048_576,
+  max_output_tokens: 393_216,
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    capabilities: ['reasoning', 'tool_calling'],
+    tools: [] as const,
+  },
+} as const satisfies ModelMeta
+
 export type BytePlusProviderToolKind = never
 
 /**
@@ -304,6 +328,8 @@ const GPT_OSS_120B_250805 = {
  * All supported BytePlus chat model identifiers.
  */
 export const BYTEPLUS_CHAT_MODELS = [
+  DEEPSEEK_V4_FLASH_GA_260731.name,
+  DEEPSEEK_V4_PRO_GA_260813.name,
   DOLA_SEED_2_1_TURBO.name,
   SEED_2_0_LITE_260428.name,
   SEED_2_0_MINI_260428.name,
@@ -450,6 +476,8 @@ export type BytePlusModelInputModalitiesByName = {
   [DEEPSEEK_V4_FLASH_260425.name]: typeof DEEPSEEK_V4_FLASH_260425.supports.input
   [DEEPSEEK_V3_2_251201.name]: typeof DEEPSEEK_V3_2_251201.supports.input
   [GPT_OSS_120B_250805.name]: typeof GPT_OSS_120B_250805.supports.input
+  [DEEPSEEK_V4_FLASH_GA_260731.name]: typeof DEEPSEEK_V4_FLASH_GA_260731.supports.input
+  [DEEPSEEK_V4_PRO_GA_260813.name]: typeof DEEPSEEK_V4_PRO_GA_260813.supports.input
 }
 
 /**

--- a/packages/ai-elevenlabs/src/model-meta.ts
+++ b/packages/ai-elevenlabs/src/model-meta.ts
@@ -11,6 +11,7 @@ import type { ElevenLabs } from '@elevenlabs/elevenlabs-js'
  * @see https://elevenlabs.io/docs/models
  */
 export const ELEVENLABS_TTS_MODELS = [
+  'eleven_v3_conversational',
   'eleven_v3',
   'eleven_multilingual_v2',
   'eleven_flash_v2_5',

--- a/packages/ai-groq/src/model-meta.ts
+++ b/packages/ai-groq/src/model-meta.ts
@@ -320,7 +320,27 @@ const QWEN3_32B = {
 /**
  * All supported Groq chat model identifiers.
  */
+const QWEN_QWEN3_8_27B = {
+  name: 'qwen/qwen3.8-27b',
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming'],
+    tools: [] as const,
+  },
+  pricing: {
+    input: {
+      normal: 0,
+    },
+    output: {
+      normal: 0,
+    },
+  },
+} as const satisfies ModelMeta<GroqTextProviderOptions>
+
 export const GROQ_CHAT_MODELS = [
+  QWEN_QWEN3_8_27B.name,
   LLAMA_3_1_8B_INSTANT.name,
   LLAMA_3_3_70B_VERSATILE.name,
   LLAMA_4_MAVERICK_17B_128E_INSTRUCT.name,
@@ -356,6 +376,7 @@ export type GroqModelInputModalitiesByName = {
   [GPT_OSS_SAFEGUARD_20B.name]: typeof GPT_OSS_SAFEGUARD_20B.supports.input
   [KIMI_K2_INSTRUCT_0905.name]: typeof KIMI_K2_INSTRUCT_0905.supports.input
   [QWEN3_32B.name]: typeof QWEN3_32B.supports.input
+  [QWEN_QWEN3_8_27B.name]: typeof QWEN_QWEN3_8_27B.supports.input
 }
 
 /**
@@ -384,6 +405,7 @@ export type GroqChatModelToolCapabilitiesByName = {
   [GPT_OSS_SAFEGUARD_20B.name]: typeof GPT_OSS_SAFEGUARD_20B.supports.tools
   [KIMI_K2_INSTRUCT_0905.name]: typeof KIMI_K2_INSTRUCT_0905.supports.tools
   [QWEN3_32B.name]: typeof QWEN3_32B.supports.tools
+  [QWEN_QWEN3_8_27B.name]: typeof QWEN_QWEN3_8_27B.supports.tools
 }
 
 /**

--- a/packages/ai-mistral/src/model-meta.ts
+++ b/packages/ai-mistral/src/model-meta.ts
@@ -5,6 +5,256 @@ import type {
 } from './embedding/embedding-provider-options'
 
 /** Provider options for vision-capable Mistral models (pixtral-*). */
+const CODESTRAL_2508 = {
+  name: 'codestral-2508',
+  context_window: 256_000,
+  max_completion_tokens: 204_800,
+  supports: {
+    input: ['text', 'document'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming', 'tools', 'json_object', 'json_schema'],
+  },
+  pricing: {
+    input: {
+      normal: 0.3,
+      cached: 0.03,
+    },
+    output: {
+      normal: 0.9,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
+const LABS_LEANSTRAL_1_5 = {
+  name: 'labs-leanstral-1-5',
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming'],
+  },
+  pricing: {
+    input: {
+      normal: 0,
+    },
+    output: {
+      normal: 0,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
+const LABS_LEANSTRAL_1_5_1 = {
+  name: 'labs-leanstral-1-5-1',
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming'],
+  },
+  pricing: {
+    input: {
+      normal: 0,
+    },
+    output: {
+      normal: 0,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
+const MINISTRAL_14B_2512 = {
+  name: 'ministral-14b-2512',
+  context_window: 262_144,
+  max_completion_tokens: 209_715,
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming', 'tools', 'json_object', 'json_schema', 'vision'],
+  },
+  pricing: {
+    input: {
+      normal: 0.2,
+      cached: 0.02,
+    },
+    output: {
+      normal: 0.2,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
+const MINISTRAL_14B_LATEST = {
+  name: 'ministral-14b-latest',
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming'],
+  },
+  pricing: {
+    input: {
+      normal: 0,
+    },
+    output: {
+      normal: 0,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
+const MINISTRAL_3B_2512 = {
+  name: 'ministral-3b-2512',
+  context_window: 131_072,
+  max_completion_tokens: 104_857,
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming', 'tools', 'json_object', 'json_schema', 'vision'],
+  },
+  pricing: {
+    input: {
+      normal: 0.1,
+      cached: 0.01,
+    },
+    output: {
+      normal: 0.1,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
+const MINISTRAL_8B_2512 = {
+  name: 'ministral-8b-2512',
+  context_window: 262_144,
+  max_completion_tokens: 209_715,
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming', 'tools', 'json_object', 'json_schema', 'vision'],
+  },
+  pricing: {
+    input: {
+      normal: 0.15,
+      cached: 0.015,
+    },
+    output: {
+      normal: 0.15,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
+const MISTRAL_LARGE_2512 = {
+  name: 'mistral-large-2512',
+  context_window: 262_144,
+  max_completion_tokens: 209_715,
+  supports: {
+    input: ['text', 'image', 'document'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming', 'tools', 'json_object', 'json_schema', 'vision'],
+  },
+  pricing: {
+    input: {
+      normal: 0.5,
+      cached: 0.05,
+    },
+    output: {
+      normal: 1.5,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
+const MISTRAL_MEDIUM = {
+  name: 'mistral-medium',
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming'],
+  },
+  pricing: {
+    input: {
+      normal: 0,
+    },
+    output: {
+      normal: 0,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
+const MISTRAL_MEDIUM_2604 = {
+  name: 'mistral-medium-2604',
+  supports: {
+    input: ['text'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: ['streaming'],
+  },
+  pricing: {
+    input: {
+      normal: 0,
+    },
+    output: {
+      normal: 0,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
+const MISTRAL_MEDIUM_3_5 = {
+  name: 'mistral-medium-3-5',
+  context_window: 262_144,
+  max_completion_tokens: 209_715,
+  supports: {
+    input: ['text', 'image', 'document'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: [
+      'streaming',
+      'tools',
+      'json_object',
+      'json_schema',
+      'reasoning',
+      'vision',
+    ],
+  },
+  pricing: {
+    input: {
+      normal: 1.5,
+    },
+    output: {
+      normal: 7.5,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
+const MISTRAL_SMALL_2603 = {
+  name: 'mistral-small-2603',
+  context_window: 262_144,
+  max_completion_tokens: 209_715,
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat'],
+    features: [
+      'streaming',
+      'tools',
+      'json_object',
+      'json_schema',
+      'reasoning',
+      'vision',
+    ],
+  },
+  pricing: {
+    input: {
+      normal: 0.15,
+      cached: 0.015,
+    },
+    output: {
+      normal: 0.6,
+    },
+  },
+} as const satisfies ModelMeta<MistralTextProviderOptions>
+
 export type MistralVisionProviderOptions = MistralTextProviderOptions
 
 /** Provider options for reasoning-capable Mistral models (magistral-*). */
@@ -270,6 +520,18 @@ const CODESTRAL_2 = {
  * All supported Mistral chat model identifiers.
  */
 export const MISTRAL_CHAT_MODELS = [
+  CODESTRAL_2508.name,
+  LABS_LEANSTRAL_1_5.name,
+  LABS_LEANSTRAL_1_5_1.name,
+  MINISTRAL_14B_2512.name,
+  MINISTRAL_14B_LATEST.name,
+  MINISTRAL_3B_2512.name,
+  MINISTRAL_8B_2512.name,
+  MISTRAL_LARGE_2512.name,
+  MISTRAL_MEDIUM.name,
+  MISTRAL_MEDIUM_2604.name,
+  MISTRAL_MEDIUM_3_5.name,
+  MISTRAL_SMALL_2603.name,
   MISTRAL_LARGE_LATEST.name,
   MISTRAL_MEDIUM_LATEST.name,
   MISTRAL_SMALL_LATEST.name,
@@ -320,6 +582,18 @@ export type MistralModelInputModalitiesByName = {
   [MISTRAL_MEDIUM_3.name]: typeof MISTRAL_MEDIUM_3.supports.input
   [MISTRAL_SMALL_2503.name]: typeof MISTRAL_SMALL_2503.supports.input
   [CODESTRAL_2.name]: typeof CODESTRAL_2.supports.input
+  [CODESTRAL_2508.name]: typeof CODESTRAL_2508.supports.input
+  [LABS_LEANSTRAL_1_5.name]: typeof LABS_LEANSTRAL_1_5.supports.input
+  [LABS_LEANSTRAL_1_5_1.name]: typeof LABS_LEANSTRAL_1_5_1.supports.input
+  [MINISTRAL_14B_2512.name]: typeof MINISTRAL_14B_2512.supports.input
+  [MINISTRAL_14B_LATEST.name]: typeof MINISTRAL_14B_LATEST.supports.input
+  [MINISTRAL_3B_2512.name]: typeof MINISTRAL_3B_2512.supports.input
+  [MINISTRAL_8B_2512.name]: typeof MINISTRAL_8B_2512.supports.input
+  [MISTRAL_LARGE_2512.name]: typeof MISTRAL_LARGE_2512.supports.input
+  [MISTRAL_MEDIUM.name]: typeof MISTRAL_MEDIUM.supports.input
+  [MISTRAL_MEDIUM_2604.name]: typeof MISTRAL_MEDIUM_2604.supports.input
+  [MISTRAL_MEDIUM_3_5.name]: typeof MISTRAL_MEDIUM_3_5.supports.input
+  [MISTRAL_SMALL_2603.name]: typeof MISTRAL_SMALL_2603.supports.input
 }
 
 /**
@@ -340,6 +614,18 @@ export type MistralChatModelProviderOptionsByName = {
   [MISTRAL_MEDIUM_3.name]: MistralVisionProviderOptions
   [MISTRAL_SMALL_2503.name]: MistralVisionProviderOptions
   [CODESTRAL_2.name]: MistralTextProviderOptions
+  [CODESTRAL_2508.name]: MistralTextProviderOptions
+  [LABS_LEANSTRAL_1_5.name]: MistralTextProviderOptions
+  [LABS_LEANSTRAL_1_5_1.name]: MistralTextProviderOptions
+  [MINISTRAL_14B_2512.name]: MistralTextProviderOptions
+  [MINISTRAL_14B_LATEST.name]: MistralTextProviderOptions
+  [MINISTRAL_3B_2512.name]: MistralTextProviderOptions
+  [MINISTRAL_8B_2512.name]: MistralTextProviderOptions
+  [MISTRAL_LARGE_2512.name]: MistralTextProviderOptions
+  [MISTRAL_MEDIUM.name]: MistralTextProviderOptions
+  [MISTRAL_MEDIUM_2604.name]: MistralTextProviderOptions
+  [MISTRAL_MEDIUM_3_5.name]: MistralTextProviderOptions
+  [MISTRAL_SMALL_2603.name]: MistralTextProviderOptions
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@faker-js/faker':
         specifier: ^10.1.0
         version: 10.1.0
+      '@modelschemas/client':
+        specifier: 0.1.0
+        version: 0.1.0
       '@stylistic/eslint-plugin':
         specifier: ^5.10.0
         version: 5.10.0(eslint@9.39.4(jiti@2.7.0))
@@ -5822,6 +5825,9 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelschemas/client@0.1.0':
+    resolution: {integrity: sha512-MVtC9gsZcx05ITdqh6Krc8G9lMxne7mPO2VfX6cyjQbpGNWOe/dwyZuETVfwohC3Dnsnsrfi3oIRNQNc+xx87Q==}
 
   '@msgpack/msgpack@3.1.3':
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
@@ -20983,6 +20989,8 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
+
+  '@modelschemas/client@0.1.0': {}
 
   '@msgpack/msgpack@3.1.3': {}
 

--- a/scripts/model-sync/catalog.test.ts
+++ b/scripts/model-sync/catalog.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   alreadySynced,
+  elevenLabsIdArray,
   findOpenRouterEnrichment,
   hasImageOutput,
   openRouterRawIdCandidates,
+  outputsText,
   parseCatalogModels,
   skipNativeModelReason,
   toSyncModel,
@@ -58,6 +60,28 @@ describe('parseCatalogModels', () => {
       inputModalities: ['text', 'image'],
       capabilities: ['tools', 'reasoning'],
     })
+  })
+
+  it('maps BytePlus object capabilities onto supported_parameters', () => {
+    const models = parseCatalogModels({
+      models: [
+        {
+          rawId: 'deepseek-v4-pro-ga-260813',
+          activity: 'chat',
+          capabilities: {
+            tools: { function_calling: true },
+            structured_outputs: { json_schema: false, json_object: false },
+            maxReasoningTokens: 393216,
+          },
+        },
+      ],
+    })
+    expect(models[0]?.capabilities).toEqual([
+      'tools',
+      'tool_choice',
+      'reasoning',
+      'include_reasoning',
+    ])
   })
 })
 
@@ -158,6 +182,50 @@ describe('skipNativeModelReason', () => {
         cutoff,
       ),
     ).toBe('non-chat family')
+  })
+
+  it('keeps audio rows when audio is an accepted activity', () => {
+    expect(
+      skipNativeModelReason(
+        native({ activity: 'audio', rawId: 'eleven_v3' }),
+        'elevenlabs',
+        [],
+        cutoff,
+        ['audio'],
+      ),
+    ).toBeNull()
+  })
+
+  it('keeps Groq rows with no activity', () => {
+    expect(
+      skipNativeModelReason(
+        native({ activity: null, rawId: 'qwen/qwen3.8-27b' }),
+        'groq',
+        [],
+        cutoff,
+        [null],
+      ),
+    ).toBeNull()
+  })
+})
+
+describe('outputsText', () => {
+  it('treats empty modalities plus unset activity as chat', () => {
+    const model = toSyncModel(
+      native({ activity: null, rawId: 'qwen/qwen3.8-27b' }),
+      undefined,
+      'groq',
+    )
+    expect(outputsText(model, null)).toBe(true)
+  })
+})
+
+describe('elevenLabsIdArray', () => {
+  it('routes TTS, skips STS, and classifies scribe / music', () => {
+    expect(elevenLabsIdArray('eleven_v3_conversational')).toBe('tts')
+    expect(elevenLabsIdArray('eleven_multilingual_sts_v2')).toBeNull()
+    expect(elevenLabsIdArray('scribe_v2')).toBe('transcription')
+    expect(elevenLabsIdArray('music_v1')).toBe('audio')
   })
 })
 

--- a/scripts/model-sync/catalog.test.ts
+++ b/scripts/model-sync/catalog.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import {
+  alreadySynced,
+  findOpenRouterEnrichment,
+  hasImageOutput,
+  openRouterRawIdCandidates,
+  parseCatalogModels,
+  skipNativeModelReason,
+  toSyncModel,
+} from './catalog'
+import type { CatalogModel } from './catalog'
+
+function native(overrides: Partial<CatalogModel> = {}): CatalogModel {
+  return {
+    provider: 'anthropic',
+    rawId: 'claude-sonnet-5',
+    activity: 'chat',
+    firstSeenAt: 1_780_000_000,
+    deprecatedAt: null,
+    contextWindow: null,
+    maxOutput: null,
+    inputModalities: [],
+    outputModalities: [],
+    pricing: {
+      prompt: undefined,
+      completion: undefined,
+      input_cache_read: undefined,
+    },
+    capabilities: [],
+    ...overrides,
+  }
+}
+
+describe('parseCatalogModels', () => {
+  it('reads modelschemas listModels payloads and drops rows without rawId', () => {
+    const models = parseCatalogModels({
+      count: 2,
+      models: [
+        {
+          provider: 'openai',
+          rawId: 'gpt-5',
+          activity: 'chat',
+          contextWindow: 400_000,
+          maxOutput: 128_000,
+          modalities: { input: ['text', 'image'], output: ['text'] },
+          pricing: { prompt: '0.00000125', completion: '0.00001' },
+          capabilities: ['tools', 'reasoning'],
+          firstSeenAt: 1_754_425_777,
+          deprecatedAt: null,
+        },
+        { provider: 'openai', activity: 'chat' },
+      ],
+    })
+    expect(models).toHaveLength(1)
+    expect(models[0]).toMatchObject({
+      rawId: 'gpt-5',
+      contextWindow: 400_000,
+      inputModalities: ['text', 'image'],
+      capabilities: ['tools', 'reasoning'],
+    })
+  })
+})
+
+describe('openRouterRawIdCandidates', () => {
+  it('hyphen/dot-maps Anthropic ids and strips dated snapshots', () => {
+    expect(
+      openRouterRawIdCandidates(
+        native({ rawId: 'claude-haiku-4-5-20251001' }),
+        'anthropic',
+      ),
+    ).toEqual([
+      'anthropic/claude-haiku-4-5-20251001',
+      'anthropic/claude-haiku-4-5',
+      'anthropic/claude-haiku-4.5-20251001',
+      'anthropic/claude-haiku-4.5',
+    ])
+  })
+
+  it('prefixes Gemini with google/ and Grok with x-ai/', () => {
+    expect(
+      openRouterRawIdCandidates(
+        native({ rawId: 'gemini-3.1-pro', provider: 'gemini' }),
+        'gemini',
+      ),
+    ).toEqual(['google/gemini-3.1-pro'])
+    expect(
+      openRouterRawIdCandidates(
+        native({ rawId: 'grok-4.6', provider: 'grok' }),
+        'grok',
+      ),
+    ).toEqual(['x-ai/grok-4.6'])
+  })
+})
+
+describe('findOpenRouterEnrichment / toSyncModel', () => {
+  it('joins a hyphenated Anthropic id to the dotted OpenRouter row', () => {
+    const enrich = native({
+      provider: 'openrouter',
+      rawId: 'anthropic/claude-sonnet-4.5',
+      contextWindow: 200_000,
+      maxOutput: 64_000,
+      inputModalities: ['text', 'image'],
+      outputModalities: ['text'],
+      pricing: { prompt: '0.000003', completion: '0.000015' },
+      capabilities: ['tools', 'temperature'],
+    })
+    const row = native({ rawId: 'claude-sonnet-4-5' })
+    const found = findOpenRouterEnrichment(row, 'anthropic', [enrich])
+    expect(found?.rawId).toBe('anthropic/claude-sonnet-4.5')
+    const synced = toSyncModel(row, found, 'anthropic')
+    expect(synced.nativeId).toBe('claude-sonnet-4-5')
+    expect(synced.contextWindow).toBe(200_000)
+    expect(synced.supportedParameters).toEqual(['tools', 'temperature'])
+    expect(synced.pricing.prompt).toBe('0.000003')
+  })
+})
+
+describe('skipNativeModelReason', () => {
+  const cutoff = 1_700_000_000
+
+  it('skips dated Anthropic snapshots, non-chat activity, and old rows', () => {
+    expect(
+      skipNativeModelReason(
+        native({ rawId: 'claude-haiku-4-5-20251001' }),
+        'anthropic',
+        [],
+        cutoff,
+      ),
+    ).toBe('dated snapshot')
+    expect(
+      skipNativeModelReason(
+        native({ activity: 'image', rawId: 'grok-imagine-image' }),
+        'grok',
+        [],
+        cutoff,
+      ),
+    ).toBe('activity image')
+    expect(
+      skipNativeModelReason(
+        native({ firstSeenAt: cutoff - 1 }),
+        'anthropic',
+        [],
+        cutoff,
+      ),
+    ).toBe('too old')
+  })
+
+  it('keeps a current chat model', () => {
+    expect(skipNativeModelReason(native(), 'anthropic', [], cutoff)).toBeNull()
+  })
+
+  it('treats transcribe ids as non-chat even when activity is chat', () => {
+    expect(
+      skipNativeModelReason(
+        native({ rawId: 'gemini-3.5-transcribe', provider: 'gemini' }),
+        'gemini',
+        [],
+        cutoff,
+      ),
+    ).toBe('non-chat family')
+  })
+})
+
+describe('hasImageOutput / alreadySynced', () => {
+  it('treats image activity and image output as image models', () => {
+    expect(hasImageOutput(native({ activity: 'image' }))).toBe(true)
+    expect(
+      hasImageOutput(native({ outputModalities: ['image', 'text'] })),
+    ).toBe(true)
+    expect(hasImageOutput(native({ outputModalities: ['text'] }))).toBe(false)
+  })
+
+  it('matches existing ids with dots or dashes', () => {
+    expect(
+      alreadySynced(
+        'claude-sonnet-4.5',
+        new Set(['claude-sonnet-4-5']),
+        new Set(),
+      ),
+    ).toBe(true)
+    expect(
+      alreadySynced('gpt-5.6-luna', new Set(), new Set(['GPT_5_6_LUNA'])),
+    ).toBe(true)
+    expect(alreadySynced('gpt-5.6-luna', new Set(), new Set())).toBe(false)
+  })
+})

--- a/scripts/model-sync/catalog.ts
+++ b/scripts/model-sync/catalog.ts
@@ -1,0 +1,256 @@
+/**
+ * modelschemas catalog rows for native-provider model-meta inserts.
+ *
+ * Native catalogs have the provider's own ids and activity. OpenRouter
+ * rows on modelschemas supply pricing, modalities, and supported_parameters
+ * when the native row leaves those fields empty.
+ */
+
+import { toModelConstName, toNativeProviderId } from './ids'
+import type { SyncedProvider } from './provider-supports'
+
+export const OPENROUTER_PREFIX: Record<SyncedProvider, string> = {
+  openai: 'openai/',
+  anthropic: 'anthropic/',
+  gemini: 'google/',
+  grok: 'x-ai/',
+}
+
+const NON_CHAT_MODEL_PREFIXES = [
+  'lyria-',
+  'veo-',
+  'imagen-',
+  'sora-',
+  'dall-e-',
+  'tts-',
+]
+
+export interface CatalogPricing {
+  prompt: string | undefined
+  completion: string | undefined
+  input_cache_read: string | undefined
+}
+
+export interface CatalogModel {
+  provider: string
+  rawId: string
+  activity: string | null
+  firstSeenAt: number | null
+  deprecatedAt: number | null
+  contextWindow: number | null
+  maxOutput: number | null
+  inputModalities: Array<string>
+  outputModalities: Array<string>
+  pricing: CatalogPricing
+  capabilities: Array<string>
+}
+
+export interface SyncModel {
+  nativeId: string
+  firstSeenAt: number | null
+  contextWindow: number | null
+  maxOutput: number | null
+  inputModalities: Array<string>
+  outputModalities: Array<string>
+  pricing: CatalogPricing
+  supportedParameters: Array<string>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asStringArray(value: unknown): Array<string> {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function asPricing(value: unknown): CatalogPricing {
+  if (!isRecord(value)) {
+    return {
+      prompt: undefined,
+      completion: undefined,
+      input_cache_read: undefined,
+    }
+  }
+  return {
+    prompt: typeof value.prompt === 'string' ? value.prompt : undefined,
+    completion:
+      typeof value.completion === 'string' ? value.completion : undefined,
+    input_cache_read:
+      typeof value.input_cache_read === 'string'
+        ? value.input_cache_read
+        : undefined,
+  }
+}
+
+export function parseCatalogModel(value: unknown): CatalogModel | null {
+  if (!isRecord(value)) return null
+  if (typeof value.rawId !== 'string' || value.rawId.length === 0) return null
+  const modalities = isRecord(value.modalities) ? value.modalities : null
+  return {
+    provider: typeof value.provider === 'string' ? value.provider : '',
+    rawId: value.rawId,
+    activity: typeof value.activity === 'string' ? value.activity : null,
+    firstSeenAt: asFiniteNumber(value.firstSeenAt),
+    deprecatedAt: asFiniteNumber(value.deprecatedAt),
+    contextWindow: asFiniteNumber(value.contextWindow),
+    maxOutput: asFiniteNumber(value.maxOutput),
+    inputModalities: asStringArray(modalities?.input),
+    outputModalities: asStringArray(modalities?.output),
+    pricing: asPricing(value.pricing),
+    capabilities: asStringArray(value.capabilities),
+  }
+}
+
+export function parseCatalogModels(data: unknown): Array<CatalogModel> {
+  const record = isRecord(data) ? data : null
+  const rows = Array.isArray(record?.models)
+    ? record.models
+    : Array.isArray(data)
+      ? data
+      : []
+  const models: Array<CatalogModel> = []
+  for (const row of rows) {
+    const parsed = parseCatalogModel(row)
+    if (parsed) models.push(parsed)
+  }
+  return models
+}
+
+/** OpenRouter dots Anthropic version suffixes (`4.5`); native ids use dashes. */
+function anthropicOpenRouterId(nativeId: string): string {
+  return nativeId.replace(/(\d)-(\d)/g, '$1.$2')
+}
+
+export function openRouterRawIdCandidates(
+  native: CatalogModel,
+  provider: SyncedProvider,
+): Array<string> {
+  const prefix = OPENROUTER_PREFIX[provider]
+  const ids = new Set<string>([native.rawId])
+  if (provider === 'anthropic') {
+    const undated = native.rawId.replace(/-\d{8}$/, '')
+    ids.add(undated)
+    ids.add(anthropicOpenRouterId(native.rawId))
+    ids.add(anthropicOpenRouterId(undated))
+  }
+  return [...ids].map((id) => prefix + id)
+}
+
+export function findOpenRouterEnrichment(
+  native: CatalogModel,
+  provider: SyncedProvider,
+  openrouter: Array<CatalogModel>,
+): CatalogModel | undefined {
+  const wanted = new Set(openRouterRawIdCandidates(native, provider))
+  return openrouter.find((model) => wanted.has(model.rawId))
+}
+
+function pickNumber(
+  preferred: number | null,
+  fallback: number | null,
+): number | null {
+  return preferred ?? fallback
+}
+
+function pickList(
+  preferred: Array<string>,
+  fallback: Array<string>,
+): Array<string> {
+  return preferred.length > 0 ? preferred : fallback
+}
+
+export function toSyncModel(
+  native: CatalogModel,
+  enrich: CatalogModel | undefined,
+  provider: SyncedProvider,
+): SyncModel {
+  const src = enrich ?? native
+  return {
+    nativeId: toNativeProviderId(native.rawId, provider),
+    firstSeenAt: native.firstSeenAt,
+    contextWindow: pickNumber(src.contextWindow, native.contextWindow),
+    maxOutput: pickNumber(src.maxOutput, native.maxOutput),
+    inputModalities: pickList(src.inputModalities, native.inputModalities),
+    outputModalities: pickList(src.outputModalities, native.outputModalities),
+    pricing:
+      src.pricing.prompt != null || src.pricing.completion != null
+        ? src.pricing
+        : native.pricing,
+    supportedParameters:
+      src.capabilities.length > 0 ? src.capabilities : native.capabilities,
+  }
+}
+
+export function matchesSkipPattern(
+  rawId: string,
+  patterns: Array<string>,
+): boolean {
+  return patterns.some((pattern) => rawId.startsWith(pattern))
+}
+
+export function isNonChatFamily(rawId: string): boolean {
+  if (rawId.includes('transcribe')) return true
+  return NON_CHAT_MODEL_PREFIXES.some((prefix) => rawId.startsWith(prefix))
+}
+
+export function isDatedAnthropicSnapshot(rawId: string): boolean {
+  return /-\d{8}$/.test(rawId)
+}
+
+export function hasImageOutput(model: {
+  activity: string | null
+  outputModalities: Array<string>
+}): boolean {
+  return model.activity === 'image' || model.outputModalities.includes('image')
+}
+
+export function outputsText(
+  model: SyncModel,
+  activity: string | null,
+): boolean {
+  if (model.outputModalities.includes('text')) return true
+  return model.outputModalities.length === 0 && activity === 'chat'
+}
+
+/**
+ * Why this native row should not be inserted. `null` means keep going.
+ */
+export function skipNativeModelReason(
+  model: CatalogModel,
+  provider: SyncedProvider,
+  skipPatterns: Array<string>,
+  cutoffTimestamp: number,
+): string | null {
+  if (model.deprecatedAt != null) return 'deprecated'
+  if (model.activity != null && model.activity !== 'chat') {
+    return `activity ${model.activity}`
+  }
+  if (model.rawId.includes(':')) return 'routing variant'
+  if (isNonChatFamily(model.rawId)) return 'non-chat family'
+  if (matchesSkipPattern(model.rawId, skipPatterns)) return 'skip pattern'
+  if (provider === 'anthropic' && isDatedAnthropicSnapshot(model.rawId)) {
+    return 'dated snapshot'
+  }
+  if (model.firstSeenAt != null && model.firstSeenAt < cutoffTimestamp) {
+    return 'too old'
+  }
+  return null
+}
+
+export function alreadySynced(
+  nativeId: string,
+  existingIds: Set<string>,
+  existingConstNames: Set<string>,
+): boolean {
+  const normalized = nativeId.replaceAll('.', '-')
+  return (
+    existingIds.has(normalized) ||
+    existingConstNames.has(toModelConstName(nativeId))
+  )
+}

--- a/scripts/model-sync/catalog.ts
+++ b/scripts/model-sync/catalog.ts
@@ -9,11 +9,13 @@
 import { toModelConstName, toNativeProviderId } from './ids'
 import type { SyncedProvider } from './provider-supports'
 
-export const OPENROUTER_PREFIX: Record<SyncedProvider, string> = {
+export const OPENROUTER_PREFIX: Partial<Record<SyncedProvider, string>> = {
   openai: 'openai/',
   anthropic: 'anthropic/',
   gemini: 'google/',
   grok: 'x-ai/',
+  groq: 'groq/',
+  mistral: 'mistralai/',
 }
 
 const NON_CHAT_MODEL_PREFIXES = [
@@ -69,6 +71,31 @@ function asFiniteNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
+function asSupportedParameters(value: unknown): Array<string> {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string')
+  }
+  if (!isRecord(value)) return []
+  const params: Array<string> = []
+  const tools = isRecord(value.tools) ? value.tools : null
+  if (tools?.function_calling === true) {
+    params.push('tools', 'tool_choice')
+  }
+  const structured = isRecord(value.structured_outputs)
+    ? value.structured_outputs
+    : null
+  if (structured?.json_schema === true || structured?.json_object === true) {
+    params.push('structured_outputs', 'response_format')
+  }
+  if (
+    typeof value.maxReasoningTokens === 'number' &&
+    value.maxReasoningTokens > 0
+  ) {
+    params.push('reasoning', 'include_reasoning')
+  }
+  return params
+}
+
 function asPricing(value: unknown): CatalogPricing {
   if (!isRecord(value)) {
     return {
@@ -103,7 +130,7 @@ export function parseCatalogModel(value: unknown): CatalogModel | null {
     inputModalities: asStringArray(modalities?.input),
     outputModalities: asStringArray(modalities?.output),
     pricing: asPricing(value.pricing),
-    capabilities: asStringArray(value.capabilities),
+    capabilities: asSupportedParameters(value.capabilities),
   }
 }
 
@@ -132,6 +159,7 @@ export function openRouterRawIdCandidates(
   provider: SyncedProvider,
 ): Array<string> {
   const prefix = OPENROUTER_PREFIX[provider]
+  if (!prefix) return []
   const ids = new Set<string>([native.rawId])
   if (provider === 'anthropic') {
     const undated = native.rawId.replace(/-\d{8}$/, '')
@@ -215,7 +243,16 @@ export function outputsText(
   activity: string | null,
 ): boolean {
   if (model.outputModalities.includes('text')) return true
-  return model.outputModalities.length === 0 && activity === 'chat'
+  if (
+    model.outputModalities.includes('image') ||
+    model.outputModalities.includes('video')
+  ) {
+    return false
+  }
+  return (
+    model.outputModalities.length === 0 &&
+    (activity === 'chat' || activity === null)
+  )
 }
 
 /**
@@ -226,9 +263,10 @@ export function skipNativeModelReason(
   provider: SyncedProvider,
   skipPatterns: Array<string>,
   cutoffTimestamp: number,
+  acceptedActivities: Array<string | null> = ['chat'],
 ): string | null {
   if (model.deprecatedAt != null) return 'deprecated'
-  if (model.activity != null && model.activity !== 'chat') {
+  if (!acceptedActivities.includes(model.activity)) {
     return `activity ${model.activity}`
   }
   if (model.rawId.includes(':')) return 'routing variant'
@@ -240,6 +278,17 @@ export function skipNativeModelReason(
   if (model.firstSeenAt != null && model.firstSeenAt < cutoffTimestamp) {
     return 'too old'
   }
+  return null
+}
+
+/** ElevenLabs STS / voice-conversion ids have no TanStack adapter. */
+export function elevenLabsIdArray(
+  rawId: string,
+): 'tts' | 'audio' | 'transcription' | null {
+  if (rawId.includes('_sts_')) return null
+  if (rawId.startsWith('scribe')) return 'transcription'
+  if (rawId.includes('text_to_sound') || rawId === 'music_v1') return 'audio'
+  if (rawId.startsWith('eleven_')) return 'tts'
   return null
 }
 

--- a/scripts/model-sync/ids.ts
+++ b/scripts/model-sync/ids.ts
@@ -29,7 +29,7 @@ export function rejectRoutingAliases<T extends { id: string }>(
  */
 export function toNativeProviderId(
   strippedId: string,
-  provider: 'openai' | 'anthropic' | 'gemini' | 'grok',
+  provider: string,
 ): string {
   if (provider === 'anthropic') {
     return strippedId.replaceAll('.', '-')

--- a/scripts/model-sync/modelschemas.ts
+++ b/scripts/model-sync/modelschemas.ts
@@ -1,0 +1,82 @@
+/**
+ * Thin wrapper around `@modelschemas/client` for the native model sync.
+ */
+
+import { createModelschemasClient, listModels } from '@modelschemas/client'
+import { parseCatalogModels } from './catalog'
+import type { CatalogModel } from './catalog'
+import type { SyncedProvider } from './provider-supports'
+
+export const MODELSCHEMAS_BASE_URL = 'https://modelschemas.com'
+
+const NATIVE_PROVIDERS: Array<SyncedProvider> = [
+  'openai',
+  'anthropic',
+  'gemini',
+  'grok',
+]
+
+export function createSyncClient(options?: {
+  apiKey?: string
+  fetch?: typeof globalThis.fetch
+  baseUrl?: string
+}) {
+  const apiKey = options?.apiKey ?? process.env.MODELSCHEMAS_API_KEY
+  return createModelschemasClient({
+    baseUrl: options?.baseUrl ?? MODELSCHEMAS_BASE_URL,
+    ...(apiKey ? { apiKey } : {}),
+    ...(options?.fetch ? { fetch: options.fetch } : {}),
+  })
+}
+
+type SyncClient = ReturnType<typeof createSyncClient>
+
+function errorMessage(error: unknown): string {
+  if (typeof error === 'string') return error
+  if (!error || typeof error !== 'object') return String(error)
+  const record = error as Record<string, unknown>
+  const nested = record.error
+  if (nested && typeof nested === 'object') {
+    const inner = nested as Record<string, unknown>
+    if (typeof inner.message === 'string') return inner.message
+  }
+  if (typeof record.message === 'string') return record.message
+  return JSON.stringify(error)
+}
+
+export async function fetchCatalog(
+  client: SyncClient,
+  query: {
+    provider: string
+    activity?:
+      | 'chat'
+      | 'image'
+      | 'video'
+      | 'audio'
+      | 'embeddings'
+      | 'moderation'
+  },
+): Promise<Array<CatalogModel>> {
+  const result = await listModels({ client, query })
+  if (result.error !== undefined) {
+    throw new Error(
+      `modelschemas listModels provider=${query.provider}: ${errorMessage(result.error)}`,
+    )
+  }
+  return parseCatalogModels(result.data)
+}
+
+export async function fetchSyncCatalogs(client: SyncClient): Promise<{
+  native: Record<SyncedProvider, Array<CatalogModel>>
+  openrouter: Array<CatalogModel>
+}> {
+  const [openrouter, ...nativeLists] = await Promise.all([
+    fetchCatalog(client, { provider: 'openrouter' }),
+    ...NATIVE_PROVIDERS.map((provider) => fetchCatalog(client, { provider })),
+  ])
+  const native = {} as Record<SyncedProvider, Array<CatalogModel>>
+  for (const [index, provider] of NATIVE_PROVIDERS.entries()) {
+    native[provider] = nativeLists[index] ?? []
+  }
+  return { native, openrouter }
+}

--- a/scripts/model-sync/modelschemas.ts
+++ b/scripts/model-sync/modelschemas.ts
@@ -5,16 +5,10 @@
 import { createModelschemasClient, listModels } from '@modelschemas/client'
 import { parseCatalogModels } from './catalog'
 import type { CatalogModel } from './catalog'
+import { SYNCED_PROVIDERS } from './provider-supports'
 import type { SyncedProvider } from './provider-supports'
 
 export const MODELSCHEMAS_BASE_URL = 'https://modelschemas.com'
-
-const NATIVE_PROVIDERS: Array<SyncedProvider> = [
-  'openai',
-  'anthropic',
-  'gemini',
-  'grok',
-]
 
 export function createSyncClient(options?: {
   apiKey?: string
@@ -72,10 +66,10 @@ export async function fetchSyncCatalogs(client: SyncClient): Promise<{
 }> {
   const [openrouter, ...nativeLists] = await Promise.all([
     fetchCatalog(client, { provider: 'openrouter' }),
-    ...NATIVE_PROVIDERS.map((provider) => fetchCatalog(client, { provider })),
+    ...SYNCED_PROVIDERS.map((provider) => fetchCatalog(client, { provider })),
   ])
   const native = {} as Record<SyncedProvider, Array<CatalogModel>>
-  for (const [index, provider] of NATIVE_PROVIDERS.entries()) {
+  for (const [index, provider] of SYNCED_PROVIDERS.entries()) {
     native[provider] = nativeLists[index] ?? []
   }
   return { native, openrouter }

--- a/scripts/model-sync/native-insert.test.ts
+++ b/scripts/model-sync/native-insert.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { applyChatModelCatalogInserts } from './native-insert'
+import {
+  addToStringLiteralArray,
+  applyChatModelCatalogInserts,
+  extractStringLiteralArrayValues,
+} from './native-insert'
 
 const STUB = `const FOO = {
   id: 'claude-foo',
@@ -102,5 +106,22 @@ export type OpenAIModelInputModalitiesByName = {
 
     expect(result).toContain('[GPT6.name]: typeof GPT6.supports.tools')
     expect(result).toContain('GPT6.name,')
+  })
+})
+
+describe('string-literal arrays', () => {
+  const stub = `export const ELEVENLABS_TTS_MODELS = [
+  'eleven_v3',
+] as const
+`
+
+  it('inserts quoted ids after the opening bracket', () => {
+    const result = addToStringLiteralArray(stub, 'ELEVENLABS_TTS_MODELS', [
+      'eleven_v3_conversational',
+    ])
+    expect(result).toContain("  'eleven_v3_conversational',")
+    expect(
+      extractStringLiteralArrayValues(result, 'ELEVENLABS_TTS_MODELS'),
+    ).toEqual(new Set(['eleven_v3_conversational', 'eleven_v3']))
   })
 })

--- a/scripts/model-sync/native-insert.ts
+++ b/scripts/model-sync/native-insert.ts
@@ -24,6 +24,39 @@ export function insertConstants(
  * carries its own trailing comma so the existing body does not need a
  * comma-guess. See the grok-4.5 single-line array breakage.
  */
+export function addToStringLiteralArray(
+  content: string,
+  arrayName: string,
+  values: Array<string>,
+): string {
+  if (values.length === 0) return content
+  const open = `export const ${arrayName} = [`
+  const openIndex = content.indexOf(open)
+  if (openIndex === -1) {
+    console.warn(`  Warning: Could not find array '${arrayName}' in file`)
+    return content
+  }
+  const newEntries = values.map((value) => `  '${value}',`).join('\n')
+  const insertAt = openIndex + open.length
+  return `${content.slice(0, insertAt)}\n${newEntries}${content.slice(insertAt)}`
+}
+
+export function extractStringLiteralArrayValues(
+  content: string,
+  arrayName: string,
+): Set<string> {
+  const ids = new Set<string>()
+  const block = content.match(
+    new RegExp(`export const ${arrayName} = \\[([\\s\\S]*?)\\] as const`),
+  )
+  if (!block) return ids
+  const quoted = block[1]!.matchAll(/'([^']+)'/g)
+  for (const match of quoted) {
+    ids.add(match[1]!)
+  }
+  return ids
+}
+
 function addToArray(
   content: string,
   arrayName: string,

--- a/scripts/model-sync/provider-supports.test.ts
+++ b/scripts/model-sync/provider-supports.test.ts
@@ -46,6 +46,31 @@ describe('buildProviderSupportsBody', () => {
     expect(body).toContain('thinking')
   })
 
+  it('writes Groq features without copying hosted tools', () => {
+    const body = buildProviderSupportsBody({
+      provider: 'groq',
+      inputModalities: ['text'],
+      supportedParameters: ['tools', 'structured_outputs'],
+    })
+    expect(body).toContain("endpoints: ['chat']")
+    expect(body).toContain('tools: [] as const')
+    expect(body).toContain("'json_schema'")
+    expect(body).not.toContain('browser_search')
+  })
+
+  it('writes BytePlus capabilities from catalog flags', () => {
+    const body = buildProviderSupportsBody({
+      provider: 'byteplus',
+      inputModalities: ['text', 'image'],
+      outputModalities: ['text'],
+      supportedParameters: ['tools', 'reasoning'],
+    })
+    expect(body).toContain('tool_calling')
+    expect(body).toContain('reasoning')
+    expect(body).toContain('tools: [] as const')
+    expect(body).not.toContain('structured_outputs')
+  })
+
   it('does not invent Grok x_search', () => {
     const body = buildProviderSupportsBody({
       provider: 'grok',

--- a/scripts/model-sync/provider-supports.ts
+++ b/scripts/model-sync/provider-supports.ts
@@ -2,7 +2,8 @@
  * Conservative `supports` blocks for newly synced native-provider models.
  *
  * The generator only writes facts it can see: input modalities from
- * OpenRouter, plus features inferred from `supported_parameters`.
+ * the modelschemas catalog (OpenRouter enrich when the native row is
+ * empty), plus features inferred from `supported_parameters`.
  * It does not copy a reference model's tool list (computer_use, x_search,
  * google_search, …) onto every new id.
  */

--- a/scripts/model-sync/provider-supports.ts
+++ b/scripts/model-sync/provider-supports.ts
@@ -8,11 +8,23 @@
  * google_search, …) onto every new id.
  */
 
-export type SyncedProvider = 'openai' | 'anthropic' | 'gemini' | 'grok'
+export const SYNCED_PROVIDERS = [
+  'openai',
+  'anthropic',
+  'gemini',
+  'grok',
+  'groq',
+  'mistral',
+  'byteplus',
+  'elevenlabs',
+] as const
+
+export type SyncedProvider = (typeof SYNCED_PROVIDERS)[number]
 
 export interface ProviderSupportsInput {
   provider: SyncedProvider
   inputModalities: Array<string>
+  outputModalities?: Array<string>
   supportedParameters?: Array<string>
 }
 
@@ -143,5 +155,55 @@ export function buildProviderSupportsBody(
       lines.push(`    tools: [],`)
       return lines.join('\n')
     }
+    case 'groq': {
+      const features = ['streaming']
+      if (hasTools) features.push('tools')
+      if (hasStructured) {
+        features.push('json_object', 'json_schema')
+      }
+      if (hasReasoning) features.push('reasoning')
+      if (input.inputModalities.includes('image')) features.push('vision')
+      return [
+        `    input: ${inputList},`,
+        `    output: ['text'],`,
+        `    endpoints: ['chat'],`,
+        `    features: ${quoteList(features)},`,
+        `    tools: [] as const,`,
+      ].join('\n')
+    }
+    case 'mistral': {
+      const features = ['streaming']
+      if (hasTools) features.push('tools')
+      if (hasStructured) {
+        features.push('json_object', 'json_schema')
+      }
+      if (hasReasoning) features.push('reasoning')
+      if (input.inputModalities.includes('image')) features.push('vision')
+      return [
+        `    input: ${inputList},`,
+        `    output: ['text'],`,
+        `    endpoints: ['chat'],`,
+        `    features: ${quoteList(features)},`,
+      ].join('\n')
+    }
+    case 'byteplus': {
+      const capabilities: Array<string> = []
+      if (hasReasoning) capabilities.push('reasoning')
+      if (hasTools) capabilities.push('tool_calling')
+      if (hasStructured) capabilities.push('structured_outputs')
+      const output = quoteList(
+        (input.outputModalities ?? ['text']).length > 0
+          ? (input.outputModalities ?? ['text'])
+          : ['text'],
+      )
+      const lines = [`    input: ${inputList},`, `    output: ${output},`]
+      if (capabilities.length > 0) {
+        lines.push(`    capabilities: ${quoteList(capabilities)},`)
+      }
+      lines.push(`    tools: [] as const,`)
+      return lines.join('\n')
+    }
+    case 'elevenlabs':
+      return `    input: ${inputList},`
   }
 }

--- a/scripts/sync-provider-models.ts
+++ b/scripts/sync-provider-models.ts
@@ -1,7 +1,7 @@
 /**
  * Syncs modelschemas catalogs into native provider model-meta.ts files.
  *
- * For each supported provider (OpenAI, Anthropic, Gemini, Grok), this script:
+ * For each synced provider, this script:
  * 1. Lists that provider's models from modelschemas (`@modelschemas/client`)
  * 2. Enriches empty pricing/modalities/capabilities from the OpenRouter
  *    catalog on modelschemas
@@ -15,18 +15,14 @@
  *
  * ## Providers deliberately NOT synced
  *
- * The sync is only safe when the provider's own model ids are the catalog
- * ids. These are excluded on purpose:
- *
- * - **byteplus** (`@tanstack/ai-byteplus`) — capability tables are
- *   live-probe-verified because published metadata is wrong in both
- *   directions. Use `/gap-analysis byteplus` instead; the probe recipe is
- *   in that package's `model-meta.ts`.
- * - **fal**, **elevenlabs** — media-only providers whose endpoint ids need
- *   manual size/duration maps. fal image fields have their own generator
- *   (`scripts/generate-fal-image-field-map.ts`).
+ * - **fal** — 1k+ model-grained endpoints; image field maps have their own
+ *   generator (`scripts/generate-fal-image-field-map.ts`).
  * - **bedrock** — ids are AWS-region-qualified; see
  *   `scripts/fetch-bedrock-models.ts`.
+ * - **ollama**, **llmgateway**, **vercel-gateway**, **lovable** — different
+ *   catalogs (local, aggregator, or their own fetch scripts).
+ * - **claude-code**, **codex**, **opencode**, **grok-build** — harness aliases.
+ * BytePlus video/image duration and size tables stay hand-curated.
  */
 
 import { execFileSync } from 'node:child_process'
@@ -35,6 +31,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
   alreadySynced,
+  elevenLabsIdArray,
   findOpenRouterEnrichment,
   hasImageOutput,
   outputsText,
@@ -44,7 +41,9 @@ import {
 import type { SyncModel } from './model-sync/catalog'
 import { toModelConstName } from './model-sync/ids'
 import {
+  addToStringLiteralArray,
   applyChatModelCatalogInserts,
+  extractStringLiteralArrayValues,
   insertConstants,
 } from './model-sync/native-insert'
 import { createSyncClient, fetchSyncCatalogs } from './model-sync/modelschemas'
@@ -102,6 +101,18 @@ interface ProviderConfig {
   providerOptionsIsMappedType: boolean
   /** Model ID patterns to always skip (matched against stripped ID) */
   skipPatterns: Array<string>
+  /** Activities to insert. `null` means the catalog left activity unset. */
+  acceptedActivities: Array<string | null>
+  /**
+   * When true, skip a native id until the modelschemas OpenRouter catalog
+   * has a matching row (openai/anthropic/gemini/grok). BytePlus and
+   * ElevenLabs publish usable native rows, so they stay false.
+   */
+  requireOpenRouterEnrich: boolean
+  includePricing: boolean
+  outputTokenField: 'max_output_tokens' | 'max_completion_tokens'
+  /** ElevenLabs is id-literal arrays, not ModelMeta constants. */
+  insertKind: 'model-meta' | 'id-arrays'
 }
 
 const PROVIDER_MAP: Record<SyncedProvider, ProviderConfig> = {
@@ -129,6 +140,11 @@ const PROVIDER_MAP: Record<SyncedProvider, ProviderConfig> = {
       'gpt-oss-', // Open-source/experimental models
       'chatgpt-', // ChatGPT branded models
     ],
+    acceptedActivities: ['chat'],
+    requireOpenRouterEnrich: true,
+    includePricing: true,
+    outputTokenField: 'max_output_tokens',
+    insertKind: 'model-meta',
   },
   anthropic: {
     packageName: '@tanstack/ai-anthropic',
@@ -149,6 +165,11 @@ const PROVIDER_MAP: Record<SyncedProvider, ProviderConfig> = {
     hasBothNameAndId: true,
     providerOptionsIsMappedType: false,
     skipPatterns: [],
+    acceptedActivities: ['chat'],
+    requireOpenRouterEnrich: true,
+    includePricing: true,
+    outputTokenField: 'max_output_tokens',
+    insertKind: 'model-meta',
   },
   gemini: {
     packageName: '@tanstack/ai-gemini',
@@ -170,6 +191,11 @@ const PROVIDER_MAP: Record<SyncedProvider, ProviderConfig> = {
     skipPatterns: [
       'gemma-', // Gemma open-source models (not Gemini API models)
     ],
+    acceptedActivities: ['chat'],
+    requireOpenRouterEnrich: true,
+    includePricing: true,
+    outputTokenField: 'max_output_tokens',
+    insertKind: 'model-meta',
   },
   grok: {
     packageName: '@tanstack/ai-grok',
@@ -187,6 +213,107 @@ const PROVIDER_MAP: Record<SyncedProvider, ProviderConfig> = {
     hasBothNameAndId: false,
     providerOptionsIsMappedType: true,
     skipPatterns: [],
+    acceptedActivities: ['chat'],
+    requireOpenRouterEnrich: true,
+    includePricing: true,
+    outputTokenField: 'max_output_tokens',
+    insertKind: 'model-meta',
+  },
+  groq: {
+    packageName: '@tanstack/ai-groq',
+    metaFile: resolve(ROOT, 'packages/ai-groq/src/model-meta.ts'),
+    arrayRef: '.name',
+    contextField: 'context_window',
+    chatArrayName: 'GROQ_CHAT_MODELS',
+    providerOptionsTypeName: 'GroqChatModelProviderOptionsByName',
+    inputModalitiesTypeName: 'GroqModelInputModalitiesByName',
+    toolCapabilitiesTypeName: 'GroqChatModelToolCapabilitiesByName',
+    validInputModalities: ['text', 'image', 'audio'],
+    kind: 'groq',
+    referenceSatisfies: 'ModelMeta<GroqTextProviderOptions>',
+    referenceProviderOptionsEntry: 'GroqTextProviderOptions',
+    hasBothNameAndId: false,
+    providerOptionsIsMappedType: true,
+    skipPatterns: ['whisper-', 'canopylabs/'],
+    acceptedActivities: [null, 'chat'],
+    requireOpenRouterEnrich: false,
+    includePricing: true,
+    outputTokenField: 'max_completion_tokens',
+    insertKind: 'model-meta',
+  },
+  mistral: {
+    packageName: '@tanstack/ai-mistral',
+    metaFile: resolve(ROOT, 'packages/ai-mistral/src/model-meta.ts'),
+    arrayRef: '.name',
+    contextField: 'context_window',
+    chatArrayName: 'MISTRAL_CHAT_MODELS',
+    providerOptionsTypeName: 'MistralChatModelProviderOptionsByName',
+    inputModalitiesTypeName: 'MistralModelInputModalitiesByName',
+    validInputModalities: ['text', 'image', 'audio', 'document'],
+    kind: 'mistral',
+    referenceSatisfies: 'ModelMeta<MistralTextProviderOptions>',
+    referenceProviderOptionsEntry: 'MistralTextProviderOptions',
+    hasBothNameAndId: false,
+    providerOptionsIsMappedType: false,
+    skipPatterns: [
+      'mistral-embed',
+      'codestral-embed',
+      'mistral-ocr',
+      'mistral-moderation',
+      'voxtral-',
+      'mistral-vibe',
+      'mistral-code-fim',
+      'mistral-code-',
+      'glm-',
+      'zai-',
+    ],
+    acceptedActivities: [null, 'chat'],
+    requireOpenRouterEnrich: false,
+    includePricing: true,
+    outputTokenField: 'max_completion_tokens',
+    insertKind: 'model-meta',
+  },
+  byteplus: {
+    packageName: '@tanstack/ai-byteplus',
+    metaFile: resolve(ROOT, 'packages/ai-byteplus/src/model-meta.ts'),
+    arrayRef: '.name',
+    contextField: 'context_window',
+    chatArrayName: 'BYTEPLUS_CHAT_MODELS',
+    providerOptionsTypeName: 'BytePlusChatModelProviderOptionsByName',
+    inputModalitiesTypeName: 'BytePlusModelInputModalitiesByName',
+    validInputModalities: ['text', 'image', 'audio', 'video', 'document'],
+    kind: 'byteplus',
+    referenceSatisfies: 'ModelMeta',
+    referenceProviderOptionsEntry: 'BytePlusTextProviderOptions',
+    hasBothNameAndId: false,
+    providerOptionsIsMappedType: true,
+    skipPatterns: [],
+    acceptedActivities: ['chat'],
+    requireOpenRouterEnrich: false,
+    includePricing: false,
+    outputTokenField: 'max_output_tokens',
+    insertKind: 'model-meta',
+  },
+  elevenlabs: {
+    packageName: '@tanstack/ai-elevenlabs',
+    metaFile: resolve(ROOT, 'packages/ai-elevenlabs/src/model-meta.ts'),
+    arrayRef: '.name',
+    contextField: 'context_window',
+    chatArrayName: 'ELEVENLABS_TTS_MODELS',
+    providerOptionsTypeName: 'ElevenLabsUnused',
+    inputModalitiesTypeName: 'ElevenLabsUnused',
+    validInputModalities: ['text', 'audio'],
+    kind: 'elevenlabs',
+    referenceSatisfies: 'never',
+    referenceProviderOptionsEntry: 'never',
+    hasBothNameAndId: false,
+    providerOptionsIsMappedType: true,
+    skipPatterns: [],
+    acceptedActivities: ['audio'],
+    requireOpenRouterEnrich: false,
+    includePricing: false,
+    outputTokenField: 'max_output_tokens',
+    insertKind: 'id-arrays',
   },
 }
 
@@ -306,28 +433,33 @@ function generateModelConstant(
     )
   }
   if (model.maxOutput != null && model.maxOutput > 0) {
-    lines.push(`  max_output_tokens: ${formatNumber(model.maxOutput)},`)
+    lines.push(
+      `  ${config.outputTokenField}: ${formatNumber(model.maxOutput)},`,
+    )
   }
   lines.push(`  supports: {`)
   lines.push(
     buildProviderSupportsBody({
       provider: config.kind,
       inputModalities,
+      outputModalities: model.outputModalities,
       supportedParameters: model.supportedParameters,
     }),
   )
   lines.push(`  },`)
-  lines.push(`  pricing: {`)
-  lines.push(`    input: {`)
-  lines.push(`      normal: ${inputNormal},`)
-  if (inputCached > 0) {
-    lines.push(`      cached: ${inputCached},`)
+  if (config.includePricing) {
+    lines.push(`  pricing: {`)
+    lines.push(`    input: {`)
+    lines.push(`      normal: ${inputNormal},`)
+    if (inputCached > 0) {
+      lines.push(`      cached: ${inputCached},`)
+    }
+    lines.push(`    },`)
+    lines.push(`    output: {`)
+    lines.push(`      normal: ${outputNormal},`)
+    lines.push(`    },`)
+    lines.push(`  },`)
   }
-  lines.push(`    },`)
-  lines.push(`    output: {`)
-  lines.push(`      normal: ${outputNormal},`)
-  lines.push(`    },`)
-  lines.push(`  },`)
   lines.push(`} as const satisfies ${satisfiesClause(model, config)}`)
   return lines.join('\n')
 }
@@ -383,8 +515,11 @@ async function main() {
 
   const client = createSyncClient()
   const catalogs = await fetchSyncCatalogs(client)
+  const counts = Object.entries(catalogs.native)
+    .map(([id, rows]) => `${id}=${rows.length}`)
+    .join(', ')
   console.log(
-    `Fetched modelschemas catalogs: openai=${catalogs.native.openai.length}, anthropic=${catalogs.native.anthropic.length}, gemini=${catalogs.native.gemini.length}, grok=${catalogs.native.grok.length}, openrouter=${catalogs.openrouter.length}`,
+    `Fetched modelschemas catalogs: ${counts}, openrouter=${catalogs.openrouter.length}`,
   )
 
   for (const [provider, config] of Object.entries(PROVIDER_MAP) as Array<
@@ -407,10 +542,65 @@ async function main() {
 
     const existingIds = extractExistingModelIds(content)
     const existingConstNames = extractExistingConstNames(content)
+    if (config.insertKind === 'id-arrays') {
+      for (const arrayName of [
+        'ELEVENLABS_TTS_MODELS',
+        'ELEVENLABS_AUDIO_MODELS',
+        'ELEVENLABS_TRANSCRIPTION_MODELS',
+      ]) {
+        for (const id of extractStringLiteralArrayValues(content, arrayName)) {
+          existingIds.add(id)
+        }
+      }
+    }
 
     console.log(
       `  Existing models in file: ${existingIds.size} IDs, ${existingConstNames.size} constants`,
     )
+
+    if (config.insertKind === 'id-arrays') {
+      const byArray: Record<string, Array<string>> = {
+        ELEVENLABS_TTS_MODELS: [],
+        ELEVENLABS_AUDIO_MODELS: [],
+        ELEVENLABS_TRANSCRIPTION_MODELS: [],
+      }
+      for (const row of providerModels) {
+        const skip = skipNativeModelReason(
+          row,
+          config.kind,
+          config.skipPatterns,
+          cutoffTimestamp,
+          config.acceptedActivities,
+        )
+        if (skip) continue
+        const bucket = elevenLabsIdArray(row.rawId)
+        if (!bucket) continue
+        if (alreadySynced(row.rawId, existingIds, existingConstNames)) continue
+        const arrayName =
+          bucket === 'tts'
+            ? 'ELEVENLABS_TTS_MODELS'
+            : bucket === 'audio'
+              ? 'ELEVENLABS_AUDIO_MODELS'
+              : 'ELEVENLABS_TRANSCRIPTION_MODELS'
+        byArray[arrayName]!.push(row.rawId)
+        existingIds.add(row.rawId)
+      }
+      const added = Object.values(byArray).flat()
+      if (added.length === 0) {
+        console.log('  No new models to add.')
+        continue
+      }
+      console.log(`  Adding ${added.length} new models:`)
+      for (const id of added) console.log(`    - ${id}`)
+      for (const [arrayName, ids] of Object.entries(byArray)) {
+        content = addToStringLiteralArray(content, arrayName, ids)
+      }
+      await writeFile(config.metaFile, content, 'utf-8')
+      console.log(`  Wrote updated file: ${config.metaFile}`)
+      totalAdded += added.length
+      changedPackages.add(config.packageName)
+      continue
+    }
 
     const newModels: Array<{
       model: SyncModel
@@ -424,6 +614,7 @@ async function main() {
         config.kind,
         config.skipPatterns,
         cutoffTimestamp,
+        config.acceptedActivities,
       )
       if (skip) continue
 
@@ -432,12 +623,11 @@ async function main() {
         config.kind,
         catalogs.openrouter,
       )
-      // Native catalogs often omit pricing/modalities/capabilities.
-      // Skip until OpenRouter has a matching row so we do not insert
-      // empty chat stubs for transcribe/live/experimental ids.
-      if (!enrich) continue
+      if (config.requireOpenRouterEnrich && !enrich) continue
       const model = toSyncModel(row, enrich, config.kind)
       if (
+        config.acceptedActivities.includes('chat') &&
+        !config.acceptedActivities.includes('image') &&
         hasImageOutput({
           activity: row.activity,
           outputModalities: model.outputModalities,

--- a/scripts/sync-provider-models.ts
+++ b/scripts/sync-provider-models.ts
@@ -1,33 +1,29 @@
 /**
- * Syncs OpenRouter models into native provider model-meta.ts files.
+ * Syncs modelschemas catalogs into native provider model-meta.ts files.
  *
  * For each supported provider (OpenAI, Anthropic, Gemini, Grok), this script:
- * 1. Reads the OpenRouter model list
- * 2. Filters models matching the provider prefix
+ * 1. Lists that provider's models from modelschemas (`@modelschemas/client`)
+ * 2. Enriches empty pricing/modalities/capabilities from the OpenRouter
+ *    catalog on modelschemas
  * 3. Identifies models missing from the provider's model-meta.ts
  * 4. Generates and inserts new model constants, array entries, and type map entries
  *
  * Usage:
  *   pnpm tsx scripts/sync-provider-models.ts
  *
+ * Optional: MODELSCHEMAS_API_KEY raises the modelschemas rate limit.
+ *
  * ## Providers deliberately NOT synced
  *
- * The sync is only safe when the provider's own model ids can be derived from
- * OpenRouter's. Adding an entry to `PROVIDER_MAP` for a provider where that
- * doesn't hold generates ids that 404 at request time, which is worse than no
- * automation. These are excluded on purpose:
+ * The sync is only safe when the provider's own model ids are the catalog
+ * ids. These are excluded on purpose:
  *
- * - **byteplus** (`@tanstack/ai-byteplus`) — OpenRouter lists the same models
- *   under undated slugs (`bytedance-seed/seed-1.6`), but BytePlus Ark
- *   addresses them by *date-suffixed* id (`seed-1-6-250615`), and the suffix
- *   is not derivable from anything OpenRouter publishes. Ark's own `GET
- *   /models` is the catalog, and it is not exhaustive. On top of that the
- *   package's capability tables are live-probe-verified specifically because
- *   the published metadata is wrong in both directions, so a metadata-driven
- *   sync would overwrite probed facts with worse ones. Use `/gap-analysis
- *   byteplus` instead; the probe recipe is in that package's `model-meta.ts`.
- * - **fal**, **elevenlabs** — media-only providers whose endpoint ids are not
- *   OpenRouter models at all. fal image fields have their own generator
+ * - **byteplus** (`@tanstack/ai-byteplus`) — capability tables are
+ *   live-probe-verified because published metadata is wrong in both
+ *   directions. Use `/gap-analysis byteplus` instead; the probe recipe is
+ *   in that package's `model-meta.ts`.
+ * - **fal**, **elevenlabs** — media-only providers whose endpoint ids need
+ *   manual size/duration maps. fal image fields have their own generator
  *   (`scripts/generate-fal-image-field-map.ts`).
  * - **bedrock** — ids are AWS-region-qualified; see
  *   `scripts/fetch-bedrock-models.ts`.
@@ -38,28 +34,28 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
-  isRoutingAlias,
-  toModelConstName,
-  toNativeProviderId,
-} from './model-sync/ids'
+  alreadySynced,
+  findOpenRouterEnrichment,
+  hasImageOutput,
+  outputsText,
+  skipNativeModelReason,
+  toSyncModel,
+} from './model-sync/catalog'
+import type { SyncModel } from './model-sync/catalog'
+import { toModelConstName } from './model-sync/ids'
 import {
   applyChatModelCatalogInserts,
   insertConstants,
 } from './model-sync/native-insert'
+import { createSyncClient, fetchSyncCatalogs } from './model-sync/modelschemas'
 import {
   buildAnthropicProviderOptionsType,
   buildProviderSupportsBody,
 } from './model-sync/provider-supports'
 import type { SyncedProvider } from './model-sync/provider-supports'
-import { models } from './openrouter.models'
-import type { OpenRouterModel } from './openrouter.models'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..')
-
-// ---------------------------------------------------------------------------
-// Provider configuration
-// ---------------------------------------------------------------------------
 
 /** Seconds in 30 days — models older than this before the last sync are skipped */
 const MAX_MODEL_AGE_SECONDS = 30 * 24 * 60 * 60
@@ -108,8 +104,8 @@ interface ProviderConfig {
   skipPatterns: Array<string>
 }
 
-const PROVIDER_MAP: Record<string, ProviderConfig> = {
-  'openai/': {
+const PROVIDER_MAP: Record<SyncedProvider, ProviderConfig> = {
+  openai: {
     packageName: '@tanstack/ai-openai',
     metaFile: resolve(ROOT, 'packages/ai-openai/src/model-meta.ts'),
     arrayRef: '.name',
@@ -134,7 +130,7 @@ const PROVIDER_MAP: Record<string, ProviderConfig> = {
       'chatgpt-', // ChatGPT branded models
     ],
   },
-  'anthropic/': {
+  anthropic: {
     packageName: '@tanstack/ai-anthropic',
     metaFile: resolve(ROOT, 'packages/ai-anthropic/src/model-meta.ts'),
     arrayRef: '.id',
@@ -154,7 +150,7 @@ const PROVIDER_MAP: Record<string, ProviderConfig> = {
     providerOptionsIsMappedType: false,
     skipPatterns: [],
   },
-  'google/': {
+  gemini: {
     packageName: '@tanstack/ai-gemini',
     metaFile: resolve(ROOT, 'packages/ai-gemini/src/model-meta.ts'),
     arrayRef: '.name',
@@ -175,7 +171,7 @@ const PROVIDER_MAP: Record<string, ProviderConfig> = {
       'gemma-', // Gemma open-source models (not Gemini API models)
     ],
   },
-  'x-ai/': {
+  grok: {
     packageName: '@tanstack/ai-grok',
     metaFile: resolve(ROOT, 'packages/ai-grok/src/model-meta.ts'),
     arrayRef: '.name',
@@ -194,10 +190,6 @@ const PROVIDER_MAP: Record<string, ProviderConfig> = {
   },
 }
 
-// ---------------------------------------------------------------------------
-// Utility functions
-// ---------------------------------------------------------------------------
-
 type InputModality = 'text' | 'image' | 'audio' | 'video' | 'document'
 
 const MODALITY_MAP: Record<string, InputModality> = {
@@ -209,30 +201,16 @@ const MODALITY_MAP: Record<string, InputModality> = {
   document: 'document',
 }
 
-/**
- * Map OpenRouter input modalities to our standard modality types.
- * Same mapping as the existing convert-openrouter-models.ts script.
- */
 function mapInputModalities(modalities: Array<string>): Array<InputModality> {
   const mapped = modalities
     .map((m) => MODALITY_MAP[m.toLowerCase()])
     .filter((m): m is InputModality => m !== undefined)
-  // Ensure at least 'text' is present
   if (!mapped.includes('text')) {
     mapped.unshift('text')
   }
   return mapped
 }
 
-/** Strip the provider prefix from an OpenRouter model ID */
-function stripPrefix(prefix: string, modelId: string): string {
-  return modelId.slice(prefix.length)
-}
-
-/**
- * Convert an OpenRouter price string to per-million-token pricing.
- * Same logic as the existing convert script.
- */
 function convertPrice(priceStr: string | undefined): number {
   const price = parseFloat(priceStr ?? '0')
   if (isNaN(price)) return 0
@@ -240,66 +218,43 @@ function convertPrice(priceStr: string | undefined): number {
   return Math.round(result * 1e10) / 1e10
 }
 
-function anthropicOptionsType(model: OpenRouterModel): string {
+function anthropicOptionsType(model: SyncModel): string {
   return buildAnthropicProviderOptionsType({
-    supportedParameters: model.supported_parameters,
-    reasoningMandatory: model.reasoning?.mandatory === true,
+    supportedParameters: model.supportedParameters,
+    reasoningMandatory: false,
     hasCachedPricing: convertPrice(model.pricing.input_cache_read) > 0,
   })
 }
 
 function providerOptionsEntryFor(
-  model: OpenRouterModel,
+  model: SyncModel,
   config: ProviderConfig,
 ): string {
   if (config.kind === 'anthropic') return anthropicOptionsType(model)
   return config.referenceProviderOptionsEntry
 }
 
-function satisfiesClause(
-  model: OpenRouterModel,
-  config: ProviderConfig,
-): string {
+function satisfiesClause(model: SyncModel, config: ProviderConfig): string {
   if (config.kind === 'anthropic') {
     return `ModelMeta<${anthropicOptionsType(model)}>`
   }
   return config.referenceSatisfies
 }
 
-/**
- * Normalize a model ID for comparison.
- * Handles cases where the same model uses dots vs dashes
- * (e.g., Anthropic's 'claude-3-5-haiku' vs OpenRouter's 'claude-3.5-haiku').
- */
-function normalizeId(id: string): string {
-  return id.replace(/[.]/g, '-')
-}
-
-/**
- * Extract existing model IDs from a model-meta file.
- * Matches BOTH name: 'xxx' AND id: 'xxx' lines to get a complete set,
- * since providers like Anthropic use different naming between name and id.
- * Returns a normalized set for comparison purposes.
- */
 function extractExistingModelIds(content: string): Set<string> {
   const ids = new Set<string>()
-  // Match both name and id fields inside const blocks
   const nameRegex = /^\s+name:\s*'([^']+)'/gm
   const idRegex = /^\s+id:\s*'([^']+)'/gm
   let match
   while ((match = nameRegex.exec(content)) !== null) {
-    ids.add(normalizeId(match[1]!))
+    ids.add(match[1]!.replaceAll('.', '-'))
   }
   while ((match = idRegex.exec(content)) !== null) {
-    ids.add(normalizeId(match[1]!))
+    ids.add(match[1]!.replaceAll('.', '-'))
   }
   return ids
 }
 
-/**
- * Extract existing constant names from a model-meta file.
- * Matches: const UPPER_CASE_NAME =
- */
 function extractExistingConstNames(content: string): Set<string> {
   const names = new Set<string>()
   const regex = /^const\s+([A-Z][A-Z0-9_]+)\s*=/gm
@@ -310,59 +265,6 @@ function extractExistingConstNames(content: string): Set<string> {
   return names
 }
 
-/**
- * Check if an OpenRouter model outputs text (for chat model array).
- */
-function outputsText(model: OpenRouterModel): boolean {
-  return model.architecture.output_modalities.includes('text')
-}
-
-/**
- * Check if an OpenRouter model produces image output.
- *
- * Image-generation models are skipped entirely by the sync — regardless of
- * whether they ALSO output text — because image model arrays require manual
- * curation with specialized type maps (sizes, provider options, the native
- * image union). This covers text+image "native" image models such as the
- * Gemini "Nano Banana" family (`gemini-*-image`, e.g.
- * `gemini-3.1-flash-lite-image`), which would otherwise be misclassified as
- * chat models (they output text) and inserted with a bogus `output: ['text']`.
- */
-function outputsImage(model: OpenRouterModel): boolean {
-  return model.architecture.output_modalities.includes('image')
-}
-
-/**
- * Non-chat model family prefixes to exclude from chat model arrays.
- * These are audio/music/video/image generation models that happen to
- * include 'text' in their output modalities but are not chat models.
- */
-const NON_CHAT_MODEL_PREFIXES = [
-  'lyria-', // Google music generation
-  'veo-', // Google video generation
-  'imagen-', // Google image generation
-  'sora-', // OpenAI video generation
-  'dall-e-', // OpenAI image generation
-  'tts-', // Text-to-speech models
-]
-
-function isNonChatModel(strippedId: string): boolean {
-  return NON_CHAT_MODEL_PREFIXES.some((p) => strippedId.startsWith(p))
-}
-
-/**
- * Check if a model should be skipped based on provider-specific patterns.
- */
-function matchesSkipPattern(
-  strippedId: string,
-  patterns: Array<string>,
-): boolean {
-  return patterns.some((p) => strippedId.startsWith(p))
-}
-
-/**
- * Read the last sync run timestamp. Returns epoch seconds, or null if no previous run.
- */
 async function readLastRunTimestamp(): Promise<number | null> {
   try {
     const content = await readFile(LAST_RUN_FILE, 'utf-8')
@@ -373,84 +275,48 @@ async function readLastRunTimestamp(): Promise<number | null> {
   }
 }
 
-/**
- * Write the current timestamp as the last sync run.
- */
 async function writeLastRunTimestamp(): Promise<void> {
   const now = Math.floor(Date.now() / 1000)
   await writeFile(LAST_RUN_FILE, String(now) + '\n', 'utf-8')
 }
 
-/**
- * Check if a model is too old to sync. Models created more than 30 days
- * before the last sync run are considered deprecated/legacy and skipped.
- */
-function isModelTooOld(
-  model: OpenRouterModel,
-  cutoffTimestamp: number,
-): boolean {
-  if (!model.created) return false // No date = don't skip
-  return model.created < cutoffTimestamp
-}
-
-// ---------------------------------------------------------------------------
-// Model constant generation
-// ---------------------------------------------------------------------------
-
 function generateModelConstant(
-  model: OpenRouterModel,
-  prefix: string,
+  model: SyncModel,
   config: ProviderConfig,
 ): string {
-  const strippedId = stripPrefix(prefix, model.id)
-  const nativeId = toNativeProviderId(strippedId, config.kind)
-  const constName = toModelConstName(nativeId)
+  const constName = toModelConstName(model.nativeId)
 
   const inputNormal = convertPrice(model.pricing.prompt)
   const inputCached = convertPrice(model.pricing.input_cache_read)
   const outputNormal = convertPrice(model.pricing.completion)
 
-  // Use actual input modalities from OpenRouter data, filtered to what this provider supports
-  const inputModalities = mapInputModalities(
-    model.architecture.input_modalities,
-  ).filter((m) => config.validInputModalities.includes(m))
+  const inputModalities = mapInputModalities(model.inputModalities).filter(
+    (m) => config.validInputModalities.includes(m),
+  )
 
   const lines: Array<string> = []
   lines.push(`const ${constName} = {`)
-
-  // name field
-  lines.push(`  name: '${nativeId}',`)
-
-  // id field (Anthropic has both name and id, set to same value for new models)
+  lines.push(`  name: '${model.nativeId}',`)
   if (config.hasBothNameAndId) {
-    lines.push(`  id: '${nativeId}',`)
+    lines.push(`  id: '${model.nativeId}',`)
   }
-
-  // context / max_input_tokens
-  if (model.context_length > 0) {
+  if (model.contextWindow != null && model.contextWindow > 0) {
     lines.push(
-      `  ${config.contextField}: ${formatNumber(model.context_length)},`,
+      `  ${config.contextField}: ${formatNumber(model.contextWindow)},`,
     )
   }
-
-  // max_output_tokens
-  if (model.top_provider.max_completion_tokens) {
-    lines.push(
-      `  max_output_tokens: ${formatNumber(model.top_provider.max_completion_tokens)},`,
-    )
+  if (model.maxOutput != null && model.maxOutput > 0) {
+    lines.push(`  max_output_tokens: ${formatNumber(model.maxOutput)},`)
   }
-
   lines.push(`  supports: {`)
   lines.push(
     buildProviderSupportsBody({
       provider: config.kind,
       inputModalities,
-      supportedParameters: model.supported_parameters,
+      supportedParameters: model.supportedParameters,
     }),
   )
   lines.push(`  },`)
-
-  // pricing
   lines.push(`  pricing: {`)
   lines.push(`    input: {`)
   lines.push(`      normal: ${inputNormal},`)
@@ -462,20 +328,13 @@ function generateModelConstant(
   lines.push(`      normal: ${outputNormal},`)
   lines.push(`    },`)
   lines.push(`  },`)
-
   lines.push(`} as const satisfies ${satisfiesClause(model, config)}`)
-
   return lines.join('\n')
 }
 
-/**
- * Format a number with underscore separators for readability.
- * E.g. 131072 -> '131_072', 200000 -> '200_000'
- */
 function formatNumber(n: number): string {
   if (n < 1000) return String(n)
   const str = String(n)
-  // Insert underscores every 3 digits from the right
   const parts: Array<string> = []
   let remaining = str
   while (remaining.length > 3) {
@@ -486,15 +345,6 @@ function formatNumber(n: number): string {
   return parts.join('_')
 }
 
-// ---------------------------------------------------------------------------
-// Git-based change detection
-// ---------------------------------------------------------------------------
-
-/**
- * Detect packages with uncommitted changes by running `git diff`.
- * This captures changes from ALL prior pipeline steps (e.g. convert-openrouter-models.ts)
- * not just the models added by this script.
- */
 function detectChangedPackages(): Set<string> {
   const changed = new Set<string>()
   try {
@@ -506,7 +356,6 @@ function detectChangedPackages(): Set<string> {
     if (!diff) return changed
 
     for (const line of diff.split('\n')) {
-      // packages/ai-openrouter/... → @tanstack/ai-openrouter
       const match = line.match(/^packages\/([\w-]+)\//)
       if (match) {
         changed.add(`@tanstack/${match[1]}`)
@@ -518,15 +367,10 @@ function detectChangedPackages(): Set<string> {
   return changed
 }
 
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
-
 async function main() {
   let totalAdded = 0
   const changedPackages = new Set<string>()
 
-  // Determine age cutoff: skip models created >30 days before last run
   const lastRun = await readLastRunTimestamp()
   const now = Math.floor(Date.now() / 1000)
   const cutoffTimestamp = (lastRun ?? now) - MAX_MODEL_AGE_SECONDS
@@ -537,16 +381,22 @@ async function main() {
     `Model age cutoff: ${cutoffDate} (skipping models created before this date)`,
   )
 
-  for (const [prefix, config] of Object.entries(PROVIDER_MAP)) {
-    console.log(`\nProcessing provider: ${prefix}`)
+  const client = createSyncClient()
+  const catalogs = await fetchSyncCatalogs(client)
+  console.log(
+    `Fetched modelschemas catalogs: openai=${catalogs.native.openai.length}, anthropic=${catalogs.native.anthropic.length}, gemini=${catalogs.native.gemini.length}, grok=${catalogs.native.grok.length}, openrouter=${catalogs.openrouter.length}`,
+  )
 
-    // Filter OpenRouter models for this prefix
-    const providerModels = models.filter((m) => m.id.startsWith(prefix))
+  for (const [provider, config] of Object.entries(PROVIDER_MAP) as Array<
+    [SyncedProvider, ProviderConfig]
+  >) {
+    console.log(`\nProcessing provider: ${provider}`)
+
+    const providerModels = catalogs.native[provider]
     console.log(
-      `  Found ${providerModels.length} OpenRouter models with prefix '${prefix}'`,
+      `  Found ${providerModels.length} modelschemas models for '${provider}'`,
     )
 
-    // Read the provider's model-meta.ts
     let content: string
     try {
       content = await readFile(config.metaFile, 'utf-8')
@@ -555,7 +405,6 @@ async function main() {
       continue
     }
 
-    // Extract existing model IDs (normalized) and constant names
     const existingIds = extractExistingModelIds(content)
     const existingConstNames = extractExistingConstNames(content)
 
@@ -563,50 +412,47 @@ async function main() {
       `  Existing models in file: ${existingIds.size} IDs, ${existingConstNames.size} constants`,
     )
 
-    // Find new models
     const newModels: Array<{
-      model: OpenRouterModel
+      model: SyncModel
+      activity: string | null
       constName: string
-      strippedId: string
     }> = []
 
-    for (const model of providerModels) {
-      if (isRoutingAlias(model.id)) {
-        continue
-      }
+    for (const row of providerModels) {
+      const skip = skipNativeModelReason(
+        row,
+        config.kind,
+        config.skipPatterns,
+        cutoffTimestamp,
+      )
+      if (skip) continue
 
-      const strippedId = stripPrefix(prefix, model.id)
-      const nativeId = toNativeProviderId(strippedId, config.kind)
-      const constName = toModelConstName(nativeId)
-
-      // Skip models with ':' variants (e.g., 'anthropic/claude-3.7-sonnet:thinking')
-      // These are routing variants, not separate models
-      if (strippedId.includes(':')) {
-        continue
-      }
-
-      // Skip non-chat model families (audio/music/video/image generation)
-      if (isNonChatModel(strippedId)) {
-        continue
-      }
-
-      // Skip provider-specific patterns (deprecated/legacy model families)
-      if (matchesSkipPattern(strippedId, config.skipPatterns)) {
-        continue
-      }
-
-      // Skip models that are too old (created >30 days before last sync)
-      if (isModelTooOld(model, cutoffTimestamp)) {
-        continue
-      }
-
-      // Normalize for comparison to handle dots-vs-dashes naming differences
+      const enrich = findOpenRouterEnrichment(
+        row,
+        config.kind,
+        catalogs.openrouter,
+      )
+      // Native catalogs often omit pricing/modalities/capabilities.
+      // Skip until OpenRouter has a matching row so we do not insert
+      // empty chat stubs for transcribe/live/experimental ids.
+      if (!enrich) continue
+      const model = toSyncModel(row, enrich, config.kind)
       if (
-        !existingIds.has(normalizeId(strippedId)) &&
-        !existingConstNames.has(constName)
+        hasImageOutput({
+          activity: row.activity,
+          outputModalities: model.outputModalities,
+        })
       ) {
-        newModels.push({ model, constName, strippedId: nativeId })
+        continue
       }
+      if (alreadySynced(model.nativeId, existingIds, existingConstNames)) {
+        continue
+      }
+      newModels.push({
+        model,
+        activity: row.activity,
+        constName: toModelConstName(model.nativeId),
+      })
     }
 
     if (newModels.length === 0) {
@@ -615,40 +461,18 @@ async function main() {
     }
 
     console.log(`  Adding ${newModels.length} new models:`)
-    for (const { strippedId, constName } of newModels) {
-      console.log(`    - ${strippedId} (${constName})`)
+    for (const { model, constName } of newModels) {
+      console.log(`    - ${model.nativeId} (${constName})`)
     }
 
-    // Filter out image-generation models (they need manual curation for
-    // size/provider type maps + the native image union). This includes
-    // text+image models like the Gemini "Nano Banana" native image family,
-    // not just image-only models.
-    const filteredModels = newModels.filter(({ model }) => !outputsImage(model))
-    const skippedImageModels = newModels.length - filteredModels.length
-    if (skippedImageModels > 0) {
-      console.log(
-        `  Skipping ${skippedImageModels} image-generation models (require manual curation)`,
-      )
-    }
-
-    if (filteredModels.length === 0) {
-      console.log('  No eligible models to add after filtering.')
-      continue
-    }
-
-    // Generate constants
-    const constants = filteredModels.map(({ model }) =>
-      generateModelConstant(model, prefix, config),
+    const constants = newModels.map(({ model }) =>
+      generateModelConstant(model, config),
     )
-
-    // Insert constants before first export
     content = insertConstants(content, constants)
 
-    // NOTE: We intentionally do NOT add models to image arrays.
-    // Image model arrays have specialized type maps (sizes, provider options)
-    // that require manual curation.
-
-    const chatModels = filteredModels.filter(({ model }) => outputsText(model))
+    const chatModels = newModels.filter(({ model, activity }) =>
+      outputsText(model, activity),
+    )
     content = applyChatModelCatalogInserts(
       content,
       {
@@ -663,24 +487,20 @@ async function main() {
       chatModels.map(({ model, constName }) => ({
         constName,
         providerOptionsEntry: providerOptionsEntryFor(model, config),
-        hasMaxOutputTokens: Boolean(model.top_provider.max_completion_tokens),
+        hasMaxOutputTokens: model.maxOutput != null && model.maxOutput > 0,
       })),
     )
 
-    // Write the modified file
     await writeFile(config.metaFile, content, 'utf-8')
     console.log(`  Wrote updated file: ${config.metaFile}`)
-    totalAdded += filteredModels.length
+    totalAdded += newModels.length
     changedPackages.add(config.packageName)
   }
 
   console.log(`\nDone. Added ${totalAdded} new models total.`)
 
-  // Record this run's timestamp for future age-based filtering
   await writeLastRunTimestamp()
 
-  // Detect all packages with uncommitted changes (includes changes from
-  // convert-openrouter-models.ts which runs before this script)
   const allChangedPackages = detectChangedPackages()
   for (const pkg of changedPackages) {
     allChangedPackages.add(pkg)
@@ -691,10 +511,6 @@ async function main() {
   }
 }
 
-/**
- * Create or update the sync-models changeset file.
- * If one already exists, merges the package lists. Otherwise creates a new one.
- */
 async function createChangeset(changedPackages: Set<string>) {
   const changesetDir = resolve(ROOT, '.changeset')
   const { readdir } = await import('node:fs/promises')
@@ -707,7 +523,6 @@ async function createChangeset(changedPackages: Set<string>) {
     const existingPath = resolve(changesetDir, existing)
     const existingContent = await readFile(existingPath, 'utf-8')
 
-    // Merge existing packages into the set
     const pkgRegex = /'([^']+)':\s*patch/g
     let match
     while ((match = pkgRegex.exec(existingContent)) !== null) {
@@ -732,7 +547,7 @@ function buildChangesetContent(packages: Set<string>): string {
     .sort()
     .map((pkg) => `'${pkg}': patch`)
     .join('\n')
-  return `---\n${packageLines}\n---\n\nUpdate model metadata from OpenRouter API\n`
+  return `---\n${packageLines}\n---\n\nUpdate model metadata from modelschemas\n`
 }
 
 main().catch((err) => {


### PR DESCRIPTION
You can pass `qwen/qwen3.8-27b` to Groq `chat()`, plus new Mistral chat ids, BytePlus DeepSeek GA ids, and ElevenLabs `eleven_v3_conversational`. The daily sync reads those ids from modelschemas native catalogs. Capabilities and modalities come from the native row. OpenRouter only fills empty prices.

## 🎯 Changes

`pnpm generate:models` inserts new native models for Groq, Mistral, BytePlus, and ElevenLabs from [modelschemas](https://modelschemas.com).

- OpenAI, Anthropic, Gemini, and Grok: native id, limits, modalities, and capabilities. Skip the id until OpenRouter has a price row.
- Groq, Mistral, BytePlus, and ElevenLabs: insert from the native catalog even when OpenRouter has no row. Groq and Mistral often leave `activity` null.
- ElevenLabs writes id literals into `ELEVENLABS_TTS_MODELS` (and audio / transcription arrays). The generator skips voice-conversion (`*_sts_*`) ids.
- This run added `qwen/qwen3.8-27b`, twelve Mistral chat ids, `deepseek-v4-flash-ga-260731`, `deepseek-v4-pro-ga-260813`, and `eleven_v3_conversational`.
- Fal, Ollama, Bedrock, Cohere, and harness packages stay off this path.

`docs/` pages were not edited. Adapter `model-meta.ts` files are the catalog. `CONTRIBUTING.md` documents the providers and the native-first fill order.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

**Commands run.**

1. `pnpm exec vitest run scripts/model-sync` — 36 passed.
2. `pnpm --filter @tanstack/ai-groq --filter @tanstack/ai-mistral exec tsc --noEmit` — passed after the native-capabilities commit.
3. Live `pnpm tsx scripts/sync-provider-models.ts` against modelschemas produced the inserts in this PR.
4. I did not run `pnpm test:pr` locally. CI on this PR is the full suite.

**Manual test.**

1. Run `pnpm tsx scripts/sync-provider-models.ts`.
2. Confirm the log prints catalog counts for openai, anthropic, gemini, grok, groq, mistral, byteplus, elevenlabs, and openrouter.
3. Confirm a second run adds 0 models when the catalogs match the files.
4. Confirm `packages/ai-groq/src/model-meta.ts` lists `qwen/qwen3.8-27b` with tools, reasoning, and vision.
5. Confirm `packages/ai-elevenlabs/src/model-meta.ts` lists `eleven_v3_conversational`.

**How this PR makes testing easy.** `scripts/model-sync/*.test.ts` covers catalog parse, native capabilities over OpenRouter extras, BytePlus object capabilities, Groq/Mistral empty-modality text output, ElevenLabs array inserts, and skip rules.

## Public API change

New ids join the exported model unions. Call sites that used only the old ids still type-check.

**Before**

```ts
chat({ adapter: groqText(), model: 'qwen/qwen3-32b', messages })
```

**After**

```ts
chat({ adapter: groqText(), model: 'qwen/qwen3.8-27b', messages })
```

BytePlus `deepseek-v4-*-ga-*`, Mistral dated chat ids, and ElevenLabs `eleven_v3_conversational` work the same way on their adapters.

## Risk / rollback

New model ids can fail at runtime if the provider has not shipped that id yet. This branch is behind `main`. Revert this PR to drop the generator change and the inserts. The daily workflow will not re-add these providers until this lands on `main`.
