### PR TITLE
fix(openai-base): fix 400 error on multiple reasoning items

### DIFF
--- a/packages/openai-base/src/adapters/responses-text.ts
+++ b/packages/openai-base/src/adapters/responses-text.ts
@@ -1923,6 +1923,7 @@ export abstract class OpenAIBaseResponsesTextAdapter<
     messages: Array<ModelMessage>,
   ): ResponseInput {
     const result: ResponseInput = []
+    const seenReasoningIds = new Set<string>()
 
     for (const message of messages) {
       // Handle tool messages - convert to FunctionToolCallOutput
@@ -1944,11 +1945,17 @@ export abstract class OpenAIBaseResponsesTextAdapter<
 
       // Handle assistant messages
       if (message.role === 'assistant') {
+        const hasMultipleReasoning = (message.thinking?.length ?? 0) > 1
+
         if (message.thinking) {
           for (const thinking of message.thinking) {
             if (!thinking.signature) continue
             const packed = unpackResponsesReasoningSignature(thinking.signature)
             if (!packed?.id) continue
+            
+            if (seenReasoningIds.has(packed.id)) continue
+            seenReasoningIds.add(packed.id)
+
             result.push({
               type: 'reasoning',
               id: packed.id,
@@ -1978,7 +1985,7 @@ export abstract class OpenAIBaseResponsesTextAdapter<
             result.push({
               type: 'function_call',
               call_id: toolCall.id,
-              ...(itemId && { id: itemId }),
+              ...(!hasMultipleReasoning && itemId && { id: itemId }),
               name: toolCall.function.name,
               arguments: argumentsString,
             })


### PR DESCRIPTION
Closes #1345. Fixes the issue where replaying a transcript with multiple reasoning items caused OpenAI to return a 400 error due to strict item-pairing validation. This fix deduplicates reasoning IDs globally during rebuild and omits the function_call \id\ when multiple reasoning items exist in a single message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate reasoning content from appearing when processing requests with repeated reasoning entries.
  - Improved function-call request handling when multiple reasoning steps are present, supporting more consistent request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->