### PR TITLE
feat(ai-openai): add GPT-6 Astra

### DIFF
--- a/.changeset/gpt-6-astra.md
+++ b/.changeset/gpt-6-astra.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/ai-openai": minor
+---
+
+Add GPT-6 Astra with model-specific reasoning options, input and tool capabilities, and sampling parameter handling. Support text-only Chat Completions with native options; use the Responses adapter for tool calls.

--- a/.changeset/gpt-6-astra.md
+++ b/.changeset/gpt-6-astra.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/ai-openai": minor
+'@tanstack/ai-openai': minor
 ---
 
 Add GPT-6 Astra with model-specific reasoning options, input and tool capabilities, and sampling parameter handling. Support text-only Chat Completions with native options; use the Responses adapter for tool calls.

--- a/docs/adapters/openai.md
+++ b/docs/adapters/openai.md
@@ -46,6 +46,34 @@ const stream = chat({
 });
 ```
 
+## GPT-6 Astra
+
+Use `openaiText("gpt-6-astra")` for text, images, and tool calls through the Responses API.
+
+```typescript
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+const stream = chat({
+  adapter: openaiText("gpt-6-astra"),
+  messages: [{ role: "user", content: "Explain this design tradeoff." }],
+  modelOptions: {
+    reasoning: { effort: "max", summary: "auto" },
+  },
+});
+
+for await (const chunk of stream) {
+  if (chunk.type === "TEXT_MESSAGE_CONTENT") process.stdout.write(chunk.delta);
+}
+```
+
+- Reasoning effort accepts `low`, `medium`, `high`, `xhigh`, or `max`.
+- The context window is 1,050,000 tokens. The maximum output is 128,000 tokens.
+- The adapter removes `temperature` and `top_p` from Astra requests. Astra does not support log-probability options.
+- For text without tools, `openaiChatCompletions("gpt-6-astra")` accepts native `reasoning_effort` and `max_completion_tokens` options. These option types are specific to Astra; other models retain their existing option types. Tool calls require `openaiText`.
+
+See the [OpenAI model guide](https://developers.openai.com/api/docs/guides/latest-model) for Astra API restrictions and prompt caching changes.
+
 ## Chat Completions API
 
 `@tanstack/ai-openai` ships two text adapters that hit different OpenAI endpoints. `openaiText` (default) calls the Responses API (`/v1/responses`). `openaiChatCompletions` calls the older Chat Completions API (`/v1/chat/completions`).

--- a/docs/config.json
+++ b/docs/config.json
@@ -940,7 +940,7 @@
           "label": "OpenAI",
           "to": "adapters/openai",
           "addedAt": "2026-04-15",
-          "updatedAt": "2026-07-22"
+          "updatedAt": "2026-09-04"
         },
         {
           "label": "Anthropic",

--- a/packages/ai-openai/src/adapters/text-chat-completions.ts
+++ b/packages/ai-openai/src/adapters/text-chat-completions.ts
@@ -8,10 +8,14 @@ import type {
   OpenAIChatModelToolCapabilitiesByName,
   OpenAIModelInputModalitiesByName,
 } from '../model-meta'
-import type { Modality } from '@tanstack/ai'
+import type { ChatCompletionCreateParamsStreaming } from 'openai/resources/chat/completions'
+import type { Modality, TextOptions } from '@tanstack/ai'
 import type { OpenAIMessageMetadataByModality } from '../message-types'
 import type { OpenAIClientConfig } from '../utils/client'
-import type { ExternalTextProviderOptions } from '../text/text-provider-options'
+import type {
+  ExternalTextProviderOptions,
+  OpenAIAstraChatCompletionsOptions,
+} from '../text/text-provider-options'
 
 /**
  * Configuration for the OpenAI Chat Completions adapter.
@@ -26,9 +30,11 @@ export interface OpenAIChatCompletionsConfig extends OpenAIClientConfig {}
 export type OpenAIChatCompletionsProviderOptions = ExternalTextProviderOptions
 
 type ResolveProviderOptions<TModel extends string> =
-  TModel extends keyof OpenAIChatModelProviderOptionsByName
-    ? OpenAIChatModelProviderOptionsByName[TModel]
-    : OpenAIChatCompletionsProviderOptions
+  TModel extends 'gpt-6-astra'
+    ? OpenAIAstraChatCompletionsOptions
+    : TModel extends keyof OpenAIChatModelProviderOptionsByName
+      ? OpenAIChatModelProviderOptionsByName[TModel]
+      : OpenAIChatCompletionsProviderOptions
 
 type ResolveInputModalities<TModel extends string> =
   TModel extends keyof OpenAIModelInputModalitiesByName
@@ -36,9 +42,11 @@ type ResolveInputModalities<TModel extends string> =
     : readonly ['text', 'image', 'audio']
 
 type ResolveToolCapabilities<TModel extends string> =
-  TModel extends keyof OpenAIChatModelToolCapabilitiesByName
-    ? NonNullable<OpenAIChatModelToolCapabilitiesByName[TModel]>
-    : readonly []
+  TModel extends 'gpt-6-astra'
+    ? readonly []
+    : TModel extends keyof OpenAIChatModelToolCapabilitiesByName
+      ? NonNullable<OpenAIChatModelToolCapabilitiesByName[TModel]>
+      : readonly []
 
 /**
  * OpenAI Text adapter targeting the **Chat Completions** API
@@ -66,6 +74,31 @@ export class OpenAIChatCompletionsTextAdapter<
 
   constructor(config: OpenAIChatCompletionsConfig, model: TModel) {
     super(model, 'openai-chat', new OpenAI(config))
+  }
+
+  protected override mapOptionsToRequest(
+    options: TextOptions<TProviderOptions>,
+  ): ChatCompletionCreateParamsStreaming {
+    const request = super.mapOptionsToRequest(options)
+    if (options.model === 'gpt-6-astra') {
+      if (
+        request.tools?.length ||
+        request.messages.some(
+          (message) =>
+            message.role === 'tool' ||
+            (message.role === 'assistant' && message.tool_calls?.length),
+        )
+      ) {
+        throw new Error(
+          'GPT-6 Astra tool calls require openaiText (Responses API).',
+        )
+      }
+      delete request.temperature
+      delete request.top_p
+      delete request.top_logprobs
+      delete request.logprobs
+    }
+    return request
   }
 }
 

--- a/packages/ai-openai/src/adapters/text.ts
+++ b/packages/ai-openai/src/adapters/text.ts
@@ -148,6 +148,15 @@ export class OpenAITextAdapter<
       delete request.top_p
     }
 
+    if (options.model === 'gpt-6-astra') {
+      delete request.top_logprobs
+      if (request.include) {
+        request.include = request.include.filter(
+          (item) => item !== 'message.output_text.logprobs',
+        )
+      }
+    }
+
     // Reasoning models pair each function_call with a reasoning item. Request
     // the encrypted blob so convertMessagesToInput can replay it. Pre-5 chat
     // models do not emit those items, so leave include unset for them.

--- a/packages/ai-openai/src/model-meta.ts
+++ b/packages/ai-openai/src/model-meta.ts
@@ -1,4 +1,5 @@
 import type {
+  OpenAIAstraOptions,
   OpenAIBaseOptions,
   OpenAIMetadataOptions,
   OpenAIReasoningOptions,
@@ -68,6 +69,34 @@ interface ModelMeta<TProviderOptions = unknown> {
    */
   providerOptions?: TProviderOptions
 }
+
+// https://developers.openai.com/api/docs/models/gpt-6-astra
+const GPT_6_ASTRA = {
+  name: 'gpt-6-astra',
+  context_window: 1_050_000,
+  max_output_tokens: 128_000,
+  knowledge_cutoff: '2026-04-30',
+  supports: {
+    input: ['text', 'image'],
+    output: ['text'],
+    endpoints: ['chat', 'chat-completions', 'batch'],
+    features: ['streaming', 'function_calling', 'structured_outputs'],
+    tools: [
+      'web_search',
+      'file_search',
+      'image_generation',
+      'code_interpreter',
+      'mcp',
+      'computer_use',
+      'shell',
+      'apply_patch',
+    ],
+  },
+  pricing: {
+    input: { normal: 10, cached: 1 },
+    output: { normal: 50 },
+  },
+} as const satisfies ModelMeta<OpenAIAstraOptions>
 
 const GPT5_2 = {
   name: 'gpt-5.2',
@@ -2450,6 +2479,7 @@ const GPT_5_6_TERRA_PRO = {
 >
 
 export const OPENAI_CHAT_MODELS = [
+  GPT_6_ASTRA.name,
   GPT_5_6_LUNA_PRO.name,
   GPT_5_6_SOL_PRO.name,
   GPT_5_6_TERRA_PRO.name,
@@ -2520,18 +2550,19 @@ export type OpenAIChatModel = (typeof OPENAI_CHAT_MODELS)[number]
  * Whether a model rejects the `temperature` / `top_p` sampling knobs.
  *
  * OpenAI's reasoning models — the o-series (`o1`, `o3`, `o4`, …) and the GPT-5
- * reasoning family — return `400 Unsupported parameter: 'temperature'` if either
- * is sent. Their `*-chat-latest` counterparts are ordinary chat models that
- * still accept them, so those are excluded. Matching by name (rather than a
- * per-model flag) keeps future `gpt-5.x` reasoning models covered automatically.
+ * and GPT-6 families — reject `temperature` and `top_p`. Their `*-chat-latest`
+ * counterparts are ordinary chat models that still accept them, so those are
+ * excluded. Matching by name (rather than a
+ * per-model flag) covers new GPT-5 and GPT-6 reasoning model names automatically.
  * See the note in `text/text-provider-options.ts`.
  */
 export function openAIModelRejectsSamplingParams(model: string): boolean {
   if (/^o\d/.test(model)) return true
-  if (model.startsWith('gpt-5') && !model.endsWith('-chat-latest')) return true
+  if (/^gpt-[56]/.test(model) && !model.endsWith('-chat-latest')) return true
   if (model === 'codex-mini-latest') return true
   return false
 }
+
 
 // Image generation models (based on endpoints: "image-generation" or "image-edit")
 export const OPENAI_IMAGE_MODELS = [
@@ -2635,6 +2666,7 @@ export type OpenAIEmbeddingModelInputModalitiesByName = {
  * Manually defined to ensure accurate type narrowing per model.
  */
 export type OpenAIChatModelProviderOptionsByName = {
+  [GPT_6_ASTRA.name]: OpenAIAstraOptions
   [GPT5_2.name]: OpenAIBaseOptions &
     OpenAIReasoningOptions &
     OpenAIStructuredOutputOptions &
@@ -2896,6 +2928,7 @@ export type OpenAIChatModelProviderOptionsByName = {
  * tuple from each model constant.
  */
 export type OpenAIChatModelToolCapabilitiesByName = {
+  [GPT_6_ASTRA.name]: typeof GPT_6_ASTRA.supports.tools
   [GPT5_2.name]: typeof GPT5_2.supports.tools
   [GPT5_2_PRO.name]: typeof GPT5_2_PRO.supports.tools
   [GPT5_2_CHAT.name]: typeof GPT5_2_CHAT.supports.tools
@@ -2955,6 +2988,7 @@ export type OpenAIChatModelToolCapabilitiesByName = {
  * when consumed by external packages.
  */
 export type OpenAIModelInputModalitiesByName = {
+  [GPT_6_ASTRA.name]: typeof GPT_6_ASTRA.supports.input
   [GPT5_2.name]: typeof GPT5_2.supports.input
   [GPT5_2_PRO.name]: typeof GPT5_2_PRO.supports.input
   [GPT5_2_CHAT.name]: typeof GPT5_2_CHAT.supports.input

--- a/packages/ai-openai/src/model-meta.ts
+++ b/packages/ai-openai/src/model-meta.ts
@@ -2563,7 +2563,6 @@ export function openAIModelRejectsSamplingParams(model: string): boolean {
   return false
 }
 
-
 // Image generation models (based on endpoints: "image-generation" or "image-edit")
 export const OPENAI_IMAGE_MODELS = [
   GPT_IMAGE_2.name,

--- a/packages/ai-openai/src/text/text-provider-options.ts
+++ b/packages/ai-openai/src/text/text-provider-options.ts
@@ -176,6 +176,39 @@ export interface OpenAIReasoningOptions {
   }
 }
 
+/** Reasoning levels supported by GPT-6 Astra. */
+type AstraReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+
+export type OpenAIAstraOptions = Omit<
+  OpenAIBaseOptions,
+  'top_logprobs' | 'include' | 'prompt_cache_retention'
+> &
+  OpenAIStructuredOutputOptions &
+  OpenAIToolsOptions &
+  OpenAIStreamingOptions &
+  OpenAIMetadataOptions & {
+    reasoning?: {
+      effort?: AstraReasoningEffort
+      summary?: ReasoningSummary
+    }
+    include?: Array<
+      Exclude<
+        OpenAI.Responses.ResponseIncludable,
+        'message.output_text.logprobs'
+      >
+    >
+  }
+
+/** Astra tool calls require the Responses API. */
+export type OpenAIAstraChatCompletionsOptions = Pick<
+  OpenAI.Chat.ChatCompletionCreateParamsStreaming,
+  | 'max_completion_tokens'
+  | 'response_format'
+  | 'store'
+  | 'metadata'
+  | 'service_tier'
+> & { reasoning_effort?: AstraReasoningEffort }
+
 /**
  * Reasoning options for computer-use-preview model (includes 'concise' summary).
  */

--- a/packages/ai-openai/tests/astra.test.ts
+++ b/packages/ai-openai/tests/astra.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { resolveDebugOption } from '@tanstack/ai/adapter-internals'
+import { OpenAITextAdapter } from '../src/adapters/text'
+import { OpenAIChatCompletionsTextAdapter } from '../src/adapters/text-chat-completions'
+import { OPENAI_CHAT_MODELS } from '../src/model-meta'
+import type {
+  OpenAIChatModelProviderOptionsByName,
+  OpenAIChatModelToolCapabilitiesByName,
+  OpenAIModelInputModalitiesByName,
+} from '../src/model-meta'
+import type { OpenAIAstraChatCompletionsOptions } from '../src/text/text-provider-options'
+import type { TextOptions } from '@tanstack/ai'
+
+type AstraOptions = OpenAIChatModelProviderOptionsByName['gpt-6-astra']
+
+class ResponsesAdapter extends OpenAITextAdapter<'gpt-6-astra'> {
+  request(options: TextOptions<AstraOptions>) {
+    return this.mapOptionsToRequest(options)
+  }
+}
+
+class ChatCompletionsAdapter extends OpenAIChatCompletionsTextAdapter<'gpt-6-astra'> {
+  request(options: TextOptions<OpenAIAstraChatCompletionsOptions>) {
+    return this.mapOptionsToRequest(options)
+  }
+}
+
+const input = {
+  logger: resolveDebugOption(false),
+  model: 'gpt-6-astra',
+  messages: [{ role: 'user', content: 'Hello' }],
+} as const
+
+describe('GPT-6 Astra', () => {
+  it('registers supported reasoning, input modalities, and provider tools', () => {
+    expect(OPENAI_CHAT_MODELS).toContain('gpt-6-astra')
+    expectTypeOf<
+      NonNullable<AstraOptions['reasoning']>['effort']
+    >().toEqualTypeOf<'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined>()
+    expectTypeOf<
+      OpenAIModelInputModalitiesByName['gpt-6-astra'][number]
+    >().toEqualTypeOf<'text' | 'image'>()
+    expectTypeOf<
+      OpenAIChatModelToolCapabilitiesByName['gpt-6-astra'][number]
+    >().toEqualTypeOf<
+      | 'web_search'
+      | 'file_search'
+      | 'image_generation'
+      | 'code_interpreter'
+      | 'mcp'
+      | 'computer_use'
+      | 'shell'
+      | 'apply_patch'
+    >()
+    expectTypeOf<AstraOptions>().not.toHaveProperty('prompt_cache_retention')
+    expectTypeOf<AstraOptions>().not.toHaveProperty('top_logprobs')
+  })
+
+  it('preserves max reasoning and strips unsupported Responses parameters', () => {
+    const adapter = new ResponsesAdapter({ apiKey: 'test-key' }, 'gpt-6-astra')
+    const request = adapter.request({
+      ...input,
+      messages: [...input.messages],
+      modelOptions: {
+        reasoning: { effort: 'max', summary: 'auto' },
+        temperature: 0.3,
+        top_p: 0.8,
+        max_output_tokens: 128,
+      },
+    })
+    expect(request.reasoning).toEqual({ effort: 'max', summary: 'auto' })
+    expect(request.include).toEqual(['reasoning.encrypted_content'])
+    expect(request.max_output_tokens).toBe(128)
+    expect(request).not.toHaveProperty('temperature')
+    expect(request).not.toHaveProperty('top_p')
+
+    // Untyped callers can still supply log-probability options.
+    const modelOptions = {
+      top_logprobs: 5,
+      include: ['message.output_text.logprobs', 'reasoning.encrypted_content'],
+    } as any
+    const filtered = adapter.request({
+      ...input,
+      messages: [...input.messages],
+      modelOptions,
+    })
+    expect(filtered).not.toHaveProperty('top_logprobs')
+    expect(filtered.include).toEqual(['reasoning.encrypted_content'])
+  })
+
+  it('forwards native Chat Completions options and rejects tool calls', () => {
+    const adapter = new ChatCompletionsAdapter(
+      { apiKey: 'test-key' },
+      'gpt-6-astra',
+    )
+    const options = {
+      ...input,
+      messages: [...input.messages],
+      modelOptions: {
+        reasoning_effort: 'max' as const,
+        max_completion_tokens: 128,
+      },
+    }
+    expect(adapter.request(options)).toMatchObject({
+      model: 'gpt-6-astra',
+      reasoning_effort: 'max',
+      max_completion_tokens: 128,
+    })
+    expect(() =>
+      adapter.request({
+        ...options,
+        tools: [{ name: 'lookup', description: 'Look up a value' }],
+      }),
+    ).toThrow('GPT-6 Astra tool calls require openaiText')
+    expect(() =>
+      adapter.request({
+        ...options,
+        messages: [{ role: 'tool', toolCallId: 'call_1', content: 'result' }],
+      }),
+    ).toThrow('GPT-6 Astra tool calls require openaiText')
+  })
+
+})

--- a/packages/ai-openai/tests/astra.test.ts
+++ b/packages/ai-openai/tests/astra.test.ts
@@ -119,5 +119,4 @@ describe('GPT-6 Astra', () => {
       }),
     ).toThrow('GPT-6 Astra tool calls require openaiText')
   })
-
 })

--- a/packages/ai-openai/tests/model-sampling-support.test.ts
+++ b/packages/ai-openai/tests/model-sampling-support.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { openAIModelRejectsSamplingParams } from '../src/model-meta'
 
 describe('openAIModelRejectsSamplingParams', () => {
-  it('flags o-series and GPT-5 reasoning models', () => {
+  it('flags o-series, GPT-5, and GPT-6 reasoning models', () => {
     for (const model of [
+      'gpt-6-astra',
+      // Synthetic future names verify family matching without catalog entries.
+      'gpt-6-future',
+      'gpt-6-astra-2099-01-01',
       'o1',
       'o1-pro',
       'o3',
@@ -30,6 +34,8 @@ describe('openAIModelRejectsSamplingParams', () => {
 
   it('leaves chat-latest and pre-5 chat models alone', () => {
     for (const model of [
+      'gpt-6-chat-latest',
+      'gpt-6-future-chat-latest',
       'gpt-5-chat-latest',
       'gpt-5.1-chat-latest',
       'gpt-5.2-chat-latest',

--- a/testing/e2e/fixtures/chat/gpt-6-astra.json
+++ b/testing/e2e/fixtures/chat/gpt-6-astra.json
@@ -1,0 +1,11 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "model": "gpt-6-astra",
+        "userMessage": "[gpt-6-astra] recommend a guitar"
+      },
+      "response": { "content": "Try the Fender Stratocaster." }
+    }
+  ]
+}

--- a/testing/e2e/tests/gpt-6-astra.spec.ts
+++ b/testing/e2e/tests/gpt-6-astra.spec.ts
@@ -1,0 +1,59 @@
+import { chat } from '@tanstack/ai'
+import {
+  createOpenaiChat,
+  createOpenaiChatCompletions,
+} from '@tanstack/ai-openai'
+import { test, expect } from './fixtures'
+
+for (const endpoint of ['Responses', 'Chat Completions'] as const) {
+  test(`GPT-6 Astra streams through ${endpoint}`, async ({
+    aimockPort,
+    testId,
+  }) => {
+    const payloads: Array<Record<string, unknown>> = []
+    const config = {
+      baseURL: `http://127.0.0.1:${aimockPort}/v1`,
+      defaultHeaders: { 'X-Test-Id': testId },
+      fetch: async (url: RequestInfo | URL, init?: RequestInit) => {
+        payloads.push(JSON.parse(String(init?.body)))
+        return fetch(url, init)
+      },
+    }
+    const adapter =
+      endpoint === 'Responses'
+        ? createOpenaiChat('gpt-6-astra', 'e2e-dummy', config)
+        : createOpenaiChatCompletions('gpt-6-astra', 'e2e-dummy', config)
+    let text = ''
+    let finished = false
+    for await (const chunk of chat({
+      adapter,
+      messages: [{ role: 'user', content: '[gpt-6-astra] recommend a guitar' }],
+      modelOptions:
+        endpoint === 'Responses'
+          ? { reasoning: { effort: 'max' }, temperature: 0.3, top_p: 0.8 }
+          : { reasoning_effort: 'max', max_completion_tokens: 128 },
+    })) {
+      expect(chunk.type).not.toBe('RUN_ERROR')
+      if (chunk.type === 'TEXT_MESSAGE_CONTENT') text += chunk.delta
+      if (chunk.type === 'RUN_FINISHED') finished = true
+    }
+    expect(text).toContain('Fender Stratocaster')
+    expect(finished).toBe(true)
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0]).toMatchObject(
+      endpoint === 'Responses'
+        ? {
+            model: 'gpt-6-astra',
+            reasoning: { effort: 'max' },
+            include: ['reasoning.encrypted_content'],
+          }
+        : {
+            model: 'gpt-6-astra',
+            reasoning_effort: 'max',
+            max_completion_tokens: 128,
+          },
+    )
+    expect(payloads[0]).not.toHaveProperty('temperature')
+    expect(payloads[0]).not.toHaveProperty('top_p')
+  })
+}


### PR DESCRIPTION
You can now use `gpt-6-astra` with `openaiText` and `openaiChatCompletions`. The model has typed reasoning effort from `low` to `max`, text and image input, and the existing Responses provider tools. Tool calls require `openaiText`.

## 🎯 Changes

Register `gpt-6-astra` in `model-meta.ts` with its context window, output limit, pricing, input modalities, and provider tools. Add `OpenAIAstraOptions` for the Responses adapter. The type accepts reasoning effort `low`, `medium`, `high`, `xhigh`, and `max`. It does not include `top_logprobs`, `prompt_cache_retention`, or `message.output_text.logprobs`.

Both adapters remove `temperature`, `top_p`, and log-probability options from Astra requests. `openAIModelRejectsSamplingParams` now matches `gpt-5*` and `gpt-6*` names, except `-chat-latest`.

The Chat Completions adapter accepts native `reasoning_effort` and `max_completion_tokens` for Astra only. It rejects tool calls, because OpenAI requires the Responses API for Astra tool calls. Other models keep their Responses-shaped option types. That existing mismatch is separate work.

Not included: `skills` and `tool_search` provider tools, async tool calling, `configuration_update`, and `prompt_cache_options`.

<https://developers.openai.com/api/docs/models/gpt-6-astra>
<https://developers.openai.com/api/docs/guides/latest-model#gpt-6-astra-update-api-and-model-parameters>

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Testing

Commands run on the final diff:

- `pnpm test:pr`: passed.
- `pnpm --filter @tanstack/ai-e2e exec playwright test tests/gpt-6-astra.spec.ts --workers=1`: 2 passed.
- Full E2E run: 2 failures in the Vercel Gateway structured-output tests. This branch does not touch `@tanstack/openai-base` or `@tanstack/ai-vercel-gateway`, so it cannot cause them.
- No live requests to `gpt-6-astra`. The E2E tests use aimock fixtures.

Manual test:

1. Run `pnpm --filter @tanstack/ai-e2e exec playwright test tests/gpt-6-astra.spec.ts --workers=1`. Both tests pass. The Responses payload has `reasoning.effort: 'max'` and no `temperature`.
2. If you have a key with Astra access, set `OPENAI_API_KEY`. Then run the snippet in `docs/adapters/openai.md`, section "GPT-6 Astra".

Tests on the branch: `packages/ai-openai/tests/astra.test.ts`, `packages/ai-openai/tests/model-sampling-support.test.ts`, `testing/e2e/tests/gpt-6-astra.spec.ts`.

## Risk / rollback

Low. One shared change: `openAIModelRejectsSamplingParams` now also matches `gpt-6*` names. If OpenAI ships a GPT-6 chat model without the `-chat-latest` suffix, that model loses `temperature` and `top_p`. Rollback: revert the PR.

## Public API change

**Before**

```ts
openaiText('gpt-6-astra') // Type error: not in the supported model union.
```

**After**

```ts
chat({
  adapter: openaiText('gpt-6-astra'),
  messages: [{ role: 'user', content: 'Explain this design.' }],
  modelOptions: { reasoning: { effort: 'max' } },
})
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the GPT-6 Astra model in the OpenAI adapter.
  - Supports text, image inputs, reasoning effort levels, structured outputs, and tool calls through the Responses API.
  - Supports text generation through Chat Completions with native reasoning and completion-token options.
  - Added model-specific handling for unsupported sampling and log-probability parameters.

- **Documentation**
  - Added GPT-6 Astra usage guidance, capabilities, limits, and endpoint-specific options to the OpenAI adapter documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->