### PR TITLE
Add an Adapters nav tab to the docs config

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1104,11 +1104,11 @@
           "updatedAt": "2026-08-21"
         }
       ],
-      "tab": "guides"
+      "tab": "adapters"
     },
     {
       "label": "Community Adapters",
-      "tab": "guides",
+      "tab": "adapters",
       "children": [
         {
           "label": "Community Adapters Guide",


### PR DESCRIPTION
## What changed

`docs/config.json` declares an `Adapters` nav tab and moves the Adapters and Community Adapters sections under it. tanstack.com reads extra tabs from the config (TanStack/tanstack.com#1232), shows them between Guides and API, and lands the tab on the first page of its first section, which is the OpenAI adapter.

## Why

Adapters are a top-level way people browse TanStack AI, and they were buried in Guides.

## Notes

- Nothing else changes. An earlier revision of this PR added a generated coverage file; that was dropped in favour of the tab landing on the adapter docs directly.
- The `$schema` on tanstack.com gains the `tabs` field in the same site PR.

https://claude.ai/code/session_01YFZ1i6q5qEeQL63B7zQXBX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the “Adapters” and “Community Adapters” navigation sections to use the correct adapters category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->