### PR TITLE
chore: let non-core maintainers approve model-sync PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,10 @@
 nx.json @TanStack/tanstack-core
 .changeset/config.json @TanStack/tanstack-core
 scripts/ @TanStack/tanstack-core
-# Generated model catalogs — written by .github/workflows/sync-models.yml,
-# reviewable by AI maintainers. Keep in sync with that workflow's `git add`.
-scripts/*.models.json @TanStack/ai-maintainers
-scripts/openrouter.video-models.json @TanStack/ai-maintainers
-scripts/.sync-models-last-run @TanStack/ai-maintainers
+# Generated model catalogs — written by .github/workflows/sync-models.yml.
+# No owner: any write-access maintainer can merge. Keep in sync with that
+# workflow's `git add`.
+scripts/*.models.json
+scripts/openrouter.video-models.json
+scripts/.sync-models-last-run
 .npmrc @TanStack/tanstack-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,9 @@
 nx.json @TanStack/tanstack-core
 .changeset/config.json @TanStack/tanstack-core
 scripts/ @TanStack/tanstack-core
+# Generated model catalogs — written by .github/workflows/sync-models.yml,
+# reviewable by any maintainer. Keep in sync with that workflow's `git add`.
+scripts/*.models.json
+scripts/openrouter.video-models.json
+scripts/.sync-models-last-run
 .npmrc @TanStack/tanstack-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@ nx.json @TanStack/tanstack-core
 .changeset/config.json @TanStack/tanstack-core
 scripts/ @TanStack/tanstack-core
 # Generated model catalogs — written by .github/workflows/sync-models.yml,
-# reviewable by any maintainer. Keep in sync with that workflow's `git add`.
-scripts/*.models.json
-scripts/openrouter.video-models.json
-scripts/.sync-models-last-run
+# reviewable by AI maintainers. Keep in sync with that workflow's `git add`.
+scripts/*.models.json @TanStack/ai-maintainers
+scripts/openrouter.video-models.json @TanStack/ai-maintainers
+scripts/.sync-models-last-run @TanStack/ai-maintainers
 .npmrc @TanStack/tanstack-core


### PR DESCRIPTION
Review this CODEOWNERS change. After merge, nightly model-sync PRs no longer require a `@TanStack/tanstack-core` review.

Generated catalogs under `scripts/` inherit the `scripts/` owner today. This PR clears that owner. The default-branch ruleset requires code-owner review and sets required approvals to 0. A PR that only touches unowned files can merge with no review once `Test` and `E2E Tests` are green. A person with write access still has to click merge.

## 🎯 Changes

CODEOWNERS is last-match-wins. A rule with no owner clears ownership. This PR appends those rules after `scripts/ @TanStack/tanstack-core`:

- `scripts/*.models.json` (openrouter, vercel-gateway, lovable-gateway catalogs)
- `scripts/openrouter.video-models.json`
- `scripts/.sync-models-last-run`

The `.ts` fetchers and converters stay core-owned. A change there still needs a core review.

No package code changed. No changeset. No docs. No E2E.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/ai/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with `pnpm run test:pr`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.
- [x] Docs: I updated `docs/` for this change, or this change is not user-facing.
- [x] Changeset: I added a changeset (`pnpm changeset`), or this PR does not change a published package.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

## Testing

**Commands run.** None. `pnpm test:pr` does not cover CODEOWNERS. These tests do not apply.

**Manual test.**

1. Open `.github/CODEOWNERS`.
2. Make sure that the three generated-catalog lines have no owner, and that they sit after the `scripts/` line.
3. After merge, open the next `chore: sync model metadata` PR.
4. Make sure that GitHub does not request `@TanStack/tanstack-core` as a required reviewer.

**How this PR makes testing easy.** None. The next nightly sync PR is the real check.

## Linked issues

Closes #1360

## Risk / rollback

A model-sync PR that only touches unowned files can merge with no review. The ruleset sets required approvals to 0.

The fetchers, converters, and the rest of `scripts/` stay core-owned.

Revert this PR to restore core review on the catalogs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership rules for model catalog and synchronization files.
  * Removed designated AI maintainer ownership from these files.
  * Clarified that any maintainer with write access can merge changes to them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->