### PR TITLE
feat: accept baseURL and defaultHeaders on every provider adapter

### DIFF
--- a/.changeset/normalize-baseurl-defaultheaders.md
+++ b/.changeset/normalize-baseurl-defaultheaders.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/ai-gemini': minor
+'@tanstack/ai-cohere': minor
+'@tanstack/ai-elevenlabs': minor
+'@tanstack/ai-mistral': minor
+'@tanstack/ai-ollama': minor
+'@tanstack/ai-bedrock': patch
+---
+
+Accept `baseURL` and `defaultHeaders` on every adapter's client config so one gateway config (Cloudflare AI Gateway, Vercel AI Gateway, a corporate proxy) can be spread into any adapter. The vendor-specific names (`httpOptions`, `serverURL`, `host`, `baseUrl`, `headers`) keep working. Bedrock's Converse adapter now applies `defaultHeaders` too.

--- a/docs/adapters/bedrock.md
+++ b/docs/adapters/bedrock.md
@@ -119,9 +119,25 @@ AWS_SESSION_TOKEN=...   # optional, for temporary credentials
 | `auth` | `'apikey' \| 'sigv4' \| 'auto'` | `'auto'` | Authentication mode |
 | `apiKey` | `string` | — | Explicit API key (overrides env vars) |
 | `baseURL` | `string` | — | Override the computed base URL entirely |
+| `defaultHeaders` | `Record<string, string>` | none | Headers sent with every request |
 | `endpoint` | `'runtime' \| 'mantle'` | `'runtime'` | Bedrock endpoint to target (Chat Completions path only) |
 
 The `endpoint` option only applies when `api: 'chat'`. The `runtime` endpoint (`bedrock-runtime`) hosts the broad open-weight catalog; `mantle` is an alternative. The Responses API always targets mantle.
+
+## Behind a proxy
+
+Route every request through a gateway, such as Cloudflare AI Gateway or a corporate proxy, with `baseURL` and `defaultHeaders`. These two option names are the same on every TanStack AI adapter, so one gateway config works for all of them.
+
+```typescript
+import { createBedrockText } from "@tanstack/ai-bedrock";
+
+const adapter = createBedrockText("us.amazon.nova-pro-v1:0", process.env.BEDROCK_API_KEY!, {
+  baseURL: "https://gateway.example.com/aws-bedrock",
+  defaultHeaders: { "cf-aig-authorization": `Bearer ${process.env.GATEWAY_TOKEN}` },
+});
+```
+
+All three Bedrock APIs accept these options. On the Converse API the headers are added before SigV4 signing, so a signed request still includes them.
 
 ## Converse API (default)
 

--- a/docs/adapters/cohere.md
+++ b/docs/adapters/cohere.md
@@ -205,6 +205,21 @@ const embedAdapter = createCohereEmbedding(
 const rerankAdapter = createCohereRerank("rerank-v3.5", "your-cohere-api-key");
 ```
 
+## Behind a proxy
+
+Route every request through a gateway, such as Cloudflare AI Gateway or a corporate proxy, with `baseURL` and `defaultHeaders`. These two option names are the same on every TanStack AI adapter, so one gateway config works for all of them.
+
+```typescript
+import { createCohereEmbedding } from "@tanstack/ai-cohere";
+
+const adapter = createCohereEmbedding("embed-v4.0", process.env.COHERE_API_KEY!, {
+  baseURL: "https://gateway.example.com/cohere",
+  defaultHeaders: { "cf-aig-authorization": `Bearer ${process.env.GATEWAY_TOKEN}` },
+});
+```
+
+`baseUrl` and `headers` are aliases of the same two options. If you set both forms, `baseURL` and `defaultHeaders` win.
+
 ## API Reference
 
 ### `cohereEmbedding(model, config?)`
@@ -212,8 +227,8 @@ const rerankAdapter = createCohereRerank("rerank-v3.5", "your-cohere-api-key");
 Creates an embedding adapter using `COHERE_API_KEY` from the environment.
 
 - `model`: `"embed-v4.0"`
-- `config.baseUrl`: override the API base URL (default `https://api.cohere.com`)
-- `config.headers`: extra request headers
+- `config.baseURL`: override the API base URL (default `https://api.cohere.com`). `baseUrl` is an alias.
+- `config.defaultHeaders`: extra request headers. `headers` is an alias.
 - `config.allowUrlFetch`: download `http(s)` image URLs and inline them as base64 (default `false`)
 
 ### `createCohereEmbedding(model, apiKey, config?)`
@@ -225,8 +240,8 @@ Same as `cohereEmbedding` with an explicit API key.
 Creates a rerank adapter using `COHERE_API_KEY` from the environment.
 
 - `model`: one of the rerank models above
-- `config.baseUrl`: override the API base URL (default `https://api.cohere.com`)
-- `config.headers`: extra request headers
+- `config.baseURL`: override the API base URL (default `https://api.cohere.com`). `baseUrl` is an alias.
+- `config.defaultHeaders`: extra request headers. `headers` is an alias.
 
 ### `createCohereRerank(model, apiKey, config?)`
 

--- a/docs/adapters/elevenlabs.md
+++ b/docs/adapters/elevenlabs.md
@@ -338,6 +338,21 @@ const result = await generateTranscription({
 console.log(result.text);
 ```
 
+## Behind a proxy
+
+Route every request through a gateway, such as Cloudflare AI Gateway or a corporate proxy, with `baseURL` and `defaultHeaders`. These two option names are the same on every TanStack AI adapter, so one gateway config works for all of them.
+
+```typescript
+import { createElevenLabsSpeech } from "@tanstack/ai-elevenlabs";
+
+const adapter = createElevenLabsSpeech("eleven_v3", process.env.ELEVENLABS_API_KEY!, {
+  baseURL: "https://gateway.example.com/elevenlabs",
+  defaultHeaders: { "cf-aig-authorization": `Bearer ${process.env.GATEWAY_TOKEN}` },
+});
+```
+
+This applies to the speech, audio, and transcription adapters. `baseUrl` and `headers` are aliases of the same two options. If you set both forms, `baseURL` and `defaultHeaders` win.
+
 ## API Reference
 
 ### `elevenlabsRealtimeToken(options)`

--- a/docs/adapters/gemini.md
+++ b/docs/adapters/gemini.md
@@ -94,7 +94,7 @@ const adapter = createGeminiChat("gemini-3.8-flash", process.env.GEMINI_API_KEY!
 });
 ```
 
-`baseURL` sets `httpOptions.baseUrl`. `defaultHeaders` merges into `httpOptions.headers`. If you set both forms, `baseURL` and `defaultHeaders` win.
+`baseURL` sets `httpOptions.baseUrl` and `defaultHeaders` sets `httpOptions.headers`. If you set both forms, `baseURL` and `defaultHeaders` win.
 
 ## Example: Chat Completion
 

--- a/docs/adapters/gemini.md
+++ b/docs/adapters/gemini.md
@@ -73,14 +73,28 @@ const stream = chat({
 import { createGeminiChat, type GeminiTextConfig } from "@tanstack/ai-gemini";
 
 const config: Omit<GeminiTextConfig, "apiKey"> = {
-  httpOptions: {
-    baseUrl: "https://generativelanguage.googleapis.com/v1beta", // Optional
-  },
+  baseURL: "https://generativelanguage.googleapis.com/v1beta", // Optional
+  defaultHeaders: { "X-Custom-Header": "value" }, // Optional
 };
 
 const adapter = createGeminiChat("gemini-3.1-pro-preview", process.env.GEMINI_API_KEY!, config);
 ```
   
+
+## Behind a proxy
+
+Route every request through a gateway, such as Cloudflare AI Gateway or a corporate proxy, with `baseURL` and `defaultHeaders`. These two option names are the same on every TanStack AI adapter, so one gateway config works for all of them.
+
+```typescript
+import { createGeminiChat } from "@tanstack/ai-gemini";
+
+const adapter = createGeminiChat("gemini-3.8-flash", process.env.GEMINI_API_KEY!, {
+  baseURL: "https://gateway.example.com/google-ai-studio",
+  defaultHeaders: { "cf-aig-authorization": `Bearer ${process.env.GATEWAY_TOKEN}` },
+});
+```
+
+`baseURL` sets `httpOptions.baseUrl`. `defaultHeaders` merges into `httpOptions.headers`. If you set both forms, `baseURL` and `defaultHeaders` win.
 
 ## Example: Chat Completion
 

--- a/docs/adapters/mistral.md
+++ b/docs/adapters/mistral.md
@@ -69,7 +69,7 @@ import {
 } from "@tanstack/ai-mistral";
 
 const config: Omit<MistralTextConfig, "apiKey"> = {
-  serverURL: "https://api.mistral.ai", // Optional, this is the default
+  baseURL: "https://api.mistral.ai", // Optional, this is the default
   defaultHeaders: {
     "X-Custom-Header": "value",
   },
@@ -81,6 +81,21 @@ const adapter = createMistralText(
   config,
 );
 ```
+
+## Behind a proxy
+
+Route every request through a gateway, such as Cloudflare AI Gateway or a corporate proxy, with `baseURL` and `defaultHeaders`. These two option names are the same on every TanStack AI adapter, so one gateway config works for all of them.
+
+```typescript
+import { createMistralText } from "@tanstack/ai-mistral";
+
+const adapter = createMistralText("mistral-large-latest", process.env.MISTRAL_API_KEY!, {
+  baseURL: "https://gateway.example.com/mistral",
+  defaultHeaders: { "cf-aig-authorization": `Bearer ${process.env.GATEWAY_TOKEN}` },
+});
+```
+
+`serverURL` is an alias of `baseURL`. If you set both, `baseURL` wins.
 
 ## Mistral on Vertex
 
@@ -401,7 +416,7 @@ Creates a Mistral text adapter using the `MISTRAL_API_KEY` environment variable.
 **Parameters:**
 
 - `model` — The model name (e.g., `'mistral-large-latest'`)
-- `config.serverURL?` — Custom base URL (optional)
+- `config.baseURL?`: custom base URL (optional). `serverURL` is an alias.
 - `config.defaultHeaders?` — Headers to attach to every request (optional)
 
 **Returns:** A Mistral text adapter instance.
@@ -414,7 +429,7 @@ Creates a Mistral text adapter with an explicit API key.
 
 - `model` — The model name
 - `apiKey` — Your Mistral API key
-- `config.serverURL?` — Custom base URL (optional)
+- `config.baseURL?`: custom base URL (optional). `serverURL` is an alias.
 - `config.defaultHeaders?` — Headers to attach to every request (optional)
 
 **Returns:** A Mistral text adapter instance.

--- a/docs/adapters/ollama.md
+++ b/docs/adapters/ollama.md
@@ -72,6 +72,21 @@ const adapter2 = createOllamaChat("llama3", {
 });
 ```
 
+## Behind a proxy
+
+Route every request through a gateway, such as Cloudflare AI Gateway or a corporate proxy, with `baseURL` and `defaultHeaders`. These two option names are the same on every TanStack AI adapter, so one gateway config works for all of them.
+
+```typescript
+import { createOllamaChat } from "@tanstack/ai-ollama";
+
+const adapter = createOllamaChat("llama3", {
+  baseURL: "https://gateway.example.com/ollama",
+  defaultHeaders: { Authorization: `Bearer ${process.env.GATEWAY_TOKEN}` },
+});
+```
+
+`host` and `headers` are aliases of the same two options. If you set both forms, `baseURL` and `defaultHeaders` win.
+
 ## Available Models
 
 To see available models on your Ollama instance:
@@ -315,7 +330,7 @@ Creates an Ollama text/chat adapter with an explicit host or client config.
 **Parameters:**
 
 - `model` - Model name
-- `hostOrConfig?` - Either an `OLLAMA_HOST`-style URL string, or an `OllamaClientConfig` object (e.g. `{ host, headers, fetch }`).
+- `hostOrConfig?` - Either an `OLLAMA_HOST`-style URL string, or an `OllamaClientConfig` object (e.g. `{ baseURL, defaultHeaders }`). `host` and `headers` are aliases.
 
 ### `ollamaSummarize(model)` / `createOllamaSummarize(model, hostOrConfig?)`
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -947,7 +947,7 @@
           "label": "Google Gemini",
           "to": "adapters/gemini",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-09-02"
+          "updatedAt": "2026-09-03"
         },
         {
           "label": "Google Vertex AI",
@@ -959,7 +959,7 @@
           "label": "Ollama",
           "to": "adapters/ollama",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-22"
+          "updatedAt": "2026-09-03"
         },
         {
           "label": "Grok (xAI)",
@@ -977,18 +977,19 @@
           "label": "Mistral",
           "to": "adapters/mistral",
           "addedAt": "2026-06-30",
-          "updatedAt": "2026-08-19"
+          "updatedAt": "2026-09-03"
         },
         {
           "label": "Cohere",
           "to": "adapters/cohere",
           "addedAt": "2026-06-25",
-          "updatedAt": "2026-08-10"
+          "updatedAt": "2026-09-03"
         },
         {
           "label": "ElevenLabs",
           "to": "adapters/elevenlabs",
-          "addedAt": "2026-04-15"
+          "addedAt": "2026-04-15",
+          "updatedAt": "2026-09-03"
         },
         {
           "label": "fal.ai",
@@ -1064,7 +1065,7 @@
           "label": "Amazon Bedrock",
           "to": "adapters/bedrock",
           "addedAt": "2026-06-25",
-          "updatedAt": "2026-09-02"
+          "updatedAt": "2026-09-03"
         },
         {
           "label": "BytePlus",

--- a/packages/ai-bedrock/src/adapters/converse-text.ts
+++ b/packages/ai-bedrock/src/adapters/converse-text.ts
@@ -125,9 +125,31 @@ export class BedrockConverseTextAdapter<
           },
           'runtime',
         )
-        return new BedrockRuntimeClient(
+        const client = new BedrockRuntimeClient(
           this.buildClientConfig(resolved, region, this.clientConfig.baseURL),
         )
+        const defaultHeaders = this.clientConfig.defaultHeaders
+        if (defaultHeaders) {
+          // `build` runs before SigV4 signing, so gateway headers are signed
+          // along with the rest of the request.
+          client.middlewareStack.add(
+            (next) => (args) => {
+              const request = args.request
+              if (
+                typeof request === 'object' &&
+                request !== null &&
+                'headers' in request &&
+                typeof request.headers === 'object' &&
+                request.headers !== null
+              ) {
+                Object.assign(request.headers, defaultHeaders)
+              }
+              return next(args)
+            },
+            { step: 'build', name: 'tanstackDefaultHeaders' },
+          )
+        }
+        return client
       })().catch((error: unknown) => {
         // Don't cache a rejected promise — clear it so a later call can retry
         // (e.g. after a transient import failure or fixed auth config).

--- a/packages/ai-bedrock/tests/converse/adapter.test.ts
+++ b/packages/ai-bedrock/tests/converse/adapter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { EventType } from '@tanstack/ai'
 import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
 import { BedrockConverseTextAdapter } from '../../src/adapters/converse-text'
+import type * as BedrockRuntime from '@aws-sdk/client-bedrock-runtime'
 import type {
   ConverseCommandOutput,
   ConverseStreamCommandInput,
@@ -473,6 +474,37 @@ describe('BedrockConverseTextAdapter', () => {
     // ignored — this is the contract that keeps API-key auth working.
     expect(cfg.authSchemePreference).toEqual(['httpBearerAuth'])
     expect(cfg.token).toEqual({ token: 'ABSK-test-token' })
+  })
+
+  it('registers a build middleware that applies defaultHeaders', async () => {
+    type Middleware = (
+      next: (args: unknown) => unknown,
+    ) => (args: unknown) => unknown
+    const added: Array<Middleware> = []
+    class FakeClient {
+      middlewareStack = { add: (mw: Middleware) => added.push(mw) }
+    }
+    class Probe extends BedrockConverseTextAdapter<'us.amazon.nova-pro-v1:0'> {
+      protected override importBedrockRuntime() {
+        return Promise.resolve({
+          BedrockRuntimeClient: FakeClient,
+        } as unknown as typeof BedrockRuntime)
+      }
+      client() {
+        return this.getClient()
+      }
+    }
+    const a = new Probe(
+      { apiKey: 'k', defaultHeaders: { 'X-Gateway': 'yes' } },
+      'us.amazon.nova-pro-v1:0',
+    )
+    expect(await a.client()).toBeInstanceOf(FakeClient)
+    expect(added).toHaveLength(1)
+
+    const request = { headers: { host: 'bedrock' } }
+    const next = (args: unknown) => args
+    added[0]!(next)({ request })
+    expect(request.headers).toEqual({ host: 'bedrock', 'X-Gateway': 'yes' })
   })
 
   it('declares it does not support combined tools and schema', () => {

--- a/packages/ai-cohere/src/adapters/embedding.ts
+++ b/packages/ai-cohere/src/adapters/embedding.ts
@@ -2,7 +2,7 @@ import { BaseEmbeddingAdapter } from '@tanstack/ai/adapters'
 import { toRunErrorPayload } from '@tanstack/ai/adapter-internals'
 import { arrayBufferToBase64, generateId } from '@tanstack/ai-utils'
 import { resolveEmbeddingInput } from '@tanstack/ai'
-import { getCohereApiKeyFromEnv } from '../utils/client'
+import { getCohereApiKeyFromEnv, resolveCohereTransport } from '../utils/client'
 import type {
   EmbeddingOptions,
   EmbeddingResult,
@@ -22,7 +22,6 @@ import type { CohereClientConfig } from '../utils/client'
  */
 export interface CohereEmbeddingConfig extends CohereClientConfig {}
 
-const DEFAULT_BASE_URL = 'https://api.cohere.com'
 const DEFAULT_TIMEOUT_MS = 30_000
 
 /**
@@ -184,14 +183,15 @@ export class CohereEmbeddingAdapter<
       )
 
       const timeoutMs = this.clientConfig.timeout ?? DEFAULT_TIMEOUT_MS
+      const transport = resolveCohereTransport(this.clientConfig)
       const response = await fetchWithTimeout(
-        `${this.clientConfig.baseUrl ?? DEFAULT_BASE_URL}/v2/embed`,
+        `${transport.baseUrl}/v2/embed`,
         {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${this.clientConfig.apiKey}`,
             'Content-Type': 'application/json',
-            ...this.clientConfig.headers,
+            ...transport.headers,
           },
           body: JSON.stringify(body),
         },

--- a/packages/ai-cohere/src/adapters/rerank.ts
+++ b/packages/ai-cohere/src/adapters/rerank.ts
@@ -1,8 +1,5 @@
 import { BaseRerankAdapter } from '@tanstack/ai/adapters'
-import {
-  COHERE_DEFAULT_BASE_URL,
-  getCohereApiKeyFromEnv,
-} from '../utils/client'
+import { resolveCohereTransport, getCohereApiKeyFromEnv } from '../utils/client'
 import type { CohereClientConfig } from '../utils/client'
 import type {
   CohereRerankModel,
@@ -56,11 +53,9 @@ export class CohereRerankAdapter<
   constructor(config: CohereClientConfig, model: TModel) {
     super({}, model)
     this.apiKey = config.apiKey
-    this.baseUrl = (config.baseUrl ?? COHERE_DEFAULT_BASE_URL).replace(
-      /\/+$/,
-      '',
-    )
-    this.headers = config.headers ?? {}
+    const transport = resolveCohereTransport(config)
+    this.baseUrl = transport.baseUrl
+    this.headers = transport.headers
   }
 
   async rerank(

--- a/packages/ai-cohere/src/utils/client.ts
+++ b/packages/ai-cohere/src/utils/client.ts
@@ -19,8 +19,8 @@ export interface CohereClientConfig {
   baseUrl?: string
 
   /**
-   * Headers sent with every request. Merged on top of `headers`. Same option
-   * name as the other adapters.
+   * Headers sent with every request. Same option name as the other adapters.
+   * Wins over `headers` when both are set.
    */
   defaultHeaders?: Record<string, string>
 
@@ -40,7 +40,7 @@ export interface CohereClientConfig {
 
 export const COHERE_DEFAULT_BASE_URL = 'https://api.cohere.com'
 
-/** Resolve the effective base URL (no trailing slash) and merged headers. */
+/** Resolve the effective base URL (no trailing slash) and headers. */
 export function resolveCohereTransport(config: CohereClientConfig): {
   baseUrl: string
   headers: Record<string, string>
@@ -51,7 +51,7 @@ export function resolveCohereTransport(config: CohereClientConfig): {
       config.baseUrl ??
       COHERE_DEFAULT_BASE_URL
     ).replace(/\/+$/, ''),
-    headers: { ...config.headers, ...config.defaultHeaders },
+    headers: config.defaultHeaders ?? config.headers ?? {},
   }
 }
 

--- a/packages/ai-cohere/src/utils/client.ts
+++ b/packages/ai-cohere/src/utils/client.ts
@@ -8,10 +8,23 @@ export interface CohereClientConfig {
   /** Cohere API key. */
   apiKey: string
 
-  /** Optional base URL override (defaults to `https://api.cohere.com`). */
+  /**
+   * Base URL for every request (defaults to `https://api.cohere.com`). Same
+   * option name as the other adapters, so a gateway config can be spread into
+   * any of them. Wins over `baseUrl` when both are set.
+   */
+  baseURL?: string
+
+  /** Alias of `baseURL`. */
   baseUrl?: string
 
-  /** Optional default headers to include with every request. */
+  /**
+   * Headers sent with every request. Merged on top of `headers`. Same option
+   * name as the other adapters.
+   */
+  defaultHeaders?: Record<string, string>
+
+  /** Alias of `defaultHeaders`. */
   headers?: Record<string, string>
 
   /**
@@ -26,6 +39,21 @@ export interface CohereClientConfig {
 }
 
 export const COHERE_DEFAULT_BASE_URL = 'https://api.cohere.com'
+
+/** Resolve the effective base URL (no trailing slash) and merged headers. */
+export function resolveCohereTransport(config: CohereClientConfig): {
+  baseUrl: string
+  headers: Record<string, string>
+} {
+  return {
+    baseUrl: (
+      config.baseURL ??
+      config.baseUrl ??
+      COHERE_DEFAULT_BASE_URL
+    ).replace(/\/+$/, ''),
+    headers: { ...config.headers, ...config.defaultHeaders },
+  }
+}
 
 /**
  * Gets Cohere API key from environment variables.

--- a/packages/ai-cohere/tests/client.test.ts
+++ b/packages/ai-cohere/tests/client.test.ts
@@ -33,7 +33,7 @@ describe('resolveCohereTransport', () => {
       }),
     ).toEqual({
       baseUrl: 'https://new.example',
-      headers: { a: '1', b: 'new' },
+      headers: { b: 'new' },
     })
   })
 })

--- a/packages/ai-cohere/tests/client.test.ts
+++ b/packages/ai-cohere/tests/client.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCohereTransport } from '../src/utils/client'
+
+describe('resolveCohereTransport', () => {
+  it('defaults to api.cohere.com with no headers', () => {
+    expect(resolveCohereTransport({ apiKey: 'k' })).toEqual({
+      baseUrl: 'https://api.cohere.com',
+      headers: {},
+    })
+  })
+
+  it('maps baseURL and defaultHeaders', () => {
+    expect(
+      resolveCohereTransport({
+        apiKey: 'k',
+        baseURL: 'https://gw.example/cohere/',
+        defaultHeaders: { 'cf-aig-authorization': 'Bearer t' },
+      }),
+    ).toEqual({
+      baseUrl: 'https://gw.example/cohere',
+      headers: { 'cf-aig-authorization': 'Bearer t' },
+    })
+  })
+
+  it('keeps baseUrl and headers working, normalized names win', () => {
+    expect(
+      resolveCohereTransport({
+        apiKey: 'k',
+        baseUrl: 'https://old.example',
+        headers: { a: '1', b: 'old' },
+        baseURL: 'https://new.example',
+        defaultHeaders: { b: 'new' },
+      }),
+    ).toEqual({
+      baseUrl: 'https://new.example',
+      headers: { a: '1', b: 'new' },
+    })
+  })
+})

--- a/packages/ai-cohere/tests/rerank-adapter.test.ts
+++ b/packages/ai-cohere/tests/rerank-adapter.test.ts
@@ -43,6 +43,23 @@ const adapter = () => createCohereRerank('rerank-v3.5', 'test-key')
 const documents = ['sunny day at the beach', 'rainy afternoon in the city']
 
 describe('CohereRerankAdapter', () => {
+  it('sends baseURL and defaultHeaders through to fetch', async () => {
+    fetchMock.mockResolvedValue(cohereResponse(defaultBody()))
+
+    await rerank({
+      adapter: createCohereRerank('rerank-v3.5', 'test-key', {
+        baseURL: 'https://gw.example/cohere',
+        defaultHeaders: { 'X-Gateway': 'yes' },
+      }),
+      query: 'beach',
+      documents,
+    })
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('https://gw.example/cohere/v2/rerank')
+    expect(init?.headers).toMatchObject({ 'X-Gateway': 'yes' })
+  })
+
   it('POSTs to /v2/rerank with auth and the expected request body', async () => {
     fetchMock.mockResolvedValue(cohereResponse(defaultBody()))
 

--- a/packages/ai-elevenlabs/src/utils/client.ts
+++ b/packages/ai-elevenlabs/src/utils/client.ts
@@ -25,8 +25,8 @@ export interface ElevenLabsClientConfig {
   /** Override the number of SDK-level retries. */
   maxRetries?: number
   /**
-   * Headers sent with every request. Merged on top of `headers`. Same option
-   * name as the other adapters.
+   * Headers sent with every request. Same option name as the other adapters.
+   * Wins over `headers` when both are set.
    */
   defaultHeaders?: Record<string, string>
   /** Alias of `defaultHeaders`. */
@@ -78,10 +78,7 @@ export function createElevenLabsClient(
 ): ElevenLabsClient {
   const apiKey = config?.apiKey ?? getElevenLabsApiKeyFromEnv()
   const baseUrl = config?.baseURL ?? config?.baseUrl
-  const headers =
-    config?.headers || config?.defaultHeaders
-      ? { ...config.headers, ...config.defaultHeaders }
-      : undefined
+  const headers = config?.defaultHeaders ?? config?.headers
   return new ElevenLabsClient({
     apiKey,
     ...(baseUrl ? { baseUrl } : {}),

--- a/packages/ai-elevenlabs/src/utils/client.ts
+++ b/packages/ai-elevenlabs/src/utils/client.ts
@@ -12,13 +12,24 @@ import type { ElevenLabsOutputFormat } from '../model-meta'
  */
 export interface ElevenLabsClientConfig {
   apiKey?: string
-  /** Override the API base URL — handy for tests + self-hosted proxies. */
+  /**
+   * Base URL for every request. Same option name as the other adapters, so a
+   * gateway config can be spread into any of them. Wins over `baseUrl` when
+   * both are set.
+   */
+  baseURL?: string
+  /** Alias of `baseURL`. */
   baseUrl?: string
   /** Per-request timeout passed through to the SDK (ms). */
   timeoutInSeconds?: number
   /** Override the number of SDK-level retries. */
   maxRetries?: number
-  /** Extra headers attached to every request (e.g. test multiplexing). */
+  /**
+   * Headers sent with every request. Merged on top of `headers`. Same option
+   * name as the other adapters.
+   */
+  defaultHeaders?: Record<string, string>
+  /** Alias of `defaultHeaders`. */
   headers?: Record<string, string>
 }
 
@@ -66,14 +77,19 @@ export function createElevenLabsClient(
   config?: ElevenLabsClientConfig,
 ): ElevenLabsClient {
   const apiKey = config?.apiKey ?? getElevenLabsApiKeyFromEnv()
+  const baseUrl = config?.baseURL ?? config?.baseUrl
+  const headers =
+    config?.headers || config?.defaultHeaders
+      ? { ...config.headers, ...config.defaultHeaders }
+      : undefined
   return new ElevenLabsClient({
     apiKey,
-    ...(config?.baseUrl ? { baseUrl: config.baseUrl } : {}),
+    ...(baseUrl ? { baseUrl } : {}),
     ...(config?.timeoutInSeconds != null
       ? { timeoutInSeconds: config.timeoutInSeconds }
       : {}),
     ...(config?.maxRetries != null ? { maxRetries: config.maxRetries } : {}),
-    ...(config?.headers ? { headers: config.headers } : {}),
+    ...(headers ? { headers } : {}),
   })
 }
 

--- a/packages/ai-elevenlabs/tests/client.test.ts
+++ b/packages/ai-elevenlabs/tests/client.test.ts
@@ -42,7 +42,7 @@ describe('createElevenLabsClient', () => {
     expect(constructorSpy).toHaveBeenCalledExactlyOnceWith({
       apiKey: 'k',
       baseUrl: 'https://new.example',
-      headers: { a: '1', b: 'new' },
+      headers: { b: 'new' },
     })
   })
 })

--- a/packages/ai-elevenlabs/tests/client.test.ts
+++ b/packages/ai-elevenlabs/tests/client.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createElevenLabsClient } from '../src/utils/client'
+
+const constructorSpy = vi.hoisted(() =>
+  vi.fn<(options: Record<string, unknown>) => void>(),
+)
+
+vi.mock('@elevenlabs/elevenlabs-js', () => ({
+  ElevenLabsClient: class {
+    constructor(options: Record<string, unknown>) {
+      constructorSpy(options)
+    }
+  },
+}))
+
+describe('createElevenLabsClient', () => {
+  beforeEach(() => {
+    constructorSpy.mockClear()
+  })
+
+  it('maps baseURL and defaultHeaders onto the SDK options', () => {
+    createElevenLabsClient({
+      apiKey: 'k',
+      baseURL: 'https://gw.example/elevenlabs',
+      defaultHeaders: { 'X-Gateway': 'yes' },
+    })
+    expect(constructorSpy).toHaveBeenCalledExactlyOnceWith({
+      apiKey: 'k',
+      baseUrl: 'https://gw.example/elevenlabs',
+      headers: { 'X-Gateway': 'yes' },
+    })
+  })
+
+  it('keeps baseUrl and headers working, normalized names win', () => {
+    createElevenLabsClient({
+      apiKey: 'k',
+      baseUrl: 'https://old.example',
+      headers: { a: '1', b: 'old' },
+      baseURL: 'https://new.example',
+      defaultHeaders: { b: 'new' },
+    })
+    expect(constructorSpy).toHaveBeenCalledExactlyOnceWith({
+      apiKey: 'k',
+      baseUrl: 'https://new.example',
+      headers: { a: '1', b: 'new' },
+    })
+  })
+})

--- a/packages/ai-gemini/src/utils/client.ts
+++ b/packages/ai-gemini/src/utils/client.ts
@@ -2,7 +2,19 @@ import { GoogleGenAI } from '@google/genai'
 import { generateId as _generateId, getApiKeyFromEnv } from '@tanstack/ai-utils'
 import type { GoogleGenAIOptions } from '@google/genai'
 
-export type GeminiClientConfig = GoogleGenAIOptions
+export interface GeminiClientConfig extends GoogleGenAIOptions {
+  /**
+   * Base URL for every request. Maps onto `httpOptions.baseUrl` and wins
+   * over it when both are set. Same option name as the other adapters, so a
+   * gateway config can be spread into any of them.
+   */
+  baseURL?: string
+  /**
+   * Headers sent with every request. Merged on top of `httpOptions.headers`.
+   * Same option name as the other adapters.
+   */
+  defaultHeaders?: Record<string, string>
+}
 
 /**
  * Creates a Google Generative AI client instance.
@@ -20,7 +32,17 @@ export function createGeminiClient(config: GeminiClientConfig): GoogleGenAI {
       'A Gemini API key is required when vertexai and enterprise are not set. Pass apiKey, or set GOOGLE_API_KEY or GEMINI_API_KEY.',
     )
   }
-  return new GoogleGenAI(config)
+  const { baseURL, defaultHeaders, ...options } = config
+  if (baseURL !== undefined || defaultHeaders !== undefined) {
+    options.httpOptions = {
+      ...options.httpOptions,
+      ...(baseURL !== undefined ? { baseUrl: baseURL } : {}),
+      ...(defaultHeaders !== undefined
+        ? { headers: { ...options.httpOptions?.headers, ...defaultHeaders } }
+        : {}),
+    }
+  }
+  return new GoogleGenAI(options)
 }
 
 /**

--- a/packages/ai-gemini/src/utils/client.ts
+++ b/packages/ai-gemini/src/utils/client.ts
@@ -10,8 +10,8 @@ export interface GeminiClientConfig extends GoogleGenAIOptions {
    */
   baseURL?: string
   /**
-   * Headers sent with every request. Merged on top of `httpOptions.headers`.
-   * Same option name as the other adapters.
+   * Headers sent with every request. Maps onto `httpOptions.headers` and wins
+   * over it when both are set. Same option name as the other adapters.
    */
   defaultHeaders?: Record<string, string>
 }
@@ -37,9 +37,7 @@ export function createGeminiClient(config: GeminiClientConfig): GoogleGenAI {
     options.httpOptions = {
       ...options.httpOptions,
       ...(baseURL !== undefined ? { baseUrl: baseURL } : {}),
-      ...(defaultHeaders !== undefined
-        ? { headers: { ...options.httpOptions?.headers, ...defaultHeaders } }
-        : {}),
+      ...(defaultHeaders !== undefined ? { headers: defaultHeaders } : {}),
     }
   }
   return new GoogleGenAI(options)

--- a/packages/ai-gemini/tests/client.test.ts
+++ b/packages/ai-gemini/tests/client.test.ts
@@ -69,3 +69,47 @@ describe('createGeminiClient', () => {
     })
   })
 })
+
+describe('createGeminiClient proxy options', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('maps baseURL and defaultHeaders onto httpOptions', () => {
+    createGeminiClient({
+      apiKey: 'k',
+      baseURL: 'https://gw.example/gemini',
+      defaultHeaders: { 'cf-aig-authorization': 'Bearer t' },
+    })
+
+    expect(mocks.constructorSpy).toHaveBeenCalledExactlyOnceWith({
+      apiKey: 'k',
+      httpOptions: {
+        baseUrl: 'https://gw.example/gemini',
+        headers: { 'cf-aig-authorization': 'Bearer t' },
+      },
+    })
+  })
+
+  it('merges with existing httpOptions, normalized names win', () => {
+    createGeminiClient({
+      apiKey: 'k',
+      httpOptions: {
+        baseUrl: 'https://old.example',
+        headers: { a: '1', b: 'old' },
+        timeout: 5,
+      },
+      baseURL: 'https://new.example',
+      defaultHeaders: { b: 'new' },
+    })
+
+    expect(mocks.constructorSpy).toHaveBeenCalledExactlyOnceWith({
+      apiKey: 'k',
+      httpOptions: {
+        baseUrl: 'https://new.example',
+        headers: { a: '1', b: 'new' },
+        timeout: 5,
+      },
+    })
+  })
+})

--- a/packages/ai-gemini/tests/client.test.ts
+++ b/packages/ai-gemini/tests/client.test.ts
@@ -91,7 +91,7 @@ describe('createGeminiClient proxy options', () => {
     })
   })
 
-  it('merges with existing httpOptions, normalized names win', () => {
+  it('keeps other httpOptions, normalized names win', () => {
     createGeminiClient({
       apiKey: 'k',
       httpOptions: {
@@ -107,7 +107,7 @@ describe('createGeminiClient proxy options', () => {
       apiKey: 'k',
       httpOptions: {
         baseUrl: 'https://new.example',
-        headers: { a: '1', b: 'new' },
+        headers: { b: 'new' },
         timeout: 5,
       },
     })

--- a/packages/ai-mistral/src/adapters/text.ts
+++ b/packages/ai-mistral/src/adapters/text.ts
@@ -720,7 +720,11 @@ export class MistralTextAdapter<
     params: ChatCompletionStreamRequest,
     config: MistralClientConfig,
   ): AsyncGenerator<MistralRawChunk> {
-    const serverURL = (config.serverURL ?? 'https://api.mistral.ai')
+    const serverURL = (
+      config.baseURL ??
+      config.serverURL ??
+      'https://api.mistral.ai'
+    )
       .replace(/\/+$/, '')
       .replace(/\/v1$/, '')
     const url =

--- a/packages/ai-mistral/src/utils/client.ts
+++ b/packages/ai-mistral/src/utils/client.ts
@@ -4,7 +4,14 @@ export interface MistralClientConfig {
   /** Mistral API key. */
   apiKey: string
 
-  /** Optional server URL override. */
+  /**
+   * Base URL for every request. Same option name as the other adapters, so a
+   * gateway config can be spread into any of them. Wins over `serverURL` when
+   * both are set.
+   */
+  baseURL?: string
+
+  /** Alias of `baseURL`. */
   serverURL?: string
 
   /** Optional request timeout (ms). */
@@ -35,12 +42,13 @@ export interface MistralClientConfig {
 export function createMistralClient(config: MistralClientConfig): Mistral {
   const {
     apiKey,
-    serverURL,
+    baseURL,
     timeoutMs,
     defaultHeaders,
     getAccessToken,
     resolveRequestUrl,
   } = config
+  const serverURL = baseURL ?? config.serverURL
 
   const needsHook =
     (defaultHeaders !== undefined && Object.keys(defaultHeaders).length > 0) ||

--- a/packages/ai-mistral/tests/client.test.ts
+++ b/packages/ai-mistral/tests/client.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMistralClient } from '../src/utils/client'
+
+const constructorSpy = vi.hoisted(() =>
+  vi.fn<(options: Record<string, unknown>) => void>(),
+)
+
+vi.mock('@mistralai/mistralai', () => ({
+  Mistral: class {
+    constructor(options: Record<string, unknown>) {
+      constructorSpy(options)
+    }
+  },
+  HTTPClient: class {
+    addHook() {}
+  },
+}))
+
+describe('createMistralClient', () => {
+  beforeEach(() => {
+    constructorSpy.mockClear()
+  })
+
+  it('maps baseURL onto serverURL', () => {
+    createMistralClient({ apiKey: 'k', baseURL: 'https://gw.example/mistral' })
+    expect(constructorSpy).toHaveBeenCalledExactlyOnceWith({
+      apiKey: 'k',
+      serverURL: 'https://gw.example/mistral',
+    })
+  })
+
+  it('keeps serverURL working, baseURL wins', () => {
+    createMistralClient({
+      apiKey: 'k',
+      serverURL: 'https://old.example',
+      baseURL: 'https://new.example',
+    })
+    expect(constructorSpy).toHaveBeenCalledExactlyOnceWith({
+      apiKey: 'k',
+      serverURL: 'https://new.example',
+    })
+  })
+})

--- a/packages/ai-mistral/tests/mistral-adapter.test.ts
+++ b/packages/ai-mistral/tests/mistral-adapter.test.ts
@@ -317,6 +317,34 @@ describe('Mistral AG-UI event emission', () => {
     }
   })
 
+  it('posts the raw stream to baseURL with defaultHeaders', async () => {
+    setupMockStream([
+      {
+        id: 'cmpl-1',
+        model: 'mistral-large-latest',
+        choices: [{ index: 0, delta: {}, finishReason: 'stop' }],
+      },
+    ])
+    const adapter = createMistralText('mistral-large-latest', 'test-api-key', {
+      baseURL: 'https://gw.example/mistral/',
+      defaultHeaders: { 'X-Gateway': 'yes' },
+    })
+
+    for await (const _chunk of adapter.chatStream(
+      chatOpts({
+        model: 'mistral-large-latest',
+        messages: [{ role: 'user', content: 'Hello' }],
+      }),
+    )) {
+      // drain
+    }
+
+    const fetchMock = vi.mocked(globalThis.fetch)
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('https://gw.example/mistral/v1/chat/completions')
+    expect(init?.headers).toMatchObject({ 'X-Gateway': 'yes' })
+  })
+
   it('emits TEXT_MESSAGE_START before TEXT_MESSAGE_CONTENT', async () => {
     const streamChunks = [
       {

--- a/packages/ai-ollama/src/utils/client.ts
+++ b/packages/ai-ollama/src/utils/client.ts
@@ -2,7 +2,20 @@ import { Ollama } from 'ollama'
 import { generateId as _generateId } from '@tanstack/ai-utils'
 
 export interface OllamaClientConfig {
+  /**
+   * Base URL for every request. Same option name as the other adapters, so a
+   * gateway config can be spread into any of them. Wins over `host` when both
+   * are set.
+   */
+  baseURL?: string
+  /** Alias of `baseURL`. */
   host?: string
+  /**
+   * Headers sent with every request. Merged on top of `headers`. Same option
+   * name as the other adapters.
+   */
+  defaultHeaders?: Record<string, string>
+  /** Alias of `defaultHeaders`. */
   headers?: Record<string, string> | undefined
 }
 
@@ -11,8 +24,11 @@ export interface OllamaClientConfig {
  */
 export function createOllamaClient(config: OllamaClientConfig = {}): Ollama {
   return new Ollama({
-    host: config.host || 'http://localhost:11434',
-    headers: config.headers,
+    host: config.baseURL || config.host || 'http://localhost:11434',
+    headers:
+      config.headers || config.defaultHeaders
+        ? { ...config.headers, ...config.defaultHeaders }
+        : undefined,
   })
 }
 

--- a/packages/ai-ollama/src/utils/client.ts
+++ b/packages/ai-ollama/src/utils/client.ts
@@ -11,8 +11,8 @@ export interface OllamaClientConfig {
   /** Alias of `baseURL`. */
   host?: string
   /**
-   * Headers sent with every request. Merged on top of `headers`. Same option
-   * name as the other adapters.
+   * Headers sent with every request. Same option name as the other adapters.
+   * Wins over `headers` when both are set.
    */
   defaultHeaders?: Record<string, string>
   /** Alias of `defaultHeaders`. */
@@ -25,10 +25,7 @@ export interface OllamaClientConfig {
 export function createOllamaClient(config: OllamaClientConfig = {}): Ollama {
   return new Ollama({
     host: config.baseURL || config.host || 'http://localhost:11434',
-    headers:
-      config.headers || config.defaultHeaders
-        ? { ...config.headers, ...config.defaultHeaders }
-        : undefined,
+    headers: config.defaultHeaders ?? config.headers,
   })
 }
 

--- a/packages/ai-ollama/tests/utils.test.ts
+++ b/packages/ai-ollama/tests/utils.test.ts
@@ -61,7 +61,7 @@ describe('createOllamaClient', () => {
       config: { host: string; headers: Record<string, string> }
     }
     expect(client.config.host).toBe('https://new.example')
-    expect(client.config.headers).toEqual({ a: '1', b: 'new' })
+    expect(client.config.headers).toEqual({ b: 'new' })
   })
 })
 

--- a/packages/ai-ollama/tests/utils.test.ts
+++ b/packages/ai-ollama/tests/utils.test.ts
@@ -39,6 +39,30 @@ describe('createOllamaClient', () => {
     }) as unknown as { config: { headers: Record<string, string> } }
     expect(client.config.headers).toEqual({ Authorization: 'Bearer xyz' })
   })
+
+  it('maps baseURL and defaultHeaders onto host and headers', () => {
+    const client = createOllamaClient({
+      baseURL: 'https://gw.example/ollama',
+      defaultHeaders: { 'X-Gateway': 'yes' },
+    }) as unknown as {
+      config: { host: string; headers: Record<string, string> }
+    }
+    expect(client.config.host).toBe('https://gw.example/ollama')
+    expect(client.config.headers).toEqual({ 'X-Gateway': 'yes' })
+  })
+
+  it('lets baseURL and defaultHeaders win over host and headers', () => {
+    const client = createOllamaClient({
+      host: 'https://old.example',
+      headers: { a: '1', b: 'old' },
+      baseURL: 'https://new.example',
+      defaultHeaders: { b: 'new' },
+    }) as unknown as {
+      config: { host: string; headers: Record<string, string> }
+    }
+    expect(client.config.host).toBe('https://new.example')
+    expect(client.config.headers).toEqual({ a: '1', b: 'new' })
+  })
 })
 
 describe('getOllamaHostFromEnv', () => {

--- a/packages/ai/skills/ai-core/adapter-configuration/SKILL.md
+++ b/packages/ai/skills/ai-core/adapter-configuration/SKILL.md
@@ -417,6 +417,25 @@ compatible providers speak.
 > Verify the provider's current `baseURL` and model ids against its live docs —
 > they drift. See `docs/adapters/openai-compatible.md` for the full provider table.
 
+## Behind a proxy or gateway
+
+Every adapter's client config accepts `baseURL` and `defaultHeaders`. Use these
+two names to route any adapter through Cloudflare AI Gateway, Vercel AI Gateway,
+or a corporate proxy. The adapter maps them onto the vendor SDK's own option
+names (Gemini `httpOptions`, Mistral `serverURL`, Ollama `host`, Cohere and
+ElevenLabs `baseUrl`/`headers`). The vendor names still work; when both are
+set, `baseURL` and `defaultHeaders` win.
+
+```typescript
+const gateway = {
+  baseURL: 'https://gateway.example.com/google-ai-studio',
+  defaultHeaders: {
+    'cf-aig-authorization': `Bearer ${process.env.GATEWAY_TOKEN}`,
+  },
+}
+createGeminiChat('gemini-3.8-flash', apiKey, { ...gateway })
+```
+
 ## Common Mistakes
 
 ### a. HIGH: Confusing legacy monolithic with tree-shakeable adapter

--- a/testing/e2e/src/lib/providers.ts
+++ b/testing/e2e/src/lib/providers.ts
@@ -144,12 +144,7 @@ export function createTextAdapter(
       adapter: createGeminiTextInteractions(
         model as 'gemini-2.5-flash',
         DUMMY_KEY,
-        {
-          httpOptions: {
-            baseUrl: base,
-            headers: testHeaders,
-          },
-        },
+        { baseURL: base, defaultHeaders: testHeaders },
       ),
     })
   }
@@ -163,10 +158,8 @@ export function createTextAdapter(
   if (provider === 'gemini' && feature === 'video-understanding') {
     return createChatOptions({
       adapter: createGeminiChat(model as 'gemini-2.5-flash', DUMMY_KEY, {
-        httpOptions: {
-          baseUrl: `${base}/vu-interactions`,
-          headers: testHeaders,
-        },
+        baseURL: `${base}/vu-interactions`,
+        defaultHeaders: testHeaders,
       }),
     })
   }
@@ -193,10 +186,8 @@ export function createTextAdapter(
     gemini: () =>
       createChatOptions({
         adapter: createGeminiChat(model as 'gemini-2.5-flash', DUMMY_KEY, {
-          httpOptions: {
-            baseUrl: base,
-            headers: testHeaders,
-          },
+          baseURL: base,
+          defaultHeaders: testHeaders,
         }),
       }),
     // Gemini on Vertex. Dummy ADC + project/location so the SDK posts
@@ -236,10 +227,10 @@ export function createTextAdapter(
       }),
     ollama: () =>
       createChatOptions({
-        adapter: createOllamaChat(
-          model as 'mistral',
-          testHeaders ? { host: base, headers: testHeaders } : base,
-        ),
+        adapter: createOllamaChat(model as 'mistral', {
+          baseURL: base,
+          defaultHeaders: testHeaders,
+        }),
       }),
     groq: () =>
       createChatOptions({
@@ -383,7 +374,7 @@ export function createTextAdapter(
     mistral: () =>
       createChatOptions({
         adapter: createMistralText(model as 'mistral-large-latest', DUMMY_KEY, {
-          serverURL: base,
+          baseURL: base,
           defaultHeaders: testHeaders,
         }),
       }),

--- a/testing/e2e/src/routes/api.embedding.ts
+++ b/testing/e2e/src/routes/api.embedding.ts
@@ -54,11 +54,12 @@ function createEmbeddingAdapter(
       }),
     gemini: () =>
       createGeminiEmbedding('gemini-embedding-001', DUMMY_KEY, {
-        httpOptions: { baseUrl: llmockBase(aimockPort), headers },
+        baseURL: llmockBase(aimockPort),
+        defaultHeaders: headers,
       }),
     mistral: () =>
       createMistralEmbedding('mistral-embed', DUMMY_KEY, {
-        serverURL: `${llmockBase(aimockPort)}/mistral`,
+        baseURL: `${llmockBase(aimockPort)}/mistral`,
         defaultHeaders: headers,
       }),
     ollama: () =>

--- a/testing/e2e/src/routes/api.summarize.ts
+++ b/testing/e2e/src/routes/api.summarize.ts
@@ -71,7 +71,8 @@ function createSummarizeAdapter(
       }),
     gemini: () =>
       createGeminiSummarize(DUMMY_KEY, 'gemini-2.5-flash', {
-        httpOptions: { baseUrl: llmockBase(aimockPort), headers },
+        baseURL: llmockBase(aimockPort),
+        defaultHeaders: headers,
       }),
     vertex: () =>
       vertexSummarize(


### PR DESCRIPTION
Every adapter now accepts `baseURL` and `defaultHeaders`. One gateway config (Cloudflare AI Gateway, Vercel AI Gateway, a corporate proxy) can be spread into Gemini, Cohere, ElevenLabs, Mistral, and Ollama the same way it already works for the OpenAI-family adapters. The vendor names (`httpOptions`, `serverURL`, `host`, `baseUrl`, `headers`) still work. When both forms are set, `baseURL` and `defaultHeaders` win.

## 🎯 Changes

- `ai-gemini`: `baseURL` sets `httpOptions.baseUrl` and `defaultHeaders` sets `httpOptions.headers`.
- `ai-cohere`, `ai-elevenlabs`: `baseURL` and `defaultHeaders` are accepted next to `baseUrl` and `headers`.
- `ai-mistral`: `baseURL` is accepted next to `serverURL`, on the SDK client and on the raw streaming fetch.
- `ai-ollama`: `baseURL` and `defaultHeaders` are accepted next to `host` and `headers`.
- `ai-bedrock`: the Converse adapter now applies `defaultHeaders` through SDK middleware. The type already declared it, but the value was dropped.

Audit results: `ai-bedrock` already exposed `baseURL` on all three APIs. `ai-fal` has no base URL. Its `proxyUrl` is a different mechanism (the fal proxy protocol, gated to the browser by default), so it is left alone. The `docs/adapters/cloudflare.md` caveat named in the issue lives on #1309, which is not merged yet, so there is nothing to drop here.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

**Commands run.** `pnpm test:pr` (sherif, knip, docs links, kiira, oxlint, unit tests, types, build) and `pnpm --filter @tanstack/ai-e2e test:e2e`. Both passed. E2E: 650 passed, 6 flaky (passed on retry), 1 skipped.

**Manual test.**

1. Point any of the five adapters at a local echo server with `baseURL: 'http://localhost:9999'` and `defaultHeaders: { 'X-Probe': '1' }`.
2. Run one `chat()` or `embed()` call.
3. Confirm the echo server logs the request at that host with the `X-Probe` header.

**How this PR makes testing easy.**

- New unit tests per adapter assert the vendor SDK client (or the raw `fetch`) receives the mapped values: `ai-gemini/tests/client.test.ts`, `ai-cohere/tests/client.test.ts` plus a rerank case, `ai-elevenlabs/tests/client.test.ts`, `ai-mistral/tests/client.test.ts` plus a streaming case, `ai-ollama/tests/utils.test.ts`, `ai-bedrock/tests/converse/adapter.test.ts`.
- The E2E provider wiring for Gemini, Mistral, and Ollama now uses `baseURL` and `defaultHeaders`, so the whole existing E2E matrix runs through the new option names.

## Linked issues

Closes #1311

## Risk / rollback

Low. All changes are additive. Existing option names are untouched. Revert the PR to roll back.

## Public API change

**Before**

```ts
createGeminiChat('gemini-3.8-flash', apiKey, {
  httpOptions: { baseUrl: gw.url, headers: gw.headers },
})
createMistralText('mistral-large-latest', apiKey, { serverURL: gw.url, defaultHeaders: gw.headers })
```

**After**

```ts
const gw = { baseURL: 'https://gateway.example.com/...', defaultHeaders: { 'cf-aig-authorization': 'Bearer ...' } }
createGeminiChat('gemini-3.8-flash', apiKey, { ...gw })
createMistralText('mistral-large-latest', apiKey, { ...gw })
```

https://claude.ai/code/session_01RJnkfyj2VWo3LM1MD41JQh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent `baseURL` and `defaultHeaders` options across AI adapters for routing requests through gateways or proxies.
  * Preserved support for vendor-specific configuration aliases, with standardized options taking precedence.
  * Bedrock Converse requests now include configured default headers in signed requests.

* **Documentation**
  * Added gateway and proxy configuration guidance, examples, and updated adapter references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->