### PR TITLE
docs: add TanStack AI banner to package READMEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,16 @@ these TanStack-specific rules when editing docs under `docs/`:
   formatting, and factual fixes must not touch `addedAt` or `updatedAt`.
 - Run `pnpm test:docs` (link verification) before pushing.
 
+## Package README banner (mandatory)
+
+When you add or replace a `README.md` under `packages/`, the file MUST start
+with the TanStack AI `<picture>` banner from `packages/ai/README.md`
+(`https://tanstack.com/api/readme/ai.png`, plus the `?theme=dark` source).
+Do not use `media/header_ai.png`. Framework packages can add
+`?framework=<name>` (copy `packages/ai-angular/README.md`,
+`packages/ai-solid/README.md`, or `packages/ai-svelte/README.md`). Skip this
+only for non-package READMEs (examples, testing, live-tests).
+
 ## Everything Else
 
 For package manager (`pnpm@10.17.0`), monorepo layout, adapter architecture,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,6 +399,16 @@ Then also obey these TanStack-specific rules:
   it; set `"tab"` on the section or entry in `docs/config.json`
   (`home | get-started | tutorial | guides | api | examples`).
 
+### Package README banner (mandatory)
+
+When you add or replace a `README.md` under `packages/`, the file MUST start
+with the TanStack AI `<picture>` banner from `packages/ai/README.md`
+(`https://tanstack.com/api/readme/ai.png`, plus the `?theme=dark` source).
+Do not use `media/header_ai.png`. Framework packages can add
+`?framework=<name>` (copy `packages/ai-angular/README.md`,
+`packages/ai-solid/README.md`, or `packages/ai-svelte/README.md`). Skip this
+only for non-package READMEs (examples, testing, live-tests).
+
 ## Key Dependencies
 
 ### Core Runtime Dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ If the bot pushes, it only commits bugs and suggestions the review listed. Maint
 
 The pattern lives in `packages/ai-openai/`, `packages/ai-anthropic/`, `packages/ai-gemini/`, etc. New core adapters typically:
 
-1. Create `packages/ai-<provider>/` with `package.json`, `tsconfig.json`, `src/`, `tests/`, `README.md`. Copy structure from an existing adapter.
+1. Create `packages/ai-<provider>/` with `package.json`, `tsconfig.json`, `src/`, `tests/`, `README.md`. Copy structure from an existing adapter. The README must start with the TanStack AI `<picture>` banner from `packages/ai/README.md` (`https://tanstack.com/api/readme/ai.png`). Do not use `media/header_ai.png`.
 2. Implement tree-shakeable adapter exports under `src/adapters/` (`text.ts`, `embed.ts`, `summarize.ts`, etc.).
 3. Add `model-meta.ts` so per-model type safety works.
 4. Wire the provider into `testing/e2e/feature-support.ts` and `testing/e2e/test-matrix.ts`. Existing provider-coverage tests pick it up automatically.

--- a/packages/ai-acp/README.md
+++ b/packages/ai-acp/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-acp
 
 Shared [Agent Client Protocol](https://agentclientprotocol.com) (ACP) plumbing for TanStack AI **harness adapters** — the code that turns a coding-agent CLI (`grok`, `gemini --acp`, …) into a `chat()` backend inside a sandbox.

--- a/packages/ai-bedrock/README.md
+++ b/packages/ai-bedrock/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-bedrock
 
 Amazon Bedrock adapter for TanStack AI — the native Converse API (default) plus the OpenAI-compatible Chat Completions and Responses APIs, with streaming, tool calling, and reasoning.

--- a/packages/ai-byteplus/README.md
+++ b/packages/ai-byteplus/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-byteplus
 
 BytePlus ModelArk adapter for TanStack AI — Seed chat models, Seedance video

--- a/packages/ai-claude-code/README.md
+++ b/packages/ai-claude-code/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-claude-code
 
 Claude Code harness adapter for [TanStack AI](https://tanstack.com/ai) — run [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (via `@anthropic-ai/claude-agent-sdk`) as a chat backend with local tool execution, stateful coding sessions, and TanStack tool bridging.

--- a/packages/ai-cloudflare/README.md
+++ b/packages/ai-cloudflare/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-cloudflare
 
 Cloudflare adapter for TanStack AI: Workers AI chat, summarization, embeddings, image generation, text-to-speech, and transcription over the `env.AI` binding or the REST API, with AI Gateway routing for any provider.

--- a/packages/ai-code-mode-snippets/README.md
+++ b/packages/ai-code-mode-snippets/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-code-mode-snippets
 
 Persistent snippet library for TanStack AI Code Mode - LLM-created reusable code snippets.

--- a/packages/ai-code-mode/README.md
+++ b/packages/ai-code-mode/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-code-mode
 
 Code Mode for TanStack AI — let LLMs write and execute TypeScript in secure sandboxes with typed tool access.

--- a/packages/ai-codex/README.md
+++ b/packages/ai-codex/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-codex
 
 Codex harness adapter for [TanStack AI](https://tanstack.com/ai) — run [OpenAI Codex](https://developers.openai.com/codex) (via `@openai/codex-sdk`) as a chat backend with local tool execution, stateful coding sessions, and TanStack tool bridging.

--- a/packages/ai-cohere/README.md
+++ b/packages/ai-cohere/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/TanStack/ai/main/media/header_ai.png" alt="TanStack AI" />
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/ai-compaction/README.md
+++ b/packages/ai-compaction/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-compaction
 
 Context-window compaction as a `chat()` middleware. When the working message set

--- a/packages/ai-elevenlabs/README.md
+++ b/packages/ai-elevenlabs/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-elevenlabs
 
 ElevenLabs adapter for TanStack AI realtime voice conversations.

--- a/packages/ai-grok-build/README.md
+++ b/packages/ai-grok-build/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-grok-build
 
 Grok Build harness adapter for TanStack AI. Runs the Grok Build coding agent inside a sandbox with local tool execution and stateful sessions.

--- a/packages/ai-grok/README.md
+++ b/packages/ai-grok/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-grok
 
 Grok (xAI) adapter for TanStack AI

--- a/packages/ai-groq/README.md
+++ b/packages/ai-groq/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-groq
 
 Groq adapter for TanStack AI

--- a/packages/ai-isolate-cloudflare/README.md
+++ b/packages/ai-isolate-cloudflare/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-isolate-cloudflare
 
 Cloudflare Workers driver for TanStack AI Code Mode.

--- a/packages/ai-isolate-daytona/README.md
+++ b/packages/ai-isolate-daytona/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-isolate-daytona
 
 Daytona sandbox driver for TanStack AI Code Mode.

--- a/packages/ai-isolate-node/README.md
+++ b/packages/ai-isolate-node/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-isolate-node
 
 Node.js V8 isolate driver for TanStack AI Code Mode. Uses [`isolated-vm`](https://github.com/nicolo-ribaudo/isolated-vm) for fast, secure sandboxed execution.

--- a/packages/ai-isolate-quickjs-bun/README.md
+++ b/packages/ai-isolate-quickjs-bun/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-isolate-quickjs-bun
 
 Native QuickJS driver for TanStack AI Code Mode on the [Bun](https://bun.sh) runtime. Runs the same QuickJS engine as `@tanstack/ai-isolate-quickjs`, but natively through [`bun:ffi`](https://bun.sh/docs/api/ffi) instead of WebAssembly — substantially faster context creation and execution, with the same sandboxing guarantees.

--- a/packages/ai-isolate-quickjs/README.md
+++ b/packages/ai-isolate-quickjs/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-isolate-quickjs
 
 QuickJS WASM driver for TanStack AI Code Mode. Runs everywhere — Node.js, browsers, and edge runtimes — with zero native dependencies.

--- a/packages/ai-llmgateway/README.md
+++ b/packages/ai-llmgateway/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-llmgateway
 
 [LLM Gateway](https://llmgateway.io) adapter for TanStack AI — one OpenAI-compatible endpoint that routes chat, tool calling, and structured outputs to hundreds of models across many providers.

--- a/packages/ai-lovable/README.md
+++ b/packages/ai-lovable/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-lovable
 
 Lovable AI Gateway adapter for TanStack AI.

--- a/packages/ai-mcp/README.md
+++ b/packages/ai-mcp/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-mcp
 
 Host-side Model Context Protocol (MCP) client for TanStack AI.

--- a/packages/ai-mistral/README.md
+++ b/packages/ai-mistral/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-mistral
 
 Mistral adapter for TanStack AI.

--- a/packages/ai-octane/README.md
+++ b/packages/ai-octane/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-octane
 
 [TanStack AI](https://tanstack.com/ai) bindings for the

--- a/packages/ai-opencode/README.md
+++ b/packages/ai-opencode/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-opencode
 
 OpenCode harness adapter for [TanStack AI](https://tanstack.com/ai) — run [OpenCode](https://opencode.ai) (via `@opencode-ai/sdk`) as a chat backend with local tool execution, token-level streaming, stateful sessions, and TanStack tool bridging.

--- a/packages/ai-perplexity/README.md
+++ b/packages/ai-perplexity/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-perplexity
 
 [Perplexity](https://www.perplexity.ai) Search API for [TanStack AI](https://tanstack.com/ai).

--- a/packages/ai-react-ui/README.md
+++ b/packages/ai-react-ui/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-react-ui (deprecated)
 
 This package is deprecated since 0.9.0. It will be removed in 1.0.0.

--- a/packages/ai-remix/README.md
+++ b/packages/ai-remix/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-remix
 
 Remix 3 helpers for TanStack AI streaming chat.

--- a/packages/ai-sandbox-docker/README.md
+++ b/packages/ai-sandbox-docker/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-sandbox-docker
 
 Sandbox providers that run a TanStack AI harness on Docker.

--- a/packages/ai-sandbox-upstash-box/README.md
+++ b/packages/ai-sandbox-upstash-box/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-sandbox-upstash-box
 
 Upstash Box sandbox provider for [TanStack AI](https://tanstack.com/ai). Runs

--- a/packages/ai-sandbox/README.md
+++ b/packages/ai-sandbox/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-sandbox
 
 Provider-agnostic sandbox layer for [TanStack AI](https://tanstack.com/ai). Run coding-agent harness adapters (Grok Build, Claude Code, Codex, OpenCode, Gemini CLI) **inside** an isolated environment with a real filesystem, shell, and cloned repo — and stream their work back through `chat()`.

--- a/packages/ai-solid-ui/README.md
+++ b/packages/ai-solid-ui/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-solid-ui (deprecated)
 
 This package is deprecated since 0.8.0. It will be removed in 1.0.0.

--- a/packages/ai-vercel-gateway/README.md
+++ b/packages/ai-vercel-gateway/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-vercel-gateway
 
 Vercel AI Gateway adapter for TanStack AI.

--- a/packages/ai-vertex/README.md
+++ b/packages/ai-vertex/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-vertex
 
 Google Vertex AI adapter for [TanStack AI](https://tanstack.com/ai).

--- a/packages/ai-vue-ui/README.md
+++ b/packages/ai-vue-ui/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/ai-vue-ui (deprecated)
 
 This package is deprecated since 0.3.0. It will be removed in 1.0.0.

--- a/packages/openai-base/README.md
+++ b/packages/openai-base/README.md
@@ -1,3 +1,23 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/ai.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/ai.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/ai.png"
+      alt="TanStack AI"
+      width="900"
+    />
+  </picture>
+</div>
+
+<br />
+
 # @tanstack/openai-base
 
 Shared base adapters for providers that drive the official `openai` SDK


### PR DESCRIPTION
npm package pages for 36 adapters now show the TanStack AI banner. New `packages/*/README.md` files must start with that same `<picture>` block.

## 🎯 Changes

- Add the canonical `https://tanstack.com/api/readme/ai.png` banner to 35 package READMEs that had none.
- Replace the old `media/header_ai.png` image on `@tanstack/ai-cohere` with the same `<picture>` banner.
- Require that banner in `AGENTS.md`, `CLAUDE.md`, and `CONTRIBUTING.md` when an agent adds a package README.

Skipped: 13 packages that have no README yet (for example `ai-anthropic`, `ai-fal`). They get the banner when a README is added.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

## Testing

1. **Commands run.** `pnpm exec oxfmt` on the 39 changed files: pass. `pnpm test:docs`: fail on untracked leftover files under `docs/superpowers/worktrees/`, not on these READMEs. `pnpm test:pr` skipped: markdown and agent-instruction files only.
2. **Manual test.**
   1. Open any changed file, for example `packages/ai-cloudflare/README.md`.
   2. Confirm the first block is the `<picture>` banner with `tanstack.com/api/readme/ai.png`.
   3. Open `packages/ai-cohere/README.md` and confirm `header_ai.png` is gone.
   4. Search `AGENTS.md` for `Package README banner`.
3. **How this PR makes testing easy.** No automated test. The banner HTML is copied from `packages/ai/README.md`. Reviewer can grep `tanstack.com/api/readme/ai.png` vs `header_ai.png`.

## Risk / rollback

Low. README and agent-instruction text only. Revert the PR to undo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a consistent, theme-aware TanStack AI banner to package README files.
  - Updated contribution and project guidance to require the banner for new or replaced package READMEs.
  - Clarified framework-specific banner options and exclusions for non-package documentation.
  - Added documentation for newly introduced sandbox and provider packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->