### PR TITLE
fix(ai): drain structured output before finishing the run

### DIFF
--- a/.changeset/structured-completion-before-finish.md
+++ b/.changeset/structured-completion-before-finish.md
@@ -1,0 +1,8 @@
+---
+'@tanstack/ai': patch
+'@tanstack/ai-client': patch
+---
+
+Emit the native structured result before RUN_FINISHED so clients receive the final object before the run closes. Emit only RUN_ERROR if parsing fails.
+
+Wait for the active subscriber to process all events before resolving send, including streams that take more than 32 timer ticks to process.

--- a/docs/chat/connection-adapters.md
+++ b/docs/chat/connection-adapters.md
@@ -645,7 +645,7 @@ export type ConnectionAdapter =
 
 Internally, `ChatClient` normalizes both shapes to a single `subscribe`/`send` pair via `normalizeConnectionAdapter()`:
 
-- Provide `connect` and it gets wrapped in an async queue.
+- Provide `connect` and it gets wrapped in an async queue. The wrapped `send()` waits until the active subscriber processes all events or exits.
 - Provide `subscribe` + `send` natively and they are used as-is.
 
 ## Authentication

--- a/docs/structured-outputs/streaming.md
+++ b/docs/structured-outputs/streaming.md
@@ -156,7 +156,7 @@ The `structured-output` part fields:
 
 ## What the stream contains
 
-`chat({ outputSchema, stream: true })` returns a `StructuredOutputStream<T>`. The stream is the standard `StreamChunk` lifecycle plus a terminal `CUSTOM` event named `structured-output.complete`. It is not folded into `RUN_FINISHED`.
+`chat({ outputSchema, stream: true })` returns a `StructuredOutputStream<T>`. The stream includes a `CUSTOM` event named `structured-output.complete` before `RUN_FINISHED`. The completion event carries the parsed object. A parsing failure emits `RUN_ERROR` instead of a successful `RUN_FINISHED`.
 
 ```typescript ignore
 {

--- a/packages/ai-client/src/connection-adapters.ts
+++ b/packages/ai-client/src/connection-adapters.ts
@@ -1042,6 +1042,7 @@ export function normalizeConnectionAdapter(
   // Legacy connect() wrapper
   let activeBuffer: Array<StreamChunk> = []
   let activeWaiters: Array<(chunk: StreamChunk | null) => void> = []
+  let activeSubscriber: typeof activeWaiters | undefined
 
   function push(chunk: StreamChunk, runId?: string): void {
     if (runId) {
@@ -1062,18 +1063,16 @@ export function normalizeConnectionAdapter(
     // previous chunk has left processIncomingChunk. Empty waiters with an
     // empty buffer is in-flight delivery, not idle.
     const idle = () =>
-      activeBuffer.length === 0 &&
-      (activeWaiters.length > 0 || abortSignal?.aborted)
+      activeSubscriber !== activeWaiters ||
+      (activeBuffer.length === 0 &&
+        (activeWaiters.length > 0 || abortSignal?.aborted))
     for (let i = 0; i < 16 && !abortSignal?.aborted; i++) {
       if (idle()) return
       await Promise.resolve()
     }
-    let macrotaskWaits = 0
     while (!abortSignal?.aborted) {
       if (idle()) return
       await new Promise<void>((resolve) => setTimeout(resolve, 0))
-      macrotaskWaits++
-      if (activeWaiters.length === 0 && macrotaskWaits >= 32) return
     }
   }
 
@@ -1087,22 +1086,27 @@ export function normalizeConnectionAdapter(
       activeWaiters = myWaiters
 
       return (async function* () {
-        while (!abortSignal?.aborted) {
-          let chunk: StreamChunk | null
-          const buffered = myBuffer.shift()
-          if (buffered !== undefined) {
-            chunk = buffered
-          } else {
-            chunk = await new Promise<StreamChunk | null>((resolve) => {
-              const onAbort = () => resolve(null)
-              myWaiters.push((c) => {
-                abortSignal?.removeEventListener('abort', onAbort)
-                resolve(c)
+        activeSubscriber = myWaiters
+        try {
+          while (!abortSignal?.aborted) {
+            let chunk: StreamChunk | null
+            const buffered = myBuffer.shift()
+            if (buffered !== undefined) {
+              chunk = buffered
+            } else {
+              chunk = await new Promise<StreamChunk | null>((resolve) => {
+                const onAbort = () => resolve(null)
+                myWaiters.push((c) => {
+                  abortSignal?.removeEventListener('abort', onAbort)
+                  resolve(c)
+                })
+                abortSignal?.addEventListener('abort', onAbort, { once: true })
               })
-              abortSignal?.addEventListener('abort', onAbort, { once: true })
-            })
+            }
+            if (chunk !== null) yield chunk
           }
-          if (chunk !== null) yield chunk
+        } finally {
+          if (activeSubscriber === myWaiters) activeSubscriber = undefined
         }
       })()
     },

--- a/packages/ai-client/tests/connection-drain.test.ts
+++ b/packages/ai-client/tests/connection-drain.test.ts
@@ -1,0 +1,65 @@
+import { expect, it, vi } from 'vitest'
+import { EventType } from '@tanstack/ai/client'
+import { normalizeConnectionAdapter, stream } from '../src/connection-adapters'
+
+it('waits for a slow subscriber before resolving send', async () => {
+  vi.useFakeTimers()
+  let release = () => {}
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const controller = new AbortController()
+  const adapter = normalizeConnectionAdapter(
+    stream(async function* () {
+      yield {
+        type: EventType.RUN_FINISHED,
+        threadId: 'thread',
+        runId: 'run',
+        timestamp: 0,
+      }
+    }),
+  )
+  let processed = false
+  const consuming = (async () => {
+    for await (const _chunk of adapter.subscribe(controller.signal)) {
+      await gate
+      processed = true
+    }
+  })()
+  let settled = false
+  const sending = adapter.send([]).then(() => {
+    settled = true
+  })
+  try {
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(settled).toBe(false)
+    release()
+    await vi.runAllTimersAsync()
+    await sending
+    expect(processed).toBe(true)
+  } finally {
+    release()
+    controller.abort()
+    await vi.runAllTimersAsync()
+    await Promise.all([sending, consuming])
+    vi.useRealTimers()
+  }
+})
+
+it('does not wait for a subscriber that has exited', async () => {
+  const adapter = normalizeConnectionAdapter(
+    stream(async function* () {
+      yield {
+        type: EventType.RUN_FINISHED,
+        threadId: 'thread',
+        runId: 'run',
+        timestamp: 0,
+      }
+    }),
+  )
+  const consuming = (async () => {
+    for await (const _chunk of adapter.subscribe()) break
+  })()
+  await adapter.send([])
+  await consuming
+})

--- a/packages/ai/src/activities/chat/index.ts
+++ b/packages/ai/src/activities/chat/index.ts
@@ -1245,7 +1245,7 @@ class TextEngine<
                 ...this.deferredModelRunFinishedChunks,
               )
               this.deferredModelRunFinishedChunks = []
-            } else {
+            } else if (!this.finalStructuredOutput?.nativeCombined) {
               yield* this.flushDeferredModelRunFinishedChunks()
             }
           } else {
@@ -1279,6 +1279,9 @@ class TextEngine<
       ) {
         if (this.finalStructuredOutput.nativeCombined === true) {
           yield* this.harvestCombinedStructuredOutput()
+          if (!this.finalizationError && !this.isCancelled()) {
+            yield* this.flushDeferredModelRunFinishedChunks()
+          }
         } else {
           yield* this.runStructuredFinalization()
         }
@@ -3926,12 +3929,8 @@ class TextEngine<
     }
 
     // On success, emit the synthetic `structured-output.complete` carrying
-    // the parsed object + raw text. Pin the messageId so the client-side
-    // handler can target the right UIMessage even when the agent loop's
-    // terminal RUN_FINISHED has already cleared `activeMessageIds` (the
-    // complete event yields AFTER the loop ends, by which point
-    // `getActiveAssistantMessageId()` returns null and would otherwise drop
-    // the event silently).
+    // the parsed object + raw text before the deferred RUN_FINISHED. Pin
+    // the messageId so the client targets the schema-constrained turn.
     if (
       this.structuredOutputResult &&
       !this.finalizationError &&

--- a/packages/ai/tests/chat-native-combined-structured-output.test.ts
+++ b/packages/ai/tests/chat-native-combined-structured-output.test.ts
@@ -165,6 +165,7 @@ describe('chat({ outputSchema, stream: true }) — native combined mode (#605)',
     const runFinished = chunks.filter((c) => c.type === EventType.RUN_FINISHED)
     expect(runStarted.length).toBe(1)
     expect(runFinished.length).toBe(1)
+    expect(chunks.at(-1)?.type).toBe(EventType.RUN_FINISHED)
   })
 
   it('Promise<T> path skips finalization and returns the validated typed value', async () => {
@@ -226,6 +227,7 @@ describe('chat({ outputSchema, stream: true }) — native combined mode (#605)',
       | undefined
     expect(runError).toBeDefined()
     expect(runError!.code).toBe('structured-output-parse-failed')
+    expect(chunks.some((c) => c.type === EventType.RUN_FINISHED)).toBe(false)
 
     // No structured-output.complete on the parse-failure path.
     const complete = chunks.find(


### PR DESCRIPTION
Structured chat can show the previous turn's final object after the new run appears finished. This fixes two causes: premature stream completion and premature client queue draining.

## 🎯 Changes

- Keep the native combined run's finish event deferred until the structured result is emitted. Parsing failures emit an error without a successful finish.
- Wait for the active connection subscriber to process all events. Remove the 32-tick cutoff, and stop waiting when the subscriber exits.
- Add regression tests, update the streaming and connection docs, and add patch changesets for core and client.

## ✅ Checklist

- [x] I have followed the steps in the Contributing guide.
- [x] I have tested code changes locally with `pnpm run test:pr`.
- [x] I fully understand the code in this pull request.
- [x] Docs: I updated `docs/` for this change.
- [x] Changeset: I added a changeset.

## 🚀 Release Impact

- [x] This change affects published code, and I added a changeset.
- [ ] This change is docs/CI/dev-only (no release).

## Root cause

**Issue.** Multi-turn structured chat can retain the previous final result after loading stops.

**Cause.** Native combined generation emitted `RUN_FINISHED` before harvesting the structured object. Separately, `waitUntilSubscriberIdle` returned after 32 timer ticks even with queued events. Longer responses made that cutoff visible.

**Fix.** Reuse the deferred finish queue and flush it after successful harvesting. Track the active subscriber so `send()` waits for processing without a fixed time limit.

## Possible alternatives

- Increase the timer limit. This still fails for a slower subscriber or a longer response.
- Add waits to the browser test. This hides the client state bug.

## Testing

Commands run:

- `pnpm test:pr`: passed with Node 24, pinned base `c9681f7a`, and worktree-local Nx cache paths. Node 26 cannot load the existing `isolated-vm` binary on this Mac.
- Native combined, event-source, and middleware unit tests: 28 passed.
- Connection adapter and drain unit tests passed. The drain tests also cover an exited subscriber.
- `playwright test tests/multi-turn-structured.spec.ts tests/byok.spec.ts --workers=4 --retries=0`: 20 passed.
- Full browser suite: 677 passed, 1 passed on retry, 1 skipped. The retry was an unrelated multimodal wire-format test. No structured-output retries.

Agent-written regression checks on clean main and this branch:

```text
main c9681f7a, chat-native-combined-structured-output.test.ts:
Tests 2 failed | 5 passed
Expected final event RUN_FINISHED, received CUSTOM.
Expected no RUN_FINISHED on parse failure, received one.

fixed branch, same test:
Tests 7 passed

main c9681f7a, connection-drain.test.ts:
Tests 1 failed | 1 passed
Expected send to remain unsettled while subscriber is blocked, received settled.

fixed branch, same test:
Tests 2 passed
```

Manual check:

1. Run the E2E app and open the multi-turn structured feature for OpenAI.
2. Send the three recipe prompts from `multi-turn-structured.spec.ts`.
3. Check that the third final result contains Gluten-Free and the first two recipes remain unchanged.

The existing provider-wide browser test exercises the larger third response. The new unit assertions pin event order and deliberately block a subscriber past the old cutoff.

## Risk / rollback

This changes finish timing for native structured output and wrapped `connect()` transports. Subscriber exit and tool lifecycle tests cover adjacent paths. Revert this PR to roll back.

Security review: no dependency, install script, CI permission, or new network changes. CodeRabbit: no PR existed during the initial review.
