### PR TITLE
fix(ai-client): keep the reply when a rejoined run reasons before it answers

### DIFF
--- a/.changeset/rejoin-reasoning-first-reply.md
+++ b/.changeset/rejoin-reasoning-first-reply.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/ai-client': patch
+---
+
+Fix a `joinRun` rejoin losing the whole reply when the model reasons before it answers. The `REASONING_*` and `STEP_FINISHED` chunks that open a run already create the assistant message; the rebuild drop then ran on the later `TEXT_MESSAGE_START`, removed that message from the transcript while the processor kept its state, and every text chunk after it went to a message the UI no longer held. The transcript stayed on the user message with no reply and no `onFinish`. Those chunk types now count as rebuild triggers, so the drop runs before any assistant message exists.

--- a/packages/ai-client/src/chat-client.ts
+++ b/packages/ai-client/src/chat-client.ts
@@ -322,12 +322,22 @@ const REJOIN_CONNECT_DEADLINE_MS = 2000
  * in-flight partial is dropped only when one of these arrives — never on
  * `RUN_STARTED` alone — so a rejoin that connects but delivers no content cannot
  * leave an empty assistant bubble.
+ *
+ * Every chunk the processor answers with `ensureAssistantMessage()` has to be
+ * here. A model that reasons before it answers sends `REASONING_*` and
+ * `STEP_FINISHED` chunks first; those create the assistant message, and if the
+ * drop only ran on the later `TEXT_MESSAGE_START` it would remove that message
+ * from the list while the processor kept its state, so every text chunk after
+ * it would land on a message the transcript no longer holds.
  */
 const REJOIN_REBUILD_TRIGGERS = new Set<string>([
   'TEXT_MESSAGE_START',
   'TEXT_MESSAGE_CONTENT',
   'TOOL_CALL_START',
   'MESSAGES_SNAPSHOT',
+  'REASONING_MESSAGE_CONTENT',
+  'REASONING_ENCRYPTED_VALUE',
+  'STEP_FINISHED',
 ])
 
 export class ChatClient<

--- a/packages/ai-client/tests/chat-client-join-run-reasoning.test.ts
+++ b/packages/ai-client/tests/chat-client-join-run-reasoning.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+import { EventType } from '@tanstack/ai/client'
+import { ChatClient } from '../src/chat-client'
+import { createUIMessage } from './test-utils'
+import type { ResumableConnectConnectionAdapter } from '../src/connection-adapters'
+import type { StreamChunk, UIMessage } from '@tanstack/ai/client'
+
+/**
+ * A reasoning model writes its thinking step to the delivery log before any
+ * text: `REASONING_*` and `STEP_FINISHED` chunks, then `TEXT_MESSAGE_START`.
+ * On a rejoin the reasoning chunks already create the assistant message, so
+ * the rebuild drop has to run on them, not on the later text chunk.
+ */
+const reasonedReply: Array<StreamChunk> = [
+  { type: EventType.RUN_STARTED, runId: 'r1', threadId: 't1', timestamp: 1 },
+  {
+    type: EventType.REASONING_MESSAGE_START,
+    messageId: 'reasoning-1',
+    role: 'reasoning',
+    timestamp: 2,
+  },
+  { type: EventType.STEP_STARTED, stepName: 'step-1', timestamp: 3 },
+  {
+    type: EventType.REASONING_MESSAGE_END,
+    messageId: 'reasoning-1',
+    timestamp: 4,
+  },
+  {
+    type: EventType.REASONING_ENCRYPTED_VALUE,
+    subtype: 'message',
+    entityId: 'step-1',
+    encryptedValue: 'opaque',
+    timestamp: 5,
+  },
+  {
+    type: EventType.TEXT_MESSAGE_START,
+    messageId: 'assistant-1',
+    role: 'assistant',
+    timestamp: 6,
+  },
+  {
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    messageId: 'assistant-1',
+    delta: 'Hello!',
+    timestamp: 7,
+  },
+  { type: EventType.TEXT_MESSAGE_END, messageId: 'assistant-1', timestamp: 8 },
+  { type: EventType.RUN_FINISHED, runId: 'r1', threadId: 't1', timestamp: 9 },
+]
+
+function assistantText(messages: Array<UIMessage>): string {
+  return messages
+    .filter((message) => message.role === 'assistant')
+    .flatMap((message) => message.parts)
+    .map((part) => (part.type === 'text' ? part.content : ''))
+    .join('')
+}
+
+describe('joinRun replay of a run that reasons before it answers', () => {
+  it('keeps the assistant message the reasoning chunks created', async () => {
+    const connection: ResumableConnectConnectionAdapter = {
+      connect: async function* () {},
+      joinRun: async function* () {
+        yield* reasonedReply
+      },
+      hydrate: () =>
+        Promise.resolve({
+          messages: [],
+          activeRun: { runId: 'r1' },
+          interrupts: null,
+        }),
+    }
+
+    let messages: Array<UIMessage> = []
+    const client = new ChatClient({
+      threadId: 't1',
+      connection,
+      persistence: true,
+      initialMessages: [createUIMessage('user-1', 'hi')],
+      onMessagesChange: (next) => {
+        messages = next
+      },
+    })
+    client.attach()
+
+    await vi.waitFor(() => {
+      expect(assistantText(messages)).toBe('Hello!')
+    })
+    expect(messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+    ])
+
+    client.dispose()
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

`ChatClient.resumeInFlightRun` drops the hydrated in-flight assistant message the first time a chunk in `REJOIN_REBUILD_TRIGGERS` arrives, so the replay can rebuild it cleanly. That set only held `TEXT_MESSAGE_START`, `TEXT_MESSAGE_CONTENT`, `TOOL_CALL_START` and `MESSAGES_SNAPSHOT`.

A model that reasons before it answers (OpenAI gpt-5.x, Anthropic with extended thinking) opens its run with `REASONING_MESSAGE_START`, `STEP_STARTED`, `STEP_FINISHED` and `REASONING_ENCRYPTED_VALUE` before any text. The stream processor answers those with `ensureAssistantMessage()`, so the assistant message already exists when `TEXT_MESSAGE_START` arrives. The drop then fires on that first text chunk, removes the message from `processor.messages` through `setMessages()`, and leaves the processor's `messageStates` and `activeMessageIds` pointing at it. Every text chunk after that lands on a message the transcript no longer holds.

What the user sees on a `persistence: true` mount while a run streams (a reload mid-stream, or a route change that remounts the chat): the user message, `isLoading` true for the whole run, then nothing. No assistant message, and `onFinish` runs against a transcript without the reply. The server side is fine, the whole log replays; it is only the client that discards it. Verified against a real durability log where the client received every chunk through `onChunk` while `messages` never changed.

Fix: add `REASONING_MESSAGE_CONTENT`, `REASONING_ENCRYPTED_VALUE` and `STEP_FINISHED` to `REJOIN_REBUILD_TRIGGERS`, which are the other chunk types the processor creates the assistant message on. The drop then runs before any assistant message exists on a rejoin, and a hydrated partial is still rebuilt from the first content chunk as before.

Test: `packages/ai-client/tests/chat-client-join-run-reasoning.test.ts` rejoins a run whose log opens with reasoning chunks through a fake connection and asserts the reply is present. It fails on `main` (assistant text is empty, one message) and passes with this change.

No docs change: the behaviour matches what the rejoin docs already describe.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where rejoining an AI run could lose the assistant’s reply when reasoning occurred before text generation.
  * Assistant messages now remain intact when a run is resumed after reasoning or completed-step events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->