### PR TITLE
fix(ai-sandbox-daytona): keep workspace secrets out of Daytona records

### DIFF
--- a/.changeset/daytona-workspace-secrets.md
+++ b/.changeset/daytona-workspace-secrets.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-sandbox-daytona': patch
+---
+
+fix: mount workspace secrets as Daytona organization Secrets so values never land in the sandbox record or command strings

--- a/.changeset/daytona-workspace-secrets.md
+++ b/.changeset/daytona-workspace-secrets.md
@@ -1,5 +1,6 @@
 ---
 '@tanstack/ai-sandbox-daytona': patch
+'@tanstack/ai-isolate-daytona': patch
 ---
 
 fix: mount workspace secrets as Daytona organization Secrets so values never land in the sandbox record or command strings

--- a/docs/config.json
+++ b/docs/config.json
@@ -698,7 +698,7 @@
           "label": "Providers",
           "to": "sandbox/providers",
           "addedAt": "2026-06-29",
-          "updatedAt": "2026-08-24"
+          "updatedAt": "2026-09-04"
         },
         {
           "label": "Harnesses",

--- a/docs/sandbox/providers.md
+++ b/docs/sandbox/providers.md
@@ -191,9 +191,13 @@ const daytona = daytonaSandbox({
 
 - **Isolation:** a managed cloud sandbox on a remote VM you do not run yourself.
 - **Auth / env:** needs `DAYTONA_API_KEY`. Put harness credentials in
-  [workspace secrets](./provisioning). They are applied to the live sandbox
-  at create, resume, and restore. They are not stored on the Daytona create
-  record, and they are not written into command history.
+  [workspace secrets](./provisioning). At create and snapshot restore,
+  Daytona stores each value as an organization Secret and mounts a
+  placeholder in the sandbox env. The create record, the dashboard env
+  view, and session command strings do not contain the real value. Daytona
+  substitutes the value on outbound HTTPS requests. Per-command `opts.env`
+  uses `executeCommand`'s env argument or a sourced env file. It never
+  writes `export KEY=` prefixes into the command string.
 - **Snapshot / resume:** point-in-time snapshots after setup (default when
   `lifecycle.snapshot` is `'after-setup'`). Pass `snapshot` on
   `daytonaSandbox()` to pick the Daytona image (for example

--- a/packages/ai-isolate-daytona/package.json
+++ b/packages/ai-isolate-daytona/package.json
@@ -52,7 +52,7 @@
     "@tanstack/ai-code-mode": "workspace:^"
   },
   "devDependencies": {
-    "@daytona/sdk": "^0.191.0",
+    "@daytona/sdk": "^0.192.0",
     "@tanstack/ai-code-mode": "workspace:*",
     "@vitest/coverage-v8": "4.1.10"
   }

--- a/packages/ai-sandbox-daytona/package.json
+++ b/packages/ai-sandbox-daytona/package.json
@@ -42,7 +42,7 @@
     "test:types": "tsc"
   },
   "dependencies": {
-    "@daytona/sdk": "^0.191.0"
+    "@daytona/sdk": "^0.192.0"
   },
   "peerDependencies": {
     "@tanstack/ai-sandbox": "workspace:^"

--- a/packages/ai-sandbox-daytona/src/handle.ts
+++ b/packages/ai-sandbox-daytona/src/handle.ts
@@ -3,8 +3,10 @@
  * isolation: fs/exec/git operate inside the remote sandbox; paths are real
  * sandbox paths (default workdir `/home/daytona/workspace`).
  *
- * fs and git use the native Daytona SDK. Blocking exec sends env through
- * `executeCommand`'s env argument so secret values never enter the stored
+ * fs and git use the native Daytona SDK. Workspace secrets are mounted as
+ * Daytona organization Secrets at create (opaque `dtn_secret_*` placeholders
+ * in the sandbox env). Blocking exec sends leftover per-call env through
+ * `executeCommand`'s env argument so those values never enter the stored
  * command string. Spawn sources a workdir env file for the same reason.
  *
  * NOTE: Daytona's `executeCommand` returns a single combined `result` string
@@ -151,6 +153,13 @@ export interface DaytonaHandleDeps {
   sandbox: Sandbox
   /** Working directory inside the sandbox (the `/workspace` virtual root maps here). */
   workdir: string
+  /**
+   * When false, `env.set` does not overlay values onto exec/spawn. Use this
+   * after workspace secrets are mounted as Daytona organization Secrets so
+   * later `env.set` (bootstrap, resume) cannot put plaintext into command
+   * env, the spawn env file, or the process environment.
+   */
+  applyEnvSet?: boolean
 }
 
 export class DaytonaHandle implements SandboxHandle {
@@ -166,11 +175,13 @@ export class DaytonaHandle implements SandboxHandle {
 
   private readonly sandbox: Sandbox
   private readonly workdir: string
+  private readonly applyEnvSet: boolean
   private readonly envVars: Record<string, string> = {}
 
   constructor(deps: DaytonaHandleDeps) {
     this.sandbox = deps.sandbox
     this.workdir = deps.workdir
+    this.applyEnvSet = deps.applyEnvSet ?? true
     this.workspaceRoot = deps.workdir
     this.id = deps.sandbox.id
 
@@ -234,7 +245,7 @@ export class DaytonaHandle implements SandboxHandle {
 
     this.env = {
       set: (vars) => {
-        Object.assign(this.envVars, vars)
+        if (this.applyEnvSet) Object.assign(this.envVars, vars)
         return Promise.resolve()
       },
     }

--- a/packages/ai-sandbox-daytona/src/provider.ts
+++ b/packages/ai-sandbox-daytona/src/provider.ts
@@ -1,4 +1,5 @@
-import { Daytona } from '@daytona/sdk'
+import { createHash } from 'node:crypto'
+import { Daytona, DaytonaConflictError } from '@daytona/sdk'
 import { DAYTONA_CAPS, DaytonaHandle } from './handle'
 import type {
   CreateSandboxFromSnapshotParams,
@@ -51,6 +52,21 @@ function shQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
+/**
+ * Organization Secret names must match `^[a-zA-Z_][a-zA-Z0-9_-]*$`.
+ * The value hash keeps two different values for the same env key from sharing one Secret.
+ */
+function daytonaOrgSecretName(envKey: string, value: string): string {
+  const hash = createHash('sha256').update(value).digest('hex').slice(0, 12)
+  const safe = envKey.replace(/[^a-zA-Z0-9_-]/g, '_')
+  const body = /^[a-zA-Z_]/.test(safe) ? safe : `k_${safe}`
+  return `tanstack_${body}_${hash}`
+}
+
+function isConflictError(error: unknown): boolean {
+  return error instanceof DaytonaConflictError
+}
+
 class DaytonaProvider implements SandboxProvider {
   readonly name = 'daytona'
   private readonly daytona: Daytona
@@ -80,15 +96,17 @@ class DaytonaProvider implements SandboxProvider {
    */
   private async wrapCreated(
     sandbox: Awaited<ReturnType<Daytona['create']>>,
+    applyEnvSet: boolean,
   ): Promise<SandboxHandle> {
     await sandbox.process.executeCommand(`mkdir -p ${shQuote(this.workdir)}`)
-    return new DaytonaHandle({ sandbox, workdir: this.workdir })
+    return new DaytonaHandle({ sandbox, workdir: this.workdir, applyEnvSet })
   }
 
   private createParams(input: {
     snapshot?: string
     id?: string
     policy?: SandboxCreateInput['policy']
+    secrets?: Record<string, string>
   }): CreateSandboxFromSnapshotParams {
     return {
       language: this.config.language ?? 'typescript',
@@ -103,37 +121,62 @@ class DaytonaProvider implements SandboxProvider {
       ...(input.policy?.capabilities?.network === 'deny'
         ? { networkBlockAll: true }
         : {}),
+      ...(input.secrets !== undefined ? { secrets: input.secrets } : {}),
     }
   }
 
-  private async wrapReady(
-    sandbox: Awaited<ReturnType<Daytona['create']>>,
+  /**
+   * Create-or-reuse organization Secrets and return env-var → secret-name.
+   * Empty values are skipped. A 409 means this name (key + value hash) already
+   * exists, so the mapping can reuse it.
+   */
+  private async ensureOrgSecrets(
     env?: Record<string, string>,
-  ): Promise<SandboxHandle> {
-    const handle = await this.wrapCreated(sandbox)
-    if (env !== undefined) await handle.env.set(env)
-    return handle
+  ): Promise<Record<string, string> | undefined> {
+    if (env === undefined) return undefined
+    const secrets: Record<string, string> = {}
+    for (const [key, value] of Object.entries(env)) {
+      if (value === '') continue
+      const name = daytonaOrgSecretName(key, value)
+      try {
+        await this.daytona.secret.create({
+          name,
+          value,
+          description: 'TanStack AI workspace secret',
+        })
+      } catch (error) {
+        if (!isConflictError(error)) throw error
+      }
+      secrets[key] = name
+    }
+    return Object.keys(secrets).length > 0 ? secrets : undefined
   }
 
   async create(input: SandboxCreateInput): Promise<SandboxHandle> {
+    const secrets = await this.ensureOrgSecrets(input.env)
     const sandbox = await this.daytona.create(
       this.createParams({
         snapshot: this.config.snapshot,
         id: input.id,
         policy: input.policy,
+        ...(secrets !== undefined ? { secrets } : {}),
       }),
     )
-    return this.wrapReady(sandbox, input.env)
+    // Workspace secrets live in Daytona OS env as placeholders. Do not overlay
+    // plaintext via env.set (bootstrap and resume also call env.set).
+    return this.wrapCreated(sandbox, secrets === undefined)
   }
 
   async restoreSnapshot(input: SandboxRestoreInput): Promise<SandboxHandle> {
+    const secrets = await this.ensureOrgSecrets(input.env)
     const sandbox = await this.daytona.create(
       this.createParams({
         snapshot: input.snapshotId,
         policy: input.policy,
+        ...(secrets !== undefined ? { secrets } : {}),
       }),
     )
-    return this.wrapReady(sandbox, input.env)
+    return this.wrapCreated(sandbox, secrets === undefined)
   }
 
   async resume(input: SandboxResumeInput): Promise<SandboxHandle | null> {
@@ -144,7 +187,13 @@ class DaytonaProvider implements SandboxProvider {
       if (sandbox.state === 'stopped' || sandbox.state === 'archived') {
         await sandbox.start()
       }
-      return new DaytonaHandle({ sandbox, workdir: this.workdir })
+      // Secrets mounted at create stay in the sandbox env as placeholders.
+      // applyWorkspaceSecrets would otherwise overlay plaintext on spawn/exec.
+      return new DaytonaHandle({
+        sandbox,
+        workdir: this.workdir,
+        applyEnvSet: false,
+      })
     } catch {
       // Gone / not found.
       return null

--- a/packages/ai-sandbox-daytona/tests/handle.test.ts
+++ b/packages/ai-sandbox-daytona/tests/handle.test.ts
@@ -240,6 +240,37 @@ describe('DaytonaHandle env and native fs', () => {
     expect(command).not.toContain('export ')
   })
 
+  it('applyEnvSet: false keeps env.set values out of executeCommand', async () => {
+    const executeCommand = vi.fn(
+      async (
+        _command: string,
+        _cwd?: string,
+        _env?: Record<string, string>,
+      ) => ({ result: '', exitCode: 0 }),
+    )
+    const sandbox = {
+      id: 'sbx-1',
+      process: { executeCommand },
+      delete: vi.fn(async () => {}),
+    } as unknown as Sandbox
+    const handle = new DaytonaHandle({
+      sandbox,
+      workdir: '/home/daytona/workspace',
+      applyEnvSet: false,
+    })
+
+    await handle.env.set({ ANTHROPIC_API_KEY: 'sk-secret-value' })
+    await handle.process.exec('echo hello', {
+      env: { GIT_ASKPASS_TOKEN: 'ghs_secret' },
+    })
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      'echo hello',
+      '/home/daytona/workspace',
+      { GIT_ASKPASS_TOKEN: 'ghs_secret' },
+    )
+  })
+
   it('writes files through native uploadFile, not a base64 exec command', async () => {
     const uploadFile = vi.fn(async () => {})
     const createFolder = vi.fn(async () => {})

--- a/packages/ai-sandbox-daytona/tests/provider.test.ts
+++ b/packages/ai-sandbox-daytona/tests/provider.test.ts
@@ -6,16 +6,29 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Sandbox } from '@daytona/sdk'
 
-const create = vi.fn()
-const get = vi.fn()
-const del = vi.fn()
+const { create, get, del, secretCreate, DaytonaConflictError } = vi.hoisted(
+  () => {
+    class DaytonaConflictError extends Error {
+      statusCode = 409
+    }
+    return {
+      create: vi.fn(),
+      get: vi.fn(),
+      del: vi.fn(),
+      secretCreate: vi.fn(),
+      DaytonaConflictError,
+    }
+  },
+)
 
 vi.mock('@daytona/sdk', () => ({
   Daytona: class {
     create = create
     get = get
     delete = del
+    secret = { create: secretCreate }
   },
+  DaytonaConflictError,
 }))
 
 import { daytonaSandbox } from '../src/index'
@@ -25,6 +38,7 @@ function fakeRemoteSandbox(
   extras: {
     state?: string
     start?: ReturnType<typeof vi.fn>
+    executeCommand?: ReturnType<typeof vi.fn>
   } = {},
 ): Sandbox {
   // Sandbox from @daytona/sdk is a large class. Tests only need these fields.
@@ -33,7 +47,9 @@ function fakeRemoteSandbox(
     state: extras.state ?? 'started',
     start: extras.start ?? vi.fn(async () => {}),
     process: {
-      executeCommand: vi.fn(async () => ({ result: '', exitCode: 0 })),
+      executeCommand:
+        extras.executeCommand ??
+        vi.fn(async () => ({ result: '', exitCode: 0 })),
     },
     delete: vi.fn(async () => {}),
   } as unknown as Sandbox
@@ -43,6 +59,8 @@ beforeEach(() => {
   create.mockReset()
   get.mockReset()
   del.mockReset()
+  secretCreate.mockReset()
+  secretCreate.mockResolvedValue({ name: 'created' })
 })
 
 describe('daytonaSandbox snapshots', () => {
@@ -68,6 +86,30 @@ describe('daytonaSandbox snapshots', () => {
     )
     expect(handle.id).toBe('sbx-restored')
     expect(handle.provider).toBe('daytona')
+  })
+
+  it('mounts workspace secrets as organization Secrets on restore', async () => {
+    const restored = fakeRemoteSandbox('sbx-restored')
+    create.mockResolvedValue(restored)
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    await provider.restoreSnapshot!({
+      snapshotId: 'tanstack-ai-sandbox-snapshot-sbx-1-after-setup',
+      env: { ANTHROPIC_API_KEY: 'sk-secret-value' },
+    })
+
+    const payload = create.mock.calls[0]?.[0] as {
+      snapshot?: string
+      secrets?: Record<string, string>
+      envVars?: unknown
+    }
+    expect(payload.snapshot).toBe(
+      'tanstack-ai-sandbox-snapshot-sbx-1-after-setup',
+    )
+    expect(payload.secrets?.ANTHROPIC_API_KEY).toMatch(
+      /^tanstack_ANTHROPIC_API_KEY_[0-9a-f]{12}$/,
+    )
+    expect(payload.envVars).toBeUndefined()
   })
 })
 
@@ -120,11 +162,35 @@ describe('daytonaSandbox resume', () => {
 
     await expect(provider.resume({ id: 'missing' })).resolves.toBeNull()
   })
+
+  it('does not overlay secret plaintext after resume', async () => {
+    const executeCommand = vi.fn(
+      async (
+        _command: string,
+        _cwd?: string,
+        _env?: Record<string, string>,
+      ) => ({ result: '', exitCode: 0 }),
+    )
+    get.mockResolvedValue(fakeRemoteSandbox('sbx-live', { executeCommand }))
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    const handle = await provider.resume({ id: 'sbx-live' })
+    expect(handle).not.toBeNull()
+    await handle!.env.set({ ANTHROPIC_API_KEY: 'sk-secret-value' })
+    await handle!.process.exec('echo hello')
+
+    const overlay = executeCommand.mock.calls.filter((call) => {
+      const env = call[2] as Record<string, string> | undefined
+      return env !== undefined && Object.values(env).includes('sk-secret-value')
+    })
+    expect(overlay).toEqual([])
+  })
 })
 
 // Issue #1084: create-time envVars stay in the Daytona sandbox record
-// (GET /sandbox/:id returns them in plain text). Secrets go onto the
-// handle after create, not into the create payload.
+// (GET /sandbox/:id returns them in plain text). Workspace secrets are
+// organization Secrets referenced by name. The sandbox env holds a
+// placeholder, not the value.
 // Issue #1085: create must forward name, auto-stop, ephemeral, and
 // network block from the portable input / config.
 describe('daytonaSandbox create', () => {
@@ -141,9 +207,153 @@ describe('daytonaSandbox create', () => {
         envVars: expect.anything(),
       }),
     )
-    const payload = create.mock.calls[0]?.[0] as { envVars?: unknown }
+    const payload = create.mock.calls[0]?.[0] as {
+      envVars?: unknown
+      secrets?: Record<string, string>
+    }
     expect(payload.envVars).toBeUndefined()
     expect(handle.id).toBe('sbx-1')
+  })
+
+  it('mounts workspace secrets as Daytona organization Secrets', async () => {
+    create.mockResolvedValue(fakeRemoteSandbox('sbx-1'))
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    await provider.create({
+      env: { ANTHROPIC_API_KEY: 'sk-secret-value' },
+    })
+
+    expect(secretCreate).toHaveBeenCalledWith({
+      name: expect.stringMatching(/^tanstack_ANTHROPIC_API_KEY_[0-9a-f]{12}$/),
+      value: 'sk-secret-value',
+      description: 'TanStack AI workspace secret',
+    })
+    const secretName = (secretCreate.mock.calls[0]?.[0] as { name: string })
+      .name
+    const payload = create.mock.calls[0]?.[0] as {
+      secrets?: Record<string, string>
+      envVars?: unknown
+    }
+    expect(payload.secrets).toEqual({ ANTHROPIC_API_KEY: secretName })
+    expect(payload.envVars).toBeUndefined()
+    expect(secretCreate.mock.invocationCallOrder[0]).toBeLessThan(
+      create.mock.invocationCallOrder[0] ?? Infinity,
+    )
+  })
+
+  it('reuses an organization Secret when the name already exists', async () => {
+    secretCreate.mockRejectedValue(new DaytonaConflictError('exists'))
+    create.mockResolvedValue(fakeRemoteSandbox('sbx-1'))
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    await provider.create({
+      env: { ANTHROPIC_API_KEY: 'sk-secret-value' },
+    })
+
+    const payload = create.mock.calls[0]?.[0] as {
+      secrets?: Record<string, string>
+    }
+    expect(payload.secrets?.ANTHROPIC_API_KEY).toMatch(
+      /^tanstack_ANTHROPIC_API_KEY_[0-9a-f]{12}$/,
+    )
+  })
+
+  it('skips empty secret values', async () => {
+    create.mockResolvedValue(fakeRemoteSandbox('sbx-1'))
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    await provider.create({
+      env: { ANTHROPIC_API_KEY: '' },
+    })
+
+    expect(secretCreate).not.toHaveBeenCalled()
+    const payload = create.mock.calls[0]?.[0] as { secrets?: unknown }
+    expect(payload.secrets).toBeUndefined()
+  })
+
+  it('does not overlay secret plaintext onto exec after create', async () => {
+    const executeCommand = vi.fn(
+      async (
+        _command: string,
+        _cwd?: string,
+        _env?: Record<string, string>,
+      ) => ({ result: '', exitCode: 0 }),
+    )
+    create.mockResolvedValue(fakeRemoteSandbox('sbx-1', { executeCommand }))
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    const handle = await provider.create({
+      env: { ANTHROPIC_API_KEY: 'sk-secret-value' },
+    })
+    // bootstrapWorkspace / applyWorkspaceSecrets call env.set with the
+    // resolved plaintext. That must not reach executeCommand.
+    await handle.env.set({ ANTHROPIC_API_KEY: 'sk-secret-value' })
+    await handle.process.exec('echo hello')
+
+    const secretCalls = executeCommand.mock.calls.filter((call) => {
+      const env = call[2] as Record<string, string> | undefined
+      return env !== undefined && Object.values(env).includes('sk-secret-value')
+    })
+    expect(secretCalls).toEqual([])
+    const commandCalls = executeCommand.mock.calls.filter(
+      (call) => call[0] === 'echo hello',
+    )
+    expect(commandCalls.length).toBeGreaterThan(0)
+    for (const call of commandCalls) {
+      expect(String(call[0])).not.toContain('sk-secret-value')
+    }
+  })
+
+  it('does not write secret plaintext into the spawn env file', async () => {
+    const executeCommand = vi.fn(
+      async (
+        _command: string,
+        _cwd?: string,
+        _env?: Record<string, string>,
+      ) => ({ result: '', exitCode: 0 }),
+    )
+    const uploadFile = vi.fn(async (_data: Buffer, _path: string) => {})
+    const createFolder = vi.fn(async () => {})
+    const executeSessionCommand = vi.fn(
+      async (_sessionId: string, _request: { command: string }) => ({
+        cmdId: 'cmd-1',
+      }),
+    )
+    const sandbox = fakeRemoteSandbox('sbx-1', { executeCommand })
+    Object.assign(sandbox, {
+      fs: { uploadFile, createFolder },
+      process: {
+        ...sandbox.process,
+        createSession: vi.fn(async () => {}),
+        executeSessionCommand,
+        getSessionCommandLogs: vi.fn(async () => {}),
+        getSessionCommand: vi.fn(async () => ({ exitCode: 0 })),
+        deleteSession: vi.fn(async () => {}),
+        sendSessionCommandInput: vi.fn(async () => {}),
+      },
+    })
+    create.mockResolvedValue(sandbox)
+    const provider = daytonaSandbox({ apiKey: 'test-key' })
+
+    const handle = await provider.create({
+      env: { ANTHROPIC_API_KEY: 'sk-secret-value' },
+    })
+    await handle.env.set({ ANTHROPIC_API_KEY: 'sk-secret-value' })
+    const proc = await handle.process.spawn('echo hi')
+    await proc.wait()
+
+    for (const call of uploadFile.mock.calls) {
+      const data = call[0]
+      const body =
+        typeof data === 'string'
+          ? data
+          : Buffer.isBuffer(data)
+            ? data.toString('utf8')
+            : ''
+      expect(body).not.toContain('sk-secret-value')
+    }
+    const command = executeSessionCommand.mock.calls[0]?.[1]?.command
+    expect(command).not.toContain('sk-secret-value')
   })
 
   it('forwards the deterministic instance id as the Daytona name', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2167,8 +2167,8 @@ importers:
   packages/ai-isolate-daytona:
     devDependencies:
       '@daytona/sdk':
-        specifier: ^0.191.0
-        version: 0.191.0(ws@8.21.0)
+        specifier: ^0.192.0
+        version: 0.192.0(ws@8.21.0)
       '@tanstack/ai-code-mode':
         specifier: workspace:*
         version: link:../ai-code-mode
@@ -4528,20 +4528,11 @@ packages:
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
-  '@daytona/api-client@0.191.0':
-    resolution: {integrity: sha512-wa5mZugJ4I/o7nRHcZArkzY1+OHw/f3niKCoVZ/pkqwIo5O5ANBWN94CktmoS8THZKmZuSJM+ysjYQ80O+/5bg==}
-
   '@daytona/api-client@0.192.0':
     resolution: {integrity: sha512-fBzQ7KT9ZW2c4TgryYVGI8KUiUH02SCuKl1m0hqJQZDVkE6sbMiMlm5DZ0jwMCbQ8afWyOscvXmSSxdGQ/jUKQ==}
 
-  '@daytona/sdk@0.191.0':
-    resolution: {integrity: sha512-4HImbAQRrUXO2iszhH8ZP9IQKcF+6KRnuHr+6c9wJJm+98g0zFm15Dhc5TYldaUiVNaJPLMiPfVmw8M9Pt+ikw==}
-
   '@daytona/sdk@0.192.0':
     resolution: {integrity: sha512-pAA1curJCiZ0rqZcE0BUIjsgS90QdDFZ2QYw8nVWwGjjdr+Fndof4MaJfoZRjpcMHjUBoqEZpzO9C5HPv38QeA==}
-
-  '@daytona/toolbox-api-client@0.191.0':
-    resolution: {integrity: sha512-NAW7Ic3O7pKjRw0mLVgqMAs4cokC7ZK8IszRkTvNk44KdGXKzH/bbzGxn0q/vcWQOOpO7mBwZvbMtnGDKGiR8Q==}
 
   '@daytona/toolbox-api-client@0.192.0':
     resolution: {integrity: sha512-fEyA3YPK+IJezECBfZoNhf29qtZhy8AqI0lcgR+Bob6hEiInx9+sH26506ZkxmpGM4/5EApeLzUI1g5B9u2XHA==}
@@ -19593,49 +19584,12 @@ snapshots:
 
   '@date-fns/tz@1.4.1': {}
 
-  '@daytona/api-client@0.191.0':
-    dependencies:
-      axios: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@daytona/api-client@0.192.0':
     dependencies:
       axios: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - debug
       - supports-color
-
-  '@daytona/sdk@0.191.0(ws@8.21.0)':
-    dependencies:
-      '@aws-sdk/client-s3': 3.1075.0
-      '@aws-sdk/lib-storage': 3.1075.0(@aws-sdk/client-s3@3.1075.0)
-      '@daytona/api-client': 0.191.0
-      '@daytona/toolbox-api-client': 0.191.0
-      '@iarna/toml': 2.2.5
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-http': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-node': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      axios: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
-      busboy: 1.6.0
-      dotenv: 17.4.2
-      expand-tilde: 2.0.2
-      fast-glob: 3.3.3
-      form-data: 4.0.6
-      isomorphic-ws: 5.0.0(ws@8.21.0)
-      pathe: 2.0.3
-      shell-quote: 1.8.3
-      tar: 7.5.16
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-      - ws
 
   '@daytona/sdk@0.192.0(ws@8.21.0)':
     dependencies:
@@ -19666,13 +19620,6 @@ snapshots:
       - debug
       - supports-color
       - ws
-
-  '@daytona/toolbox-api-client@0.191.0':
-    dependencies:
-      axios: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   '@daytona/toolbox-api-client@0.192.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2670,8 +2670,8 @@ importers:
   packages/ai-sandbox-daytona:
     dependencies:
       '@daytona/sdk':
-        specifier: ^0.191.0
-        version: 0.191.0(ws@8.21.0)
+        specifier: ^0.192.0
+        version: 0.192.0(ws@8.21.0)
     devDependencies:
       '@tanstack/ai-sandbox':
         specifier: workspace:*
@@ -4531,11 +4531,20 @@ packages:
   '@daytona/api-client@0.191.0':
     resolution: {integrity: sha512-wa5mZugJ4I/o7nRHcZArkzY1+OHw/f3niKCoVZ/pkqwIo5O5ANBWN94CktmoS8THZKmZuSJM+ysjYQ80O+/5bg==}
 
+  '@daytona/api-client@0.192.0':
+    resolution: {integrity: sha512-fBzQ7KT9ZW2c4TgryYVGI8KUiUH02SCuKl1m0hqJQZDVkE6sbMiMlm5DZ0jwMCbQ8afWyOscvXmSSxdGQ/jUKQ==}
+
   '@daytona/sdk@0.191.0':
     resolution: {integrity: sha512-4HImbAQRrUXO2iszhH8ZP9IQKcF+6KRnuHr+6c9wJJm+98g0zFm15Dhc5TYldaUiVNaJPLMiPfVmw8M9Pt+ikw==}
 
+  '@daytona/sdk@0.192.0':
+    resolution: {integrity: sha512-pAA1curJCiZ0rqZcE0BUIjsgS90QdDFZ2QYw8nVWwGjjdr+Fndof4MaJfoZRjpcMHjUBoqEZpzO9C5HPv38QeA==}
+
   '@daytona/toolbox-api-client@0.191.0':
     resolution: {integrity: sha512-NAW7Ic3O7pKjRw0mLVgqMAs4cokC7ZK8IszRkTvNk44KdGXKzH/bbzGxn0q/vcWQOOpO7mBwZvbMtnGDKGiR8Q==}
+
+  '@daytona/toolbox-api-client@0.192.0':
+    resolution: {integrity: sha512-fEyA3YPK+IJezECBfZoNhf29qtZhy8AqI0lcgR+Bob6hEiInx9+sH26506ZkxmpGM4/5EApeLzUI1g5B9u2XHA==}
 
   '@deno/shim-deno-test@0.5.0':
     resolution: {integrity: sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==}
@@ -19591,6 +19600,13 @@ snapshots:
       - debug
       - supports-color
 
+  '@daytona/api-client@0.192.0':
+    dependencies:
+      axios: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@daytona/sdk@0.191.0(ws@8.21.0)':
     dependencies:
       '@aws-sdk/client-s3': 3.1075.0
@@ -19621,7 +19637,44 @@ snapshots:
       - supports-color
       - ws
 
+  '@daytona/sdk@0.192.0(ws@8.21.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1075.0
+      '@aws-sdk/lib-storage': 3.1075.0(@aws-sdk/client-s3@3.1075.0)
+      '@daytona/api-client': 0.192.0
+      '@daytona/toolbox-api-client': 0.192.0
+      '@iarna/toml': 2.2.5
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      axios: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      busboy: 1.6.0
+      dotenv: 17.4.2
+      expand-tilde: 2.0.2
+      fast-glob: 3.3.3
+      form-data: 4.0.6
+      isomorphic-ws: 5.0.0(ws@8.21.0)
+      pathe: 2.0.3
+      shell-quote: 1.8.3
+      tar: 7.5.16
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+      - ws
+
   '@daytona/toolbox-api-client@0.191.0':
+    dependencies:
+      axios: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@daytona/toolbox-api-client@0.192.0':
     dependencies:
       axios: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:


### PR DESCRIPTION
Workspace secrets on Daytona no longer land in the sandbox record or in session command strings. Create and snapshot restore store each value as a Daytona organization Secret and mount a placeholder in the sandbox env. `@tanstack/ai-isolate-daytona` uses the same `@daytona/sdk` version so the workspace version check passes.

## 🎯 Changes

Daytona create and restore now call `daytona.secret.create`, then pass `secrets: { ENV_NAME: secretName }` into `daytona.create`. The sandbox env holds `dtn_secret_*`, not the plaintext value. `env.set` from bootstrap and resume does not overlay that plaintext onto exec or spawn.

`@daytona/sdk` is bumped from `^0.191.0` to `^0.192.0` (the first release with organization Secrets) in both `@tanstack/ai-sandbox-daytona` and `@tanstack/ai-isolate-daytona`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

Package-scoped gates ran and passed: `test:lib`, `test:types`, `test:oxlint` on `@tanstack/ai-sandbox-daytona`, plus `pnpm test:docs`. Full `pnpm test:pr` was not run.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Root cause

**Issue.** On Daytona, workspace secrets stayed in records that org members can read: create-time `envVars` on `GET /sandbox/:id`, and the command string (or spawn env file) of each session command. Harness keys such as `ANTHROPIC_API_KEY` and git tokens were in those records for the life of the sandbox or session.

**Cause.** `ensure()` resolves `createSecrets()` into `SandboxCreateInput.env`. Before this PR, the Daytona adapter either put that map in `envVars` (original bug) or called `handle.env.set` after create (PR #1094). `env.set` then merged those values into every `executeCommand` env argument and into `.tanstack-ai-env` for spawn. Session execute has no env field, so spawn wrote the values to a file the Daytona FS API can read. The adapter also stayed on `@daytona/sdk` 0.191.0, which has no organization Secrets API.

**Fix.** Create each workspace secret as a Daytona organization Secret (name includes a value hash; a 409 reuses the existing name). Pass the env-var-to-secret-name map as `secrets` on `daytona.create`. The sandbox env then holds an opaque placeholder. Handles built by create, restore, and resume set `applyEnvSet: false`, so later `env.set` cannot overlay plaintext onto exec or spawn.

## Possible alternatives

- **Keep #1094 only (executeCommand env + spawn env file, no Secrets).** That already kept values out of create-time `envVars` and out of the command string. The spawn env file and `executeCommand` env argument still hold plaintext. This PR needs the Secrets API to keep values out of those records too.
- **Write secrets to `~/.bashrc` or a profile file inside the sandbox.** That is still a readable file on the sandbox filesystem. Organization Secrets keep the plaintext on Daytona's secret store instead.
- **Restrict `hosts` with a built-in map of API hostnames.** A wrong host would break the harness CLI. This PR omits `hosts` (unrestricted substitution) so unknown APIs still work.

## Testing

### Commands run

- `pnpm nx run @tanstack/ai-sandbox-daytona:test:lib` — 73 passed, 3 skipped (live journal tests without extra coverage). Live Daytona tests in `daytona.test.ts` passed with `DAYTONA_API_KEY`.
- `pnpm nx run @tanstack/ai-sandbox-daytona:test:types` — passed
- `pnpm nx run @tanstack/ai-sandbox-daytona:test:oxlint` — passed
- `pnpm test:docs` — no broken links
- `pnpm test:sherif` — passed after aligning `@daytona/sdk` on `@tanstack/ai-isolate-daytona`
- Full `pnpm test:pr` — not run. CI Test failed on `root:test:sherif` (`@daytona/sdk` `^0.192.0` vs `^0.191.0`). That is the follow-up commit on this branch.
- Playwright E2E suite — not run. There is no Daytona sandbox spec in `testing/e2e`. The new unit tests are the coverage for this change.

### Gate 1 repro

Agent-written vitest file (not in the PR). It creates a Daytona provider with `env: { ANTHROPIC_API_KEY: 'sk-secret-value' }`, then `env.set`s the same map (bootstrap/resume path), then `spawn`s. It asserts `secret.create` was called, `create` did not receive the plaintext in `envVars`, and the spawn command / env file do not contain `sk-secret-value`.

**Clean main (`62e4e4699`) — fail**

```
FAIL  tests/repro-1084.test.ts > issue 1084: daytona workspace secrets stay out of readable records
AssertionError: expected "vi.fn()" to be called at least once
 ❯ tests/repro-1084.test.ts:85:26
     expect(secretCreate).toHaveBeenCalled()
```

Main never calls `daytona.secret.create`.

**This branch — pass**

```
✓ tests/repro-1084.test.ts (1 test) 3ms
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

### Manual test

1. On main, create a Daytona sandbox with `createSecrets({ ANTHROPIC_API_KEY: 'sk-secret-value' })`. Inspect `GET /sandbox/:id` and a session command after spawn. The value can appear in the spawn env file (`.tanstack-ai-env`) even when it is absent from create-time `envVars`.
2. On this branch, create the same sandbox. `GET /sandbox/:id` must show a `dtn_secret_*` placeholder, not `sk-secret-value`. Session command strings and `.tanstack-ai-env` must not contain `sk-secret-value`. The in-sandbox process still authenticates because Daytona substitutes the value on outbound HTTPS.

### How this PR makes testing easy

Unit tests in `packages/ai-sandbox-daytona/tests/provider.test.ts` and `handle.test.ts` cover organization Secret create, 409 reuse, empty values, no plaintext on exec after create/resume, and no plaintext in the spawn env file.

## Linked issues

Fixes #1084

## Risk / rollback

Create now needs a Daytona API key with `manage:secrets`. A 409 is treated as reuse. A different error (missing permission, network) fails sandbox create. Revert this PR to restore the #1094 path (no organization Secrets, `env.set` overlay). Organization Secrets created during the window stay in the Daytona org until someone deletes them.

## CodeRabbit

no PR yet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Workspace secrets are stored as Daytona organization Secrets and mounted using opaque placeholders.
  * Secret values are excluded from sandbox records, dashboard environment views, command strings, and spawned process environments.
  * Existing organization Secrets are reused, while empty values are skipped.

* **Documentation**
  * Updated Daytona provider documentation to explain secret handling and per-command environment variables.

* **Bug Fixes**
  * Improved secret handling during sandbox creation, resumption, and snapshot restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->